### PR TITLE
Website Fix - for footer links

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -538,7 +538,7 @@
                 >
                 ·
                 <a
-                    href="https://github.com/egithub.com/ogulcancelik/herdr/releases"
+                    href="https://github.com/ogulcancelik/herdr/releases"
                     >releases</a
                 >
             </p>


### PR DESCRIPTION
- fixes a miss typed url in the footer to the github releases.