### PR TITLE
fix: detect omp agents

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -289,6 +289,7 @@ per-agent values:
 
 available agent keys:
 - `pi`
+- `omp`
 - `claude`
 - `codex`
 - `gemini`

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ automatic detection works out of the box. process name matching plus terminal ou
 | agent | idle / done | working | blocked |
 |-------|-------------|---------|---------|
 | [pi](https://pi.dev) | ✓ | ✓ | partial |
+| [omp](https://pi.dev) | ✓ | ✓ | partial |
 | [claude code](https://docs.anthropic.com/en/docs/claude-code) | ✓ | ✓ | ✓ |
 | [codex](https://github.com/openai/codex) | ✓ | ✓ | ✓ |
 | [droid](https://factory.ai) | ✓ | ✓ | ✓ |

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -26,6 +26,7 @@ pub struct SoundConfig {
 #[serde(default)]
 pub struct AgentSoundOverrides {
     pub pi: AgentSoundSetting,
+    pub omp: AgentSoundSetting,
     pub claude: AgentSoundSetting,
     pub codex: AgentSoundSetting,
     pub gemini: AgentSoundSetting,
@@ -112,6 +113,7 @@ impl AgentSoundOverrides {
     pub fn for_agent(&self, agent: Option<Agent>) -> AgentSoundSetting {
         match agent {
             Some(Agent::Pi) => self.pi,
+            Some(Agent::Omp) => self.omp,
             Some(Agent::Claude) => self.claude,
             Some(Agent::Codex) => self.codex,
             Some(Agent::Gemini) => self.gemini,
@@ -143,6 +145,7 @@ impl Default for AgentSoundOverrides {
     fn default() -> Self {
         Self {
             pi: AgentSoundSetting::Default,
+            omp: AgentSoundSetting::Default,
             claude: AgentSoundSetting::Default,
             codex: AgentSoundSetting::Default,
             gemini: AgentSoundSetting::Default,

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -20,6 +20,7 @@ pub enum AgentState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Agent {
     Pi,
+    Omp,
     Claude,
     Codex,
     Gemini,
@@ -35,6 +36,7 @@ pub enum Agent {
 pub fn agent_label(agent: Agent) -> &'static str {
     match agent {
         Agent::Pi => "pi",
+        Agent::Omp => "omp",
         Agent::Claude => "claude",
         Agent::Codex => "codex",
         Agent::Gemini => "gemini",
@@ -52,6 +54,7 @@ pub fn parse_agent_label(agent: &str) -> Option<Agent> {
     let name = agent.trim().to_lowercase();
     match name.as_str() {
         "pi" => Some(Agent::Pi),
+        "omp" | "oh-my-pi" | "oh_my_pi" => Some(Agent::Omp),
         "claude" | "claude-code" => Some(Agent::Claude),
         "codex" => Some(Agent::Codex),
         "gemini" => Some(Agent::Gemini),
@@ -73,6 +76,7 @@ pub fn identify_agent(process_name: &str) -> Option<Agent> {
     // Match against known binary names
     match name.as_str() {
         "pi" => Some(Agent::Pi),
+        "omp" => Some(Agent::Omp),
         "claude" | "claude-code" => Some(Agent::Claude),
         "codex" => Some(Agent::Codex),
         "gemini" => Some(Agent::Gemini),
@@ -114,6 +118,7 @@ pub fn detect_state(agent: Option<Agent>, screen_content: &str) -> AgentState {
     };
     match agent {
         Agent::Pi => detect_pi(screen_content),
+        Agent::Omp => detect_opencode(screen_content),
         Agent::Claude => detect_claude(screen_content),
         Agent::Codex => detect_codex(screen_content),
         Agent::Gemini => detect_gemini(screen_content),
@@ -661,6 +666,7 @@ mod tests {
     #[test]
     fn identify_known_agents() {
         assert_eq!(identify_agent("pi"), Some(Agent::Pi));
+        assert_eq!(identify_agent("omp"), Some(Agent::Omp));
         assert_eq!(identify_agent("claude"), Some(Agent::Claude));
         assert_eq!(identify_agent("claude-code"), Some(Agent::Claude));
         assert_eq!(identify_agent("codex"), Some(Agent::Codex));
@@ -675,6 +681,7 @@ mod tests {
     #[test]
     fn parse_known_agent_labels() {
         assert_eq!(parse_agent_label("pi"), Some(Agent::Pi));
+        assert_eq!(parse_agent_label("omp"), Some(Agent::Omp));
         assert_eq!(parse_agent_label("claude"), Some(Agent::Claude));
         assert_eq!(parse_agent_label("copilot"), Some(Agent::GithubCopilot));
         assert_eq!(
@@ -687,6 +694,7 @@ mod tests {
     #[test]
     fn agent_labels_use_display_names() {
         assert_eq!(agent_label(Agent::Pi), "pi");
+        assert_eq!(agent_label(Agent::Omp), "omp");
         assert_eq!(agent_label(Agent::GithubCopilot), "copilot");
         assert_eq!(agent_label(Agent::OpenCode), "opencode");
     }
@@ -1040,6 +1048,19 @@ mod tests {
             detect_opencode("△ Permission required"),
             AgentState::Blocked
         );
+    }
+
+    #[test]
+    fn omp_uses_opencode_style_terminal_heuristics() {
+        assert_eq!(
+            detect_state(Some(Agent::Omp), "running tool\nesc to interrupt"),
+            AgentState::Working
+        );
+        assert_eq!(
+            detect_state(Some(Agent::Omp), "△ Permission required"),
+            AgentState::Blocked
+        );
+        assert_eq!(detect_state(Some(Agent::Omp), "> "), AgentState::Idle);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Detect `omp` foreground processes as a first-class agent with the `omp` label.
- Reuse the existing OpenCode-style terminal heuristics for OMP working/blocked/idle state detection.
- Document OMP in supported agents and per-agent sound keys.

## Flow
```mermaid
flowchart TD
  A[Foreground process probe] --> B{process name}
  B -->|omp| C[Agent::Omp]
  C --> D[agent_label: omp]
  C --> E[OpenCode-style terminal heuristics]
  E --> F[Herdr sidebar/status state]
```

## State diagram
```mermaid
stateDiagram-v2
  [*] --> Unknown
  Unknown --> Omp: foreground process = omp
  Omp --> Working: interrupt/status text detected
  Omp --> Blocked: permission/question prompt detected
  Omp --> Idle: prompt/no active markers
  Working --> Idle
  Blocked --> Working
  Idle --> Unknown: process exits or shell returns
```

## Tests
- `cargo fmt --check`
- `cargo test detect::tests::` could not run locally because `build.rs` requires `zig`, and `zig` is not installed in PATH on this machine.

## Contributors
- Navaneeth's Agent
