### PR TITLE
feat: add Scheduled agent state for armed background wakeups

### DIFF
--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -684,6 +684,7 @@ pub enum EventData {
 pub enum PaneAgentState {
     Idle,
     Working,
+    Scheduled,
     Blocked,
     Unknown,
 }
@@ -693,6 +694,7 @@ pub enum PaneAgentState {
 pub enum AgentStatus {
     Idle,
     Working,
+    Scheduled,
     Blocked,
     Done,
     Unknown,
@@ -741,6 +743,14 @@ mod tests {
         let json = serde_json::to_string(&request).unwrap();
         let restored: Request = serde_json::from_str(&json).unwrap();
         assert_eq!(restored, request);
+    }
+
+    #[test]
+    fn pane_agent_state_scheduled_serializes_as_snake_case() {
+        let json = serde_json::to_string(&PaneAgentState::Scheduled).unwrap();
+        assert_eq!(json, "\"scheduled\"");
+        let restored: PaneAgentState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, PaneAgentState::Scheduled);
     }
 
     #[test]

--- a/src/app/api_helpers.rs
+++ b/src/app/api_helpers.rs
@@ -1,8 +1,9 @@
 pub(super) fn tab_attention_priority(state: crate::detect::AgentState, seen: bool) -> u8 {
     match (state, seen) {
-        (crate::detect::AgentState::Blocked, _) => 4,
-        (crate::detect::AgentState::Idle, false) => 3,
-        (crate::detect::AgentState::Working, _) => 2,
+        (crate::detect::AgentState::Blocked, _) => 5,
+        (crate::detect::AgentState::Idle, false) => 4,
+        (crate::detect::AgentState::Working, _) => 3,
+        (crate::detect::AgentState::Scheduled, _) => 2,
         (crate::detect::AgentState::Idle, true) => 1,
         (crate::detect::AgentState::Unknown, _) => 0,
     }
@@ -62,6 +63,7 @@ pub(super) fn detect_state_from_api(
     match state {
         crate::api::schema::PaneAgentState::Idle => crate::detect::AgentState::Idle,
         crate::api::schema::PaneAgentState::Working => crate::detect::AgentState::Working,
+        crate::api::schema::PaneAgentState::Scheduled => crate::detect::AgentState::Scheduled,
         crate::api::schema::PaneAgentState::Blocked => crate::detect::AgentState::Blocked,
         crate::api::schema::PaneAgentState::Unknown => crate::detect::AgentState::Unknown,
     }
@@ -75,6 +77,7 @@ pub(super) fn pane_agent_status(
         (crate::detect::AgentState::Idle, false) => crate::api::schema::AgentStatus::Done,
         (crate::detect::AgentState::Idle, true) => crate::api::schema::AgentStatus::Idle,
         (crate::detect::AgentState::Working, _) => crate::api::schema::AgentStatus::Working,
+        (crate::detect::AgentState::Scheduled, _) => crate::api::schema::AgentStatus::Scheduled,
         (crate::detect::AgentState::Blocked, _) => crate::api::schema::AgentStatus::Blocked,
         (crate::detect::AgentState::Unknown, _) => crate::api::schema::AgentStatus::Unknown,
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1399,11 +1399,12 @@ fn parse_agent_status(value: &str) -> std::io::Result<AgentStatus> {
     match value {
         "idle" => Ok(AgentStatus::Idle),
         "working" => Ok(AgentStatus::Working),
+        "scheduled" => Ok(AgentStatus::Scheduled),
         "blocked" => Ok(AgentStatus::Blocked),
         "done" => Ok(AgentStatus::Done),
         "unknown" => Ok(AgentStatus::Unknown),
         _ => Err(std::io::Error::other(format!(
-            "invalid agent status: {value} (expected idle, working, blocked, done, or unknown)"
+            "invalid agent status: {value} (expected idle, working, scheduled, blocked, done, or unknown)"
         ))),
     }
 }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -10,6 +10,9 @@ pub enum AgentState {
     Idle,
     /// Agent is actively working/processing.
     Working,
+    /// Agent has armed a background cron / scheduled wakeup and is
+    /// dormant until it fires. Reported only via hook authority.
+    Scheduled,
     /// Agent needs human input and is blocked on a response.
     Blocked,
     /// Plain shell or unrecognized program.

--- a/src/ui/mobile.rs
+++ b/src/ui/mobile.rs
@@ -820,11 +820,13 @@ fn agent_priority_label(app: &AppState) -> String {
     };
     let mut blocked = 0usize;
     let mut working = 0usize;
+    let mut scheduled = 0usize;
     let mut done = 0usize;
     for detail in ws.pane_details() {
         match (detail.state, detail.seen) {
             (AgentState::Blocked, _) => blocked += 1,
             (AgentState::Working, _) => working += 1,
+            (AgentState::Scheduled, _) => scheduled += 1,
             (AgentState::Idle, false) => done += 1,
             _ => {}
         }
@@ -835,6 +837,8 @@ fn agent_priority_label(app: &AppState) -> String {
         format!(" {working} working")
     } else if done > 0 {
         format!(" {done} done")
+    } else if scheduled > 0 {
+        format!(" ⏱ {scheduled} scheduled")
     } else {
         " all idle".to_string()
     }

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -101,6 +101,7 @@ pub(super) fn state_dot(state: AgentState, seen: bool, p: &Palette) -> (&'static
     match (state, seen) {
         (AgentState::Blocked, _) => ("●", Style::default().fg(p.red)),
         (AgentState::Working, _) => ("●", Style::default().fg(p.yellow)),
+        (AgentState::Scheduled, _) => ("●", Style::default().fg(p.mauve)),
         (AgentState::Idle, false) => ("●", Style::default().fg(p.teal)),
         (AgentState::Idle, true) => ("○", Style::default().fg(p.green)),
         (AgentState::Unknown, _) => ("·", Style::default().fg(p.overlay0)),
@@ -116,6 +117,7 @@ pub(super) fn agent_icon(
     match (state, seen) {
         (AgentState::Blocked, _) => ("◉", Style::default().fg(p.red)),
         (AgentState::Working, _) => (super::spinner_frame(tick), Style::default().fg(p.yellow)),
+        (AgentState::Scheduled, _) => ("⏱", Style::default().fg(p.mauve)),
         (AgentState::Idle, false) => ("●", Style::default().fg(p.teal)),
         (AgentState::Idle, true) => ("✓", Style::default().fg(p.green)),
         (AgentState::Unknown, _) => ("○", Style::default().fg(p.overlay0)),
@@ -126,6 +128,7 @@ pub(super) fn state_label(state: AgentState, seen: bool) -> &'static str {
     match (state, seen) {
         (AgentState::Blocked, _) => "blocked",
         (AgentState::Working, _) => "working",
+        (AgentState::Scheduled, _) => "scheduled",
         (AgentState::Idle, false) => "done",
         (AgentState::Idle, true) => "idle",
         (AgentState::Unknown, _) => "idle",
@@ -136,6 +139,7 @@ pub(super) fn state_label_color(state: AgentState, seen: bool, p: &Palette) -> C
     match (state, seen) {
         (AgentState::Blocked, _) => p.red,
         (AgentState::Working, _) => p.yellow,
+        (AgentState::Scheduled, _) => p.mauve,
         (AgentState::Idle, false) => p.teal,
         (AgentState::Idle, true) => p.green,
         (AgentState::Unknown, _) => p.overlay0,

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -1,10 +1,12 @@
 use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
+    text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
 
+use super::status::state_dot;
 use super::widgets::panel_contrast_fg;
 use crate::app::AppState;
 
@@ -325,8 +327,23 @@ pub(super) fn render_tab_bar(app: &AppState, frame: &mut Frame, area: Rect) {
         };
         let width = rect.width as usize;
         let name = tab.display_name();
-        let text = format!(" {:width$}", name, width = width.saturating_sub(1));
-        frame.render_widget(Paragraph::new(text).style(style), rect);
+        if let Some((state, seen)) = tab.attention_state() {
+            let (dot, base_dot_style) = state_dot(state, seen, p);
+            let dot_style = match style.bg {
+                Some(bg) => base_dot_style.bg(bg),
+                None => base_dot_style,
+            };
+            let name_text = format!("{:width$}", name, width = width.saturating_sub(3));
+            let line = Line::from(vec![
+                Span::styled(" ", style),
+                Span::styled(dot, dot_style),
+                Span::styled(format!(" {name_text}"), style),
+            ]);
+            frame.render_widget(Paragraph::new(line), rect);
+        } else {
+            let text = format!(" {:width$}", name, width = width.saturating_sub(1));
+            frame.render_widget(Paragraph::new(text).style(style), rect);
+        }
     }
 
     if let Some(crate::app::state::DragState {

--- a/src/workspace/aggregate.rs
+++ b/src/workspace/aggregate.rs
@@ -23,6 +23,17 @@ impl Tab {
             .any(|pane| pane.state == AgentState::Working)
     }
 
+    /// Highest-priority pane state in this tab, used to drive the tab-strip
+    /// visual indicator. Returns `None` if no pane warrants an indicator
+    /// (all panes Unknown or Idle-seen).
+    pub fn attention_state(&self) -> Option<(AgentState, bool)> {
+        self.panes
+            .values()
+            .map(|pane| (pane.state, pane.seen))
+            .max_by_key(|(state, seen)| pane_attention_priority(*state, *seen))
+            .filter(|(state, seen)| pane_attention_priority(*state, *seen) >= 2)
+    }
+
     pub fn pane_details(&self) -> Vec<PaneDetail> {
         self.layout
             .pane_ids()
@@ -47,9 +58,10 @@ impl Tab {
 
 fn pane_attention_priority(state: AgentState, seen: bool) -> u8 {
     match (state, seen) {
-        (AgentState::Blocked, _) => 4,
-        (AgentState::Idle, false) => 3,
-        (AgentState::Working, _) => 2,
+        (AgentState::Blocked, _) => 5,
+        (AgentState::Idle, false) => 4,
+        (AgentState::Working, _) => 3,
+        (AgentState::Scheduled, _) => 2,
         (AgentState::Idle, true) => 1,
         (AgentState::Unknown, _) => 0,
     }
@@ -115,6 +127,74 @@ mod tests {
         let (state, seen) = ws.aggregate_state();
         assert_eq!(state, AgentState::Working);
         assert!(seen);
+    }
+
+    #[test]
+    fn aggregate_state_working_beats_scheduled() {
+        let mut ws = Workspace::test_new("test");
+        let id2 = ws.test_split(Direction::Horizontal);
+        let root_id = ws.tabs[0]
+            .panes
+            .keys()
+            .find(|id| **id != id2)
+            .copied()
+            .unwrap();
+        ws.tabs[0].panes.get_mut(&root_id).unwrap().state = AgentState::Scheduled;
+        ws.tabs[0].panes.get_mut(&id2).unwrap().state = AgentState::Working;
+
+        let (state, _) = ws.aggregate_state();
+        assert_eq!(state, AgentState::Working);
+    }
+
+    #[test]
+    fn aggregate_state_scheduled_beats_idle_seen() {
+        let mut ws = Workspace::test_new("test");
+        let id2 = ws.test_split(Direction::Horizontal);
+        let root_id = ws.tabs[0]
+            .panes
+            .keys()
+            .find(|id| **id != id2)
+            .copied()
+            .unwrap();
+        ws.tabs[0].panes.get_mut(&root_id).unwrap().state = AgentState::Idle;
+        ws.tabs[0].panes.get_mut(&id2).unwrap().state = AgentState::Scheduled;
+
+        let (state, _) = ws.aggregate_state();
+        assert_eq!(state, AgentState::Scheduled);
+    }
+
+    #[test]
+    fn attention_state_surfaces_scheduled() {
+        let mut ws = Workspace::test_new("test");
+        let root_id = ws.tabs[0].root_pane;
+        ws.tabs[0].panes.get_mut(&root_id).unwrap().state = AgentState::Scheduled;
+
+        let attention = ws.tabs[0].attention_state();
+        assert_eq!(attention, Some((AgentState::Scheduled, true)));
+    }
+
+    #[test]
+    fn attention_state_none_for_idle_seen_tab() {
+        let ws = Workspace::test_new("test");
+        // Default pane state is Unknown + seen=true; nothing to surface.
+        assert_eq!(ws.tabs[0].attention_state(), None);
+    }
+
+    #[test]
+    fn attention_state_blocked_beats_scheduled() {
+        let mut ws = Workspace::test_new("test");
+        let id2 = ws.test_split(Direction::Horizontal);
+        let root_id = ws.tabs[0]
+            .panes
+            .keys()
+            .find(|id| **id != id2)
+            .copied()
+            .unwrap();
+        ws.tabs[0].panes.get_mut(&root_id).unwrap().state = AgentState::Scheduled;
+        ws.tabs[0].panes.get_mut(&id2).unwrap().state = AgentState::Blocked;
+
+        let attention = ws.tabs[0].attention_state();
+        assert_eq!(attention, Some((AgentState::Blocked, true)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new `AgentState::Scheduled` variant for panes that have armed a background cron / scheduled wakeup and are currently dormant until it fires. This surfaces externally-armed work (e.g. Claude's `ScheduleWakeup` / `CronCreate`) so the user can see at a glance that a tab is dormant-but-not-done — closing it would lose the wakeup.

**Reported only via hook authority** (`pane.report_agent`) — not derivable from terminal output. The detector keeps the existing 4-state model; `Scheduled` is purely hook-driven.

## Visual changes

- **Sidebar agent panel:** mauve dot in `state_dot`, "⏱" icon in `agent_icon`, "scheduled" label.
- **Tab strip:** new per-tab attention dot. Previously tabs had no state coloring — only `active` / `auto-named` styling. Now each tab gets a leading colored dot driven by `Tab::attention_state()` when any pane is in a non-trivial state (Scheduled, Working, Blocked, Done-unseen).
- **Mobile bar:** "⏱ N scheduled" bucket shown when no higher-priority bucket has activity.

## Priority

Attention priority slots `Scheduled` between `Idle-seen` and `Working` — present but dormant, less urgent than active work. Order is now: `Unknown < Idle-seen < Scheduled < Working < Done-unseen < Blocked`.

## Notifications

No new toasts or sounds. Transitions into `Scheduled` fall through the existing wildcards in `notification_*_for_state_change`, so they're silent. Subsequent transitions from `Scheduled` to `Working` (cron fires), `Blocked` (cron fires + needs input), or `Idle-unseen` (done) follow the existing notification rules.

## Files

- `src/detect.rs` — new variant.
- `src/api/schema.rs` — `PaneAgentState::Scheduled`, `AgentStatus::Scheduled` (+ round-trip test).
- `src/app/api_helpers.rs` — wire conversion + status mapping + `tab_attention_priority`.
- `src/cli.rs` — accept `scheduled` in `parse_agent_status`.
- `src/ui/status.rs` — dot/icon/label/color for the new state (mauve).
- `src/ui/tabs.rs` — render per-tab attention dot via new `attention_state()`.
- `src/ui/mobile.rs` — add `scheduled` counter to the mobile priority label.
- `src/workspace/aggregate.rs` — `Tab::attention_state()` + extend priority + tests.

## Test plan

- [ ] CI: `just ci` (clippy + nextest)
- [ ] Manual: arm a Claude `/loop` or `ScheduleWakeup` in a herdr pane, verify the tab strip + sidebar show the mauve dot and "scheduled" label
- [ ] Manual: confirm no toast/sound when state transitions into `Scheduled`
- [ ] Manual: confirm the tab dot disappears when the wakeup fires and the pane goes back to `Working`/`Idle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)