### PR TITLE
fix: extend selection when wheel-scrolling during a drag

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3051,10 +3051,8 @@ impl AppState {
 
         self.focus_pane(pane_id);
 
-        // Measure the actual scroll delta: wheel requests LINES_PER_NOTCH,
-        // but the pane clamps at top/bottom of scrollback. Passing the
-        // requested notch straight into the selection math would over-extend
-        // the selection at those boundaries.
+        // Use the actual scroll delta — the pane clamps at the scrollback
+        // edges, so the notch we requested may not match what scrolled.
         let before_offset = self
             .pane_scroll_metrics(pane_id)
             .map(|m| m.offset_from_bottom);
@@ -4508,11 +4506,6 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_during_drag_extends_selection_beyond_viewport() {
-        // Regression: dragging a selection to the bottom of the viewport and
-        // then scrolling the wheel upward used to shrink the selection because
-        // the wheel handler recalculated the cursor from the stuck mouse
-        // position combined with the new scroll metrics. The fix extends the
-        // selection by the effective scroll delta instead.
         let mut app = app_for_mouse_test();
         let mut ws = Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
@@ -4542,8 +4535,6 @@ mod tests {
         let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
         let col = info.inner_rect.x + 2;
 
-        // Click at the top of the viewport and drag to the bottom. This
-        // selects the full viewport height.
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, top_row));
         app.handle_mouse(mouse(
             MouseEventKind::Drag(MouseButton::Left),
@@ -4560,8 +4551,6 @@ mod tests {
             "sanity: drag should select multiple rows (got {before_rows})"
         );
 
-        // Scroll wheel up while still holding — should extend the selection
-        // upward into the scrollback, not shrink it.
         app.handle_mouse(mouse(MouseEventKind::ScrollUp, col, bottom_row));
 
         let selection_after = app.state.selection.as_ref().expect("selection after wheel");
@@ -4598,12 +4587,6 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_down_during_reverse_drag_extends_selection() {
-        // Symmetric to the scroll-up case. The original bug is asymmetric:
-        // it appears when the mouse sits on the side opposite to the scroll
-        // direction. For ScrollDown that case is a reverse drag (bottom →
-        // top), leaving the mouse at the top of the viewport while new rows
-        // enter from the bottom. The fix must extend the bottom endpoint
-        // past the original viewport bottom.
         let mut app = app_for_mouse_test();
         let mut ws = Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
@@ -4625,8 +4608,6 @@ mod tests {
         app.state.mode = Mode::Terminal;
         app.state.view.pane_infos = pane_infos;
 
-        // Scroll up into the scrollback first so ScrollDown has room to
-        // advance.
         if let Some(rt) = app.state.workspaces[0]
             .tabs
             .first()
@@ -4648,8 +4629,6 @@ mod tests {
         let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
         let col = info.inner_rect.x + 2;
 
-        // Reverse drag: click at bottom, drag up to top. The mouse now sits
-        // at the top row of the viewport.
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             col,
@@ -4666,10 +4645,6 @@ mod tests {
         let before_rows = before_bottom.0 - before_top.0 + 1;
         assert!(before_rows >= 10, "sanity: reverse drag should select rows");
 
-        // Scroll wheel down while still holding. With the buggy code the
-        // new top = new_viewport_top + 0 advances with the scroll, shrinking
-        // the selection from the top. The fix must extend the bottom
-        // endpoint instead and keep the top anchored.
         app.handle_mouse(mouse(MouseEventKind::ScrollDown, col, top_row));
 
         let selection_after = app.state.selection.as_ref().expect("selection after wheel");

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3051,8 +3051,8 @@ impl AppState {
 
         self.focus_pane(pane_id);
 
-        // Use the actual scroll delta — the pane clamps at the scrollback
-        // edges, so the notch we requested may not match what scrolled.
+        // Use the actual scroll delta, since the pane clamps at the scrollback
+        // edges and the notch we requested may not match what scrolled.
         let before_offset = self
             .pane_scroll_metrics(pane_id)
             .map(|m| m.offset_from_bottom);
@@ -3333,6 +3333,35 @@ mod tests {
             .map(|i| format!("{i:06}\r\n"))
             .collect::<String>()
             .into_bytes()
+    }
+
+    /// Build an `App` with a single workspace that contains one pane backed by
+    /// a runtime with 64 lines of scrollback. Returns the app, the pane id, and
+    /// a clone of the pane info so tests can read `inner_rect` without touching
+    /// `app.state.view.pane_infos` again.
+    fn app_with_scrollback_pane() -> (App, crate::layout::PaneId, PaneInfo) {
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
+        ws.tabs[0].runtimes.insert(
+            pane_id,
+            crate::pane::PaneRuntime::test_with_scrollback_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                16 * 1024,
+                &numbered_lines_bytes(64),
+            ),
+        );
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        (app, pane_id, info)
     }
 
     fn capture_snapshot(state: &AppState) -> crate::persist::SessionSnapshot {
@@ -4450,26 +4479,7 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_keeps_in_progress_selection_and_extends_it() {
-        let mut app = app_for_mouse_test();
-        let mut ws = Workspace::test_new("test");
-        let pane_id = ws.tabs[0].root_pane;
-        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
-        let info = pane_infos[0].clone();
-        ws.tabs[0].runtimes.insert(
-            pane_id,
-            crate::pane::PaneRuntime::test_with_scrollback_bytes(
-                info.inner_rect.width,
-                info.inner_rect.height,
-                16 * 1024,
-                &numbered_lines_bytes(64),
-            ),
-        );
-
-        app.state.workspaces = vec![ws];
-        app.state.active = Some(0);
-        app.state.selected = 0;
-        app.state.mode = Mode::Terminal;
-        app.state.view.pane_infos = pane_infos;
+        let (mut app, pane_id, info) = app_with_scrollback_pane();
 
         let start_metrics = app.state.workspaces[0]
             .runtime(pane_id)
@@ -4506,26 +4516,7 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_during_drag_extends_selection_beyond_viewport() {
-        let mut app = app_for_mouse_test();
-        let mut ws = Workspace::test_new("test");
-        let pane_id = ws.tabs[0].root_pane;
-        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
-        let info = pane_infos[0].clone();
-        ws.tabs[0].runtimes.insert(
-            pane_id,
-            crate::pane::PaneRuntime::test_with_scrollback_bytes(
-                info.inner_rect.width,
-                info.inner_rect.height,
-                16 * 1024,
-                &numbered_lines_bytes(64),
-            ),
-        );
-
-        app.state.workspaces = vec![ws];
-        app.state.active = Some(0);
-        app.state.selected = 0;
-        app.state.mode = Mode::Terminal;
-        app.state.view.pane_infos = pane_infos;
+        let (mut app, pane_id, info) = app_with_scrollback_pane();
 
         let start_metrics = app.state.workspaces[0]
             .runtime(pane_id)
@@ -4587,26 +4578,7 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_down_during_reverse_drag_extends_selection() {
-        let mut app = app_for_mouse_test();
-        let mut ws = Workspace::test_new("test");
-        let pane_id = ws.tabs[0].root_pane;
-        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
-        let info = pane_infos[0].clone();
-        ws.tabs[0].runtimes.insert(
-            pane_id,
-            crate::pane::PaneRuntime::test_with_scrollback_bytes(
-                info.inner_rect.width,
-                info.inner_rect.height,
-                16 * 1024,
-                &numbered_lines_bytes(64),
-            ),
-        );
-
-        app.state.workspaces = vec![ws];
-        app.state.active = Some(0);
-        app.state.selected = 0;
-        app.state.mode = Mode::Terminal;
-        app.state.view.pane_infos = pane_infos;
+        let (mut app, pane_id, info) = app_with_scrollback_pane();
 
         if let Some(rt) = app.state.workspaces[0]
             .tabs

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3042,13 +3042,43 @@ impl AppState {
             return false;
         }
         let pane_id = selection.pane_id;
-        self.focus_pane(pane_id);
-        match mouse.kind {
-            MouseEventKind::ScrollUp => self.scroll_pane_up(pane_id, LINES_PER_NOTCH),
-            MouseEventKind::ScrollDown => self.scroll_pane_down(pane_id, LINES_PER_NOTCH),
+
+        let scroll_up = match mouse.kind {
+            MouseEventKind::ScrollUp => true,
+            MouseEventKind::ScrollDown => false,
             _ => return false,
+        };
+
+        self.focus_pane(pane_id);
+
+        // Measure the actual scroll delta: wheel requests LINES_PER_NOTCH,
+        // but the pane clamps at top/bottom of scrollback. Passing the
+        // requested notch straight into the selection math would over-extend
+        // the selection at those boundaries.
+        let before_offset = self
+            .pane_scroll_metrics(pane_id)
+            .map(|m| m.offset_from_bottom);
+        if scroll_up {
+            self.scroll_pane_up(pane_id, LINES_PER_NOTCH);
+        } else {
+            self.scroll_pane_down(pane_id, LINES_PER_NOTCH);
         }
-        self.update_selection_cursor(pane_id, mouse.column, mouse.row);
+        let after_offset = self
+            .pane_scroll_metrics(pane_id)
+            .map(|m| m.offset_from_bottom);
+
+        let effective_delta = match (before_offset, after_offset) {
+            (Some(before), Some(after)) if scroll_up => after.saturating_sub(before) as u32,
+            (Some(before), Some(after)) => before.saturating_sub(after) as u32,
+            _ => 0,
+        };
+
+        if effective_delta > 0 {
+            if let Some(selection) = self.selection.as_mut() {
+                selection.extend_in_scroll_direction(scroll_up, effective_delta);
+            }
+        }
+
         true
     }
 
@@ -4474,6 +4504,200 @@ mod tests {
                 (start_metrics.max_offset_from_bottom as u32, 2),
             )
         );
+    }
+
+    #[tokio::test]
+    async fn wheel_scroll_during_drag_extends_selection_beyond_viewport() {
+        // Regression: dragging a selection to the bottom of the viewport and
+        // then scrolling the wheel upward used to shrink the selection because
+        // the wheel handler recalculated the cursor from the stuck mouse
+        // position combined with the new scroll metrics. The fix extends the
+        // selection by the effective scroll delta instead.
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
+        ws.tabs[0].runtimes.insert(
+            pane_id,
+            crate::pane::PaneRuntime::test_with_scrollback_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                16 * 1024,
+                &numbered_lines_bytes(64),
+            ),
+        );
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        let start_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("initial scroll metrics");
+        let top_row = info.inner_rect.y;
+        let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
+        let col = info.inner_rect.x + 2;
+
+        // Click at the top of the viewport and drag to the bottom. This
+        // selects the full viewport height.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, top_row));
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            col,
+            bottom_row,
+        ));
+
+        let selection_before = app.state.selection.as_ref().expect("selection after drag");
+        assert!(selection_before.is_visible());
+        let (before_top, before_bottom) = selection_before.ordered_cells();
+        let before_rows = before_bottom.0 - before_top.0 + 1;
+        assert!(
+            before_rows >= 10,
+            "sanity: drag should select multiple rows (got {before_rows})"
+        );
+
+        // Scroll wheel up while still holding — should extend the selection
+        // upward into the scrollback, not shrink it.
+        app.handle_mouse(mouse(MouseEventKind::ScrollUp, col, bottom_row));
+
+        let selection_after = app.state.selection.as_ref().expect("selection after wheel");
+        assert!(
+            selection_after.is_visible(),
+            "selection stays visible after wheel"
+        );
+
+        let (after_top, after_bottom) = selection_after.ordered_cells();
+        let after_rows = after_bottom.0 - after_top.0 + 1;
+
+        assert!(
+            after_top.0 < before_top.0,
+            "top row should move upward after scroll up: before={} after={}",
+            before_top.0,
+            after_top.0
+        );
+        assert_eq!(
+            after_bottom.0, before_bottom.0,
+            "bottom row should stay anchored: before={} after={}",
+            before_bottom.0, after_bottom.0
+        );
+        assert!(
+            after_rows > before_rows,
+            "selection should grow, not shrink: before_rows={before_rows} after_rows={after_rows}"
+        );
+
+        let end_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("metrics after wheel");
+        assert!(end_metrics.offset_from_bottom > start_metrics.offset_from_bottom);
+    }
+
+    #[tokio::test]
+    async fn wheel_scroll_down_during_reverse_drag_extends_selection() {
+        // Symmetric to the scroll-up case. The original bug is asymmetric:
+        // it appears when the mouse sits on the side opposite to the scroll
+        // direction. For ScrollDown that case is a reverse drag (bottom →
+        // top), leaving the mouse at the top of the viewport while new rows
+        // enter from the bottom. The fix must extend the bottom endpoint
+        // past the original viewport bottom.
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
+        ws.tabs[0].runtimes.insert(
+            pane_id,
+            crate::pane::PaneRuntime::test_with_scrollback_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                16 * 1024,
+                &numbered_lines_bytes(64),
+            ),
+        );
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        // Scroll up into the scrollback first so ScrollDown has room to
+        // advance.
+        if let Some(rt) = app.state.workspaces[0]
+            .tabs
+            .first()
+            .and_then(|tab| tab.runtimes.get(&pane_id))
+        {
+            rt.scroll_up(10);
+        }
+
+        let start_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("initial scroll metrics");
+        assert!(
+            start_metrics.offset_from_bottom > 0,
+            "pane should start scrolled into scrollback"
+        );
+
+        let top_row = info.inner_rect.y;
+        let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
+        let col = info.inner_rect.x + 2;
+
+        // Reverse drag: click at bottom, drag up to top. The mouse now sits
+        // at the top row of the viewport.
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            col,
+            bottom_row,
+        ));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), col, top_row));
+
+        let (before_top, before_bottom) = app
+            .state
+            .selection
+            .as_ref()
+            .expect("selection after drag")
+            .ordered_cells();
+        let before_rows = before_bottom.0 - before_top.0 + 1;
+        assert!(before_rows >= 10, "sanity: reverse drag should select rows");
+
+        // Scroll wheel down while still holding. With the buggy code the
+        // new top = new_viewport_top + 0 advances with the scroll, shrinking
+        // the selection from the top. The fix must extend the bottom
+        // endpoint instead and keep the top anchored.
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, col, top_row));
+
+        let selection_after = app.state.selection.as_ref().expect("selection after wheel");
+        assert!(selection_after.is_visible());
+        let (after_top, after_bottom) = selection_after.ordered_cells();
+        let after_rows = after_bottom.0 - after_top.0 + 1;
+
+        assert_eq!(
+            after_top.0, before_top.0,
+            "top row should stay anchored: before={} after={}",
+            before_top.0, after_top.0
+        );
+        assert!(
+            after_bottom.0 > before_bottom.0,
+            "bottom row should move downward after scroll down: before={} after={}",
+            before_bottom.0,
+            after_bottom.0
+        );
+        assert!(
+            after_rows > before_rows,
+            "selection should grow, not shrink: before_rows={before_rows} after_rows={after_rows}"
+        );
+
+        let end_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("metrics after wheel");
+        assert!(end_metrics.offset_from_bottom < start_metrics.offset_from_bottom);
     }
 
     #[test]

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -102,24 +102,13 @@ impl Selection {
         matches!(self.phase, Phase::Anchored | Phase::Dragging)
     }
 
-    /// Extend the selection by `rows` in the direction of a scroll.
-    ///
-    /// `scroll_up == true` moves the top endpoint (smaller absolute row)
-    /// upward; `scroll_up == false` moves the bottom endpoint (larger
-    /// absolute row) downward. Top and bottom are chosen dynamically from
-    /// `anchor` vs `cursor` by absolute row — this means the stored
-    /// `anchor` can be mutated when it is the endpoint on the scrolled side,
-    /// which matches the UX the user expects (selection grows toward the
-    /// newly revealed content).
-    ///
-    /// Preserves the `Anchored → Dragging` transition that the existing
-    /// wheel handler relies on: a click without drag followed by a wheel
-    /// scroll must become a visible selection.
+    /// Extend the selection by `rows` rows toward the scroll direction.
+    /// Either endpoint may be mutated, depending on which side is currently
+    /// the top.
     pub(crate) fn extend_in_scroll_direction(&mut self, scroll_up: bool, rows: u32) {
-        // Choose the logically earlier endpoint with the same ordering rule
-        // as `ordered()`: row first, column as tie-breaker. This matters
-        // for single-row selections dragged right-to-left, where the
-        // leftmost endpoint is the cursor, not the anchor.
+        // Endpoint pick must match `ordered()` exactly, including the column
+        // tie-breaker — otherwise a single-row right-to-left drag moves the
+        // wrong side.
         let anchor_precedes_cursor = self.anchor.0 < self.cursor.0
             || (self.anchor.0 == self.cursor.0 && self.anchor.1 <= self.cursor.1);
         let (top, bottom) = if anchor_precedes_cursor {
@@ -341,7 +330,6 @@ mod tests {
 
     #[test]
     fn extend_scroll_up_moves_top_endpoint() {
-        // anchor is top, cursor is bottom
         let mut sel = make_sel(10, 2, 20, 5);
         sel.extend_in_scroll_direction(true, 3);
         assert_eq!(sel.ordered_cells(), ((7, 2), (20, 5)));
@@ -349,7 +337,6 @@ mod tests {
 
     #[test]
     fn extend_scroll_down_moves_bottom_endpoint() {
-        // anchor is top, cursor is bottom
         let mut sel = make_sel(10, 2, 20, 5);
         sel.extend_in_scroll_direction(false, 3);
         assert_eq!(sel.ordered_cells(), ((10, 2), (23, 5)));
@@ -357,32 +344,26 @@ mod tests {
 
     #[test]
     fn extend_scroll_up_when_cursor_is_top() {
-        // cursor is top, anchor is bottom (reverse drag)
         let mut sel = make_sel(20, 5, 10, 2);
         sel.extend_in_scroll_direction(true, 4);
-        // cursor moves up from (10,2) to (6,2), anchor stays (20,5)
         assert_eq!(sel.ordered_cells(), ((6, 2), (20, 5)));
     }
 
     #[test]
     fn extend_scroll_down_when_anchor_is_bottom() {
-        // cursor is top, anchor is bottom
         let mut sel = make_sel(20, 5, 10, 2);
         sel.extend_in_scroll_direction(false, 4);
-        // anchor moves down from (20,5) to (24,5), cursor stays (10,2)
         assert_eq!(sel.ordered_cells(), ((10, 2), (24, 5)));
     }
 
     #[test]
     fn extend_from_anchored_transitions_to_dragging() {
-        // click without drag — phase Anchored, anchor == cursor
         let mut sel = Selection::anchor(PaneId::from_raw(0), 5, 10, None);
         assert!(sel.was_just_click());
         assert!(!sel.is_visible());
 
         sel.extend_in_scroll_direction(true, 3);
 
-        // Transitioned to Dragging, selection is now visible
         assert!(!sel.was_just_click());
         assert!(sel.is_visible());
         assert_eq!(sel.ordered_cells(), ((2, 10), (5, 10)));
@@ -397,17 +378,11 @@ mod tests {
 
     #[test]
     fn extend_single_row_right_to_left_drag_uses_col_tiebreak() {
-        // Single-row selection dragged right-to-left: anchor=(5,20),
-        // cursor=(5,5). Logical top is cursor (leftmost column), not anchor.
-        // The helper must pick the same endpoint as `ordered()` or the wrong
-        // side of the selection gets extended.
         let mut sel = make_sel(5, 20, 5, 5);
         assert_eq!(sel.ordered_cells(), ((5, 5), (5, 20)));
 
         sel.extend_in_scroll_direction(true, 3);
 
-        // Top endpoint (the one at col 5) should have moved up to row 2.
-        // The other endpoint (col 20 on row 5) should stay put.
         assert_eq!(sel.ordered_cells(), ((2, 5), (5, 20)));
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -107,7 +107,7 @@ impl Selection {
     /// the top.
     pub(crate) fn extend_in_scroll_direction(&mut self, scroll_up: bool, rows: u32) {
         // Endpoint pick must match `ordered()` exactly, including the column
-        // tie-breaker — otherwise a single-row right-to-left drag moves the
+        // tie-breaker; otherwise a single-row right-to-left drag moves the
         // wrong side.
         let anchor_precedes_cursor = self.anchor.0 < self.cursor.0
             || (self.anchor.0 == self.cursor.0 && self.anchor.1 <= self.cursor.1);

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -102,6 +102,43 @@ impl Selection {
         matches!(self.phase, Phase::Anchored | Phase::Dragging)
     }
 
+    /// Extend the selection by `rows` in the direction of a scroll.
+    ///
+    /// `scroll_up == true` moves the top endpoint (smaller absolute row)
+    /// upward; `scroll_up == false` moves the bottom endpoint (larger
+    /// absolute row) downward. Top and bottom are chosen dynamically from
+    /// `anchor` vs `cursor` by absolute row — this means the stored
+    /// `anchor` can be mutated when it is the endpoint on the scrolled side,
+    /// which matches the UX the user expects (selection grows toward the
+    /// newly revealed content).
+    ///
+    /// Preserves the `Anchored → Dragging` transition that the existing
+    /// wheel handler relies on: a click without drag followed by a wheel
+    /// scroll must become a visible selection.
+    pub(crate) fn extend_in_scroll_direction(&mut self, scroll_up: bool, rows: u32) {
+        // Choose the logically earlier endpoint with the same ordering rule
+        // as `ordered()`: row first, column as tie-breaker. This matters
+        // for single-row selections dragged right-to-left, where the
+        // leftmost endpoint is the cursor, not the anchor.
+        let anchor_precedes_cursor = self.anchor.0 < self.cursor.0
+            || (self.anchor.0 == self.cursor.0 && self.anchor.1 <= self.cursor.1);
+        let (top, bottom) = if anchor_precedes_cursor {
+            (&mut self.anchor, &mut self.cursor)
+        } else {
+            (&mut self.cursor, &mut self.anchor)
+        };
+
+        if scroll_up {
+            top.0 = top.0.saturating_sub(rows);
+        } else {
+            bottom.0 = bottom.0.saturating_add(rows);
+        }
+
+        if self.cursor != self.anchor {
+            self.phase = Phase::Dragging;
+        }
+    }
+
     /// Returns (start, end) in reading order (top-left to bottom-right).
     fn ordered(&self) -> ((u32, u16), (u32, u16)) {
         let (ar, ac) = self.anchor;
@@ -300,6 +337,78 @@ mod tests {
         assert!(sel.contains(1, 40, metrics));
         assert!(sel.contains(2, 4, metrics));
         assert!(!sel.contains(3, 4, metrics));
+    }
+
+    #[test]
+    fn extend_scroll_up_moves_top_endpoint() {
+        // anchor is top, cursor is bottom
+        let mut sel = make_sel(10, 2, 20, 5);
+        sel.extend_in_scroll_direction(true, 3);
+        assert_eq!(sel.ordered_cells(), ((7, 2), (20, 5)));
+    }
+
+    #[test]
+    fn extend_scroll_down_moves_bottom_endpoint() {
+        // anchor is top, cursor is bottom
+        let mut sel = make_sel(10, 2, 20, 5);
+        sel.extend_in_scroll_direction(false, 3);
+        assert_eq!(sel.ordered_cells(), ((10, 2), (23, 5)));
+    }
+
+    #[test]
+    fn extend_scroll_up_when_cursor_is_top() {
+        // cursor is top, anchor is bottom (reverse drag)
+        let mut sel = make_sel(20, 5, 10, 2);
+        sel.extend_in_scroll_direction(true, 4);
+        // cursor moves up from (10,2) to (6,2), anchor stays (20,5)
+        assert_eq!(sel.ordered_cells(), ((6, 2), (20, 5)));
+    }
+
+    #[test]
+    fn extend_scroll_down_when_anchor_is_bottom() {
+        // cursor is top, anchor is bottom
+        let mut sel = make_sel(20, 5, 10, 2);
+        sel.extend_in_scroll_direction(false, 4);
+        // anchor moves down from (20,5) to (24,5), cursor stays (10,2)
+        assert_eq!(sel.ordered_cells(), ((10, 2), (24, 5)));
+    }
+
+    #[test]
+    fn extend_from_anchored_transitions_to_dragging() {
+        // click without drag — phase Anchored, anchor == cursor
+        let mut sel = Selection::anchor(PaneId::from_raw(0), 5, 10, None);
+        assert!(sel.was_just_click());
+        assert!(!sel.is_visible());
+
+        sel.extend_in_scroll_direction(true, 3);
+
+        // Transitioned to Dragging, selection is now visible
+        assert!(!sel.was_just_click());
+        assert!(sel.is_visible());
+        assert_eq!(sel.ordered_cells(), ((2, 10), (5, 10)));
+    }
+
+    #[test]
+    fn extend_scroll_up_saturates_at_zero() {
+        let mut sel = make_sel(2, 0, 4, 0);
+        sel.extend_in_scroll_direction(true, 10);
+        assert_eq!(sel.ordered_cells(), ((0, 0), (4, 0)));
+    }
+
+    #[test]
+    fn extend_single_row_right_to_left_drag_uses_col_tiebreak() {
+        // Single-row selection dragged right-to-left: anchor=(5,20),
+        // cursor=(5,5). Logical top is cursor (leftmost column), not anchor.
+        // The helper must pick the same endpoint as `ordered()` or the wrong
+        // side of the selection gets extended.
+        let mut sel = make_sel(5, 20, 5, 5);
+        assert_eq!(sel.ordered_cells(), ((5, 5), (5, 20)));
+
+        sel.extend_in_scroll_direction(true, 3);
+
+        // Top endpoint (the one at col 5) should have moved up to row 2.
+        // The other endpoint (col 20 on row 5) should stay put.
+        assert_eq!(sel.ordered_cells(), ((2, 5), (5, 20)));
     }
 
     #[test]


### PR DESCRIPTION
Bug fix I hit copying shell output. `just ci` clean. Flagging one opinionated call near the end.

## what's broken

Hold left, drag to select text in a pane, then roll the wheel to keep pulling the selection past the viewport. The selection shrinks instead of growing. Shells, Codex, anything that leaves mouse reporting off. Claude Code panes don't reproduce because the click goes to the TUI before a selection ever exists.

`scroll_selection_with_wheel` scrolled the pane and then called `update_selection_cursor(mouse.column, mouse.row)`. The mouse sits wherever the user stopped dragging, usually the viewport edge, so `Selection::drag` recomputes the absolute row as `new_viewport_top + clamped_viewport_row`. As `new_viewport_top` moves with the scroll, the cursor chases the scroll instead of extending the selection.

## the fix

Two commits plus a cleanup:

1. New `Selection::extend_in_scroll_direction(scroll_up, rows)` in `src/selection.rs`. `pub(crate)` helper that moves the top or bottom endpoint by `rows`, picking the endpoint with the same row+column ordering as `Selection::ordered`. The column tie-break matters for single-row right-to-left drags.

2. `scroll_selection_with_wheel` stops feeding mouse coordinates into the selection. Measures `offset_from_bottom` before and after the scroll, passes the real delta to the new helper. If the pane hit the scrollback boundary and couldn't scroll, the selection doesn't extend either.

3. `chore:` commit trimming narrative comments I left behind during iteration.

## the opinionated half

The stored `anchor` can now be mutated by the wheel. When `anchor` is the top endpoint and the user scrolls up, `anchor.0` decreases; when it's the bottom and they scroll down, `anchor.0` increases. The "anchor is where you first pressed" invariant no longer holds.

I chose this because it's what Alacritty does (their issue #1600 fixed the same bug with the same trade-off), and the alternative is a separate `wheel_offset` field threaded through `ordered`, `contains`, `drag`, and every caller. Too much state for a rarely-hit edge case.

If you'd rather keep `anchor` immutable and push the extra state, say so and I'll rework it. Mouse ergonomics is opinionated so this is your call, not mine.

## does this change UI / interaction / workflow?

Interaction: yes, but only for a case that was already broken. Wheel during an in-progress selection now extends instead of shrinks. Matches what I see in Alacritty, Ghostty, Kitty, iTerm2.

Everything else stays: keybinds, layout, sidebar, scrollbar, drag select outside the wheel path, auto-scroll when the drag cursor leaves the viewport, copy on release, OSC 52 write.

## tests

7 unit tests on the helper covering both scroll directions across both endpoint owners, the single-row right-to-left tie-break, the `Anchored → Dragging` phase transition, and zero-saturation. 2 end-to-end regression tests in `input.rs` for forward drag + ScrollUp and reverse drag + ScrollDown. Each fails on the old code and passes on the new one. I reverted each fix locally with the tests in place to confirm before pushing. `just ci` clean, 462 unit + 22 integration tests.

## honest caveat

If a `Drag` event arrives after the wheel extension (user moves the mouse before releasing), the existing drag handler recomputes the cursor from the physical position and can pull the wheel-extended endpoint back. Clean flow is unaffected. Leaving it as a follow-up.