### PR TITLE
Show focus on active agent in agents panel like spaces panel does

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -735,6 +735,29 @@ impl AppState {
             (24, 80)
         }
     }
+
+    /// Returns true when the given (workspace, tab, pane) refers to the
+    /// currently focused pane in the active workspace's active tab.
+    pub fn is_active_pane(
+        &self,
+        ws_idx: usize,
+        tab_idx: usize,
+        pane_id: crate::layout::PaneId,
+    ) -> bool {
+        let Some(active_ws_idx) = self.active else {
+            return false;
+        };
+        if ws_idx != active_ws_idx {
+            return false;
+        }
+        let Some(ws) = self.workspaces.get(ws_idx) else {
+            return false;
+        };
+        if tab_idx != ws.active_tab_index() {
+            return false;
+        }
+        ws.active_tab().map(|tab| tab.layout.focused()) == Some(pane_id)
+    }
 }
 
 pub fn key_matches(

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -789,18 +789,17 @@ fn render_agent_detail(app: &AppState, frame: &mut Frame, area: Rect) {
         }
 
         // Check if this agent entry corresponds to the active session
-        let is_active = app.active.map_or(false, |active_ws_idx| {
-            detail.ws_idx == active_ws_idx
-                && detail.tab_idx == app.workspaces[detail.ws_idx].active_tab_index()
-                && app.workspaces[detail.ws_idx]
-                    .active_tab()
-                    .map(|tab| tab.layout.focused())
-                    == Some(detail.pane_id)
-        });
+        let is_active = app.is_active_pane(detail.ws_idx, detail.tab_idx, detail.pane_id);
 
         let (icon, icon_style) = agent_icon(detail.state, detail.seen, app.spinner_tick, p);
         let label_color = state_label_color(detail.state, detail.seen, p);
         let label = state_label(detail.state, detail.seen);
+
+        let row_style = if is_active {
+            Style::default().bg(p.surface_dim)
+        } else {
+            Style::default()
+        };
 
         let name_style = if is_active {
             Style::default().fg(p.text).add_modifier(Modifier::BOLD)
@@ -823,23 +822,10 @@ fn render_agent_detail(app: &AppState, frame: &mut Frame, area: Rect) {
             Span::styled(primary_label, name_style),
         ]);
         frame.render_widget(
-            Paragraph::new(name_line),
+            Paragraph::new(name_line).style(row_style),
             Rect::new(body.x, row_y, body.width, 1),
         );
         row_y += 1;
-
-        // Apply background highlighting for active agent (covering both name and status lines)
-        if is_active {
-            let buf = frame.buffer_mut();
-            // Highlight name line
-            for x in body.x..body.x + body.width {
-                buf[(x, row_y - 1)].set_style(Style::default().bg(p.surface_dim));
-            }
-            // Highlight status line
-            for x in body.x..body.x + body.width {
-                buf[(x, row_y)].set_style(Style::default().bg(p.surface_dim));
-            }
-        }
 
         let mut status_spans = vec![
             Span::styled("   ", Style::default()),
@@ -850,7 +836,7 @@ fn render_agent_detail(app: &AppState, frame: &mut Frame, area: Rect) {
             status_spans.push(Span::styled(agent_label, agent_style));
         }
         frame.render_widget(
-            Paragraph::new(Line::from(status_spans)),
+            Paragraph::new(Line::from(status_spans)).style(row_style),
             Rect::new(body.x, row_y, body.width, 1),
         );
         row_y += 1;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -788,12 +788,30 @@ fn render_agent_detail(app: &AppState, frame: &mut Frame, area: Rect) {
             break;
         }
 
+        // Check if this agent entry corresponds to the active session
+        let is_active = app.active.map_or(false, |active_ws_idx| {
+            detail.ws_idx == active_ws_idx
+                && detail.tab_idx == app.workspaces[detail.ws_idx].active_tab_index()
+                && app.workspaces[detail.ws_idx]
+                    .active_tab()
+                    .map(|tab| tab.layout.focused())
+                    == Some(detail.pane_id)
+        });
+
         let (icon, icon_style) = agent_icon(detail.state, detail.seen, app.spinner_tick, p);
         let label_color = state_label_color(detail.state, detail.seen, p);
         let label = state_label(detail.state, detail.seen);
 
-        let name_style = Style::default().fg(p.subtext0).add_modifier(Modifier::BOLD);
-        let status_style = Style::default().fg(label_color).add_modifier(Modifier::DIM);
+        let name_style = if is_active {
+            Style::default().fg(p.text).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(p.subtext0).add_modifier(Modifier::BOLD)
+        };
+        let status_style = if is_active {
+            Style::default().fg(label_color)
+        } else {
+            Style::default().fg(label_color).add_modifier(Modifier::DIM)
+        };
         let agent_style = Style::default().fg(p.overlay0).add_modifier(Modifier::DIM);
 
         let primary_label =
@@ -809,6 +827,19 @@ fn render_agent_detail(app: &AppState, frame: &mut Frame, area: Rect) {
             Rect::new(body.x, row_y, body.width, 1),
         );
         row_y += 1;
+
+        // Apply background highlighting for active agent (covering both name and status lines)
+        if is_active {
+            let buf = frame.buffer_mut();
+            // Highlight name line
+            for x in body.x..body.x + body.width {
+                buf[(x, row_y - 1)].set_style(Style::default().bg(p.surface_dim));
+            }
+            // Highlight status line
+            for x in body.x..body.x + body.width {
+                buf[(x, row_y)].set_style(Style::default().bg(p.surface_dim));
+            }
+        }
 
         let mut status_spans = vec![
             Span::styled("   ", Style::default()),


### PR DESCRIPTION
In herdr, there is a panel on the left that displays the workspace and agent status. 
I noticed that while the currently active item is clearly distinguished in the workspace list, active agents are not distinguished in the agents list. Therefore, I am submitting this change. 

- When there are no agent active in working session area
- When there are detected agents but no focus
- When there is a detected agent and it has focus

Tested in Ghostty and iTerm2

<img width="1024" height="633" alt="image" src="https://github.com/user-attachments/assets/3588a563-939d-43a8-8752-83a2a31320e9">

<img width="1024" height="633" alt="image" src="https://github.com/user-attachments/assets/f40fc068-b3a2-4af4-9316-2db58476fe27">

<img width="1024" height="633" alt="image" src="https://github.com/user-attachments/assets/c6288d12-0160-4761-9a4d-b4e1d9bbef73">

<img width="1024" height="633" alt="image" src="https://github.com/user-attachments/assets/740d9ce9-86e9-42b7-a0ee-e883af72ca47">

It is currently working well. 

Thank you for creating such a great tmux alternative. It’s incredibly useful and fits my needs perfectly. 
