### PR TITLE
feat: add vesper theme

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -140,7 +140,7 @@ focus_pane_right = "alt+l"
 
 ## theme
 
-herdr ships with 9 built-in color themes. set one in config:
+herdr ships with 10 built-in color themes. set one in config:
 
 ```toml
 [theme]
@@ -160,6 +160,7 @@ name = "tokyo-night"
 | `solarized` | ethan schoonover's classic |
 | `kanagawa` | hokusai-inspired |
 | `rose-pine` | muted, elegant |
+| `vesper` | high-contrast monochrome with peach and mint accents |
 
 theme names are flexible: `tokyo-night`, `tokyonight`, and `tokyo_night` all work.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ not a gui window, not a web dashboard, not electron. herdr runs inside whatever 
 - **tabs** — first-class in the socket api and cli
 - **mouse-native** — click panes, drag borders, select text to copy; not keyboard-only
 - **notifications** — sounds and toasts for background events; tab-aware suppression
-- **9 built-in themes** — catppuccin (default), tokyo night, dracula, nord, gruvbox, one dark, solarized, kanagawa, rosé pine
+- **10 built-in themes** — catppuccin (default), tokyo night, dracula, nord, gruvbox, one dark, solarized, kanagawa, rosé pine, vesper
 - **session persistence** — pane processes survive client detach; sessions restore after full restart
 
 ## agents can use herdr too

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -250,6 +250,28 @@ impl Palette {
         }
     }
 
+    /// Vesper — minimal high-contrast monochrome with peach and mint accents.
+    pub fn vesper() -> Self {
+        Self {
+            accent: Color::Rgb(255, 199, 153),
+            panel_bg: Color::Rgb(26, 26, 26),
+            surface0: Color::Rgb(35, 35, 35),
+            surface1: Color::Rgb(40, 40, 40),
+            surface_dim: Color::Rgb(16, 16, 16),
+            overlay0: Color::Rgb(92, 92, 92),
+            overlay1: Color::Rgb(126, 126, 126),
+            text: Color::Rgb(255, 255, 255),
+            subtext0: Color::Rgb(160, 160, 160),
+            mauve: Color::Rgb(255, 209, 168),
+            green: Color::Rgb(153, 255, 228),
+            yellow: Color::Rgb(255, 199, 153),
+            red: Color::Rgb(255, 128, 128),
+            blue: Color::Rgb(176, 176, 176),
+            teal: Color::Rgb(102, 221, 204),
+            peach: Color::Rgb(255, 199, 153),
+        }
+    }
+
     /// Resolve a theme by name. Returns None for unknown names.
     pub fn from_name(name: &str) -> Option<Self> {
         match name.to_lowercase().replace([' ', '_'], "-").as_str() {
@@ -262,6 +284,7 @@ impl Palette {
             "solarized" | "solarized-dark" => Some(Self::solarized()),
             "kanagawa" => Some(Self::kanagawa()),
             "rose-pine" | "rosepine" => Some(Self::rose_pine()),
+            "vesper" => Some(Self::vesper()),
             _ => None,
         }
     }
@@ -414,6 +437,7 @@ pub const THEME_NAMES: &[&str] = &[
     "solarized",
     "kanagawa",
     "rose-pine",
+    "vesper",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 
 [theme]
 # Built-in themes: catppuccin, tokyo-night, dracula, nord, gruvbox,
-#                  one-dark, solarized, kanagawa, rose-pine
+#                  one-dark, solarized, kanagawa, rose-pine, vesper
 # name = "catppuccin"
 
 # Override individual color tokens on top of the base theme.


### PR DESCRIPTION
## summary
- add Vesper as a built-in theme option
- update theme docs and default config comments

## testing
- not run (not requested)

fixes #70