### PR TITLE
fix(input): keep Ctrl+J on legacy byte under kitty kbd flag 1

### DIFF
--- a/src/input/encode.rs
+++ b/src/input/encode.rs
@@ -4,6 +4,7 @@ use super::{KeyboardProtocol, MouseProtocolEncoding, TerminalKey};
 
 const KITTY_FLAG_REPORT_EVENT_TYPES: u16 = 0b0000_0010;
 const KITTY_FLAG_REPORT_ALTERNATE_KEYS: u16 = 0b0000_0100;
+const KITTY_FLAG_REPORT_ALL_KEYS_AS_ESCAPE_CODES: u16 = 0b0000_1000;
 
 /// Encode a key event for a PTY child using the pane's negotiated keyboard protocol.
 #[allow(dead_code)] // exercised in input unit tests; production uses PaneRuntime helpers
@@ -148,6 +149,30 @@ fn try_encode_csi_u(key: &TerminalKey, flags: u16) -> Option<Vec<u8>> {
 
     // Unmodified keys use legacy encoding (more compatible)
     if mods.is_empty() {
+        return None;
+    }
+
+    // Ghostty's default `keybind = shift+enter=text:\n` injects a raw 0x0a
+    // byte on Shift+Enter, bypassing the kitty keyboard protocol entirely.
+    // crossterm reads that byte as Ctrl+J (since 0x0a is historically ^J).
+    // If we re-encode Ctrl+J as CSI-u here, the inner app sees a literal
+    // Ctrl+J event and cannot recover the original Shift+Enter intent.
+    //
+    // Modern Node-based TUIs (pi-tui, Claude Code, Ink, ...) treat a bare
+    // `\n` as Shift+Enter whenever the kitty keyboard protocol is active,
+    // matching what ghostty itself ships out for that keybind. Preserve
+    // that round-trip by emitting the legacy byte for Ctrl+J unless the
+    // inner app has explicitly opted into REPORT_ALL_KEYS_AS_ESCAPE_CODES,
+    // which is the documented signal that it wants every key as CSI-u.
+    //
+    // Limited to Ctrl+J on purpose: this is the only ambiguity Ghostty's
+    // default keybinds create today, and it conflates real Ctrl+J
+    // keystrokes with Shift+Enter (acceptable since Ctrl+J is essentially
+    // never wired as a distinct action in modern TUIs).
+    if matches!(key.code, KeyCode::Char('j'))
+        && mods == KeyModifiers::CONTROL
+        && flags & KITTY_FLAG_REPORT_ALL_KEYS_AS_ESCAPE_CODES == 0
+    {
         return None;
     }
 
@@ -569,6 +594,46 @@ mod tests {
         assert_eq!(
             encode_key(key, KeyboardProtocol::Kitty { flags: 1 }),
             b"\x1b[13;2u"
+        );
+    }
+
+    #[test]
+    fn kitty_ctrl_j_round_trips_as_lf_byte() {
+        // Ghostty's default `keybind = shift+enter=text:\n` injects 0x0a,
+        // which crossterm reads as Ctrl+J. With kitty kbd flags 1|2|4 (the
+        // common pi-tui / Claude Code negotiation), we must NOT re-encode
+        // Ctrl+J as a CSI-u sequence — otherwise inner Node TUIs see
+        // Ctrl+J instead of Shift+Enter. Preserve the legacy byte.
+        let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        assert_eq!(encode_key(key, KeyboardProtocol::Kitty { flags: 1 }), b"\n");
+        assert_eq!(encode_key(key, KeyboardProtocol::Kitty { flags: 7 }), b"\n");
+    }
+
+    #[test]
+    fn kitty_ctrl_j_uses_csi_u_when_report_all_keys_is_set() {
+        // When the inner app explicitly opts into
+        // REPORT_ALL_KEYS_AS_ESCAPE_CODES (flag 8) it asked for every key
+        // as CSI-u, so emit the disambiguated form for Ctrl+J too.
+        let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        let flags = 1 | 2 | 4 | 8; // disambiguate + event types + alt keys + report all
+        assert_eq!(
+            encode_key(key, KeyboardProtocol::Kitty { flags }),
+            b"\x1b[106;5:1u"
+        );
+    }
+
+    #[test]
+    fn kitty_ctrl_shift_j_still_uses_csi_u() {
+        // Ctrl+Shift+J cannot collide with Ghostty's shift+enter keybind
+        // (that sends a bare \n, not a Ctrl+Shift+J event). Keep the
+        // disambiguated CSI-u so apps can bind it as a distinct shortcut.
+        let key = KeyEvent::new(
+            KeyCode::Char('j'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+        assert_eq!(
+            encode_key(key, KeyboardProtocol::Kitty { flags: 1 }),
+            b"\x1b[106;6u"
         );
     }
 


### PR DESCRIPTION
## Summary

Keep `Ctrl+J` on its legacy byte (`\n` / `0x0a`) when the inner pane has the kitty keyboard protocol active, unless the inner app explicitly opts into `REPORT_ALL_KEYS_AS_ESCAPE_CODES` (flag 8). Restores Shift+Enter for any inner TUI that pushes the kitty kbd protocol while running under herdr in Ghostty.

## Symptom

Inside a herdr pane in Ghostty:

- **Claude Code, Codex**: Shift+Enter inserts a newline. ✅
- **pi (`@earendil-works/pi-coding-agent`)**: Shift+Enter does **nothing**. ❌

Bare ghostty (no herdr in the middle) is fine for all three.

## Root cause

Three layers stack here. The bug only fires when all three line up.

### 1. Ghostty rewrites Shift+Enter to a raw `\n`

Ghostty ships with a default keybind:

```
keybind = shift+enter=text:\n
```

That bypasses the kitty keyboard protocol entirely and injects a raw `0x0a` byte for Shift+Enter, regardless of what kbd protocol the foreground app has pushed.

Confirmed with `stty raw -echo; cat | xxd -c1`:

```
Shift+Enter -> 0a
Enter       -> 0d
```

### 2. herdr (via crossterm) reads `0x0a` as a Ctrl+J KeyEvent

When that `\n` reaches herdr's outer stdin, crossterm reports it as
`KeyCode::Char('j')` + `KeyModifiers::CONTROL` — because `0x0a` is
historically `^J`. There's no provenance bit to distinguish "real Ctrl+J
keystroke" from "Ghostty's `shift+enter=text:\n` injection."

This is already covered by an existing unit test in
`src/input/parse.rs`:

```rust
#[test]
fn parse_legacy_lf_sequence_as_ctrl_j() {
    let key = parse_terminal_key_sequence("\n").unwrap();
    assert_eq!(key.code, KeyCode::Char('j'));
    assert_eq!(key.modifiers, KeyModifiers::CONTROL);
}
```

### 3. herdr's kitty-mode encoder over-eagerly emits CSI-u

`try_encode_csi_u` in `src/input/encode.rs` re-encodes any character key
with modifiers as a CSI-u sequence whenever the inner pane has any
kitty flags negotiated. With pi-tui's default push of `\e[>7u`
(flags = 1|2|4: disambiguate + report event types + alternate keys),
herdr emits:

```
Ctrl+J  ->  \e[106;5:1u
```

The inner app then sees a literal Ctrl+J event, not Shift+Enter.

### Why Claude Code and Codex were fine

They don't push the kitty keyboard protocol on their pane, so herdr's
encoder stays in `KeyboardProtocol::Legacy`. The legacy encoder
correctly returns `0x0a` for Ctrl+J, which both apps already treat as
Shift+Enter / newline-insert. They never engaged the kitty path, so
they never saw the over-eager CSI-u encoding.

### Why this is also a spec drift

Per the kitty keyboard protocol, `ctrl+letter` combos that have an
established legacy ASCII control-byte representation should keep that
legacy encoding under the basic flags. They only switch to CSI-u when
the inner app explicitly sets `REPORT_ALL_KEYS_AS_ESCAPE_CODES` (flag 8).
herdr's encoder was switching too early.

## Fix

Add an early return at the top of `try_encode_csi_u`: when the key is
`Ctrl+J` (only `CONTROL`, no other modifiers) **and** the kitty flags
do **not** include `REPORT_ALL_KEYS_AS_ESCAPE_CODES`, fall through to
the legacy encoder so the byte goes out as `0x0a`.

Scope was kept tight to `Ctrl+J` on purpose — that is the only
ambiguity Ghostty's default keybinds create today. A broader fix
covering all `ctrl+letter` combos under flag-1-only would be more
spec-compliant but has more behavioural surface; happy to do that in a
follow-up if you'd prefer. The current change is intentionally
surgical.

There is one acceptable trade-off: a genuine `Ctrl+J` keystroke now
also surfaces as `0x0a` (i.e. Shift+Enter) in inner apps with kitty
flags 1/2/4. That matches what bare Ghostty already does and what
pretty much every modern TUI assumes for `Ctrl+J`.

## Investigation steps (for reviewers)

1. Reproduced the symptom in pi under herdr in Ghostty.
2. Confirmed Ghostty sends `0x0a` for Shift+Enter (`stty raw -echo; cat | xxd -c1`).
3. Walked pi-tui's source (installed at `node_modules/@earendil-works/pi-tui/dist/`) to confirm:
   - It pushes `\e[>7u` after detecting kitty kbd support, and
   - It explicitly maps a bare `\n` to Shift+Enter when `_kittyProtocolActive` is true (see [`keys.js`](https://github.com/...) — comment literally reads `// \n = Ghostty's "keybind = shift+enter=text:\n"`).
4. Verified the herdr ↔ libghostty-vt round-trip works by sending `\e[?u` and observing `\e[?0u` come back via the `write_pty` callback.
5. Patched pi-tui's `setupStdinBuffer` to log every stdin chunk to a file, ran pi inside a herdr pane in Ghostty, and pressed Shift+Enter. Pi-tui received:
   ```
   CHUNK "\u001b[106;5:1u" kittyActive=true
   ```
   i.e. CSI-u for Ctrl+J — not a bare `\n`. That is the smoking gun for the encoder bug.
6. Implemented the fix in `try_encode_csi_u`, rebuilt herdr, re-ran pi inside the new binary in monolithic mode, and verified Shift+Enter now inserts a newline.

## Tests

Three new unit tests in `src/input/encode.rs`:

- `kitty_ctrl_j_round_trips_as_lf_byte` — Ctrl+J under flags `1` and `7` produces `b"\n"`.
- `kitty_ctrl_j_uses_csi_u_when_report_all_keys_is_set` — Ctrl+J under flags `1|2|4|8` still produces `b"\x1b[106;5:1u"`.
- `kitty_ctrl_shift_j_still_uses_csi_u` — `Ctrl+Shift+J` keeps CSI-u (`\x1b[106;6u`), since it cannot collide with Ghostty's `shift+enter=text:\n`.

Full suite: `cargo test --locked` — 931 tests pass, 0 failures.
Lint: `cargo clippy --all-targets --locked -- -D warnings` — clean.
Format: `cargo fmt --check` — clean.
Maintenance scripts: `python3 -m unittest scripts.test_changelog scripts.test_vendor_libghostty_vt` — 18 pass.

## Manual verification

Built the release binary from this branch and ran it as
`herdr --no-session` inside Ghostty.

- `pi` → Shift+Enter inserts newline ✅
- Plain Enter → submits ✅
- Claude Code → unchanged ✅ (it was never on the kitty path)

## Out of scope / follow-ups

- Broader spec compliance for the other `ctrl+letter` combos under
  flag-1-only could be done as a separate change. The current fix
  intentionally only addresses the Ghostty Shift+Enter surface.
- This does not change herdr's outward-facing kbd protocol push, only
  what it encodes for the inner pane.
