### PR TITLE
feat(opencode): report blocked state when question tool fires

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -176,6 +176,9 @@ current plugin mapping:
 - `permission.asked` → `blocked`
 - `permission.replied: once|always` → `working`
 - `permission.replied: reject` → `idle`
+- `question.asked` → `blocked`
+- `question.replied` → `working`
+- `question.rejected` → `idle`
 - `session.status: busy|retry` → `working`
 - `session.status: idle` → `idle`
 - `session.idle` → `idle`

--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -65,6 +65,7 @@ export const HerdrAgentStatePlugin = async () => {
 
       switch (type) {
         case "permission.asked":
+        case "question.asked":
           await reportState("blocked");
           break;
         case "permission.replied": {
@@ -76,6 +77,12 @@ export const HerdrAgentStatePlugin = async () => {
           }
           break;
         }
+        case "question.replied":
+          await reportState("working");
+          break;
+        case "question.rejected":
+          await reportState("idle");
+          break;
         case "session.status": {
           const status =
             typeof properties.status === "string"


### PR DESCRIPTION
## Summary

The opencode `question` tool presents a multi-choice prompt to the user and blocks AI execution until they answer. Currently herdr has no visibility into this — the pane stays in `working` state even though the agent is waiting for input.

This PR adds three event handlers to the opencode plugin to cover the full question lifecycle:

- `question.asked` → `blocked` (agent is waiting for user input)
- `question.replied` → `working` (user answered, agent resumes)
- `question.rejected` → `idle` (user dismissed with esc)

## Before Change
<img width="886" height="964" alt="Screenshot 2026-04-24 at 8 10 03 PM" src="https://github.com/user-attachments/assets/7dd59716-3292-4021-81ab-8278a9e2210f" />


## After change
<img width="878" height="968" alt="Screenshot 2026-04-24 at 7 59 50 PM" src="https://github.com/user-attachments/assets/24ec5746-bc25-4dac-9aa2-ac85181b7993" />


## How it works

opencode emits these as first-class bus events from `packages/opencode/src/question/index.ts`, delivered through the same `event` hook the plugin already uses for `permission.*` and `session.*`. The implementation follows the exact same pattern as `permission.asked`/`permission.replied`.

## Changes

- `src/integration/assets/opencode/herdr-agent-state.js` — add `question.asked`, `question.replied`, `question.rejected` cases to the event switch
- `INTEGRATIONS.md` — document the new event mappings in the opencode plugin mapping table