### PR TITLE
feat: add typescript socket sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 *.swo
 *~
 .DS_Store
+sdk/typescript/dist/
+sdk/typescript/node_modules/
 
 /docs
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://herdr.dev">herdr.dev</a> · <a href="#install">install</a> · <a href="#quick-start">quick start</a> · <a href="#supported-agents">supported agents</a> · <a href="./INTEGRATIONS.md">integrations</a> · <a href="./CONFIGURATION.md">configuration</a> · <a href="./SOCKET_API.md">socket api</a>
+  <a href="https://herdr.dev">herdr.dev</a> · <a href="#install">install</a> · <a href="#quick-start">quick start</a> · <a href="#supported-agents">supported agents</a> · <a href="./INTEGRATIONS.md">integrations</a> · <a href="./CONFIGURATION.md">configuration</a> · <a href="./SOCKET_API.md">socket api</a> · <a href="./sdk/typescript">typescript sdk</a>
 </p>
 
 ---
@@ -141,7 +141,7 @@ herdr pane read 1-2 --source recent --lines 50
 herdr pane read 1-2 --source visible --ansi
 ```
 
-full reference: [`SOCKET_API.md`](./SOCKET_API.md) and [`SKILL.md`](./SKILL.md).
+full reference: [`SOCKET_API.md`](./SOCKET_API.md), [`SKILL.md`](./SKILL.md), and the [`TypeScript SDK`](./sdk/typescript).
 
 ## supported agents
 

--- a/SOCKET_API.md
+++ b/SOCKET_API.md
@@ -6,10 +6,11 @@ if you are teaching an agent that is already running inside herdr, start with [`
 
 ## choose your integration layer
 
-there are three practical ways to integrate with herdr:
+there are four practical ways to integrate with herdr:
 
 - **agent skill** — [`SKILL.md`](./SKILL.md). best when an agent inside herdr just needs to learn the workflow quickly.
 - **cli wrappers** — `herdr server stop`, `herdr workspace ...`, `herdr tab ...`, `herdr pane ...`, `herdr wait ...`. best for shell scripts and simple orchestration.
+- **TypeScript SDK** — [`sdk/typescript`](./sdk/typescript). best for Node.js tools that want typed request/result/event shapes without shelling out.
 - **raw socket api** — best when you want direct request/response control or long-lived event subscriptions.
 
 these layers are intentionally stacked on top of the same control surface.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,105 @@
+# @herdr/sdk
+
+TypeScript SDK for controlling a running Herdr instance over the same newline-delimited JSON Unix socket used by the CLI.
+
+```ts
+import { createHerdrClient } from "@herdr/sdk";
+
+const herdr = createHerdrClient({ session: "work" });
+
+const workspace = await herdr.workspace.create({
+  cwd: "/path/to/project",
+  label: "api",
+  focus: true,
+});
+
+await herdr.pane.run(workspace.root_pane.pane_id, "npm run dev");
+
+const match = await herdr.pane.waitForOutput({
+  pane_id: workspace.root_pane.pane_id,
+  source: "recent",
+  match: { type: "substring", value: "ready" },
+  timeout_ms: 30_000,
+});
+
+console.log(match.matched_line);
+```
+
+## Connection
+
+Herdr exposes a local Unix domain socket. The SDK resolves the socket path in this order:
+
+1. `socketPath` option
+2. `session` option, mapped to `$XDG_CONFIG_HOME/herdr/sessions/<name>/herdr.sock` or `$HOME/.config/herdr/sessions/<name>/herdr.sock`
+3. `HERDR_SOCKET_PATH`
+4. `HERDR_SESSION`, using the same named-session path
+5. default path at `$XDG_CONFIG_HOME/herdr/herdr.sock` or `$HOME/.config/herdr/herdr.sock`
+
+```ts
+const defaultClient = createHerdrClient();
+const namedSession = createHerdrClient({ session: "work" });
+const explicitSocket = createHerdrClient({ socketPath: "/tmp/herdr.sock" });
+```
+
+## Raw Requests
+
+Use `request()` when you want the exact socket method. Method names, params, and result types are linked at compile time.
+
+```ts
+const read = await herdr.request("pane.read", {
+  pane_id: "1-1",
+  source: "recent",
+  lines: 80,
+});
+
+read.type; // "pane_read"
+read.read.text;
+```
+
+API errors reject with `HerdrApiError` and expose the server error code and message.
+
+## Convenience Helpers
+
+The helper groups mirror Herdr concepts:
+
+- `herdr.server.stop()` and `herdr.server.reloadConfig()`
+- `herdr.workspace.list|get|create|focus|rename|close`
+- `herdr.tab.list|get|create|focus|rename|close`
+- `herdr.pane.list|get|read|split|sendText|sendKeys|sendInput|run|waitForOutput|waitForAgentStatus|reportAgent|clearAgentAuthority|releaseAgent|close`
+- `herdr.events.subscribe|wait`
+- `herdr.integration.install|uninstall`
+
+`pane.run()` is an SDK convenience matching the CLI wrapper: it sends `pane.send_input` with the command text and `keys: ["Enter"]`.
+
+## Subscriptions
+
+`events.subscribe` keeps a socket open after the ack and yields pushed events as an async iterator.
+
+```ts
+const subscription = await herdr.events.subscribe({
+  subscriptions: [
+    {
+      type: "pane.agent_status_changed",
+      pane_id: "1-1",
+      agent_status: "done",
+    },
+  ],
+});
+
+try {
+  for await (const event of subscription) {
+    console.log(event);
+    break;
+  }
+} finally {
+  subscription.close();
+}
+```
+
+For the common CLI-style wait, use:
+
+```ts
+const event = await herdr.pane.waitForAgentStatus("1-1", "done", {
+  timeoutMs: 60_000,
+});
+```

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@herdr/sdk",
+  "version": "0.5.6",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@herdr/sdk",
+      "version": "0.5.6",
+      "license": "AGPL-3.0-or-later",
+      "devDependencies": {
+        "@types/node": "^18.19.130",
+        "typescript": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@herdr/sdk",
+  "version": "0.5.6",
+  "description": "TypeScript SDK for the Herdr Unix socket API",
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
+    "typecheck": "tsc -p tsconfig.test.json --noEmit",
+    "test": "npm run build && npm run typecheck && node --test test/*.test.mjs",
+    "check": "npm test"
+  },
+  "engines": {
+    "node": ">=18.18"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.130",
+    "typescript": "^5.9.0"
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,1181 @@
+import { createConnection, type Socket } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type EmptyParams = Record<string, never>;
+
+export type AgentStatus = "idle" | "working" | "blocked" | "done" | "unknown";
+export type PaneAgentState = "idle" | "working" | "blocked" | "unknown";
+export type ReadSource = "visible" | "recent" | "recent_unwrapped";
+export type ReadFormat = "text" | "ansi";
+export type SplitDirection = "right" | "down";
+export type IntegrationTarget = "pi" | "claude" | "codex" | "opencode";
+
+export interface WorkspaceTarget {
+  workspace_id: string;
+}
+
+export interface PaneTarget {
+  pane_id: string;
+}
+
+export interface TabTarget {
+  tab_id: string;
+}
+
+export interface WorkspaceCreateParams {
+  cwd?: string;
+  focus?: boolean;
+  label?: string;
+}
+
+export interface WorkspaceRenameParams {
+  workspace_id: string;
+  label: string;
+}
+
+export interface TabCreateParams {
+  workspace_id?: string;
+  cwd?: string;
+  focus?: boolean;
+  label?: string;
+}
+
+export interface TabListParams {
+  workspace_id?: string;
+}
+
+export interface TabRenameParams {
+  tab_id: string;
+  label: string;
+}
+
+export interface PaneSplitParams {
+  workspace_id?: string;
+  target_pane_id: string;
+  direction: SplitDirection;
+  cwd?: string;
+  focus?: boolean;
+}
+
+export interface PaneListParams {
+  workspace_id?: string;
+}
+
+export interface PaneSendTextParams {
+  pane_id: string;
+  text: string;
+}
+
+export interface PaneSendKeysParams {
+  pane_id: string;
+  keys: string[];
+}
+
+export interface PaneSendInputParams {
+  pane_id: string;
+  text?: string;
+  keys?: string[];
+}
+
+export interface PaneReadParams {
+  pane_id: string;
+  source: ReadSource;
+  lines?: number;
+  format?: ReadFormat;
+  strip_ansi?: boolean;
+}
+
+export interface PaneReportAgentParams {
+  pane_id: string;
+  source: string;
+  agent: string;
+  state: PaneAgentState;
+  message?: string;
+}
+
+export interface PaneClearAgentAuthorityParams {
+  pane_id: string;
+  source?: string;
+}
+
+export interface PaneReleaseAgentParams {
+  pane_id: string;
+  source: string;
+  agent: string;
+}
+
+export type OutputMatch =
+  | { type: "substring"; value: string }
+  | { type: "regex"; value: string };
+
+export type Subscription =
+  | { type: "workspace.created" }
+  | { type: "workspace.closed" }
+  | { type: "workspace.focused" }
+  | { type: "tab.created" }
+  | { type: "tab.closed" }
+  | { type: "tab.focused" }
+  | { type: "tab.renamed" }
+  | { type: "pane.created" }
+  | { type: "pane.closed" }
+  | { type: "pane.focused" }
+  | { type: "pane.exited" }
+  | { type: "pane.agent_detected" }
+  | {
+      type: "pane.output_matched";
+      pane_id: string;
+      source: ReadSource;
+      lines?: number;
+      match: OutputMatch;
+      strip_ansi?: boolean;
+    }
+  | {
+      type: "pane.agent_status_changed";
+      pane_id: string;
+      agent_status?: AgentStatus;
+    };
+
+export interface EventsSubscribeParams {
+  subscriptions: Subscription[];
+}
+
+export type EventMatch =
+  | { event: "workspace_created"; workspace_id?: string }
+  | { event: "workspace_closed"; workspace_id: string }
+  | { event: "workspace_renamed"; workspace_id: string; label?: string }
+  | { event: "workspace_focused"; workspace_id: string }
+  | { event: "tab_created"; tab_id?: string; workspace_id?: string }
+  | { event: "tab_closed"; tab_id: string }
+  | { event: "tab_renamed"; tab_id: string; label?: string }
+  | { event: "tab_focused"; tab_id: string }
+  | { event: "pane_created"; pane_id?: string; workspace_id?: string }
+  | { event: "pane_closed"; pane_id: string }
+  | { event: "pane_focused"; pane_id: string }
+  | { event: "pane_output_changed"; pane_id: string; min_revision?: number }
+  | { event: "pane_exited"; pane_id: string }
+  | { event: "pane_agent_detected"; pane_id: string; agent?: string }
+  | { event: "pane_agent_status_changed"; pane_id: string; agent_status: AgentStatus };
+
+export interface EventsWaitParams {
+  match_event: EventMatch;
+  timeout_ms?: number;
+}
+
+export interface PaneWaitForOutputParams {
+  pane_id: string;
+  source: ReadSource;
+  lines?: number;
+  match: OutputMatch;
+  timeout_ms?: number;
+  strip_ansi?: boolean;
+}
+
+export interface IntegrationInstallParams {
+  target: IntegrationTarget;
+}
+
+export interface IntegrationUninstallParams {
+  target: IntegrationTarget;
+}
+
+export interface WorkspaceInfo {
+  workspace_id: string;
+  number: number;
+  label: string;
+  focused: boolean;
+  pane_count: number;
+  tab_count: number;
+  active_tab_id: string;
+  agent_status: AgentStatus;
+}
+
+export interface TabInfo {
+  tab_id: string;
+  workspace_id: string;
+  number: number;
+  label: string;
+  focused: boolean;
+  pane_count: number;
+  agent_status: AgentStatus;
+}
+
+export interface PaneInfo {
+  pane_id: string;
+  workspace_id: string;
+  tab_id: string;
+  focused: boolean;
+  cwd?: string;
+  agent?: string;
+  agent_status: AgentStatus;
+  revision: number;
+}
+
+export interface PaneReadResult {
+  pane_id: string;
+  workspace_id: string;
+  tab_id: string;
+  source: ReadSource;
+  format: ReadFormat;
+  text: string;
+  revision: number;
+  truncated: boolean;
+}
+
+export interface IntegrationInstallResult {
+  messages: string[];
+}
+
+export interface IntegrationUninstallResult {
+  messages: string[];
+}
+
+export type ConfigReloadStatus = "applied" | "partial" | "failed";
+
+export interface PongResult {
+  type: "pong";
+  version: string;
+  protocol: number;
+}
+
+export interface OkResult {
+  type: "ok";
+}
+
+export interface WorkspaceInfoResult {
+  type: "workspace_info";
+  workspace: WorkspaceInfo;
+}
+
+export interface WorkspaceCreatedResult {
+  type: "workspace_created";
+  workspace: WorkspaceInfo;
+  tab: TabInfo;
+  root_pane: PaneInfo;
+}
+
+export interface WorkspaceListResult {
+  type: "workspace_list";
+  workspaces: WorkspaceInfo[];
+}
+
+export interface TabInfoResult {
+  type: "tab_info";
+  tab: TabInfo;
+}
+
+export interface TabCreatedResult {
+  type: "tab_created";
+  tab: TabInfo;
+  root_pane: PaneInfo;
+}
+
+export interface TabListResult {
+  type: "tab_list";
+  tabs: TabInfo[];
+}
+
+export interface PaneInfoResult {
+  type: "pane_info";
+  pane: PaneInfo;
+}
+
+export interface PaneListResult {
+  type: "pane_list";
+  panes: PaneInfo[];
+}
+
+export interface PaneReadResultEnvelope {
+  type: "pane_read";
+  read: PaneReadResult;
+}
+
+export interface SubscriptionStartedResult {
+  type: "subscription_started";
+}
+
+export interface WaitMatchedResult {
+  type: "wait_matched";
+  event: HerdrLifecycleEvent;
+}
+
+export interface OutputMatchedResult {
+  type: "output_matched";
+  pane_id: string;
+  revision: number;
+  matched_line?: string | null;
+  read: PaneReadResult;
+}
+
+export interface IntegrationInstallResultEnvelope {
+  type: "integration_install";
+  target: IntegrationTarget;
+  details: IntegrationInstallResult;
+}
+
+export interface IntegrationUninstallResultEnvelope {
+  type: "integration_uninstall";
+  target: IntegrationTarget;
+  details: IntegrationUninstallResult;
+}
+
+export interface ConfigReloadResult {
+  type: "config_reload";
+  status: ConfigReloadStatus;
+  diagnostics: string[];
+}
+
+export type HerdrMethodParams = {
+  ping: EmptyParams;
+  "server.stop": EmptyParams;
+  "server.reload_config": EmptyParams;
+  "workspace.create": WorkspaceCreateParams;
+  "workspace.list": EmptyParams;
+  "workspace.get": WorkspaceTarget;
+  "workspace.focus": WorkspaceTarget;
+  "workspace.rename": WorkspaceRenameParams;
+  "workspace.close": WorkspaceTarget;
+  "tab.create": TabCreateParams;
+  "tab.list": TabListParams;
+  "tab.get": TabTarget;
+  "tab.focus": TabTarget;
+  "tab.rename": TabRenameParams;
+  "tab.close": TabTarget;
+  "pane.split": PaneSplitParams;
+  "pane.list": PaneListParams;
+  "pane.get": PaneTarget;
+  "pane.send_text": PaneSendTextParams;
+  "pane.send_keys": PaneSendKeysParams;
+  "pane.send_input": PaneSendInputParams;
+  "pane.read": PaneReadParams;
+  "pane.report_agent": PaneReportAgentParams;
+  "pane.clear_agent_authority": PaneClearAgentAuthorityParams;
+  "pane.release_agent": PaneReleaseAgentParams;
+  "pane.close": PaneTarget;
+  "events.subscribe": EventsSubscribeParams;
+  "events.wait": EventsWaitParams;
+  "pane.wait_for_output": PaneWaitForOutputParams;
+  "integration.install": IntegrationInstallParams;
+  "integration.uninstall": IntegrationUninstallParams;
+};
+
+export type HerdrMethodResults = {
+  ping: PongResult;
+  "server.stop": OkResult;
+  "server.reload_config": ConfigReloadResult;
+  "workspace.create": WorkspaceCreatedResult;
+  "workspace.list": WorkspaceListResult;
+  "workspace.get": WorkspaceInfoResult;
+  "workspace.focus": WorkspaceInfoResult;
+  "workspace.rename": WorkspaceInfoResult;
+  "workspace.close": OkResult;
+  "tab.create": TabCreatedResult;
+  "tab.list": TabListResult;
+  "tab.get": TabInfoResult;
+  "tab.focus": TabInfoResult;
+  "tab.rename": TabInfoResult;
+  "tab.close": OkResult;
+  "pane.split": PaneInfoResult;
+  "pane.list": PaneListResult;
+  "pane.get": PaneInfoResult;
+  "pane.send_text": OkResult;
+  "pane.send_keys": OkResult;
+  "pane.send_input": OkResult;
+  "pane.read": PaneReadResultEnvelope;
+  "pane.report_agent": OkResult;
+  "pane.clear_agent_authority": OkResult;
+  "pane.release_agent": OkResult;
+  "pane.close": OkResult;
+  "events.subscribe": SubscriptionStartedResult;
+  "events.wait": WaitMatchedResult;
+  "pane.wait_for_output": OutputMatchedResult;
+  "integration.install": IntegrationInstallResultEnvelope;
+  "integration.uninstall": IntegrationUninstallResultEnvelope;
+};
+
+export type HerdrMethod = keyof HerdrMethodParams & keyof HerdrMethodResults;
+
+export interface HerdrRequest<M extends HerdrMethod = HerdrMethod> {
+  id: string;
+  method: M;
+  params: HerdrMethodParams[M];
+}
+
+export interface HerdrSuccessResponse<M extends HerdrMethod = HerdrMethod> {
+  id: string;
+  result: HerdrMethodResults[M];
+}
+
+export interface HerdrErrorBody {
+  code: string;
+  message: string;
+}
+
+export interface HerdrErrorResponse {
+  id: string;
+  error: HerdrErrorBody;
+}
+
+export type HerdrResponse<M extends HerdrMethod = HerdrMethod> =
+  | HerdrSuccessResponse<M>
+  | HerdrErrorResponse;
+
+export type HerdrEventKind =
+  | "workspace_created"
+  | "workspace_closed"
+  | "workspace_renamed"
+  | "workspace_focused"
+  | "tab_created"
+  | "tab_closed"
+  | "tab_renamed"
+  | "tab_focused"
+  | "pane_created"
+  | "pane_closed"
+  | "pane_focused"
+  | "pane_output_changed"
+  | "pane_exited"
+  | "pane_agent_detected"
+  | "pane_agent_status_changed";
+
+export type HerdrLifecycleEvent =
+  | {
+      event: "workspace_created";
+      data: { type: "workspace_created"; workspace: WorkspaceInfo };
+    }
+  | { event: "workspace_closed"; data: { type: "workspace_closed"; workspace_id: string } }
+  | {
+      event: "workspace_renamed";
+      data: { type: "workspace_renamed"; workspace_id: string; label: string };
+    }
+  | { event: "workspace_focused"; data: { type: "workspace_focused"; workspace_id: string } }
+  | { event: "tab_created"; data: { type: "tab_created"; tab: TabInfo } }
+  | {
+      event: "tab_closed";
+      data: { type: "tab_closed"; tab_id: string; workspace_id: string };
+    }
+  | {
+      event: "tab_renamed";
+      data: { type: "tab_renamed"; tab_id: string; workspace_id: string; label: string };
+    }
+  | {
+      event: "tab_focused";
+      data: { type: "tab_focused"; tab_id: string; workspace_id: string };
+    }
+  | { event: "pane_created"; data: { type: "pane_created"; pane: PaneInfo } }
+  | {
+      event: "pane_closed";
+      data: { type: "pane_closed"; pane_id: string; workspace_id: string };
+    }
+  | {
+      event: "pane_focused";
+      data: { type: "pane_focused"; pane_id: string; workspace_id: string };
+    }
+  | {
+      event: "pane_output_changed";
+      data: { type: "pane_output_changed"; pane_id: string; workspace_id: string; revision: number };
+    }
+  | {
+      event: "pane_exited";
+      data: { type: "pane_exited"; pane_id: string; workspace_id: string };
+    }
+  | {
+      event: "pane_agent_detected";
+      data: { type: "pane_agent_detected"; pane_id: string; workspace_id: string; agent?: string };
+    }
+  | {
+      event: "pane_agent_status_changed";
+      data: {
+        type: "pane_agent_status_changed";
+        pane_id: string;
+        workspace_id: string;
+        agent_status: AgentStatus;
+      };
+    };
+
+export interface PaneOutputMatchedSubscriptionEvent {
+  event: "pane.output_matched";
+  data: {
+    pane_id: string;
+    matched_line: string;
+    read: PaneReadResult;
+  };
+}
+
+export interface PaneAgentStatusChangedSubscriptionEvent {
+  event: "pane.agent_status_changed";
+  data: {
+    pane_id: string;
+    workspace_id: string;
+    agent_status: AgentStatus;
+    agent?: string;
+  };
+}
+
+export type HerdrSubscriptionEvent =
+  | PaneOutputMatchedSubscriptionEvent
+  | PaneAgentStatusChangedSubscriptionEvent;
+
+export type HerdrStreamEvent = HerdrLifecycleEvent | HerdrSubscriptionEvent;
+
+export interface SocketPathOptions {
+  socketPath?: string;
+  session?: string;
+  env?: Record<string, string | undefined>;
+}
+
+export interface HerdrClientOptions extends SocketPathOptions {
+  connectTimeoutMs?: number;
+  requestIdPrefix?: string;
+  responseTimeoutMs?: number;
+}
+
+export interface RequestOptions {
+  id?: string;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export interface WaitForAgentStatusOptions {
+  id?: string;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  ackTimeoutMs?: number;
+}
+
+export class HerdrError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HerdrError";
+  }
+}
+
+export class HerdrTimeoutError extends HerdrError {
+  constructor(message = "timed out waiting for herdr response") {
+    super(message);
+    this.name = "HerdrTimeoutError";
+  }
+}
+
+export class HerdrProtocolError extends HerdrError {
+  constructor(message: string) {
+    super(message);
+    this.name = "HerdrProtocolError";
+  }
+}
+
+export class HerdrApiError extends HerdrError {
+  readonly code: string;
+  readonly response: HerdrErrorResponse;
+
+  constructor(response: HerdrErrorResponse) {
+    super(`${response.error.code}: ${response.error.message}`);
+    this.name = "HerdrApiError";
+    this.code = response.error.code;
+    this.response = response;
+  }
+}
+
+const DEFAULT_REQUEST_ID_PREFIX = "herdr-sdk";
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+const SESSION_NAME_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+
+export function resolveHerdrSocketPath(options: SocketPathOptions = {}): string {
+  const env = options.env ?? process.env;
+
+  if (options.socketPath) {
+    return options.socketPath;
+  }
+
+  if (options.session !== undefined) {
+    return socketPathForSession(options.session, env);
+  }
+
+  if (env.HERDR_SOCKET_PATH) {
+    return env.HERDR_SOCKET_PATH;
+  }
+
+  return socketPathForSession(env.HERDR_SESSION, env);
+}
+
+export function createHerdrClient(options: HerdrClientOptions = {}): HerdrClient {
+  return new HerdrClient(options);
+}
+
+export class HerdrClient {
+  readonly options: HerdrClientOptions;
+  private sequence = 0;
+
+  readonly server = {
+    stop: (options?: RequestOptions) => this.request("server.stop", {}, options),
+    reloadConfig: (options?: RequestOptions) =>
+      this.request("server.reload_config", {}, options),
+  };
+
+  readonly workspace = {
+    list: (options?: RequestOptions) => this.request("workspace.list", {}, options),
+    get: (workspaceId: string, options?: RequestOptions) =>
+      this.request("workspace.get", { workspace_id: workspaceId }, options),
+    create: (params: WorkspaceCreateParams = {}, options?: RequestOptions) =>
+      this.request("workspace.create", params, options),
+    focus: (workspaceId: string, options?: RequestOptions) =>
+      this.request("workspace.focus", { workspace_id: workspaceId }, options),
+    rename: (workspaceId: string, label: string, options?: RequestOptions) =>
+      this.request("workspace.rename", { workspace_id: workspaceId, label }, options),
+    close: (workspaceId: string, options?: RequestOptions) =>
+      this.request("workspace.close", { workspace_id: workspaceId }, options),
+  };
+
+  readonly tab = {
+    list: (params: TabListParams = {}, options?: RequestOptions) =>
+      this.request("tab.list", params, options),
+    get: (tabId: string, options?: RequestOptions) =>
+      this.request("tab.get", { tab_id: tabId }, options),
+    create: (params: TabCreateParams = {}, options?: RequestOptions) =>
+      this.request("tab.create", params, options),
+    focus: (tabId: string, options?: RequestOptions) =>
+      this.request("tab.focus", { tab_id: tabId }, options),
+    rename: (tabId: string, label: string, options?: RequestOptions) =>
+      this.request("tab.rename", { tab_id: tabId, label }, options),
+    close: (tabId: string, options?: RequestOptions) =>
+      this.request("tab.close", { tab_id: tabId }, options),
+  };
+
+  readonly pane = {
+    list: (params: PaneListParams = {}, options?: RequestOptions) =>
+      this.request("pane.list", params, options),
+    get: (paneId: string, options?: RequestOptions) =>
+      this.request("pane.get", { pane_id: paneId }, options),
+    read: (params: PaneReadParams, options?: RequestOptions) =>
+      this.request("pane.read", params, options),
+    split: (params: PaneSplitParams, options?: RequestOptions) =>
+      this.request("pane.split", params, options),
+    sendText: (paneId: string, text: string, options?: RequestOptions) =>
+      this.request("pane.send_text", { pane_id: paneId, text }, options),
+    sendKeys: (paneId: string, keys: string[], options?: RequestOptions) =>
+      this.request("pane.send_keys", { pane_id: paneId, keys }, options),
+    sendInput: (params: PaneSendInputParams, options?: RequestOptions) =>
+      this.request("pane.send_input", params, options),
+    run: (paneId: string, command: string, options?: RequestOptions) =>
+      this.request("pane.send_input", { pane_id: paneId, text: command, keys: ["Enter"] }, options),
+    waitForOutput: (params: PaneWaitForOutputParams, options?: RequestOptions) =>
+      this.request("pane.wait_for_output", params, options),
+    waitForAgentStatus: (
+      paneId: string,
+      agentStatus: AgentStatus,
+      options?: WaitForAgentStatusOptions,
+    ) => this.waitForAgentStatus(paneId, agentStatus, options),
+    reportAgent: (params: PaneReportAgentParams, options?: RequestOptions) =>
+      this.request("pane.report_agent", params, options),
+    clearAgentAuthority: (params: PaneClearAgentAuthorityParams, options?: RequestOptions) =>
+      this.request("pane.clear_agent_authority", params, options),
+    releaseAgent: (params: PaneReleaseAgentParams, options?: RequestOptions) =>
+      this.request("pane.release_agent", params, options),
+    close: (paneId: string, options?: RequestOptions) =>
+      this.request("pane.close", { pane_id: paneId }, options),
+  };
+
+  readonly events = {
+    subscribe: (params: EventsSubscribeParams, options?: RequestOptions) =>
+      this.subscribe(params, options),
+    wait: (params: EventsWaitParams, options?: RequestOptions) =>
+      this.request("events.wait", params, options),
+  };
+
+  readonly integration = {
+    install: (target: IntegrationTarget, options?: RequestOptions) =>
+      this.request("integration.install", { target }, options),
+    uninstall: (target: IntegrationTarget, options?: RequestOptions) =>
+      this.request("integration.uninstall", { target }, options),
+  };
+
+  constructor(options: HerdrClientOptions = {}) {
+    this.options = { ...options };
+  }
+
+  get socketPath(): string {
+    return resolveHerdrSocketPath(this.options);
+  }
+
+  async request<M extends HerdrMethod>(
+    method: M,
+    params: HerdrMethodParams[M],
+    options: RequestOptions = {},
+  ): Promise<HerdrMethodResults[M]> {
+    const response = await this.requestEnvelope(method, params, options);
+    if (isErrorResponse(response)) {
+      throw new HerdrApiError(response);
+    }
+    return response.result;
+  }
+
+  async requestEnvelope<M extends HerdrMethod>(
+    method: M,
+    params: HerdrMethodParams[M],
+    options: RequestOptions = {},
+  ): Promise<HerdrResponse<M>> {
+    const socket = await this.openSocket(options);
+    const reader = new LineReader(socket);
+    const id = options.id ?? this.nextRequestId(method);
+    const request: HerdrRequest<M> = { id, method, params };
+
+    try {
+      await writeLine(socket, JSON.stringify(request), options.signal);
+      const line = await reader.readLine({
+        signal: options.signal,
+        timeoutMs: options.timeoutMs ?? this.options.responseTimeoutMs,
+      });
+      socket.end();
+
+      if (line === null) {
+        throw new HerdrProtocolError("herdr closed the socket before sending a response");
+      }
+
+      const response = parseJsonLine<HerdrResponse<M>>(line);
+      if (!isResponse(response)) {
+        throw new HerdrProtocolError("herdr returned an invalid response envelope");
+      }
+      return response;
+    } catch (error) {
+      socket.destroy();
+      throw error;
+    }
+  }
+
+  private async subscribe(
+    params: EventsSubscribeParams,
+    options: RequestOptions = {},
+  ): Promise<HerdrSubscription> {
+    const socket = await this.openSocket(options);
+    const reader = new LineReader(socket);
+    const id = options.id ?? this.nextRequestId("events.subscribe");
+    const request: HerdrRequest<"events.subscribe"> = {
+      id,
+      method: "events.subscribe",
+      params,
+    };
+
+    try {
+      await writeLine(socket, JSON.stringify(request), options.signal);
+      const line = await reader.readLine({
+        signal: options.signal,
+        timeoutMs: options.timeoutMs ?? this.options.responseTimeoutMs,
+      });
+
+      if (line === null) {
+        throw new HerdrProtocolError("herdr closed the subscription before sending an ack");
+      }
+
+      const ack = parseJsonLine<HerdrResponse<"events.subscribe">>(line);
+      if (!isResponse(ack)) {
+        throw new HerdrProtocolError("herdr returned an invalid subscription ack");
+      }
+      if (isErrorResponse(ack)) {
+        throw new HerdrApiError(ack);
+      }
+      if (ack.result.type !== "subscription_started") {
+        throw new HerdrProtocolError(`expected subscription_started ack, got ${ack.result.type}`);
+      }
+
+      return new HerdrSubscription(socket, reader, ack);
+    } catch (error) {
+      socket.destroy();
+      throw error;
+    }
+  }
+
+  private async waitForAgentStatus(
+    paneId: string,
+    agentStatus: AgentStatus,
+    options: WaitForAgentStatusOptions = {},
+  ): Promise<PaneAgentStatusChangedSubscriptionEvent> {
+    const subscription = await this.subscribe(
+      {
+        subscriptions: [
+          {
+            type: "pane.agent_status_changed",
+            pane_id: paneId,
+            agent_status: agentStatus,
+          },
+        ],
+      },
+      {
+        id: options.id,
+        signal: options.signal,
+        timeoutMs: options.ackTimeoutMs,
+      },
+    );
+
+    try {
+      const event = await subscription.nextEvent({
+        signal: options.signal,
+        timeoutMs: options.timeoutMs,
+      });
+      if (event === null) {
+        throw new HerdrProtocolError("subscription closed before agent status changed");
+      }
+      if (event.event !== "pane.agent_status_changed") {
+        throw new HerdrProtocolError(`expected pane.agent_status_changed event, got ${event.event}`);
+      }
+      return event;
+    } finally {
+      subscription.close();
+    }
+  }
+
+  private async openSocket(options: RequestOptions): Promise<Socket> {
+    return connectUnixSocket(this.socketPath, {
+      signal: options.signal,
+      timeoutMs: this.options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+    });
+  }
+
+  private nextRequestId(method: string): string {
+    this.sequence += 1;
+    const prefix = this.options.requestIdPrefix ?? DEFAULT_REQUEST_ID_PREFIX;
+    return `${prefix}:${method}:${this.sequence}`;
+  }
+}
+
+export class HerdrSubscription implements AsyncIterable<HerdrStreamEvent> {
+  readonly ack: HerdrSuccessResponse<"events.subscribe">;
+  private closed = false;
+
+  constructor(
+    private readonly socket: Socket,
+    private readonly reader: LineReader,
+    ack: HerdrSuccessResponse<"events.subscribe">,
+  ) {
+    this.ack = ack;
+  }
+
+  async nextEvent(options: Omit<RequestOptions, "id"> = {}): Promise<HerdrStreamEvent | null> {
+    if (this.closed) {
+      return null;
+    }
+
+    const line = await this.reader.readLine(options);
+    if (line === null) {
+      this.closed = true;
+      return null;
+    }
+
+    const event = parseJsonLine<HerdrStreamEvent>(line);
+    if (!isStreamEvent(event)) {
+      throw new HerdrProtocolError("herdr returned an invalid subscription event");
+    }
+    return event;
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.socket.end();
+    this.socket.destroy();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<HerdrStreamEvent> {
+    return {
+      next: async () => {
+        const value = await this.nextEvent();
+        if (value === null) {
+          return { done: true, value: undefined };
+        }
+        return { done: false, value };
+      },
+    };
+  }
+}
+
+interface ConnectOptions {
+  signal?: AbortSignal;
+  timeoutMs: number;
+}
+
+interface ReadLineOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+interface PendingRead {
+  resolve: (line: string | null) => void;
+  reject: (error: Error) => void;
+  timeout?: NodeJS.Timeout;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+class LineReader {
+  private buffer = "";
+  private readonly lines: string[] = [];
+  private readonly pending: PendingRead[] = [];
+  private ended = false;
+  private error: Error | undefined;
+
+  constructor(private readonly socket: Socket) {
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk: string) => this.push(chunk));
+    socket.once("end", () => this.finish());
+    socket.once("close", () => this.finish());
+    socket.once("error", (error) => this.fail(error));
+  }
+
+  readLine(options: ReadLineOptions = {}): Promise<string | null> {
+    const line = this.lines.shift();
+    if (line !== undefined) {
+      return Promise.resolve(line);
+    }
+    if (this.error) {
+      return Promise.reject(this.error);
+    }
+    if (this.ended) {
+      return Promise.resolve(null);
+    }
+    if (options.signal?.aborted) {
+      return Promise.reject(abortError(options.signal));
+    }
+
+    return new Promise<string | null>((resolve, reject) => {
+      const pending: PendingRead = { resolve, reject, signal: options.signal };
+      if (options.timeoutMs !== undefined) {
+        pending.timeout = setTimeout(() => {
+          this.removePending(pending);
+          reject(new HerdrTimeoutError());
+        }, options.timeoutMs);
+      }
+      if (options.signal) {
+        pending.onAbort = () => {
+          this.removePending(pending);
+          reject(abortError(options.signal));
+        };
+        options.signal.addEventListener("abort", pending.onAbort, { once: true });
+      }
+      this.pending.push(pending);
+    });
+  }
+
+  private push(chunk: string): void {
+    this.buffer += chunk;
+    for (;;) {
+      const newline = this.buffer.indexOf("\n");
+      if (newline === -1) {
+        break;
+      }
+      const line = this.buffer.slice(0, newline).replace(/\r$/, "");
+      this.buffer = this.buffer.slice(newline + 1);
+      this.lines.push(line);
+    }
+    this.flush();
+  }
+
+  private finish(): void {
+    if (this.ended) {
+      return;
+    }
+    if (this.buffer.length > 0) {
+      this.lines.push(this.buffer);
+      this.buffer = "";
+    }
+    this.ended = true;
+    this.flush();
+    while (this.pending.length > 0) {
+      this.resolvePending(this.pending.shift()!, null);
+    }
+  }
+
+  private fail(error: Error): void {
+    this.error = error;
+    while (this.pending.length > 0) {
+      this.rejectPending(this.pending.shift()!, error);
+    }
+  }
+
+  private flush(): void {
+    while (this.lines.length > 0 && this.pending.length > 0) {
+      this.resolvePending(this.pending.shift()!, this.lines.shift()!);
+    }
+  }
+
+  private removePending(pending: PendingRead): void {
+    const index = this.pending.indexOf(pending);
+    if (index >= 0) {
+      this.pending.splice(index, 1);
+    }
+    this.cleanupPending(pending);
+  }
+
+  private resolvePending(pending: PendingRead, line: string | null): void {
+    this.cleanupPending(pending);
+    pending.resolve(line);
+  }
+
+  private rejectPending(pending: PendingRead, error: Error): void {
+    this.cleanupPending(pending);
+    pending.reject(error);
+  }
+
+  private cleanupPending(pending: PendingRead): void {
+    if (pending.timeout) {
+      clearTimeout(pending.timeout);
+    }
+    if (pending.signal && pending.onAbort) {
+      pending.signal.removeEventListener("abort", pending.onAbort);
+    }
+  }
+}
+
+function socketPathForSession(
+  session: string | undefined,
+  env: Record<string, string | undefined>,
+): string {
+  if (!session || session === "default") {
+    return join(configHome(env), "herdr", "herdr.sock");
+  }
+  if (!SESSION_NAME_PATTERN.test(session)) {
+    throw new HerdrError(
+      "session names may contain only ASCII letters, numbers, '.', '_', and '-' and must be 1-64 characters",
+    );
+  }
+  return join(configHome(env), "herdr", "sessions", session, "herdr.sock");
+}
+
+function configHome(env: Record<string, string | undefined>): string {
+  if (env.XDG_CONFIG_HOME) {
+    return env.XDG_CONFIG_HOME;
+  }
+  const home = env.HOME ?? homedir();
+  if (!home) {
+    throw new HerdrError("cannot resolve Herdr config path without HOME or XDG_CONFIG_HOME");
+  }
+  return join(home, ".config");
+}
+
+async function connectUnixSocket(path: string, options: ConnectOptions): Promise<Socket> {
+  if (options.signal?.aborted) {
+    throw abortError(options.signal);
+  }
+
+  return new Promise<Socket>((resolve, reject) => {
+    const socket = createConnection(path);
+    let settled = false;
+    let timeout: NodeJS.Timeout | undefined;
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+      options.signal?.removeEventListener("abort", onAbort);
+      callback();
+    };
+
+    const onConnect = () => finish(() => resolve(socket));
+    const onError = (error: Error) => finish(() => reject(error));
+    const onAbort = () => finish(() => {
+      const error = abortError(options.signal);
+      socket.destroy(error);
+      reject(error);
+    });
+
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    timeout = setTimeout(() => {
+      finish(() => {
+        const error = new HerdrTimeoutError(`timed out connecting to herdr socket at ${path}`);
+        socket.destroy(error);
+        reject(error);
+      });
+    }, options.timeoutMs);
+  });
+}
+
+async function writeLine(socket: Socket, line: string, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    throw abortError(signal);
+  }
+
+  const payload = `${line}\n`;
+  const wrote = socket.write(payload, "utf8");
+  if (!wrote) {
+    await waitForDrain(socket, signal);
+  }
+}
+
+function parseJsonLine<T>(line: string): T {
+  try {
+    return JSON.parse(line) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new HerdrProtocolError(`failed to parse herdr JSON line: ${message}`);
+  }
+}
+
+function isResponse(value: unknown): value is HerdrResponse {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    return false;
+  }
+  return isRecord(value.result) || isRecord(value.error);
+}
+
+function isErrorResponse(value: HerdrResponse): value is HerdrErrorResponse {
+  return "error" in value;
+}
+
+function isStreamEvent(value: unknown): value is HerdrStreamEvent {
+  return isRecord(value) && typeof value.event === "string" && isRecord(value.data);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function waitForDrain(socket: Socket, signal: AbortSignal | undefined): Promise<void> {
+  if (signal?.aborted) {
+    throw abortError(signal);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off("drain", onDrain);
+      socket.off("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+    };
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const onDrain = () => finish(resolve);
+    const onError = (error: Error) => finish(() => reject(error));
+    const onAbort = () => finish(() => reject(abortError(signal)));
+
+    socket.once("drain", onDrain);
+    socket.once("error", onError);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function abortError(signal: AbortSignal | undefined): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  return new HerdrError(reason === undefined ? "operation aborted" : String(reason));
+}
+
+export default HerdrClient;

--- a/sdk/typescript/test/index.test.mjs
+++ b/sdk/typescript/test/index.test.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+import test from "node:test";
+
+import {
+  HerdrApiError,
+  HerdrTimeoutError,
+  createHerdrClient,
+  resolveHerdrSocketPath,
+} from "../dist/index.js";
+
+test("resolves default, environment, and named session socket paths", () => {
+  assert.equal(
+    resolveHerdrSocketPath({
+      env: { XDG_CONFIG_HOME: "/config", HOME: "/home/can" },
+    }),
+    "/config/herdr/herdr.sock",
+  );
+  assert.equal(
+    resolveHerdrSocketPath({
+      env: { HERDR_SOCKET_PATH: "/tmp/herdr.sock", HOME: "/home/can" },
+    }),
+    "/tmp/herdr.sock",
+  );
+  assert.equal(
+    resolveHerdrSocketPath({
+      session: "work",
+      env: { HERDR_SOCKET_PATH: "/tmp/ignored.sock", XDG_CONFIG_HOME: "/config" },
+    }),
+    "/config/herdr/sessions/work/herdr.sock",
+  );
+  assert.equal(
+    resolveHerdrSocketPath({
+      env: { HERDR_SESSION: "work", HOME: "/home/can" },
+    }),
+    "/home/can/.config/herdr/sessions/work/herdr.sock",
+  );
+});
+
+test("sends newline-delimited requests and returns typed results", async () => {
+  await withSocketServer(async ({ socketPath, received, respondOnce }) => {
+    respondOnce({
+      id: "test:ping",
+      result: { type: "pong", version: "0.5.6", protocol: 4 },
+    });
+
+    const client = createHerdrClient({ socketPath });
+    const result = await client.request("ping", {}, { id: "test:ping" });
+
+    assert.deepEqual(result, { type: "pong", version: "0.5.6", protocol: 4 });
+    assert.deepEqual(await received, {
+      id: "test:ping",
+      method: "ping",
+      params: {},
+    });
+  });
+});
+
+test("pane.run maps to pane.send_input with Enter", async () => {
+  await withSocketServer(async ({ socketPath, received, respondOnce }) => {
+    respondOnce({
+      id: "run",
+      result: { type: "ok" },
+    });
+
+    const client = createHerdrClient({ socketPath });
+    await client.pane.run("1-1", "npm run dev", { id: "run" });
+
+    assert.deepEqual(await received, {
+      id: "run",
+      method: "pane.send_input",
+      params: {
+        pane_id: "1-1",
+        text: "npm run dev",
+        keys: ["Enter"],
+      },
+    });
+  });
+});
+
+test("rejects API errors with server code", async () => {
+  await withSocketServer(async ({ socketPath, respondOnce }) => {
+    respondOnce({
+      id: "bad-pane",
+      error: {
+        code: "pane_not_found",
+        message: "pane 1-9 not found",
+      },
+    });
+
+    const client = createHerdrClient({ socketPath });
+    await assert.rejects(
+      () => client.pane.get("1-9", { id: "bad-pane" }),
+      (error) => {
+        assert.ok(error instanceof HerdrApiError);
+        assert.equal(error.code, "pane_not_found");
+        assert.equal(error.response.error.message, "pane 1-9 not found");
+        return true;
+      },
+    );
+  });
+});
+
+test("streams subscription events after the subscription ack", async () => {
+  await withSocketServer(async ({ socketPath, received, respondOnce }) => {
+    respondOnce(
+      {
+        id: "sub",
+        result: { type: "subscription_started" },
+      },
+      {
+        event: "pane.agent_status_changed",
+        data: {
+          pane_id: "1-1",
+          workspace_id: "w1",
+          agent_status: "done",
+          agent: "codex",
+        },
+      },
+    );
+
+    const client = createHerdrClient({ socketPath });
+    const subscription = await client.events.subscribe(
+      {
+        subscriptions: [
+          {
+            type: "pane.agent_status_changed",
+            pane_id: "1-1",
+            agent_status: "done",
+          },
+        ],
+      },
+      { id: "sub" },
+    );
+
+    assert.deepEqual(await received, {
+      id: "sub",
+      method: "events.subscribe",
+      params: {
+        subscriptions: [
+          {
+            type: "pane.agent_status_changed",
+            pane_id: "1-1",
+            agent_status: "done",
+          },
+        ],
+      },
+    });
+
+    assert.deepEqual(subscription.ack.result, { type: "subscription_started" });
+    assert.deepEqual(await subscription.nextEvent(), {
+      event: "pane.agent_status_changed",
+      data: {
+        pane_id: "1-1",
+        workspace_id: "w1",
+        agent_status: "done",
+        agent: "codex",
+      },
+    });
+    subscription.close();
+  });
+});
+
+test("times out while waiting for a response when requested", async () => {
+  await withSocketServer(async ({ socketPath }) => {
+    const client = createHerdrClient({ socketPath });
+    await assert.rejects(
+      () => client.request("ping", {}, { id: "slow", timeoutMs: 10 }),
+      (error) => {
+        assert.ok(error instanceof HerdrTimeoutError);
+        return true;
+      },
+    );
+  });
+});
+
+async function withSocketServer(run) {
+  const dir = await mkdtemp(join(tmpdir(), "herdr-sdk-"));
+  const socketPath = join(dir, "herdr.sock");
+  const responses = [];
+  let receivedResolve;
+  const received = new Promise((resolve) => {
+    receivedResolve = resolve;
+  });
+
+  const server = createServer((socket) => {
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      const newline = buffer.indexOf("\n");
+      if (newline === -1) {
+        return;
+      }
+
+      const line = buffer.slice(0, newline);
+      receivedResolve(JSON.parse(line));
+
+      const response = responses.shift();
+      if (!response) {
+        return;
+      }
+
+      for (const message of response) {
+        socket.write(`${JSON.stringify(message)}\n`);
+      }
+    });
+  });
+
+  server.listen(socketPath);
+  await once(server, "listening");
+
+  try {
+    await run({
+      socketPath,
+      received,
+      respondOnce: (...messages) => responses.push(messages),
+    });
+  } finally {
+    server.close();
+    await once(server, "close");
+    await rm(dir, { force: true, recursive: true });
+  }
+}

--- a/sdk/typescript/test/schema-parity.test.mjs
+++ b/sdk/typescript/test/schema-parity.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const sdkRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const repoRoot = dirname(dirname(sdkRoot));
+
+test("typed method map covers the Rust socket Method enum", async () => {
+  const [rustSchema, sdkSource] = await Promise.all([readRustSchema(), readSdkSource()]);
+
+  assert.deepEqual(
+    extractRustSerdeRenames(rustEnumBody(rustSchema, "Method")),
+    extractTsMapKeys(tsTypeBody(sdkSource, "HerdrMethodParams")),
+  );
+});
+
+test("typed subscriptions cover the Rust Subscription enum", async () => {
+  const [rustSchema, sdkSource] = await Promise.all([readRustSchema(), readSdkSource()]);
+
+  assert.deepEqual(
+    extractRustSerdeRenames(rustEnumBody(rustSchema, "Subscription")),
+    extractTsSubscriptionTypes(sdkSource),
+  );
+});
+
+test("typed response discriminants cover the Rust ResponseResult enum", async () => {
+  const [rustSchema, sdkSource] = await Promise.all([readRustSchema(), readSdkSource()]);
+
+  assert.deepEqual(
+    extractRustVariantNames(rustEnumBody(rustSchema, "ResponseResult")).map(toSnakeCase).sort(),
+    extractTsResultTypes(sdkSource),
+  );
+});
+
+async function readRustSchema() {
+  return readFile(join(repoRoot, "src/api/schema.rs"), "utf8");
+}
+
+async function readSdkSource() {
+  return readFile(join(sdkRoot, "src/index.ts"), "utf8");
+}
+
+function rustEnumBody(source, enumName) {
+  const start = source.indexOf(`pub enum ${enumName} {`);
+  assert.notEqual(start, -1, `missing Rust enum ${enumName}`);
+
+  const bodyStart = source.indexOf("{", start) + 1;
+  let depth = 1;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") {
+      depth += 1;
+    } else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(bodyStart, index);
+      }
+    }
+  }
+
+  throw new Error(`unterminated Rust enum ${enumName}`);
+}
+
+function tsTypeBody(source, typeName) {
+  const start = source.indexOf(`export type ${typeName} = {`);
+  assert.notEqual(start, -1, `missing TypeScript type ${typeName}`);
+
+  const bodyStart = source.indexOf("{", start) + 1;
+  const bodyEnd = source.indexOf("\n};", bodyStart);
+  assert.notEqual(bodyEnd, -1, `unterminated TypeScript type ${typeName}`);
+  return source.slice(bodyStart, bodyEnd);
+}
+
+function extractRustSerdeRenames(body) {
+  return [...body.matchAll(/#\[serde\(rename = "([^"]+)"\)\]/g)]
+    .map((match) => match[1])
+    .sort();
+}
+
+function extractRustVariantNames(body) {
+  return [...body.matchAll(/^\s{4}([A-Z][A-Za-z0-9]*)\s*(?:\{|,)/gm)].map((match) => match[1]);
+}
+
+function extractTsMapKeys(body) {
+  return [...body.matchAll(/^\s{2}(?:"([^"]+)"|([a-z][a-z_]*)):/gm)]
+    .map((match) => match[1] ?? match[2])
+    .sort();
+}
+
+function extractTsSubscriptionTypes(source) {
+  const body = source.slice(
+    source.indexOf("export type Subscription ="),
+    source.indexOf("export interface EventsSubscribeParams"),
+  );
+  assert.ok(body.startsWith("export type Subscription ="), "missing TypeScript Subscription type");
+
+  return [...body.matchAll(/type: "([^"]+)"/g)].map((match) => match[1]).sort();
+}
+
+function extractTsResultTypes(source) {
+  const body = source.slice(
+    source.indexOf("export interface PongResult"),
+    source.indexOf("export type HerdrMethodParams"),
+  );
+  assert.ok(body.startsWith("export interface PongResult"), "missing TypeScript result interfaces");
+
+  return [...body.matchAll(/type: "([^"]+)"/g)].map((match) => match[1]).sort();
+}
+
+function toSnakeCase(value) {
+  return value.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}

--- a/sdk/typescript/test/typecheck.ts
+++ b/sdk/typescript/test/typecheck.ts
@@ -1,0 +1,37 @@
+import { createHerdrClient, type HerdrApiError, type OutputMatchedResult } from "../src/index.js";
+
+const herdr = createHerdrClient({ socketPath: "/tmp/herdr.sock" });
+
+async function compileTypedCalls() {
+  const pong = await herdr.request("ping", {});
+  pong.protocol satisfies number;
+
+  const read = await herdr.request("pane.read", {
+    pane_id: "1-1",
+    source: "recent",
+    lines: 80,
+  });
+  read.read.text satisfies string;
+
+  const output = await herdr.pane.waitForOutput({
+    pane_id: "1-1",
+    source: "recent",
+    match: { type: "substring", value: "ready" },
+    timeout_ms: 30_000,
+  });
+  output satisfies OutputMatchedResult;
+
+  const done = await herdr.pane.waitForAgentStatus("1-1", "done", {
+    timeoutMs: 60_000,
+  });
+  done.data.agent_status satisfies "idle" | "working" | "blocked" | "done" | "unknown";
+
+  try {
+    await herdr.workspace.rename("1", "api");
+  } catch (error) {
+    const maybeHerdrError = error as HerdrApiError;
+    maybeHerdrError.code satisfies string;
+  }
+}
+
+void compileTypedCalls;

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/sdk/typescript/tsconfig.test.json
+++ b/sdk/typescript/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a standalone `@herdr/sdk` TypeScript package for the existing newline-delimited JSON Unix socket API
- provide typed method/result/event shapes plus helpers for server, workspace, tab, pane, events, and integrations
- document the SDK and link it from the socket API docs

## Verification
- `npm test` in `sdk/typescript`
- `npm pack --dry-run` in `sdk/typescript`
- `git diff --cached --check` before commit

## Notes
- `just check` could not run locally because `just` is not installed
- direct Rust testing was blocked by missing `zig` for the vendored Ghostty VT build
