### PR TITLE
Detect Nix-wrapped Codex processes from argv0

### DIFF
--- a/src/detect.rs
+++ b/src/detect.rs
@@ -607,7 +607,25 @@ fn normalized_process_name(process: &crate::platform::ForegroundProcess) -> Stri
         }
     }
 
+    if identify_agent(effective).is_some() {
+        return effective.to_string();
+    }
+
+    if let Some(cmdline_name) = process
+        .cmdline
+        .as_deref()
+        .and_then(cmdline_executable_name)
+        .filter(|name| identify_agent(name).is_some())
+    {
+        return cmdline_name.to_string();
+    }
+
     effective.to_string()
+}
+
+fn cmdline_executable_name(cmdline: &str) -> Option<&str> {
+    let executable = cmdline.split_whitespace().next()?;
+    std::path::Path::new(executable).file_name()?.to_str()
 }
 
 fn wrapped_agent_name_from_cmdline(cmdline: &str) -> Option<String> {
@@ -724,6 +742,24 @@ mod tests {
                     cmdline: Some("bash".to_string()),
                 },
             ],
+        };
+
+        assert_eq!(
+            identify_agent_in_job(&job),
+            Some((Agent::Codex, "codex".to_string()))
+        );
+    }
+
+    #[test]
+    fn identify_agent_in_job_detects_nix_wrapped_codex_from_argv0() {
+        let job = crate::platform::ForegroundJob {
+            process_group_id: 123,
+            processes: vec![crate::platform::ForegroundProcess {
+                pid: 1,
+                name: ".codex-wrapped".to_string(),
+                argv0: None,
+                cmdline: Some("/etc/profiles/per-user/user/bin/codex".to_string()),
+            }],
         };
 
         assert_eq!(


### PR DESCRIPTION
On NixOS, the `codex` executable installed in the user profile can be a wrapper script. In the observed package, `/etc/profiles/per-user/user/bin/codex` ultimately points to a Nix store wrapper that runs:

```sh
exec -a "$0" ".../bin/.codex-wrapped" "$@"
```

That means Linux process metadata can look like this:

- `/proc/<pid>/stat` / `comm`: `.codex-wrapped`
- `/proc/<pid>/cmdline` argv0: `/etc/profiles/per-user/user/bin/codex`

Herdr currently identifies agents primarily from the process name, and only scans cmdline tokens for generic runtimes or shells such as `node`, `bash`, or `sh`. So wrappers like `node /path/to/bin/codex` are detected, but `.codex-wrapped` is not, even though argv0 still preserves the user-facing `codex` entrypoint.

This change keeps the existing generic runtime behavior, then falls back to checking the executable name from cmdline argv0. That lets Herdr recognize Nix-wrapped Codex without special-casing `.codex-wrapped`.
