### PR TITLE
fix: forward OSC 52 clipboard writes from pane children (#29)

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -453,6 +453,9 @@ impl AppState {
                 .update_pane_state(pane_id, |pane| pane.release_agent(&source, agent))
                 .into_iter()
                 .collect(),
+            // Intercepted in App::handle_internal_event before reaching this
+            // dispatch; never touches AppState.
+            AppEvent::ClipboardWrite { .. } => Vec::new(),
         }
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2887,13 +2887,43 @@ impl AppState {
             return false;
         }
         let pane_id = selection.pane_id;
-        self.focus_pane(pane_id);
-        match mouse.kind {
-            MouseEventKind::ScrollUp => self.scroll_pane_up(pane_id, LINES_PER_NOTCH),
-            MouseEventKind::ScrollDown => self.scroll_pane_down(pane_id, LINES_PER_NOTCH),
+
+        let scroll_up = match mouse.kind {
+            MouseEventKind::ScrollUp => true,
+            MouseEventKind::ScrollDown => false,
             _ => return false,
+        };
+
+        self.focus_pane(pane_id);
+
+        // Measure the actual scroll delta: wheel requests LINES_PER_NOTCH,
+        // but the pane clamps at top/bottom of scrollback. Passing the
+        // requested notch straight into the selection math would over-extend
+        // the selection at those boundaries.
+        let before_offset = self
+            .pane_scroll_metrics(pane_id)
+            .map(|m| m.offset_from_bottom);
+        if scroll_up {
+            self.scroll_pane_up(pane_id, LINES_PER_NOTCH);
+        } else {
+            self.scroll_pane_down(pane_id, LINES_PER_NOTCH);
         }
-        self.update_selection_cursor(pane_id, mouse.column, mouse.row);
+        let after_offset = self
+            .pane_scroll_metrics(pane_id)
+            .map(|m| m.offset_from_bottom);
+
+        let effective_delta = match (before_offset, after_offset) {
+            (Some(before), Some(after)) if scroll_up => after.saturating_sub(before) as u32,
+            (Some(before), Some(after)) => before.saturating_sub(after) as u32,
+            _ => 0,
+        };
+
+        if effective_delta > 0 {
+            if let Some(selection) = self.selection.as_mut() {
+                selection.extend_in_scroll_direction(scroll_up, effective_delta);
+            }
+        }
+
         true
     }
 
@@ -4319,6 +4349,200 @@ mod tests {
                 (start_metrics.max_offset_from_bottom as u32, 2),
             )
         );
+    }
+
+    #[tokio::test]
+    async fn wheel_scroll_during_drag_extends_selection_beyond_viewport() {
+        // Regression: dragging a selection to the bottom of the viewport and
+        // then scrolling the wheel upward used to shrink the selection because
+        // the wheel handler recalculated the cursor from the stuck mouse
+        // position combined with the new scroll metrics. The fix extends the
+        // selection by the effective scroll delta instead.
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
+        ws.tabs[0].runtimes.insert(
+            pane_id,
+            crate::pane::PaneRuntime::test_with_scrollback_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                16 * 1024,
+                &numbered_lines_bytes(64),
+            ),
+        );
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        let start_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("initial scroll metrics");
+        let top_row = info.inner_rect.y;
+        let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
+        let col = info.inner_rect.x + 2;
+
+        // Click at the top of the viewport and drag to the bottom. This
+        // selects the full viewport height.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, top_row));
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            col,
+            bottom_row,
+        ));
+
+        let selection_before = app.state.selection.as_ref().expect("selection after drag");
+        assert!(selection_before.is_visible());
+        let (before_top, before_bottom) = selection_before.ordered_cells();
+        let before_rows = before_bottom.0 - before_top.0 + 1;
+        assert!(
+            before_rows >= 10,
+            "sanity: drag should select multiple rows (got {before_rows})"
+        );
+
+        // Scroll wheel up while still holding — should extend the selection
+        // upward into the scrollback, not shrink it.
+        app.handle_mouse(mouse(MouseEventKind::ScrollUp, col, bottom_row));
+
+        let selection_after = app.state.selection.as_ref().expect("selection after wheel");
+        assert!(
+            selection_after.is_visible(),
+            "selection stays visible after wheel"
+        );
+
+        let (after_top, after_bottom) = selection_after.ordered_cells();
+        let after_rows = after_bottom.0 - after_top.0 + 1;
+
+        assert!(
+            after_top.0 < before_top.0,
+            "top row should move upward after scroll up: before={} after={}",
+            before_top.0,
+            after_top.0
+        );
+        assert_eq!(
+            after_bottom.0, before_bottom.0,
+            "bottom row should stay anchored: before={} after={}",
+            before_bottom.0, after_bottom.0
+        );
+        assert!(
+            after_rows > before_rows,
+            "selection should grow, not shrink: before_rows={before_rows} after_rows={after_rows}"
+        );
+
+        let end_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("metrics after wheel");
+        assert!(end_metrics.offset_from_bottom > start_metrics.offset_from_bottom);
+    }
+
+    #[tokio::test]
+    async fn wheel_scroll_down_during_reverse_drag_extends_selection() {
+        // Symmetric to the scroll-up case. The original bug is asymmetric:
+        // it appears when the mouse sits on the side opposite to the scroll
+        // direction. For ScrollDown that case is a reverse drag (bottom →
+        // top), leaving the mouse at the top of the viewport while new rows
+        // enter from the bottom. The fix must extend the bottom endpoint
+        // past the original viewport bottom.
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let pane_infos = ws.tabs[0].layout.panes(Rect::new(26, 2, 80, 18));
+        let info = pane_infos[0].clone();
+        ws.tabs[0].runtimes.insert(
+            pane_id,
+            crate::pane::PaneRuntime::test_with_scrollback_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                16 * 1024,
+                &numbered_lines_bytes(64),
+            ),
+        );
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        // Scroll up into the scrollback first so ScrollDown has room to
+        // advance.
+        if let Some(rt) = app.state.workspaces[0]
+            .tabs
+            .first()
+            .and_then(|tab| tab.runtimes.get(&pane_id))
+        {
+            rt.scroll_up(10);
+        }
+
+        let start_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("initial scroll metrics");
+        assert!(
+            start_metrics.offset_from_bottom > 0,
+            "pane should start scrolled into scrollback"
+        );
+
+        let top_row = info.inner_rect.y;
+        let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
+        let col = info.inner_rect.x + 2;
+
+        // Reverse drag: click at bottom, drag up to top. The mouse now sits
+        // at the top row of the viewport.
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            col,
+            bottom_row,
+        ));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), col, top_row));
+
+        let (before_top, before_bottom) = app
+            .state
+            .selection
+            .as_ref()
+            .expect("selection after drag")
+            .ordered_cells();
+        let before_rows = before_bottom.0 - before_top.0 + 1;
+        assert!(before_rows >= 10, "sanity: reverse drag should select rows");
+
+        // Scroll wheel down while still holding. With the buggy code the
+        // new top = new_viewport_top + 0 advances with the scroll, shrinking
+        // the selection from the top. The fix must extend the bottom
+        // endpoint instead and keep the top anchored.
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, col, top_row));
+
+        let selection_after = app.state.selection.as_ref().expect("selection after wheel");
+        assert!(selection_after.is_visible());
+        let (after_top, after_bottom) = selection_after.ordered_cells();
+        let after_rows = after_bottom.0 - after_top.0 + 1;
+
+        assert_eq!(
+            after_top.0, before_top.0,
+            "top row should stay anchored: before={} after={}",
+            before_top.0, after_top.0
+        );
+        assert!(
+            after_bottom.0 > before_bottom.0,
+            "bottom row should move downward after scroll down: before={} after={}",
+            before_bottom.0,
+            after_bottom.0
+        );
+        assert!(
+            after_rows > before_rows,
+            "selection should grow, not shrink: before_rows={before_rows} after_rows={after_rows}"
+        );
+
+        let end_metrics = app.state.workspaces[0]
+            .runtime(pane_id)
+            .and_then(crate::pane::PaneRuntime::scroll_metrics)
+            .expect("metrics after wheel");
+        assert!(end_metrics.offset_from_bottom < start_metrics.offset_from_bottom);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2896,10 +2896,8 @@ impl AppState {
 
         self.focus_pane(pane_id);
 
-        // Measure the actual scroll delta: wheel requests LINES_PER_NOTCH,
-        // but the pane clamps at top/bottom of scrollback. Passing the
-        // requested notch straight into the selection math would over-extend
-        // the selection at those boundaries.
+        // Use the actual scroll delta — the pane clamps at the scrollback
+        // edges, so the notch we requested may not match what scrolled.
         let before_offset = self
             .pane_scroll_metrics(pane_id)
             .map(|m| m.offset_from_bottom);
@@ -4353,11 +4351,6 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_during_drag_extends_selection_beyond_viewport() {
-        // Regression: dragging a selection to the bottom of the viewport and
-        // then scrolling the wheel upward used to shrink the selection because
-        // the wheel handler recalculated the cursor from the stuck mouse
-        // position combined with the new scroll metrics. The fix extends the
-        // selection by the effective scroll delta instead.
         let mut app = app_for_mouse_test();
         let mut ws = Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
@@ -4387,8 +4380,6 @@ mod tests {
         let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
         let col = info.inner_rect.x + 2;
 
-        // Click at the top of the viewport and drag to the bottom. This
-        // selects the full viewport height.
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, top_row));
         app.handle_mouse(mouse(
             MouseEventKind::Drag(MouseButton::Left),
@@ -4405,8 +4396,6 @@ mod tests {
             "sanity: drag should select multiple rows (got {before_rows})"
         );
 
-        // Scroll wheel up while still holding — should extend the selection
-        // upward into the scrollback, not shrink it.
         app.handle_mouse(mouse(MouseEventKind::ScrollUp, col, bottom_row));
 
         let selection_after = app.state.selection.as_ref().expect("selection after wheel");
@@ -4443,12 +4432,6 @@ mod tests {
 
     #[tokio::test]
     async fn wheel_scroll_down_during_reverse_drag_extends_selection() {
-        // Symmetric to the scroll-up case. The original bug is asymmetric:
-        // it appears when the mouse sits on the side opposite to the scroll
-        // direction. For ScrollDown that case is a reverse drag (bottom →
-        // top), leaving the mouse at the top of the viewport while new rows
-        // enter from the bottom. The fix must extend the bottom endpoint
-        // past the original viewport bottom.
         let mut app = app_for_mouse_test();
         let mut ws = Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
@@ -4470,8 +4453,6 @@ mod tests {
         app.state.mode = Mode::Terminal;
         app.state.view.pane_infos = pane_infos;
 
-        // Scroll up into the scrollback first so ScrollDown has room to
-        // advance.
         if let Some(rt) = app.state.workspaces[0]
             .tabs
             .first()
@@ -4493,8 +4474,6 @@ mod tests {
         let bottom_row = info.inner_rect.y + info.inner_rect.height - 1;
         let col = info.inner_rect.x + 2;
 
-        // Reverse drag: click at bottom, drag up to top. The mouse now sits
-        // at the top row of the viewport.
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             col,
@@ -4511,10 +4490,6 @@ mod tests {
         let before_rows = before_bottom.0 - before_top.0 + 1;
         assert!(before_rows >= 10, "sanity: reverse drag should select rows");
 
-        // Scroll wheel down while still holding. With the buggy code the
-        // new top = new_viewport_top + 0 advances with the scroll, shrinking
-        // the selection from the top. The fix must extend the bottom
-        // endpoint instead and keep the top anchored.
         app.handle_mouse(mouse(MouseEventKind::ScrollDown, col, top_row));
 
         let selection_after = app.state.selection.as_ref().expect("selection after wheel");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -779,6 +779,13 @@ impl App {
     }
 
     fn handle_internal_event(&mut self, ev: AppEvent) {
+        if let AppEvent::ClipboardWrite { bytes } = ev {
+            use std::io::Write;
+            let _ = std::io::stdout().write_all(&bytes);
+            let _ = std::io::stdout().flush();
+            return;
+        }
+
         if let AppEvent::PaneDied { pane_id } = &ev {
             if let Some((ws_idx, _)) = self.find_pane(*pane_id) {
                 if let Some(public_pane_id) = self.public_pane_id(ws_idx, *pane_id) {

--- a/src/events.rs
+++ b/src/events.rs
@@ -38,4 +38,7 @@ pub enum AppEvent {
     },
     /// A new version was downloaded and installed. Restart to use it.
     UpdateReady { version: String },
+    /// A pane child emitted an OSC 52 clipboard-write sequence that the
+    /// main loop should re-emit on herdr's stdout.
+    ClipboardWrite { bytes: Vec<u8> },
 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -281,9 +281,10 @@ impl InputState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ProcessBytesResult {
     request_render: bool,
+    clipboard_writes: Vec<Vec<u8>>,
 }
 
 struct GhosttyPaneTerminal {
@@ -297,6 +298,7 @@ struct GhosttyPaneCore {
     host_terminal_theme: crate::terminal_theme::TerminalTheme,
     transient_default_color_owner_pgid: Option<u32>,
     default_color_tracker: DefaultColorOscTracker,
+    osc52_forwarder: Osc52Forwarder,
 }
 
 #[derive(Debug, Default)]
@@ -374,6 +376,120 @@ fn is_default_color_set_osc(body: &[u8]) -> bool {
     let command = &body[..separator];
     let value = &body[separator + 1..];
     matches!(command, b"10" | b"11") && !value.is_empty() && value != b"?"
+}
+
+/// 256 KiB of base64 ≈ 192 KiB of text — enough for real source-file copies
+/// while still bounding memory against stream garbage.
+const OSC52_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Osc52Terminator {
+    Bel,
+    St,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum Osc52ForwarderState {
+    #[default]
+    Ground,
+    Escape,
+    OscBody,
+    OscEscape,
+}
+
+/// Reconstructs OSC 52 clipboard-write sequences from raw PTY bytes so the
+/// main loop can re-emit them. `libghostty-vt`'s readonly stream handler
+/// drops `.clipboard_contents` actions, so without this forwarder clipboard
+/// writes from child processes never reach the host terminal.
+#[derive(Debug, Default)]
+struct Osc52Forwarder {
+    state: Osc52ForwarderState,
+    body: Vec<u8>,
+    pending: Vec<Vec<u8>>,
+}
+
+impl Osc52Forwarder {
+    fn observe(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            match self.state {
+                Osc52ForwarderState::Ground => {
+                    if byte == 0x1b {
+                        self.state = Osc52ForwarderState::Escape;
+                    }
+                }
+                Osc52ForwarderState::Escape => {
+                    if byte == b']' {
+                        self.body.clear();
+                        self.state = Osc52ForwarderState::OscBody;
+                    } else if byte == 0x1b {
+                        self.state = Osc52ForwarderState::Escape;
+                    } else {
+                        self.state = Osc52ForwarderState::Ground;
+                    }
+                }
+                Osc52ForwarderState::OscBody => match byte {
+                    0x07 => {
+                        self.finalize(Osc52Terminator::Bel);
+                        self.state = Osc52ForwarderState::Ground;
+                    }
+                    0x1b => self.state = Osc52ForwarderState::OscEscape,
+                    _ => self.body.push(byte),
+                },
+                Osc52ForwarderState::OscEscape => {
+                    if byte == b'\\' {
+                        self.finalize(Osc52Terminator::St);
+                        self.state = Osc52ForwarderState::Ground;
+                    } else {
+                        self.body.push(0x1b);
+                        self.body.push(byte);
+                        self.state = Osc52ForwarderState::OscBody;
+                    }
+                }
+            }
+
+            if self.body.len() > OSC52_MAX_PAYLOAD_BYTES {
+                self.body.clear();
+                self.state = Osc52ForwarderState::Ground;
+            }
+        }
+    }
+
+    fn finalize(&mut self, terminator: Osc52Terminator) {
+        if is_osc52_clipboard_write(&self.body) {
+            let mut sequence = Vec::with_capacity(self.body.len() + 4);
+            sequence.extend_from_slice(b"\x1b]");
+            sequence.extend_from_slice(&self.body);
+            match terminator {
+                Osc52Terminator::Bel => sequence.push(0x07),
+                Osc52Terminator::St => sequence.extend_from_slice(b"\x1b\\"),
+            }
+            self.pending.push(sequence);
+        }
+        self.body.clear();
+    }
+
+    fn drain_pending(&mut self) -> Vec<Vec<u8>> {
+        std::mem::take(&mut self.pending)
+    }
+}
+
+/// Accepts `52;c;<base64>` and `52;;<base64>` (ghostty treats the empty
+/// selector as the standard clipboard). Queries (`?`) are rejected because
+/// herdr has no path to reply to the child with clipboard contents.
+fn is_osc52_clipboard_write(body: &[u8]) -> bool {
+    let Some(rest) = body.strip_prefix(b"52;") else {
+        return false;
+    };
+    let Some(sep) = rest.iter().position(|b| *b == b';') else {
+        return false;
+    };
+    let selector = &rest[..sep];
+    let data = &rest[sep + 1..];
+    let is_standard_clipboard = selector.is_empty() || selector == b"c";
+    if !is_standard_clipboard {
+        return false;
+    }
+    !data.is_empty() && data != b"?"
 }
 
 fn foreground_job_is_shell(job: &crate::platform::ForegroundJob, shell_pid: u32) -> bool {
@@ -612,6 +728,7 @@ impl GhosttyPaneTerminal {
                 host_terminal_theme: crate::terminal_theme::TerminalTheme::default(),
                 transient_default_color_owner_pgid: None,
                 default_color_tracker: DefaultColorOscTracker::default(),
+                osc52_forwarder: Osc52Forwarder::default(),
             }),
             key_encoder: Mutex::new(key_encoder),
         })
@@ -663,6 +780,7 @@ impl GhosttyPaneTerminal {
             error!(pane = pane_id.raw(), "ghostty core lock poisoned in reader");
             return ProcessBytesResult {
                 request_render: false,
+                clipboard_writes: Vec::new(),
             };
         };
 
@@ -676,6 +794,9 @@ impl GhosttyPaneTerminal {
             }
         }
 
+        core.osc52_forwarder.observe(bytes);
+        let clipboard_writes = core.osc52_forwarder.drain_pending();
+
         core.terminal.write(bytes);
         if let Ok(mut key_encoder) = self.key_encoder.lock() {
             key_encoder.set_from_terminal(&core.terminal);
@@ -687,6 +808,7 @@ impl GhosttyPaneTerminal {
         let _ = response_writer;
         ProcessBytesResult {
             request_render: !synchronized_output,
+            clipboard_writes,
         }
     }
 
@@ -1693,6 +1815,7 @@ impl PaneRuntime {
             let render_notify = render_notify.clone();
             let render_dirty = render_dirty.clone();
             let child_pid = child_pid.clone();
+            let events = events.clone();
             tokio::task::spawn_blocking(move || {
                 let mut buf = [0u8; 8192];
                 loop {
@@ -1712,6 +1835,20 @@ impl PaneRuntime {
                             );
                             if result.request_render && !render_dirty.swap(true, Ordering::AcqRel) {
                                 render_notify.notify_one();
+                            }
+                            for bytes in result.clipboard_writes {
+                                // Non-blocking: stalling the PTY reader on a
+                                // saturated main loop would be worse than
+                                // dropping a clipboard write.
+                                if let Err(err) =
+                                    events.try_send(AppEvent::ClipboardWrite { bytes })
+                                {
+                                    warn!(
+                                        pane = pane_id.raw(),
+                                        err = %err,
+                                        "dropped OSC 52 clipboard write"
+                                    );
+                                }
                             }
                         }
                     }
@@ -2505,6 +2642,154 @@ mod tests {
 
         assert!(!tracker.observe(b"\x1b]10;?\x1b\\"));
         assert!(!tracker.observe(b"\x1b]11;?\x07"));
+    }
+
+    #[test]
+    fn osc52_forwarder_detects_write_with_bel() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGVsbG8=\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGVsbG8=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_detects_write_with_st() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGVsbG8=\x1b\\");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGVsbG8=\x1b\\");
+    }
+
+    #[test]
+    fn osc52_forwarder_detects_empty_selector_form() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;;aGVsbG8=\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;;aGVsbG8=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_ignores_query() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;?\x07");
+        assert!(fw.drain_pending().is_empty());
+    }
+
+    #[test]
+    fn osc52_forwarder_ignores_empty_selector_query() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;;?\x07");
+        assert!(fw.drain_pending().is_empty());
+    }
+
+    #[test]
+    fn osc52_forwarder_ignores_other_kinds() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;p;aGk=\x07");
+        fw.observe(b"\x1b]52;s;aGk=\x07");
+        fw.observe(b"\x1b]52;q;aGk=\x07");
+        fw.observe(b"\x1b]52;0;aGk=\x07");
+        fw.observe(b"\x1b]52;7;aGk=\x07");
+        assert!(fw.drain_pending().is_empty());
+    }
+
+    #[test]
+    fn osc52_forwarder_ignores_non_osc52() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]11;?\x07");
+        fw.observe(b"\x1b]0;title\x07");
+        fw.observe(b"\x1b]8;;https://example.com\x1b\\");
+        assert!(fw.drain_pending().is_empty());
+    }
+
+    #[test]
+    fn osc52_forwarder_handles_split_sequence_mid_payload() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGVs");
+        assert!(fw.drain_pending().is_empty());
+        fw.observe(b"bG8gd29y");
+        assert!(fw.drain_pending().is_empty());
+        fw.observe(b"bGQ=\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGVsbG8gd29ybGQ=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_handles_split_before_bel() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGk=");
+        assert!(fw.drain_pending().is_empty());
+        fw.observe(b"\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGk=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_handles_split_between_esc_and_backslash() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGk=\x1b");
+        assert!(fw.drain_pending().is_empty());
+        fw.observe(b"\\");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGk=\x1b\\");
+    }
+
+    #[test]
+    fn osc52_forwarder_payload_size_limit() {
+        let mut fw = Osc52Forwarder::default();
+        let mut huge = Vec::with_capacity(OSC52_MAX_PAYLOAD_BYTES + 32);
+        huge.extend_from_slice(b"\x1b]52;c;");
+        huge.extend(std::iter::repeat_n(b'A', OSC52_MAX_PAYLOAD_BYTES + 16));
+        huge.push(0x07);
+        fw.observe(&huge);
+        assert!(fw.drain_pending().is_empty());
+
+        fw.observe(b"\x1b]52;c;aGk=\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGk=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_recovers_after_garbage() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x01\x02random\x7fbytes\x1b]52;c;aGk=\x07tail");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGk=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_esc_in_body_not_st() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGVs\x1b[bG8=\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0], b"\x1b]52;c;aGVs\x1b[bG8=\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_multiple_in_one_chunk() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGk=\x07\x1b]52;c;Ynll\x07");
+        let pending = fw.drain_pending();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0], b"\x1b]52;c;aGk=\x07");
+        assert_eq!(pending[1], b"\x1b]52;c;Ynll\x07");
+    }
+
+    #[test]
+    fn osc52_forwarder_drain_clears_pending() {
+        let mut fw = Osc52Forwarder::default();
+        fw.observe(b"\x1b]52;c;aGk=\x07");
+        assert_eq!(fw.drain_pending().len(), 1);
+        assert!(fw.drain_pending().is_empty());
     }
 
     #[test]

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -102,6 +102,43 @@ impl Selection {
         matches!(self.phase, Phase::Anchored | Phase::Dragging)
     }
 
+    /// Extend the selection by `rows` in the direction of a scroll.
+    ///
+    /// `scroll_up == true` moves the top endpoint (smaller absolute row)
+    /// upward; `scroll_up == false` moves the bottom endpoint (larger
+    /// absolute row) downward. Top and bottom are chosen dynamically from
+    /// `anchor` vs `cursor` by absolute row — this means the stored
+    /// `anchor` can be mutated when it is the endpoint on the scrolled side,
+    /// which matches the UX the user expects (selection grows toward the
+    /// newly revealed content).
+    ///
+    /// Preserves the `Anchored → Dragging` transition that the existing
+    /// wheel handler relies on: a click without drag followed by a wheel
+    /// scroll must become a visible selection.
+    pub(crate) fn extend_in_scroll_direction(&mut self, scroll_up: bool, rows: u32) {
+        // Choose the logically earlier endpoint with the same ordering rule
+        // as `ordered()`: row first, column as tie-breaker. This matters
+        // for single-row selections dragged right-to-left, where the
+        // leftmost endpoint is the cursor, not the anchor.
+        let anchor_precedes_cursor = self.anchor.0 < self.cursor.0
+            || (self.anchor.0 == self.cursor.0 && self.anchor.1 <= self.cursor.1);
+        let (top, bottom) = if anchor_precedes_cursor {
+            (&mut self.anchor, &mut self.cursor)
+        } else {
+            (&mut self.cursor, &mut self.anchor)
+        };
+
+        if scroll_up {
+            top.0 = top.0.saturating_sub(rows);
+        } else {
+            bottom.0 = bottom.0.saturating_add(rows);
+        }
+
+        if self.cursor != self.anchor {
+            self.phase = Phase::Dragging;
+        }
+    }
+
     /// Returns (start, end) in reading order (top-left to bottom-right).
     fn ordered(&self) -> ((u32, u16), (u32, u16)) {
         let (ar, ac) = self.anchor;
@@ -295,6 +332,78 @@ mod tests {
         assert!(sel.contains(1, 40, metrics));
         assert!(sel.contains(2, 4, metrics));
         assert!(!sel.contains(3, 4, metrics));
+    }
+
+    #[test]
+    fn extend_scroll_up_moves_top_endpoint() {
+        // anchor is top, cursor is bottom
+        let mut sel = make_sel(10, 2, 20, 5);
+        sel.extend_in_scroll_direction(true, 3);
+        assert_eq!(sel.ordered_cells(), ((7, 2), (20, 5)));
+    }
+
+    #[test]
+    fn extend_scroll_down_moves_bottom_endpoint() {
+        // anchor is top, cursor is bottom
+        let mut sel = make_sel(10, 2, 20, 5);
+        sel.extend_in_scroll_direction(false, 3);
+        assert_eq!(sel.ordered_cells(), ((10, 2), (23, 5)));
+    }
+
+    #[test]
+    fn extend_scroll_up_when_cursor_is_top() {
+        // cursor is top, anchor is bottom (reverse drag)
+        let mut sel = make_sel(20, 5, 10, 2);
+        sel.extend_in_scroll_direction(true, 4);
+        // cursor moves up from (10,2) to (6,2), anchor stays (20,5)
+        assert_eq!(sel.ordered_cells(), ((6, 2), (20, 5)));
+    }
+
+    #[test]
+    fn extend_scroll_down_when_anchor_is_bottom() {
+        // cursor is top, anchor is bottom
+        let mut sel = make_sel(20, 5, 10, 2);
+        sel.extend_in_scroll_direction(false, 4);
+        // anchor moves down from (20,5) to (24,5), cursor stays (10,2)
+        assert_eq!(sel.ordered_cells(), ((10, 2), (24, 5)));
+    }
+
+    #[test]
+    fn extend_from_anchored_transitions_to_dragging() {
+        // click without drag — phase Anchored, anchor == cursor
+        let mut sel = Selection::anchor(PaneId::from_raw(0), 5, 10, None);
+        assert!(sel.was_just_click());
+        assert!(!sel.is_visible());
+
+        sel.extend_in_scroll_direction(true, 3);
+
+        // Transitioned to Dragging, selection is now visible
+        assert!(!sel.was_just_click());
+        assert!(sel.is_visible());
+        assert_eq!(sel.ordered_cells(), ((2, 10), (5, 10)));
+    }
+
+    #[test]
+    fn extend_scroll_up_saturates_at_zero() {
+        let mut sel = make_sel(2, 0, 4, 0);
+        sel.extend_in_scroll_direction(true, 10);
+        assert_eq!(sel.ordered_cells(), ((0, 0), (4, 0)));
+    }
+
+    #[test]
+    fn extend_single_row_right_to_left_drag_uses_col_tiebreak() {
+        // Single-row selection dragged right-to-left: anchor=(5,20),
+        // cursor=(5,5). Logical top is cursor (leftmost column), not anchor.
+        // The helper must pick the same endpoint as `ordered()` or the wrong
+        // side of the selection gets extended.
+        let mut sel = make_sel(5, 20, 5, 5);
+        assert_eq!(sel.ordered_cells(), ((5, 5), (5, 20)));
+
+        sel.extend_in_scroll_direction(true, 3);
+
+        // Top endpoint (the one at col 5) should have moved up to row 2.
+        // The other endpoint (col 20 on row 5) should stay put.
+        assert_eq!(sel.ordered_cells(), ((2, 5), (5, 20)));
     }
 
     #[test]

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -102,24 +102,13 @@ impl Selection {
         matches!(self.phase, Phase::Anchored | Phase::Dragging)
     }
 
-    /// Extend the selection by `rows` in the direction of a scroll.
-    ///
-    /// `scroll_up == true` moves the top endpoint (smaller absolute row)
-    /// upward; `scroll_up == false` moves the bottom endpoint (larger
-    /// absolute row) downward. Top and bottom are chosen dynamically from
-    /// `anchor` vs `cursor` by absolute row — this means the stored
-    /// `anchor` can be mutated when it is the endpoint on the scrolled side,
-    /// which matches the UX the user expects (selection grows toward the
-    /// newly revealed content).
-    ///
-    /// Preserves the `Anchored → Dragging` transition that the existing
-    /// wheel handler relies on: a click without drag followed by a wheel
-    /// scroll must become a visible selection.
+    /// Extend the selection by `rows` rows toward the scroll direction.
+    /// Either endpoint may be mutated, depending on which side is currently
+    /// the top.
     pub(crate) fn extend_in_scroll_direction(&mut self, scroll_up: bool, rows: u32) {
-        // Choose the logically earlier endpoint with the same ordering rule
-        // as `ordered()`: row first, column as tie-breaker. This matters
-        // for single-row selections dragged right-to-left, where the
-        // leftmost endpoint is the cursor, not the anchor.
+        // Endpoint pick must match `ordered()` exactly, including the column
+        // tie-breaker — otherwise a single-row right-to-left drag moves the
+        // wrong side.
         let anchor_precedes_cursor = self.anchor.0 < self.cursor.0
             || (self.anchor.0 == self.cursor.0 && self.anchor.1 <= self.cursor.1);
         let (top, bottom) = if anchor_precedes_cursor {
@@ -336,7 +325,6 @@ mod tests {
 
     #[test]
     fn extend_scroll_up_moves_top_endpoint() {
-        // anchor is top, cursor is bottom
         let mut sel = make_sel(10, 2, 20, 5);
         sel.extend_in_scroll_direction(true, 3);
         assert_eq!(sel.ordered_cells(), ((7, 2), (20, 5)));
@@ -344,7 +332,6 @@ mod tests {
 
     #[test]
     fn extend_scroll_down_moves_bottom_endpoint() {
-        // anchor is top, cursor is bottom
         let mut sel = make_sel(10, 2, 20, 5);
         sel.extend_in_scroll_direction(false, 3);
         assert_eq!(sel.ordered_cells(), ((10, 2), (23, 5)));
@@ -352,32 +339,26 @@ mod tests {
 
     #[test]
     fn extend_scroll_up_when_cursor_is_top() {
-        // cursor is top, anchor is bottom (reverse drag)
         let mut sel = make_sel(20, 5, 10, 2);
         sel.extend_in_scroll_direction(true, 4);
-        // cursor moves up from (10,2) to (6,2), anchor stays (20,5)
         assert_eq!(sel.ordered_cells(), ((6, 2), (20, 5)));
     }
 
     #[test]
     fn extend_scroll_down_when_anchor_is_bottom() {
-        // cursor is top, anchor is bottom
         let mut sel = make_sel(20, 5, 10, 2);
         sel.extend_in_scroll_direction(false, 4);
-        // anchor moves down from (20,5) to (24,5), cursor stays (10,2)
         assert_eq!(sel.ordered_cells(), ((10, 2), (24, 5)));
     }
 
     #[test]
     fn extend_from_anchored_transitions_to_dragging() {
-        // click without drag — phase Anchored, anchor == cursor
         let mut sel = Selection::anchor(PaneId::from_raw(0), 5, 10, None);
         assert!(sel.was_just_click());
         assert!(!sel.is_visible());
 
         sel.extend_in_scroll_direction(true, 3);
 
-        // Transitioned to Dragging, selection is now visible
         assert!(!sel.was_just_click());
         assert!(sel.is_visible());
         assert_eq!(sel.ordered_cells(), ((2, 10), (5, 10)));
@@ -392,17 +373,11 @@ mod tests {
 
     #[test]
     fn extend_single_row_right_to_left_drag_uses_col_tiebreak() {
-        // Single-row selection dragged right-to-left: anchor=(5,20),
-        // cursor=(5,5). Logical top is cursor (leftmost column), not anchor.
-        // The helper must pick the same endpoint as `ordered()` or the wrong
-        // side of the selection gets extended.
         let mut sel = make_sel(5, 20, 5, 5);
         assert_eq!(sel.ordered_cells(), ((5, 5), (5, 20)));
 
         sel.extend_in_scroll_direction(true, 3);
 
-        // Top endpoint (the one at col 5) should have moved up to row 2.
-        // The other endpoint (col 20 on row 5) should stay put.
         assert_eq!(sel.ordered_cells(), ((2, 5), (5, 20)));
     }
 


### PR DESCRIPTION
## tl;dr

Fixes #29. Select text inside Amp in a herdr pane, wait for the "copied" toast, paste somewhere, get nothing. Any program that writes OSC 52 from inside a pane has the same problem. Amp just happens to be the first agent on the list to hit it.

## What's happening

herdr embeds `libghostty-vt` as a full VT emulator per pane. Not a passthrough. Every escape sequence the child writes lands in the emulator and stops there unless herdr explicitly re-emits it.

The readonly stream handler at `vendor/libghostty-vt/src/terminal/stream_terminal.zig:259-266` drops several OSC actions it doesn't implement, and OSC 52 is one of them:

```zig
// Have no terminal-modifying effect
.report_pwd,
.show_desktop_notification,
.progress_report,
.clipboard_contents,   // <-- this one
.title_push,
.title_pop,
=> {},
```

So when Amp writes `\x1b]52;c;<base64>\x1b\\` into its PTY, the bytes reach `process_pty_bytes()`, the emulator parses the sequence, recognizes it, and discards it. Nothing reaches herdr's stdout, so the host terminal never sees it. Amp's toast is honest from its side: it wrote the bytes. They just died on the way up.

herdr's own selection already dodges this by writing OSC 52 straight to `std::io::stdout()` in `src/selection.rs:201-208`, skipping the emulator. That works while the user is dragging with herdr's own handler. But when a program enables mouse reporting (DECSET 1002), herdr forwards mouse events to the child, the child does its own selection, and then the copy path runs into the wall. Claude Code, opencode, and Codex don't trigger this because they don't turn mouse reporting on for selection. Amp does. The bug is structural; Amp just got there first.

## What the fix does

Added `Osc52Forwarder` in `src/pane.rs`. A small state machine (`Ground` / `Escape` / `OscBody` / `OscEscape`) watches raw PTY bytes in `process_pty_bytes` and reconstructs complete `ESC ] 52 ; c ; <base64> (BEL|ST)` sequences. It handles chunks split across `read()` calls, since PTY reads don't respect sequence boundaries. It only forwards writes to the standard clipboard: `52;c;` and `52;;` (ghostty treats the empty selector as `c`, see `clipboard_operation.zig:24-46`). Queries (`?`) and other selectors get dropped on purpose, since herdr has no path to reply to a query and nothing in the wild targets the rest.

Recognized sequences ride back on `ProcessBytesResult.clipboard_writes`. The reader task drains them and fires a new `AppEvent::ClipboardWrite`, and `handle_internal_event` writes the bytes to stdout.

One thing worth flagging, because I got it wrong on my first pass and the plan-review caught it: **don't write to stdout from the PTY reader task.** `process_pty_bytes` runs on `spawn_blocking`. The main loop is the thread that owns stdout, so `terminal.draw`, `query_host_terminal_theme`, `selection::write_osc52`, and the tmux keyboard-mode toggles all write from there. A direct stdout write from the reader would race ratatui's render output and cause intermittent terminal corruption at exactly the seam this PR is trying to close. Routing through `AppEvent::ClipboardWrite` keeps everything serialized on the main loop, same as every other stdout write in the codebase.

A couple of smaller decisions:

Payload cap at 256 KiB. Base64 at that size is about 192 KiB of raw text, which covers real source-file copies without leaving the buffer unbounded when the stream contains garbage. The upstream stream parser has a comment noting OSC 52 can be "arbitrarily large" (`stream.zig:437-446`), so I erred generous.

`try_send` on the events channel, not `block_on(send)`. If the main loop is saturated, dropping a clipboard write is the better failure mode than stalling the PTY reader. A lost copy the user can redo. A stalled reader freezes the whole pane.

Vendored `libghostty-vt` stays untouched. I looked at adding a `clipboard_write` callback to its C API in `vendor/.../c/terminal.zig:41-80` and decided it wasn't worth it: modify vendored Zig, add new FFI, rebuild the emulator, all to replicate what a small Rust observer already does from outside. If herdr ever needs OSC 52 read (host responding to a child query), that calculus changes, but we're not there yet.

## Files

- `src/events.rs` — new `AppEvent::ClipboardWrite { bytes: Vec<u8> }` variant
- `src/pane.rs` — `Osc52Forwarder`, wire-up in `GhosttyPaneCore` and `process_pty_bytes`, `try_send` in the reader task, 15 unit tests
- `src/app/mod.rs` — `handle_internal_event` early-returns on `ClipboardWrite` after writing to stdout
- `src/app/actions.rs` — no-op arm in `handle_app_event` so the match stays exhaustive

## Testing

`cargo test` runs 477 unit + 11 API + 11 CLI wrapper tests, all green. The 15 new forwarder tests cover BEL and ST terminators, empty-selector form, query rejection, non-`c` selector rejection, split sequences at three different cut points (mid-payload, just before BEL, between ESC and `\` of the ST terminator), payload-size limit with recovery, garbage-in recovery, ESC-not-followed-by-backslash inside the body, multiple sequences in one chunk, and drain-clears-pending.

`cargo clippy` is clean on the touched files. Pre-existing warnings in `build.rs` and `workspace.rs` are unrelated.

Manual:

- Ran `amp` in a herdr pane, dragged to select text, waited for the toast, pasted into another app. Works.
- Regression sanity: plain `bash` pane with no mouse reporting. herdr's native selection path still copies via `selection::write_osc52` as before.

Thanks for building herdr, it's become my daily driver for juggling agents. Happy to iterate on anything in this PR.