### PR TITLE
fix(input): forward Shift+Enter to panes as raw ESC+CR

### DIFF
--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -69,17 +69,22 @@ impl App {
         let protocol = rt.keyboard_protocol();
         let bytes = rt.encode_terminal_key(key);
 
-        if matches!(key_event.code, KeyCode::Esc)
+        if matches!(key_event.code, KeyCode::Esc | KeyCode::Enter)
             || key_event
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::ALT)
         {
+            let encoded_hex = bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<Vec<_>>()
+                .join(" ");
             debug!(
                 code = ?key_event.code,
                 modifiers = ?key_event.modifiers,
                 kind = ?key_event.kind,
                 protocol = ?protocol,
-                encoded = ?bytes,
+                encoded_hex = %encoded_hex,
                 "forwarding potentially-ambiguous terminal key to pane"
             );
         }

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -491,6 +491,25 @@ impl GhosttyPaneTerminal {
         key: crate::input::TerminalKey,
         protocol: crate::input::KeyboardProtocol,
     ) -> Vec<u8> {
+        // Ghostty's default `shift+enter=text:\x1b\r` keybind translates Shift+Enter
+        // into the literal bytes ESC+CR before they reach our stdin. Crossterm parses
+        // those bytes as Alt+Char('\r') (occasionally Alt+Enter depending on version).
+        // Re-encoding through libghostty or herdr's CSI-u encoder against the pane's
+        // mode would emit something like `\x1b[13;3:1u` (kitty Alt+Enter), which TUIs
+        // like pi do not treat as a newline. Forward the original ESC+CR bytes so the
+        // pane sees exactly what raw Ghostty would have delivered.
+        if matches!(
+            key.kind,
+            crossterm::event::KeyEventKind::Press | crossterm::event::KeyEventKind::Repeat
+        ) && key.modifiers == crossterm::event::KeyModifiers::ALT
+            && matches!(
+                key.code,
+                crossterm::event::KeyCode::Enter | crossterm::event::KeyCode::Char('\r')
+            )
+        {
+            return b"\x1b\r".to_vec();
+        }
+
         if ghostty_prefers_herdr_text_encoding(key) {
             return crate::input::encode_terminal_key(key, protocol);
         }
@@ -1260,6 +1279,34 @@ mod tests {
             crate::input::KeyboardProtocol::Legacy,
         );
         assert_eq!(after, b"\x1bOA");
+    }
+
+    #[test]
+    fn alt_enter_passes_through_as_esc_cr_regardless_of_pane_kitty_mode() {
+        // Ghostty's default `shift+enter=text:\x1b\r` keybind makes the host
+        // terminal send ESC+CR for Shift+Enter. Crossterm parses those bytes as
+        // either Alt+Enter or Alt+Char('\r'); both must produce a literal ESC+CR
+        // forward, even when the pane has pushed kitty keyboard mode, so TUIs
+        // like pi.dev that rely on the raw bytes for newline continue to work.
+        let (tx, _rx) = mpsc::channel(4);
+        let mut terminal = crate::ghostty::Terminal::new(80, 24, 0).unwrap();
+        terminal.write(b"\x1b[>7u");
+        let pane = GhosttyPaneTerminal::new(terminal, tx).unwrap();
+
+        for key in [
+            crate::input::TerminalKey::new(
+                crossterm::event::KeyCode::Enter,
+                crossterm::event::KeyModifiers::ALT,
+            ),
+            crate::input::TerminalKey::new(
+                crossterm::event::KeyCode::Char('\r'),
+                crossterm::event::KeyModifiers::ALT,
+            ),
+        ] {
+            let encoded =
+                pane.encode_terminal_key(key, crate::input::KeyboardProtocol::Kitty { flags: 7 });
+            assert_eq!(encoded, b"\x1b\r", "key={:?}", key);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Shift+Enter inside a herdr pane fails to insert a newline in TUIs like [pi.dev](https://pi.dev) (Inflection's Pi CLI), even though the same TUI handles Shift+Enter correctly when run directly in Ghostty. Claude Code happens to work because it tolerates the kitty-form Alt+Enter that herdr was sending.

## Root cause

Ghostty ships a default keybind:

```
shift+enter=text:\x1b\r
```

Keybinds are processed before kitty encoding (`Surface.zig:2672` runs `maybeHandleBinding` before `encodeKey:2775`), and `text:` actions are `consumed=true` by default (`Binding.zig:34`). So Ghostty unconditionally sends literal `ESC + CR` for Shift+Enter — pushing `REPORT_ALL_KEYS_AS_ESCAPE_CODES` from herdr cannot change that.

Crossterm parses `\x1b\r` as `KeyEvent { code: Char('\r'), modifiers: ALT }`. herdr then re-encoded that through libghostty's encoder against the **inner pane's** kitty mode and emitted `\x1b[13;3:1u` (kitty Alt+Enter). pi.dev reads it as Alt+Enter and does not treat it as a newline.

Captured from herdr-server.log:

```
code=Char('\r') modifiers=KeyModifiers(ALT) kind=Press protocol=Kitty { flags: 7 } encoded_hex=1b 5b 31 33 3b 33 3a 31 75
```

## Fix

In `GhosttyPaneTerminal::encode_terminal_key`, intercept Press/Repeat events with modifiers exactly equal to `ALT` and a code of `KeyCode::Enter` or `KeyCode::Char('\r')`, returning the literal `\x1b\r` bytes. The pane sees byte-for-byte what raw Ghostty would deliver to the same TUI outside herdr, regardless of whether the pane has pushed kitty keyboard mode. Legacy panes are unaffected (the existing path already produced `\x1b\r` for that case via `encode_legacy_inner`).

Trade-off: a real Alt+Enter press inside herdr now also produces `\x1b\r` instead of the kitty form. Acceptable — Ghostty's own default already conflates them, and the TUIs we care about (pi, Claude Code) don't distinguish.

A small diagnostic improvement is bundled: the existing potentially-ambiguous-key debug log now also fires on plain Enter and emits hex-formatted bytes, so future input bugs are diagnosable from `HERDR_LOG=herdr=debug` without adding new instrumentation.

## Test plan

- [x] `cargo test` — 843 passed, no regressions
- [x] `cargo fmt --check` clean
- [x] Manual: pi.dev in herdr, Shift+Enter inserts newline (verified by reporter)
- [x] Manual: Claude Code in herdr, Shift+Enter still inserts newline (no regression)
- [x] Manual: pi.dev in raw Ghostty (no herdr), Shift+Enter still works (out of scope, but byte-for-byte parity preserved)
- [x] New unit test `alt_enter_passes_through_as_esc_cr_regardless_of_pane_kitty_mode` covers both `KeyCode::Enter+ALT` and `KeyCode::Char('\r')+ALT` against a kitty-mode pane (flags=7, matching what pi pushes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)