### PR TITLE
feat: add independent filesystem panel to sidebar

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -386,9 +386,10 @@ impl AppState {
             return;
         }
 
-        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+        let (_, detail_area, _) = crate::ui::expanded_sidebar_sections(
             self.view.sidebar_rect,
             self.sidebar_section_split,
+            self.files_section_split,
         );
         let metrics = crate::ui::agent_panel_scroll_metrics(self, detail_area);
         let visible = metrics.viewport_rows;

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -226,6 +226,56 @@ impl AppState {
             }
         }
     }
+
+    /// Open a file from the filesystem panel by splitting the active
+    /// workspace's focused pane with `$VISUAL`/`$EDITOR` (falling back to vi).
+    pub(crate) fn open_path_in_pane(&mut self, path: &std::path::Path) {
+        let Some(ws_idx) = self.active else {
+            return;
+        };
+        let (rows, cols) = self.estimate_pane_size();
+        let new_rows = (rows / 2).max(4);
+        let new_cols = (cols / 2).max(10);
+
+        let editor = std::env::var("VISUAL")
+            .or_else(|_| std::env::var("EDITOR"))
+            .unwrap_or_else(|_| "vi".to_string());
+        let mut argv: Vec<String> = editor.split_whitespace().map(|s| s.to_string()).collect();
+        if argv.is_empty() {
+            argv.push("vi".to_string());
+        }
+        argv.push(path.to_string_lossy().into_owned());
+
+        let cwd = path.parent().map(|p| p.to_path_buf());
+
+        let Some(ws) = self.workspaces.get_mut(ws_idx) else {
+            return;
+        };
+        let Some(focused) = ws.focused_pane_id() else {
+            return;
+        };
+        let Some(Ok((_, new_pane))) = ws.split_pane_argv_command(
+            focused,
+            Direction::Horizontal,
+            new_rows,
+            new_cols,
+            cwd,
+            &argv,
+            self.pane_scrollback_limit_bytes,
+            self.host_terminal_theme,
+            true,
+        ) else {
+            return;
+        };
+        let new_id = new_pane.pane_id;
+        self.terminal_runtimes
+            .insert(new_pane.terminal.id.clone(), new_pane.runtime);
+        self.terminals
+            .insert(new_pane.terminal.id.clone(), new_pane.terminal);
+        ws.layout.focus_pane(new_id);
+        self.mark_session_dirty();
+        self.mode = Mode::Terminal;
+    }
 }
 
 #[cfg(test)]
@@ -295,6 +345,7 @@ fn capture_snapshot(state: &AppState) -> crate::persist::SessionSnapshot {
         state.agent_panel_scope,
         state.sidebar_width,
         state.sidebar_section_split,
+        state.files_section_split,
     )
 }
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -210,6 +210,14 @@ impl AppState {
                     return None;
                 }
 
+                if self.on_files_section_divider(mouse.column, mouse.row) {
+                    self.drag = Some(DragState {
+                        target: DragTarget::FilesSectionDivider,
+                    });
+                    self.set_files_section_split(mouse.row);
+                    return None;
+                }
+
                 if !in_sidebar {
                     if let Some(border) = self.find_border_at(mouse.column, mouse.row) {
                         self.drag = Some(DragState {
@@ -363,6 +371,26 @@ impl AppState {
                         self.mode = Mode::Terminal;
                         return None;
                     }
+
+                    if let Some(target) =
+                        self.files_panel_scrollbar_target_at(mouse.column, mouse.row)
+                    {
+                        if let ScrollbarClickTarget::Track { offset_from_bottom } = target {
+                            self.set_files_panel_offset_from_bottom(offset_from_bottom);
+                        }
+                        return None;
+                    }
+
+                    if let Some(target) = self.files_row_at(mouse.column, mouse.row) {
+                        if target.is_dir {
+                            if !self.files_expanded.remove(&target.path) {
+                                self.files_expanded.insert(target.path);
+                            }
+                        } else {
+                            self.open_path_in_pane(&target.path);
+                        }
+                        return None;
+                    }
                 } else if let Some(info) = self.pane_at(mouse.column, mouse.row).cloned() {
                     self.focus_pane(info.id);
                     if self.mode != Mode::Terminal {
@@ -514,6 +542,9 @@ impl AppState {
                         DragTarget::SidebarSectionDivider => {
                             self.set_sidebar_section_split(mouse.row);
                         }
+                        DragTarget::FilesSectionDivider => {
+                            self.set_files_section_split(mouse.row);
+                        }
                         DragTarget::ReleaseNotesScrollbar { .. }
                         | DragTarget::KeybindHelpScrollbar { .. } => {}
                     }
@@ -622,11 +653,18 @@ impl AppState {
             }
 
             MouseEventKind::ScrollUp if in_sidebar => {
+                let files_area = self.files_panel_rect();
+                let over_files_panel = files_area != Rect::default()
+                    && mouse.row >= files_area.y
+                    && mouse.row < files_area.y + files_area.height;
                 let agent_area = self.agent_panel_rect();
-                let over_agent_panel = agent_area != Rect::default()
+                let over_agent_panel = !over_files_panel
+                    && agent_area != Rect::default()
                     && mouse.row >= agent_area.y
                     && mouse.row < agent_area.y + agent_area.height;
-                if over_agent_panel {
+                if over_files_panel {
+                    self.scroll_files_panel(-1);
+                } else if over_agent_panel {
                     if crate::ui::should_show_scrollbar(crate::ui::agent_panel_scroll_metrics(
                         self, agent_area,
                     )) {
@@ -642,11 +680,18 @@ impl AppState {
                 }
             }
             MouseEventKind::ScrollDown if in_sidebar => {
+                let files_area = self.files_panel_rect();
+                let over_files_panel = files_area != Rect::default()
+                    && mouse.row >= files_area.y
+                    && mouse.row < files_area.y + files_area.height;
                 let agent_area = self.agent_panel_rect();
-                let over_agent_panel = agent_area != Rect::default()
+                let over_agent_panel = !over_files_panel
+                    && agent_area != Rect::default()
                     && mouse.row >= agent_area.y
                     && mouse.row < agent_area.y + agent_area.height;
-                if over_agent_panel {
+                if over_files_panel {
+                    self.scroll_files_panel(1);
+                } else if over_agent_panel {
                     if crate::ui::should_show_scrollbar(crate::ui::agent_panel_scroll_metrics(
                         self, agent_area,
                     )) {

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -18,9 +18,25 @@ impl AppState {
         if self.sidebar_collapsed || sidebar.width <= 1 || sidebar.height == 0 {
             return Rect::default();
         }
-        let (_, detail_area) =
-            crate::ui::expanded_sidebar_sections(sidebar, self.sidebar_section_split);
+        let (_, detail_area, _) = crate::ui::expanded_sidebar_sections(
+            sidebar,
+            self.sidebar_section_split,
+            self.files_section_split,
+        );
         detail_area
+    }
+
+    pub(super) fn files_panel_rect(&self) -> Rect {
+        let sidebar = self.view.sidebar_rect;
+        if self.sidebar_collapsed || sidebar.width <= 1 || sidebar.height == 0 {
+            return Rect::default();
+        }
+        let (_, _, files_area) = crate::ui::expanded_sidebar_sections(
+            sidebar,
+            self.sidebar_section_split,
+            self.files_section_split,
+        );
+        files_area
     }
 
     pub(super) fn workspace_list_scrollbar_target_at(
@@ -154,6 +170,66 @@ impl AppState {
         }
     }
 
+    pub(super) fn files_panel_scrollbar_target_at(
+        &self,
+        col: u16,
+        row: u16,
+    ) -> Option<ScrollbarClickTarget> {
+        let area = self.files_panel_rect();
+        let metrics = crate::ui::files_panel_scroll_metrics(self, area);
+        let track = crate::ui::files_panel_scrollbar_rect(self, area)?;
+        if col < track.x
+            || col >= track.x + track.width
+            || row < track.y
+            || row >= track.y + track.height
+        {
+            return None;
+        }
+        if let Some(grab_row_offset) = crate::ui::scrollbar_thumb_grab_offset(metrics, track, row) {
+            Some(ScrollbarClickTarget::Thumb { grab_row_offset })
+        } else {
+            Some(ScrollbarClickTarget::Track {
+                offset_from_bottom: crate::ui::scrollbar_offset_from_row(metrics, track, row),
+            })
+        }
+    }
+
+    pub(super) fn set_files_panel_offset_from_bottom(&mut self, offset_from_bottom: usize) {
+        let area = self.files_panel_rect();
+        let metrics = crate::ui::files_panel_scroll_metrics(self, area);
+        self.files_scroll = metrics
+            .max_offset_from_bottom
+            .saturating_sub(offset_from_bottom);
+    }
+
+    pub(super) fn scroll_files_panel(&mut self, delta: i16) {
+        let area = self.files_panel_rect();
+        let max_scroll = crate::ui::files_panel_scroll_metrics(self, area).max_offset_from_bottom;
+        if delta.is_negative() {
+            self.files_scroll = self
+                .files_scroll
+                .saturating_sub(delta.unsigned_abs() as usize);
+        } else {
+            self.files_scroll = self
+                .files_scroll
+                .saturating_add(delta as usize)
+                .min(max_scroll);
+        }
+    }
+
+    /// The filesystem-panel row under the cursor, if any.
+    pub(super) fn files_row_at(
+        &self,
+        col: u16,
+        row: u16,
+    ) -> Option<crate::app::state::FilesRowArea> {
+        self.view
+            .files_rows
+            .iter()
+            .find(|r| row == r.rect.y && col >= r.rect.x && col < r.rect.x + r.rect.width)
+            .cloned()
+    }
+
     pub(crate) fn sidebar_footer_rect(&self) -> Rect {
         let ws_area = self.workspace_list_rect();
         if ws_area == Rect::default() {
@@ -274,6 +350,43 @@ impl AppState {
         let relative_y = row.saturating_sub(sidebar.y);
         let ratio = (relative_y as f32) / (content_height as f32);
         self.sidebar_section_split = ratio.clamp(0.1, 0.9);
+        self.mark_session_dirty();
+    }
+
+    pub(super) fn on_files_section_divider(&self, col: u16, row: u16) -> bool {
+        if self.sidebar_collapsed {
+            return false;
+        }
+        let rect = crate::ui::files_section_divider_rect(
+            self.view.sidebar_rect,
+            self.sidebar_section_split,
+            self.files_section_split,
+        );
+        rect.width > 0
+            && col >= rect.x
+            && col < rect.x + rect.width
+            && row >= rect.y
+            && row < rect.y + rect.height
+    }
+
+    pub(super) fn set_files_section_split(&mut self, row: u16) {
+        let sidebar = self.view.sidebar_rect;
+        let (_, agent_area, _) = crate::ui::expanded_sidebar_sections(
+            sidebar,
+            self.sidebar_section_split,
+            self.files_section_split,
+        );
+        let lower_top = agent_area.y;
+        let lower_bottom = sidebar.y + sidebar.height;
+        let lower_h = lower_bottom.saturating_sub(lower_top);
+        if lower_h == 0 {
+            return;
+        }
+        // The divider row becomes the top of the files panel, so files take
+        // everything from `row` down to the bottom of the lower region.
+        let files_h = lower_bottom.saturating_sub(row);
+        let ratio = (files_h as f32) / (lower_h as f32);
+        self.files_section_split = ratio.clamp(0.1, 0.9);
         self.mark_session_dirty();
     }
 
@@ -400,9 +513,10 @@ impl AppState {
             return false;
         }
 
-        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+        let (_, detail_area, _) = crate::ui::expanded_sidebar_sections(
             self.view.sidebar_rect,
             self.sidebar_section_split,
+            self.files_section_split,
         );
         let rect = crate::ui::agent_panel_toggle_rect(detail_area, self.agent_panel_scope);
         rect.width > 0
@@ -682,9 +796,10 @@ mod tests {
         app.state.mode = Mode::Terminal;
         app.state.agent_panel_scroll = 3;
 
-        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+        let (_, detail_area, _) = crate::ui::expanded_sidebar_sections(
             app.state.view.sidebar_rect,
             app.state.sidebar_section_split,
+            app.state.files_section_split,
         );
         let toggle = crate::ui::agent_panel_toggle_rect(detail_area, app.state.agent_panel_scope);
         app.handle_mouse(mouse(
@@ -737,9 +852,10 @@ mod tests {
         app.state.mode = Mode::Terminal;
         app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
 
-        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+        let (_, detail_area, _) = crate::ui::expanded_sidebar_sections(
             app.state.view.sidebar_rect,
             app.state.sidebar_section_split,
+            app.state.files_section_split,
         );
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
@@ -1263,6 +1379,39 @@ mod tests {
         assert_eq!(
             snapshot.sidebar_section_split,
             Some(app.state.sidebar_section_split)
+        );
+    }
+
+    #[test]
+    fn dragging_files_section_divider_resizes_and_persists() {
+        let mut app = app_for_mouse_test();
+        // A tall sidebar so the files panel is shown and its divider exists.
+        app.state.view.sidebar_rect = ratatui::layout::Rect::new(0, 0, 26, 40);
+
+        let divider = crate::ui::files_section_divider_rect(
+            app.state.view.sidebar_rect,
+            app.state.sidebar_section_split,
+            app.state.files_section_split,
+        );
+        assert!(divider.width > 0, "files divider should be visible");
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            divider.x + 1,
+            divider.y,
+        ));
+        // Drag the divider up → files panel grows.
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            divider.x + 1,
+            divider.y - 4,
+        ));
+
+        assert!(app.state.files_section_split > 0.35);
+        let snapshot = capture_snapshot(&app.state);
+        assert_eq!(
+            snapshot.files_section_split,
+            Some(app.state.files_section_split)
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -217,6 +217,7 @@ impl App {
             sidebar_width,
             sidebar_width_source,
             sidebar_section_split,
+            files_section_split,
         ) = if no_session {
             (
                 Vec::new(),
@@ -226,6 +227,7 @@ impl App {
                 config.ui.sidebar_width,
                 state::SidebarWidthSource::ConfigDefault,
                 0.5_f32,
+                0.35_f32,
             )
         } else if let Some(snap) = crate::persist::load() {
             let (ws, terminals, terminal_runtimes) = crate::persist::restore(
@@ -253,6 +255,7 @@ impl App {
                         state::SidebarWidthSource::ConfigDefault
                     },
                     snap.sidebar_section_split.unwrap_or(0.5),
+                    snap.files_section_split.unwrap_or(0.35),
                 )
             } else {
                 crate::logging::session_restored(ws.len(), "ok");
@@ -270,6 +273,7 @@ impl App {
                         state::SidebarWidthSource::ConfigDefault
                     },
                     snap.sidebar_section_split.unwrap_or(0.5),
+                    snap.files_section_split.unwrap_or(0.35),
                 )
             }
         } else {
@@ -281,6 +285,7 @@ impl App {
                 config.ui.sidebar_width,
                 state::SidebarWidthSource::ConfigDefault,
                 0.5_f32,
+                0.35_f32,
             )
         };
 
@@ -340,6 +345,8 @@ impl App {
             keybind_help: state::KeybindHelpState { scroll: 0 },
             workspace_scroll: 0,
             agent_panel_scroll: 0,
+            files_expanded: std::collections::HashSet::new(),
+            files_scroll: 0,
             tab_scroll: 0,
             tab_scroll_follow_active: true,
             mobile_switcher_scroll: 0,
@@ -347,6 +354,7 @@ impl App {
                 layout: state::ViewLayout::Desktop,
                 sidebar_rect: Rect::default(),
                 workspace_card_areas: Vec::new(),
+                files_rows: Vec::new(),
                 tab_bar_rect: Rect::default(),
                 tab_hit_areas: Vec::new(),
                 tab_scroll_left_hit_area: Rect::default(),
@@ -379,6 +387,7 @@ impl App {
             sidebar_width_auto: false,
             sidebar_collapsed: false,
             sidebar_section_split,
+            files_section_split,
             agent_panel_scope,
             mouse_capture: config.ui.mouse_capture,
             confirm_close: config.ui.confirm_close,

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -34,6 +34,7 @@ impl App {
                 self.state.agent_panel_scope,
                 self.state.sidebar_width,
                 self.state.sidebar_section_split,
+                self.state.files_section_split,
             );
             crate::persist::save(&snap);
         }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -511,6 +511,15 @@ pub struct WorkspaceCardArea {
     pub rect: Rect,
 }
 
+/// One visible row in the filesystem panel, used for click hit-testing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesRowArea {
+    pub path: std::path::PathBuf,
+    pub is_dir: bool,
+    pub depth: u16,
+    pub rect: Rect,
+}
+
 /// Computed view geometry — derived from AppState + terminal size.
 /// Updated before each render, consumed by render and mouse handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -523,6 +532,7 @@ pub struct ViewState {
     pub layout: ViewLayout,
     pub sidebar_rect: Rect,
     pub workspace_card_areas: Vec<WorkspaceCardArea>,
+    pub files_rows: Vec<FilesRowArea>,
     pub tab_bar_rect: Rect,
     pub tab_hit_areas: Vec<Rect>,
     pub tab_scroll_left_hit_area: Rect,
@@ -703,6 +713,7 @@ pub(crate) enum DragTarget {
     },
     SidebarDivider,
     SidebarSectionDivider,
+    FilesSectionDivider,
 }
 
 /// Active mouse drag on a split border or sidebar divider.
@@ -853,6 +864,9 @@ pub struct AppState {
     pub keybind_help: KeybindHelpState,
     pub workspace_scroll: usize,
     pub agent_panel_scroll: usize,
+    /// Directories the user has expanded in the filesystem panel.
+    pub files_expanded: std::collections::HashSet<std::path::PathBuf>,
+    pub files_scroll: usize,
     pub tab_scroll: usize,
     pub tab_scroll_follow_active: bool,
     pub mobile_switcher_scroll: usize,
@@ -883,6 +897,8 @@ pub struct AppState {
     pub sidebar_collapsed: bool,
     /// Ratio of sidebar height allocated to the workspaces section.
     pub sidebar_section_split: f32,
+    /// Ratio of the lower (non-spaces) region allocated to the files panel.
+    pub files_section_split: f32,
     pub agent_panel_scope: AgentPanelScope,
     /// Capture mouse input for Herdr's own mouse UI. When false, Herdr only
     /// captures mouse while the focused pane app requests mouse reporting.
@@ -1084,6 +1100,8 @@ impl AppState {
             keybind_help: KeybindHelpState { scroll: 0 },
             workspace_scroll: 0,
             agent_panel_scroll: 0,
+            files_expanded: std::collections::HashSet::new(),
+            files_scroll: 0,
             tab_scroll: 0,
             tab_scroll_follow_active: true,
             mobile_switcher_scroll: 0,
@@ -1091,6 +1109,7 @@ impl AppState {
                 layout: ViewLayout::Desktop,
                 sidebar_rect: Rect::default(),
                 workspace_card_areas: Vec::new(),
+                files_rows: Vec::new(),
                 tab_bar_rect: Rect::default(),
                 tab_hit_areas: Vec::new(),
                 tab_scroll_left_hit_area: Rect::default(),
@@ -1123,6 +1142,7 @@ impl AppState {
             sidebar_width_auto: false,
             sidebar_collapsed: false,
             sidebar_section_split: 0.5,
+            files_section_split: 0.35,
             agent_panel_scope: AgentPanelScope::AllWorkspaces,
             mouse_capture: true,
             confirm_close: true,

--- a/src/persist/io.rs
+++ b/src/persist/io.rs
@@ -106,6 +106,7 @@ mod tests {
             agent_panel_scope: AgentPanelScope::CurrentWorkspace,
             sidebar_width: Some(26),
             sidebar_section_split: Some(0.5),
+            files_section_split: Some(0.35),
         }
     }
 

--- a/src/persist/snapshot.rs
+++ b/src/persist/snapshot.rs
@@ -25,6 +25,8 @@ pub struct SessionSnapshot {
     pub sidebar_width: Option<u16>,
     #[serde(default)]
     pub sidebar_section_split: Option<f32>,
+    #[serde(default)]
+    pub files_section_split: Option<f32>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -130,6 +132,8 @@ struct RawSessionSnapshot {
     sidebar_width: Option<u16>,
     #[serde(default)]
     sidebar_section_split: Option<f32>,
+    #[serde(default)]
+    files_section_split: Option<f32>,
 }
 
 fn migrate_snapshot(raw: RawSessionSnapshot) -> Result<SessionSnapshot, String> {
@@ -145,6 +149,7 @@ fn migrate_snapshot(raw: RawSessionSnapshot) -> Result<SessionSnapshot, String> 
         agent_panel_scope: raw.agent_panel_scope,
         sidebar_width: raw.sidebar_width,
         sidebar_section_split: raw.sidebar_section_split,
+        files_section_split: raw.files_section_split,
     })
 }
 
@@ -210,6 +215,7 @@ pub fn capture(
     agent_panel_scope: crate::app::state::AgentPanelScope,
     sidebar_width: u16,
     sidebar_section_split: f32,
+    files_section_split: f32,
 ) -> SessionSnapshot {
     SessionSnapshot {
         version: SNAPSHOT_VERSION,
@@ -222,6 +228,7 @@ pub fn capture(
         agent_panel_scope,
         sidebar_width: Some(sidebar_width),
         sidebar_section_split: Some(sidebar_section_split),
+        files_section_split: Some(files_section_split),
     }
 }
 
@@ -382,6 +389,7 @@ mod tests {
             state.agent_panel_scope,
             state.sidebar_width,
             state.sidebar_section_split,
+            state.files_section_split,
         )
     }
 
@@ -402,6 +410,7 @@ mod tests {
             agent_panel_scope: AgentPanelScope::CurrentWorkspace,
             sidebar_width: Some(26),
             sidebar_section_split: Some(0.5),
+            files_section_split: Some(0.35),
         };
         let json = serde_json::to_string(&snap).unwrap();
         let restored = parse_snapshot(&json).unwrap();
@@ -478,6 +487,7 @@ mod tests {
             agent_panel_scope: AgentPanelScope::CurrentWorkspace,
             sidebar_width: Some(26),
             sidebar_section_split: Some(0.5),
+            files_section_split: Some(0.35),
             version: SNAPSHOT_VERSION,
         };
 
@@ -803,6 +813,7 @@ mod tests {
             agent_panel_scope: AgentPanelScope::CurrentWorkspace,
             sidebar_width: Some(26),
             sidebar_section_split: Some(0.5),
+            files_section_split: Some(0.35),
         };
 
         let json = serde_json::to_string(&snap).unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,6 +6,7 @@ use ratatui::{
 };
 
 mod dialogs;
+mod files;
 mod keybind_help;
 mod menus;
 mod mobile;
@@ -20,6 +21,9 @@ mod tabs;
 mod widgets;
 
 use self::dialogs::{render_confirm_close_overlay, render_rename_overlay};
+pub(crate) use self::files::{
+    compute_files_rows, files_panel_scroll_metrics, files_panel_scrollbar_rect,
+};
 use self::keybind_help::render_keybind_help_overlay;
 use self::menus::{
     render_context_menu, render_global_launcher_menu, render_navigate_overlay,
@@ -53,8 +57,8 @@ pub(crate) use self::{
         agent_panel_body_rect, agent_panel_entries, agent_panel_scroll_metrics,
         agent_panel_scrollbar_rect, agent_panel_toggle_rect, collapsed_sidebar_sections,
         collapsed_sidebar_toggle_rect, compute_workspace_card_areas, expanded_sidebar_sections,
-        sidebar_section_divider_rect, workspace_drop_indicator_row, workspace_list_rect,
-        workspace_list_scroll_metrics, workspace_list_scrollbar_rect,
+        files_section_divider_rect, sidebar_section_divider_rect, workspace_drop_indicator_row,
+        workspace_list_rect, workspace_list_scroll_metrics, workspace_list_scrollbar_rect,
     },
 };
 pub(crate) use self::{
@@ -166,9 +170,15 @@ fn compute_view_internal(
         .workspace_scroll
         .min(app.workspaces.len().saturating_sub(1));
     if !app.sidebar_collapsed {
-        let (_, detail_area) = expanded_sidebar_sections(sidebar_area, app.sidebar_section_split);
+        let (_, detail_area, files_area) = expanded_sidebar_sections(
+            sidebar_area,
+            app.sidebar_section_split,
+            app.files_section_split,
+        );
         let max_agent_scroll = agent_panel_scroll_metrics(app, detail_area).max_offset_from_bottom;
         app.agent_panel_scroll = app.agent_panel_scroll.min(max_agent_scroll);
+        let max_files_scroll = files_panel_scroll_metrics(app, files_area).max_offset_from_bottom;
+        app.files_scroll = app.files_scroll.min(max_files_scroll);
     } else {
         app.agent_panel_scroll = 0;
     }
@@ -177,6 +187,12 @@ fn compute_view_internal(
         Vec::new()
     } else {
         compute_workspace_card_areas(app, sidebar_area)
+    };
+
+    let files_rows = if app.sidebar_collapsed {
+        Vec::new()
+    } else {
+        compute_files_rows(app, sidebar_area)
     };
 
     let tab_bar_view = app
@@ -215,6 +231,7 @@ fn compute_view_internal(
         layout: ViewLayout::Desktop,
         sidebar_rect: sidebar_area,
         workspace_card_areas,
+        files_rows,
         tab_bar_rect,
         tab_hit_areas: tab_bar_view.tab_hit_areas,
         tab_scroll_left_hit_area: tab_bar_view.scroll_left_hit_area,
@@ -272,6 +289,7 @@ fn compute_mobile_view(
         layout: ViewLayout::Mobile,
         sidebar_rect: Rect::default(),
         workspace_card_areas: Vec::new(),
+        files_rows: Vec::new(),
         tab_bar_rect: Rect::default(),
         tab_hit_areas: Vec::new(),
         tab_scroll_left_hit_area: Rect::default(),

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -1,0 +1,368 @@
+//! Filesystem panel — an independent file tree rendered at the bottom of the
+//! sidebar. Clicking a folder toggles it; clicking a file opens it in a pane.
+
+use std::path::{Path, PathBuf};
+
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::scrollbar::{render_scrollbar, should_show_scrollbar};
+use crate::app::state::{AppState, FilesRowArea, Mode};
+
+/// Header rows reserved at the top of the files panel (separator + title).
+pub(crate) const FILES_PANEL_HEADER_ROWS: u16 = 2;
+
+/// A directory entry returned by a [`DirReader`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileEntry {
+    pub name: String,
+    pub path: PathBuf,
+    pub is_dir: bool,
+}
+
+/// Reads a single directory's immediate children. Abstracted so the tree
+/// flattening logic can be unit-tested without touching the filesystem.
+pub(crate) trait DirReader {
+    fn read_dir(&self, path: &Path) -> Vec<FileEntry>;
+}
+
+/// Real filesystem reader: hides dotfiles and noisy build dirs, and sorts
+/// directories first, then alphabetically (case-insensitive).
+pub(crate) struct FsDirReader;
+
+fn is_noise(name: &str) -> bool {
+    name.starts_with('.') || matches!(name, "node_modules" | "target")
+}
+
+impl DirReader for FsDirReader {
+    fn read_dir(&self, path: &Path) -> Vec<FileEntry> {
+        let Ok(read) = std::fs::read_dir(path) else {
+            return Vec::new();
+        };
+        let mut entries: Vec<FileEntry> = read
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                if is_noise(&name) {
+                    return None;
+                }
+                let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                Some(FileEntry {
+                    name,
+                    path: e.path(),
+                    is_dir,
+                })
+            })
+            .collect();
+        sort_entries(&mut entries);
+        entries
+    }
+}
+
+pub(crate) fn sort_entries(entries: &mut [FileEntry]) {
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+}
+
+/// One flattened, visible node in the tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FlatNode {
+    pub path: PathBuf,
+    pub name: String,
+    pub is_dir: bool,
+    pub depth: u16,
+}
+
+/// Flatten the tree under `root` into the visible rows, descending only into
+/// directories present in `expanded`. Pure: filesystem access is via `reader`.
+pub(crate) fn flatten_visible<R: DirReader>(
+    root: &Path,
+    reader: &R,
+    expanded: &std::collections::HashSet<PathBuf>,
+) -> Vec<FlatNode> {
+    let mut out = Vec::new();
+    flatten_into(root, 0, reader, expanded, &mut out);
+    out
+}
+
+fn flatten_into<R: DirReader>(
+    dir: &Path,
+    depth: u16,
+    reader: &R,
+    expanded: &std::collections::HashSet<PathBuf>,
+    out: &mut Vec<FlatNode>,
+) {
+    // Guard against pathologically deep trees from a runaway expanded set.
+    if depth > 32 {
+        return;
+    }
+    for entry in reader.read_dir(dir) {
+        let is_dir = entry.is_dir;
+        let path = entry.path.clone();
+        out.push(FlatNode {
+            path: path.clone(),
+            name: entry.name,
+            is_dir,
+            depth,
+        });
+        if is_dir && expanded.contains(&path) {
+            flatten_into(&path, depth + 1, reader, expanded, out);
+        }
+    }
+}
+
+/// Directory the panel shows: the focused pane's current working directory in
+/// the relevant workspace (selected while navigating, otherwise active), so it
+/// follows the user as they switch panes or `cd`. Falls back to the workspace
+/// identity when the focused pane hasn't reported a cwd yet.
+fn files_root(app: &AppState) -> Option<PathBuf> {
+    let idx = if matches!(app.mode, Mode::Navigate) {
+        Some(app.selected)
+    } else {
+        app.active
+    }?;
+    let ws = app.workspaces.get(idx)?;
+    let tab = ws.active_tab()?;
+    tab.cwd_for_pane(tab.layout.focused(), &app.terminals, &app.terminal_runtimes)
+        .or_else(|| ws.resolved_identity_cwd_from(&app.terminals, &app.terminal_runtimes))
+}
+
+pub(crate) fn files_panel_body_rect(area: Rect, has_scrollbar: bool) -> Rect {
+    if area.width == 0 || area.height <= FILES_PANEL_HEADER_ROWS {
+        return Rect::default();
+    }
+    let body_y = area.y.saturating_add(FILES_PANEL_HEADER_ROWS);
+    let body_height = (area.y + area.height).saturating_sub(body_y);
+    let body_width = area.width.saturating_sub(u16::from(has_scrollbar));
+    Rect::new(area.x, body_y, body_width, body_height)
+}
+
+/// Compute the visible, hit-testable rows for the files panel given the full
+/// sidebar rect. Called once per render and cached on `ViewState`.
+pub(crate) fn compute_files_rows(app: &AppState, sidebar_area: Rect) -> Vec<FilesRowArea> {
+    let (_, _, files_area) = super::sidebar::expanded_sidebar_sections(
+        sidebar_area,
+        app.sidebar_section_split,
+        app.files_section_split,
+    );
+    files_rows_for_area(app, files_area, &FsDirReader)
+}
+
+pub(crate) fn files_rows_for_area<R: DirReader>(
+    app: &AppState,
+    files_area: Rect,
+    reader: &R,
+) -> Vec<FilesRowArea> {
+    if files_area.height <= FILES_PANEL_HEADER_ROWS || files_area.width == 0 {
+        return Vec::new();
+    }
+    let Some(root) = files_root(app) else {
+        return Vec::new();
+    };
+    let nodes = flatten_visible(&root, reader, &app.files_expanded);
+    let body = files_panel_body_rect(files_area, false);
+    if body.height == 0 {
+        return Vec::new();
+    }
+
+    let body_bottom = body.y + body.height;
+    (body.y..body_bottom)
+        .zip(nodes.into_iter().skip(app.files_scroll))
+        .map(|(y, node)| FilesRowArea {
+            path: node.path,
+            is_dir: node.is_dir,
+            depth: node.depth,
+            rect: Rect::new(body.x, y, body.width, 1),
+        })
+        .collect()
+}
+
+pub(crate) fn files_panel_scroll_metrics(
+    app: &AppState,
+    files_area: Rect,
+) -> crate::pane::ScrollMetrics {
+    let body = files_panel_body_rect(files_area, false);
+    let viewport_rows = body.height as usize;
+    let total_rows = match files_root(app) {
+        Some(root) => flatten_visible(&root, &FsDirReader, &app.files_expanded).len(),
+        None => 0,
+    };
+    let max_offset_from_bottom = total_rows.saturating_sub(viewport_rows);
+    let offset_from_bottom = total_rows
+        .saturating_sub(app.files_scroll)
+        .saturating_sub(viewport_rows);
+    crate::pane::ScrollMetrics {
+        offset_from_bottom,
+        max_offset_from_bottom,
+        viewport_rows,
+    }
+}
+
+pub(crate) fn files_panel_scrollbar_rect(app: &AppState, files_area: Rect) -> Option<Rect> {
+    let metrics = files_panel_scroll_metrics(app, files_area);
+    let body = files_panel_body_rect(files_area, true);
+    (should_show_scrollbar(metrics) && body.width > 0 && body.height > 0).then_some(Rect::new(
+        files_area.x + files_area.width.saturating_sub(1),
+        body.y,
+        1,
+        body.height,
+    ))
+}
+
+pub(super) fn render_files_panel(app: &AppState, frame: &mut Frame, area: Rect) {
+    if area.height <= FILES_PANEL_HEADER_ROWS || area.width == 0 {
+        return;
+    }
+    let p = &app.palette;
+
+    let dragging = matches!(
+        app.drag.as_ref().map(|d| &d.target),
+        Some(crate::app::state::DragTarget::FilesSectionDivider)
+    );
+    super::sidebar::render_section_divider(
+        frame,
+        Rect::new(area.x, area.y, area.width, 1),
+        dragging,
+        p,
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            " files",
+            Style::default().fg(p.overlay0).add_modifier(Modifier::BOLD),
+        )])),
+        Rect::new(area.x, area.y + 1, area.width, 1),
+    );
+
+    let metrics = files_panel_scroll_metrics(app, area);
+    let scrollbar_rect = files_panel_scrollbar_rect(app, area);
+
+    for row in &app.view.files_rows {
+        let indent = " ".repeat(row.depth as usize * 2);
+        let glyph = if row.is_dir {
+            if app.files_expanded.contains(&row.path) {
+                "▾ "
+            } else {
+                "▸ "
+            }
+        } else {
+            "  "
+        };
+        let name = row
+            .path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let name_color = if row.is_dir { p.subtext0 } else { p.overlay0 };
+        let avail = (row.rect.width as usize).saturating_sub(indent.len() + 2);
+        let shown = if name.chars().count() > avail && avail > 1 {
+            format!("{}…", name.chars().take(avail - 1).collect::<String>())
+        } else {
+            name
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(indent, Style::default()),
+                Span::styled(
+                    glyph,
+                    Style::default().fg(if row.is_dir { p.accent } else { p.overlay0 }),
+                ),
+                Span::styled(shown, Style::default().fg(name_color)),
+            ])),
+            row.rect,
+        );
+    }
+
+    if let Some(track) = scrollbar_rect {
+        render_scrollbar(frame, metrics, track, p.surface_dim, p.overlay0, "▕");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    struct FakeFs(std::collections::HashMap<PathBuf, Vec<FileEntry>>);
+
+    impl DirReader for FakeFs {
+        fn read_dir(&self, path: &Path) -> Vec<FileEntry> {
+            self.0.get(path).cloned().unwrap_or_default()
+        }
+    }
+
+    fn entry(parent: &str, name: &str, is_dir: bool) -> FileEntry {
+        FileEntry {
+            name: name.to_string(),
+            path: PathBuf::from(parent).join(name),
+            is_dir,
+        }
+    }
+
+    #[test]
+    fn collapsed_root_lists_only_top_level() {
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            PathBuf::from("/r"),
+            vec![entry("/r", "src", true), entry("/r", "a.txt", false)],
+        );
+        map.insert(
+            PathBuf::from("/r/src"),
+            vec![entry("/r/src", "lib.rs", false)],
+        );
+        let fs = FakeFs(map);
+
+        let nodes = flatten_visible(Path::new("/r"), &fs, &HashSet::new());
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].name, "src");
+        assert_eq!(nodes[0].depth, 0);
+        assert_eq!(nodes[1].name, "a.txt");
+    }
+
+    #[test]
+    fn expanded_dir_descends_with_depth() {
+        let mut map = std::collections::HashMap::new();
+        map.insert(PathBuf::from("/r"), vec![entry("/r", "src", true)]);
+        map.insert(
+            PathBuf::from("/r/src"),
+            vec![entry("/r/src", "lib.rs", false)],
+        );
+        let fs = FakeFs(map);
+        let mut expanded = HashSet::new();
+        expanded.insert(PathBuf::from("/r/src"));
+
+        let nodes = flatten_visible(Path::new("/r"), &fs, &expanded);
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[1].name, "lib.rs");
+        assert_eq!(nodes[1].depth, 1);
+    }
+
+    #[test]
+    fn sort_puts_dirs_first_then_alpha() {
+        let mut v = vec![
+            entry("/r", "Zed", false),
+            entry("/r", "alpha", true),
+            entry("/r", "beta", false),
+        ];
+        sort_entries(&mut v);
+        assert_eq!(v[0].name, "alpha");
+        assert_eq!(v[1].name, "beta");
+        assert_eq!(v[2].name, "Zed");
+    }
+
+    #[test]
+    fn body_rect_excludes_header_and_scrollbar() {
+        let area = Rect::new(0, 10, 20, 8);
+        let body = files_panel_body_rect(area, true);
+        assert_eq!(body, Rect::new(0, 12, 19, 6));
+    }
+}

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -44,16 +44,47 @@ fn sidebar_section_heights(total_h: u16, split_ratio: f32) -> (u16, u16) {
     (ws_h, detail_h)
 }
 
-pub(crate) fn expanded_sidebar_sections(area: Rect, split_ratio: f32) -> (Rect, Rect) {
+/// Split the lower (non-spaces) region into the agents area and a fixed-size
+/// files area at the very bottom. The files panel is only shown when the lower
+/// region is tall enough to host it without starving the agents list.
+const LOWER_MIN_AGENTS: u16 = 9;
+const LOWER_MIN_FILES: u16 = 6;
+
+fn lower_section_split(lower_h: u16, files_split: f32) -> (u16, u16) {
+    // Only carve a files panel when the lower region is tall enough to keep
+    // the agents list usable; on short sidebars agents take all of it.
+    if lower_h < LOWER_MIN_AGENTS + LOWER_MIN_FILES {
+        return (lower_h, 0);
+    }
+    let ratio = files_split.clamp(0.1, 0.9);
+    let files_h = ((lower_h as f32) * ratio).round() as u16;
+    let files_h = files_h.clamp(LOWER_MIN_FILES, lower_h - LOWER_MIN_AGENTS);
+    (lower_h - files_h, files_h)
+}
+
+/// Returns `(spaces_area, agents_area, files_area)`. `files_area` may have
+/// zero height when the sidebar is too short.
+pub(crate) fn expanded_sidebar_sections(
+    area: Rect,
+    split_ratio: f32,
+    files_split: f32,
+) -> (Rect, Rect, Rect) {
     let content = Rect::new(area.x, area.y, area.width.saturating_sub(1), area.height);
     if content.width == 0 || content.height == 0 {
-        return (Rect::default(), Rect::default());
+        return (Rect::default(), Rect::default(), Rect::default());
     }
 
-    let (ws_h, detail_h) = sidebar_section_heights(content.height, split_ratio);
+    let (ws_h, lower_h) = sidebar_section_heights(content.height, split_ratio);
+    let (agent_h, files_h) = lower_section_split(lower_h, files_split);
     let ws_area = Rect::new(content.x, content.y, content.width, ws_h);
-    let detail_area = Rect::new(content.x, content.y + ws_h, content.width, detail_h);
-    (ws_area, detail_area)
+    let agent_area = Rect::new(content.x, content.y + ws_h, content.width, agent_h);
+    let files_area = Rect::new(
+        content.x,
+        content.y + ws_h + agent_h,
+        content.width,
+        files_h,
+    );
+    (ws_area, agent_area, files_area)
 }
 
 pub(crate) fn sidebar_section_divider_rect(area: Rect, split_ratio: f32) -> Rect {
@@ -64,6 +95,44 @@ pub(crate) fn sidebar_section_divider_rect(area: Rect, split_ratio: f32) -> Rect
 
     let (ws_h, _) = sidebar_section_heights(content.height, split_ratio);
     Rect::new(content.x, content.y + ws_h, content.width, 1)
+}
+
+/// The draggable divider row between the agents and files panels. Empty when
+/// the files panel is hidden (sidebar too short).
+pub(crate) fn files_section_divider_rect(area: Rect, split_ratio: f32, files_split: f32) -> Rect {
+    let (_, _, files_area) = expanded_sidebar_sections(area, split_ratio, files_split);
+    if files_area.height == 0 || files_area.width == 0 {
+        return Rect::default();
+    }
+    Rect::new(files_area.x, files_area.y, files_area.width, 1)
+}
+
+/// Draw a section divider as a bright rule with a centered grip handle, so it
+/// reads as resizable instead of blending into the background. Turns the accent
+/// color while it is being dragged.
+pub(crate) fn render_section_divider(frame: &mut Frame, row: Rect, dragging: bool, p: &Palette) {
+    if row.width == 0 || row.height == 0 {
+        return;
+    }
+    let line_color = if dragging { p.accent } else { p.overlay1 };
+    let grip_color = if dragging { p.accent } else { p.text };
+    let grip = "⣿⣿⣿";
+    let grip_w = grip.chars().count() as u16;
+    let grip_x = row.x + row.width.saturating_sub(grip_w) / 2;
+    let buf = frame.buffer_mut();
+    for x in row.x..row.x + row.width {
+        buf[(x, row.y)].set_symbol("─");
+        buf[(x, row.y)].set_style(Style::default().fg(line_color));
+    }
+    for (i, ch) in grip.chars().enumerate() {
+        let gx = grip_x + i as u16;
+        if gx < row.x + row.width {
+            let mut tmp = [0u8; 4];
+            buf[(gx, row.y)].set_symbol(ch.encode_utf8(&mut tmp));
+            buf[(gx, row.y)]
+                .set_style(Style::default().fg(grip_color).add_modifier(Modifier::BOLD));
+        }
+    }
 }
 
 fn agent_panel_current_workspace_idx(app: &AppState) -> Option<usize> {
@@ -224,7 +293,8 @@ fn workspace_row_height(ws: &crate::workspace::Workspace) -> u16 {
 }
 
 pub(crate) fn workspace_list_rect(area: Rect, split_ratio: f32) -> Rect {
-    let (ws_area, _) = expanded_sidebar_sections(area, split_ratio);
+    // The spaces area is independent of the agents/files split ratio.
+    let (ws_area, _, _) = expanded_sidebar_sections(area, split_ratio, 0.5);
     ws_area
 }
 
@@ -556,10 +626,12 @@ pub(super) fn render_sidebar(app: &AppState, frame: &mut Frame, area: Rect) {
         buf[(sep_x, y)].set_style(sep_style);
     }
 
-    let (ws_area, detail_area) = expanded_sidebar_sections(area, app.sidebar_section_split);
+    let (ws_area, detail_area, files_area) =
+        expanded_sidebar_sections(area, app.sidebar_section_split, app.files_section_split);
 
     render_workspace_list(app, frame, ws_area, is_navigating);
     render_agent_detail(app, frame, detail_area);
+    super::files::render_files_panel(app, frame, files_area);
     render_sidebar_toggle(app, frame, area, false, p);
 }
 
@@ -755,11 +827,11 @@ fn render_agent_detail(app: &AppState, frame: &mut Frame, area: Rect) {
         return;
     }
 
-    let sep_line = "─".repeat(area.width as usize);
-    frame.render_widget(
-        Paragraph::new(Span::styled(&sep_line, Style::default().fg(p.surface_dim))),
-        Rect::new(area.x, area.y, area.width, 1),
+    let dragging = matches!(
+        app.drag.as_ref().map(|d| &d.target),
+        Some(crate::app::state::DragTarget::SidebarSectionDivider)
     );
+    render_section_divider(frame, Rect::new(area.x, area.y, area.width, 1), dragging, p);
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![Span::styled(
@@ -958,10 +1030,12 @@ mod tests {
 
     #[test]
     fn expanded_sidebar_sections_handle_tiny_heights() {
-        let (ws_area, detail_area) = expanded_sidebar_sections(Rect::new(0, 0, 20, 5), 0.9);
+        let (ws_area, detail_area, files_area) =
+            expanded_sidebar_sections(Rect::new(0, 0, 20, 5), 0.9, 0.35);
 
         assert_eq!(ws_area, Rect::new(0, 0, 19, 3));
         assert_eq!(detail_area, Rect::new(0, 3, 19, 2));
+        assert_eq!(files_area, Rect::new(0, 5, 19, 0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a third, independent **files** section at the bottom of the sidebar, separate from spaces and agents.

- Collapsible file tree rooted at the **focused pane's cwd**, so it follows the user as they switch panes or `cd`
- Click a folder to expand/collapse; click a file to open it in a new pane via `$VISUAL`/`$EDITOR` (falls back to `vi`)
- Wheel + scrollbar-track scrolling
- Functional **draggable agents/files divider** with a visible grip handle; the spaces/agents divider gets the same visible handle treatment for consistency
- `files_section_split` persisted in the session snapshot
- Auto-hidden on short sidebars so it never starves the agents list

## Implementation notes

- New `src/ui/files.rs` module; filesystem access behind a `DirReader` trait so the tree-flattening logic is unit-tested without disk
- Lazy by expansion (only expanded dirs are read); dotfiles / `node_modules` / `target` hidden
- Mirrors the existing spaces/agents divider plumbing (state, drag target, mouse handlers, snapshot persistence)

## Testing

- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- Unit tests: 929 passed (incl. new files-tree + divider-drag tests)
- Full integration suite: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)