### PR TITLE
fix(remote): keep bridge socket path under sun_path ceiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/vendor/libghostty-vt/zig-pkg/
 __pycache__/
 *.pyc
 *.swp

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -747,12 +747,47 @@ fn run_client_process(local_socket: &Path, reattach_command: &str) -> io::Result
 }
 
 fn local_forward_socket_path(target: &str, session_name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "herdr-remote-{}-{}-{}.sock",
-        std::process::id(),
-        sanitize_path_component(target),
-        sanitize_path_component(session_name)
-    ))
+    let pid = std::process::id();
+    let target_clean = sanitize_path_component(target);
+    let session_clean = sanitize_path_component(session_name);
+
+    let tmpdir = std::env::temp_dir();
+    let readable = tmpdir.join(format!(
+        "herdr-remote-{pid}-{target_clean}-{session_clean}.sock"
+    ));
+    if fits_unix_socket_path(&readable) {
+        return readable;
+    }
+
+    // macOS' per-user TMPDIR (~49 chars under /var/folders/...) can push the
+    // readable name past sun_path's 104-byte ceiling. Try a hashed short name
+    // in the same TMPDIR first, then drop to /tmp as a last resort for the
+    // rare case where TMPDIR itself is longer than the budget.
+    let target_prefix: String = target_clean.chars().take(8).collect();
+    let hash = short_socket_hash(&target_clean, &session_clean);
+    let short_name = format!("herdr-r-{pid}-{target_prefix}-{hash}.sock");
+    let short_in_tmp = tmpdir.join(&short_name);
+    if fits_unix_socket_path(&short_in_tmp) {
+        return short_in_tmp;
+    }
+    PathBuf::from("/tmp").join(short_name)
+}
+
+fn fits_unix_socket_path(path: &Path) -> bool {
+    // sun_path is 104 bytes on macOS and 108 on Linux; reserve 1 byte for the
+    // trailing NUL and use the smaller cap for portability.
+    const MAX: usize = 103;
+    path.as_os_str().as_encoded_bytes().len() <= MAX
+}
+
+fn short_socket_hash(target: &str, session: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    target.hash(&mut hasher);
+    0u8.hash(&mut hasher);
+    session.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 fn sanitize_path_component(input: &str) -> String {
@@ -922,6 +957,61 @@ mod tests {
             .expect("override source");
         assert_eq!(source.path, PathBuf::from("/tmp/herdr-aarch64"));
         assert!(source.temporary_dir.is_none());
+    }
+
+    fn remote_env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[test]
+    fn local_forward_socket_path_fits_in_sun_path() {
+        let _guard = remote_env_lock().lock().unwrap();
+        // Worst case for the readable form: macOS-style 49-char TMPDIR +
+        // max-length sanitized components. Should fall back to the hashed
+        // short name, which fits under TMPDIR.
+        let target = "mylinux.taile5417.ts.net";
+        let session = "a-fairly-long-session-name-here";
+        let path = local_forward_socket_path(target, session);
+        assert!(
+            fits_unix_socket_path(&path),
+            "socket path too long for sun_path: {} ({} bytes)",
+            path.display(),
+            path.as_os_str().as_encoded_bytes().len()
+        );
+    }
+
+    #[test]
+    fn local_forward_socket_path_falls_back_to_tmp_when_dir_is_long() {
+        let _guard = remote_env_lock().lock().unwrap();
+        // Force a TMPDIR long enough that even the hashed short name cannot
+        // fit inside it. The fallback should drop to /tmp.
+        let prior = std::env::var_os("TMPDIR");
+        let long_dir = std::env::temp_dir().join("a".repeat(80));
+        let _ = fs::create_dir_all(&long_dir);
+        std::env::set_var("TMPDIR", &long_dir);
+
+        let path = local_forward_socket_path("mylinux.taile5417.ts.net", "default");
+        let fits = fits_unix_socket_path(&path);
+        let parent = path.parent().map(Path::to_path_buf);
+        let filename = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        match prior {
+            Some(v) => std::env::set_var("TMPDIR", v),
+            None => std::env::remove_var("TMPDIR"),
+        }
+        let _ = fs::remove_dir_all(&long_dir);
+
+        assert!(fits, "fallback path still overflows: {}", path.display());
+        assert_eq!(parent.as_deref(), Some(Path::new("/tmp")));
+        assert!(
+            filename.starts_with("herdr-r-"),
+            "expected hashed fallback, got {filename}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`herdr --remote <target>` fails on macOS with:

```
Error: Error { kind: InvalidInput, message: "path must be shorter than SUN_LEN" }
```

`local_forward_socket_path` builds `{TMPDIR}/herdr-remote-{pid}-{target}-{session}.sock`. On macOS `std::env::temp_dir()` returns `/var/folders/.../T/` (~49 chars). A target name around 24 chars is enough to push the full path to 105 bytes — one over macOS' 104-byte `sun_path` ceiling — and `UnixListener::bind` rejects it.

Per-component sanitization (32-char cap each) wasn't enough because it ignored the directory prefix.

## Fix

`local_forward_socket_path` now picks the first form that fits in 103 bytes (leaving 1 for the trailing NUL, portable across macOS' 104 and Linux's 108):

1. Readable: `herdr-remote-{pid}-{target}-{session}.sock` in TMPDIR (unchanged when it fits).
2. Hashed: `herdr-r-{pid}-{target-prefix}-{8byte-hash}.sock` in TMPDIR (covers the macOS overflow case).
3. Last resort: same hashed name in `/tmp` (for the rare case where TMPDIR itself is longer than the budget).

## Test plan
- [x] `cargo test --bin herdr remote::tests::` — 16/16 pass, including two new cases that exercise both the typical overflow and the over-long-TMPDIR fallback.
- [x] End-to-end: `herdr --remote <target>` no longer errors at bind; the connection proceeds to SSH/handshake. The socket file is cleaned up on `Drop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)