### PR TITLE
feat: add windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix 0.31.2",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -386,7 +386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -407,6 +407,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -549,7 +555,9 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uds_windows",
  "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -774,7 +782,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -830,7 +838,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1265,7 +1273,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1493,6 +1501,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1762,6 +1783,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2054,12 +2086,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,14 @@ toml = "0.8"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 unicode-width = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+uds_windows = "1"
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Console",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_ProcessStatus",
+] }

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,9 @@ fn zig_target(target: &str) -> &str {
         "aarch64-unknown-linux-musl" => "aarch64-linux-musl",
         "x86_64-apple-darwin" => "x86_64-macos",
         "aarch64-apple-darwin" => "aarch64-macos",
+        "x86_64-pc-windows-msvc" => "x86_64-windows-msvc",
+        "aarch64-pc-windows-msvc" => "aarch64-windows-msvc",
+        "x86_64-pc-windows-gnu" => "x86_64-windows-gnu",
         other => panic!("unsupported target for libghostty-vt build: {other}"),
     }
 }
@@ -67,7 +70,18 @@ fn main() {
     if target.contains("apple-darwin") {
         let static_lib = lib_dir.join("libghostty-vt.a");
         println!("cargo:rustc-link-arg={}", static_lib.display());
+    } else if target.contains("windows") {
+        // zig emits `ghostty-vt.lib` (an import lib for the shipped DLL)
+        // and `ghostty-vt-static.lib` (the actual archive). Link the latter
+        // so the resulting herdr.exe has no ghostty-vt.dll dependency.
+        println!("cargo:rustc-link-lib=static=ghostty-vt-static");
     } else {
         println!("cargo:rustc-link-lib=static=ghostty-vt");
+    }
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=ws2_32");
+        println!("cargo:rustc-link-lib=userenv");
+        println!("cargo:rustc-link-lib=bcrypt");
+        println!("cargo:rustc-link-lib=ntdll");
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,7 +2,7 @@ pub mod schema;
 
 use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
+use crate::platform::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -1109,7 +1109,10 @@ fn error_response_json(id: String, code: &str, message: String) -> String {
     })
 }
 
-#[cfg(test)]
+// The integration tests below exercise raw UnixStream socketpairs and Unix
+// file permissions; they stay unix-gated. Windows coverage will need a
+// rewrite against named-pipe pair helpers.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixStream;
+use crate::platform::net::UnixStream;
 use std::time::Duration;
 
 use serde::Serialize;
@@ -179,10 +179,7 @@ fn read_server_runtime_status() -> std::io::Result<ServerRuntimeStatus> {
 }
 
 fn server_not_running_error(err: &std::io::Error) -> bool {
-    matches!(
-        err.kind(),
-        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
-    )
+    crate::platform::host::is_server_not_running_error(err)
 }
 
 fn option_label(value: Option<&str>) -> &str {

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -10,6 +10,7 @@
 //! - We avoid duplicating parsing logic in the client
 //! - Raw forwarding preserves all escape sequences faithfully
 
+#[cfg(not(windows))]
 use std::io::{self, Read};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -29,6 +30,7 @@ use super::ClientLoopEvent;
 /// This runs on a dedicated thread because stdin reading is blocking.
 /// The main loop receives the raw bytes and forwards them as
 /// `ClientMessage::Input` to the server.
+#[cfg(not(windows))]
 pub fn stdin_reader_loop(event_tx: mpsc::Sender<ClientLoopEvent>, should_quit: &Arc<AtomicBool>) {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
@@ -72,12 +74,117 @@ pub fn stdin_reader_loop(event_tx: mpsc::Sender<ClientLoopEvent>, should_quit: &
     }
 }
 
+/// Windows console doesn't deliver key/mouse events as byte sequences over
+/// stdin — they come as `INPUT_RECORD` structs and need `ReadConsoleInput`.
+/// crossterm wraps that as `event::read()` returning parsed [`Event`]s, so
+/// we read those, re-encode each event into the same VT escape sequence a
+/// Unix terminal would have produced, and feed it through the existing
+/// byte-oriented client-to-server pipeline.
+#[cfg(windows)]
+pub fn stdin_reader_loop(event_tx: mpsc::Sender<ClientLoopEvent>, should_quit: &Arc<AtomicBool>) {
+    use crossterm::event::{self, Event, KeyEventKind, MouseEventKind};
+
+    use crate::input::{
+        encode_mouse_button, encode_mouse_scroll, encode_terminal_key, KeyboardProtocol,
+        MouseProtocolEncoding, TerminalKey,
+    };
+
+    fn encode_into(batch: &mut Vec<u8>, event: Event) {
+        match event {
+            Event::Key(key) => {
+                if matches!(key.kind, KeyEventKind::Release) {
+                    return;
+                }
+                batch
+                    .extend_from_slice(&encode_terminal_key(TerminalKey::from(key), KeyboardProtocol::Legacy));
+            }
+            Event::Mouse(mouse) => {
+                let encoded = match mouse.kind {
+                    MouseEventKind::Down(_)
+                    | MouseEventKind::Up(_)
+                    | MouseEventKind::Drag(_) => encode_mouse_button(
+                        mouse.kind,
+                        mouse.column,
+                        mouse.row,
+                        mouse.modifiers,
+                        MouseProtocolEncoding::Sgr,
+                    ),
+                    MouseEventKind::ScrollUp
+                    | MouseEventKind::ScrollDown
+                    | MouseEventKind::ScrollLeft
+                    | MouseEventKind::ScrollRight => encode_mouse_scroll(
+                        mouse.kind,
+                        mouse.column,
+                        mouse.row,
+                        mouse.modifiers,
+                        MouseProtocolEncoding::Sgr,
+                    ),
+                    MouseEventKind::Moved => None,
+                };
+                if let Some(bytes) = encoded {
+                    batch.extend_from_slice(&bytes);
+                }
+            }
+            Event::Paste(text) => {
+                batch.extend_from_slice(b"\x1b[200~");
+                batch.extend_from_slice(text.as_bytes());
+                batch.extend_from_slice(b"\x1b[201~");
+            }
+            Event::FocusGained => batch.extend_from_slice(b"\x1b[I"),
+            Event::FocusLost => batch.extend_from_slice(b"\x1b[O"),
+            Event::Resize(_, _) => {}
+        }
+    }
+
+    let mut batch: Vec<u8> = Vec::with_capacity(128);
+
+    while !should_quit.load(Ordering::Acquire) {
+        // Block directly on the console event queue. crossterm wakes us
+        // immediately when a key/mouse/paste arrives, so there's no poll
+        // interval rounding the per-keystroke latency up.
+        let event = match event::read() {
+            Ok(event) => event,
+            Err(err) => {
+                tracing::warn!(?err, "crossterm event::read failed; stopping reader");
+                return;
+            }
+        };
+
+        if should_quit.load(Ordering::Acquire) {
+            return;
+        }
+
+        // Drain any already-queued events into the same batch so a burst
+        // of keystrokes round-trips as one ClientMessage::Input instead of
+        // N separate ones.
+        batch.clear();
+        encode_into(&mut batch, event);
+        while let Ok(true) = event::poll(std::time::Duration::from_secs(0)) {
+            match event::read() {
+                Ok(next) => encode_into(&mut batch, next),
+                Err(_) => break,
+            }
+        }
+
+        if batch.is_empty() {
+            continue;
+        }
+        if event_tx
+            .blocking_send(ClientLoopEvent::StdinInput(std::mem::take(&mut batch)))
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
 #[cfg(unix)]
 fn stdin_read_ready<R: AsRawFd>(reader: &R, timeout_ms: i32) -> Option<bool> {
     poll_read_ready(reader.as_raw_fd(), timeout_ms)
 }
 
 #[cfg(not(unix))]
+#[allow(dead_code)]
 fn stdin_read_ready<R>(_reader: &R, _timeout_ms: i32) -> Option<bool> {
     None
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,7 +17,7 @@ mod input;
 
 use std::collections::HashSet;
 use std::io::{self, Write as _};
-use std::os::unix::net::UnixStream;
+use crate::platform::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -217,20 +217,24 @@ fn setup_terminal_with_capabilities(
     mouse_capture: bool,
 ) -> io::Result<TerminalGuard> {
     ratatui::init();
+    let _ = crate::platform::terminal::enable_vt_input();
 
     if enable_client_protocols {
         if mouse_capture {
             execute!(io::stdout(), EnableMouseCapture)?;
-        } else {
+        } else if crate::platform::terminal::TOLERATES_UNMATCHED_MOUSE_DISABLE {
             execute!(io::stdout(), DisableMouseCapture)?;
         }
-        execute!(
-            io::stdout(),
-            EnableBracketedPaste,
-            EnableFocusChange,
-            PushKeyboardEnhancementFlags(crate::input::ime_compatible_keyboard_enhancement_flags())
-        )?;
-    } else {
+        execute!(io::stdout(), EnableBracketedPaste, EnableFocusChange)?;
+        if crate::platform::terminal::SUPPORTS_KEYBOARD_ENHANCEMENT {
+            execute!(
+                io::stdout(),
+                PushKeyboardEnhancementFlags(
+                    crate::input::ime_compatible_keyboard_enhancement_flags()
+                )
+            )?;
+        }
+    } else if crate::platform::terminal::TOLERATES_UNMATCHED_MOUSE_DISABLE {
         execute!(io::stdout(), DisableMouseCapture)?;
     }
 

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -14,12 +14,15 @@ pub fn app_dir_name() -> &'static str {
 
 pub fn config_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("XDG_CONFIG_HOME") {
-        PathBuf::from(dir).join(app_dir_name())
-    } else if let Ok(home) = std::env::var("HOME") {
-        PathBuf::from(home).join(format!(".config/{}", app_dir_name()))
-    } else {
-        PathBuf::from(format!("/tmp/{}", app_dir_name()))
+        return PathBuf::from(dir).join(app_dir_name());
     }
+    if let Ok(home) = std::env::var("HOME") {
+        return PathBuf::from(home).join(".config").join(app_dir_name());
+    }
+    if let Some(fallback) = crate::platform::host::fallback_config_dir(app_dir_name()) {
+        return fallback;
+    }
+    PathBuf::from(format!("/tmp/{}", app_dir_name()))
 }
 
 impl Config {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -995,6 +995,11 @@ fn make_executable(path: &Path) -> io::Result<()> {
         perms.set_mode(0o755);
         fs::set_permissions(path, perms)?;
     }
+    #[cfg(not(unix))]
+    {
+        // Windows infers executability from file extension; nothing to do.
+        let _ = path;
+    }
 
     Ok(())
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::io;
-use std::os::unix::fs::PermissionsExt;
-use std::os::unix::net::UnixStream;
 use std::path::Path;
+
+use crate::platform::net::UnixStream;
 
 pub(crate) fn prepare_socket_path(
     path: &Path,
@@ -40,7 +40,5 @@ pub(crate) fn prepare_socket_path(
 }
 
 pub(crate) fn restrict_socket_permissions(path: &Path, mode: u32) -> io::Result<()> {
-    let mut permissions = fs::metadata(path)?.permissions();
-    permissions.set_mode(mode);
-    fs::set_permissions(path, permissions)
+    crate::platform::host::restrict_socket_permissions(path, mode)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,17 +486,21 @@ fn main() -> io::Result<()> {
 
     let result = rt.block_on(async {
         let mut terminal = ratatui::init();
+        let _ = crate::platform::terminal::enable_vt_input();
         if config.ui.mouse_capture {
             execute!(io::stdout(), EnableMouseCapture)?;
-        } else {
+        } else if crate::platform::terminal::TOLERATES_UNMATCHED_MOUSE_DISABLE {
             execute!(io::stdout(), DisableMouseCapture)?;
         }
-        execute!(
-            io::stdout(),
-            EnableBracketedPaste,
-            EnableFocusChange,
-            PushKeyboardEnhancementFlags(crate::input::ime_compatible_keyboard_enhancement_flags())
-        )?;
+        execute!(io::stdout(), EnableBracketedPaste, EnableFocusChange)?;
+        if crate::platform::terminal::SUPPORTS_KEYBOARD_ENHANCEMENT {
+            execute!(
+                io::stdout(),
+                PushKeyboardEnhancementFlags(
+                    crate::input::ime_compatible_keyboard_enhancement_flags()
+                )
+            )?;
+        }
 
         // tmux doesn't understand kitty keyboard protocol push (\e[>1u).
         // It uses modifyOtherKeys mode to send CSI u sequences for modified keys.
@@ -529,13 +533,20 @@ fn main() -> io::Result<()> {
         if crate::kitty_graphics::is_enabled() {
             crate::kitty_graphics::clear_all_host_graphics()?;
         }
-        execute!(
-            io::stdout(),
-            PopKeyboardEnhancementFlags,
-            DisableFocusChange,
-            DisableBracketedPaste,
-            DisableMouseCapture
-        )?;
+        if crate::platform::terminal::SUPPORTS_KEYBOARD_ENHANCEMENT {
+            execute!(
+                io::stdout(),
+                PopKeyboardEnhancementFlags,
+                DisableFocusChange,
+                DisableBracketedPaste,
+                DisableMouseCapture
+            )?;
+        } else {
+            let _ = execute!(io::stdout(), DisableFocusChange, DisableBracketedPaste);
+            if config.ui.mouse_capture {
+                let _ = execute!(io::stdout(), DisableMouseCapture);
+            }
+        }
         ratatui::restore();
 
         // Drop app (and all workspaces/panes) before runtime shuts down

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -28,6 +28,8 @@ pub use self::{
 use crate::terminal::stabilize_agent_state;
 
 const RELEASE_REACQUIRE_SUPPRESSION: std::time::Duration = std::time::Duration::from_secs(1);
+
+use crate::platform::host::{default_login_shell, shell_command_runner};
 const PANE_TERM: &str = "xterm-256color";
 const PANE_COLORTERM: &str = "truecolor";
 
@@ -271,7 +273,7 @@ impl PaneRuntime {
         render_notify: Arc<Notify>,
         render_dirty: Arc<AtomicBool>,
     ) -> std::io::Result<Self> {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+        let shell = default_login_shell();
         let mut cmd = CommandBuilder::new(&shell);
         cmd.cwd(cwd);
         cmd.env(crate::HERDR_ENV_VAR, crate::HERDR_ENV_VALUE);
@@ -304,8 +306,9 @@ impl PaneRuntime {
         render_notify: Arc<Notify>,
         render_dirty: Arc<AtomicBool>,
     ) -> std::io::Result<Self> {
-        let mut cmd = CommandBuilder::new("/bin/sh");
-        cmd.arg("-c");
+        let (shell, c_flag) = shell_command_runner();
+        let mut cmd = CommandBuilder::new(shell);
+        cmd.arg(c_flag);
         cmd.arg(command);
         cmd.cwd(cwd);
         cmd.env(crate::HERDR_ENV_VAR, crate::HERDR_ENV_VALUE);
@@ -1079,8 +1082,9 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ));
-        let mut cmd = CommandBuilder::new("/bin/sh");
-        cmd.arg("-c");
+        let (shell, c_flag) = shell_command_runner();
+        let mut cmd = CommandBuilder::new(shell);
+        cmd.arg(c_flag);
         cmd.arg(format!("{command} > '{}'", output_path.display()));
         cmd.cwd(std::env::current_dir().unwrap());
         cmd.env("TERM", "xterm-ghostty");

--- a/src/platform/host.rs
+++ b/src/platform/host.rs
@@ -1,0 +1,137 @@
+//! Host integration helpers used by core modules that would otherwise need
+//! `#[cfg(target_os = "…")]` branches.
+
+#[cfg(unix)]
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Per-user config directory to use when neither `XDG_CONFIG_HOME` nor
+/// `HOME` is set. On Windows we prefer `%APPDATA%`, then
+/// `%USERPROFILE%\.config`, then the system temp directory. On Unix this
+/// returns `None` and the caller falls back to `/tmp/<app>`.
+pub fn fallback_config_dir(app_dir_name: &str) -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            return Some(PathBuf::from(appdata).join(app_dir_name));
+        }
+        if let Ok(profile) = std::env::var("USERPROFILE") {
+            return Some(PathBuf::from(profile).join(".config").join(app_dir_name));
+        }
+        return Some(std::env::temp_dir().join(app_dir_name));
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = app_dir_name;
+        None
+    }
+}
+
+/// Default interactive shell to spawn in a pane when the user hasn't
+/// overridden `$SHELL`. POSIX systems use `/bin/sh`; Windows uses
+/// `%ComSpec%` (cmd.exe) since the herdr pane reader expects a shell that
+/// produces VT-escape output via ConPTY.
+pub fn default_login_shell() -> String {
+    if let Ok(value) = std::env::var("SHELL") {
+        return value;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(value) = std::env::var("ComSpec") {
+            return value;
+        }
+        "cmd.exe".to_string()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "/bin/sh".to_string()
+    }
+}
+
+/// Returns `(shell, flag)` suitable for running a single command string
+/// via `shell <flag> "command"`. POSIX shells use `-c`; `cmd.exe` uses
+/// `/C`.
+pub fn shell_command_runner() -> (String, &'static str) {
+    #[cfg(target_os = "windows")]
+    {
+        let shell = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string());
+        (shell, "/C")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        ("/bin/sh".to_string(), "-c")
+    }
+}
+
+/// Classify whether `err` indicates "no server listening on the herdr
+/// socket" so the CLI can print a friendly message instead of a raw
+/// OS errno. On Windows the `uds_windows` AF_UNIX wrapper surfaces a
+/// missing socket as several different winsock codes (WSAENETDOWN,
+/// WSAECONNREFUSED, WSAENOTSOCK); on Unix only the standard error
+/// kinds are produced.
+/// Tighten the file-mode of a Unix-domain socket so only the current
+/// user can connect. On Unix this calls `chmod` with the supplied mode.
+/// Windows AF_UNIX sockets inherit ACLs from the parent directory, so
+/// callers should place the socket inside a per-user config dir and this
+/// becomes a no-op.
+pub fn restrict_socket_permissions(path: &Path, mode: u32) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(mode);
+        fs::set_permissions(path, permissions)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, mode);
+        Ok(())
+    }
+}
+
+/// Configure `command` so that it runs as a detached background daemon
+/// that survives the parent terminal closing. On Unix this puts the
+/// child in its own process group so it doesn't receive `SIGHUP`. On
+/// Windows it requests a hidden console (`CREATE_NO_WINDOW`) and a fresh
+/// console process group, which keeps later `CreatePseudoConsole` calls
+/// from flashing a real conhost window onto the desktop while still
+/// isolating the daemon from Ctrl+C/Ctrl+Break delivered to the
+/// launching shell.
+pub fn detach_daemon_command(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        command.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        command.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = command;
+    }
+}
+
+pub fn is_server_not_running_error(err: &io::Error) -> bool {
+    if matches!(
+        err.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+    ) {
+        return true;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(code) = err.raw_os_error() {
+            if matches!(code, 10050 | 10061 | 10038 | 2 | 3) {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -30,6 +30,10 @@ pub struct ClipboardCommand {
     pub args: &'static [&'static str],
 }
 
+pub mod host;
+pub mod net;
+pub mod terminal;
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]
@@ -40,7 +44,12 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::*;
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 mod fallback;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 pub use fallback::*;

--- a/src/platform/net.rs
+++ b/src/platform/net.rs
@@ -1,0 +1,13 @@
+//! Platform-agnostic Unix-domain socket types.
+//!
+//! On Unix this is a thin re-export of the standard `std::os::unix::net`
+//! types. On Windows we use `uds_windows`, which wraps the native AF_UNIX
+//! support shipped with Windows 10 1803+ and exposes the same blocking
+//! `UnixStream`/`UnixListener` API surface that the rest of herdr was
+//! written against.
+
+#[cfg(unix)]
+pub use std::os::unix::net::{UnixListener, UnixStream};
+
+#[cfg(windows)]
+pub use uds_windows::{UnixListener, UnixStream};

--- a/src/platform/terminal.rs
+++ b/src/platform/terminal.rs
@@ -1,0 +1,34 @@
+//! Cross-platform terminal capability gates used by the client renderer.
+//!
+//! Keeping these here lets `client/mod.rs` and `main.rs` stay free of
+//! `#[cfg(target_os)]` while still skipping crossterm primitives that
+//! aren't implemented on the Windows legacy console.
+
+use std::io;
+
+/// Switch the stdin console handle into Virtual Terminal input mode so
+/// that key and mouse events arrive as VT escape sequences instead of
+/// Win32 `INPUT_RECORD` structs. No-op on Unix targets.
+pub fn enable_vt_input() -> io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        super::enable_vt_input()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(())
+    }
+}
+
+/// Whether `crossterm::event::DisableMouseCapture` can safely be invoked
+/// without a prior matching `EnableMouseCapture`. Windows' legacy console
+/// backend requires the original mouse mode to have been cached by
+/// `Enable*` first; calling disable cold returns "Initial console modes
+/// not set". POSIX terminals tolerate the bare disable sequence.
+pub const TOLERATES_UNMATCHED_MOUSE_DISABLE: bool = !cfg!(target_os = "windows");
+
+/// Whether the kitty keyboard protocol's
+/// `PushKeyboardEnhancementFlags` / `PopKeyboardEnhancementFlags` calls
+/// are implemented for the current crossterm backend. They return
+/// `Unsupported` on Windows.
+pub const SUPPORTS_KEYBOARD_ENHANCEMENT: bool = !cfg!(target_os = "windows");

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,0 +1,266 @@
+//! Windows platform stubs.
+//!
+//! Implements the platform module API surface using std-only operations.
+//! Agent detection that relies on Unix process group semantics returns empty
+//! results; the rest of herdr continues to work as a plain multiplexer.
+
+use std::io;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use super::{ClipboardCommand, ForegroundJob, ForegroundProcess, Signal};
+
+/// Switch the stdin console handle into Virtual Terminal input mode and
+/// turn off line-buffering / echo / Ctrl+C cooking so VT mouse and key
+/// sequences arrive at the raw byte reader instead of being consumed by
+/// conhost. Idempotent and safe to call when stdin is redirected (returns
+/// Ok in that case).
+pub fn enable_vt_input() -> io::Result<()> {
+    use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Console::{
+        GetConsoleMode, GetStdHandle, SetConsoleMode, ENABLE_EXTENDED_FLAGS, ENABLE_MOUSE_INPUT,
+        ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_WINDOW_INPUT, STD_INPUT_HANDLE,
+    };
+
+    unsafe {
+        let handle: HANDLE = GetStdHandle(STD_INPUT_HANDLE);
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return Ok(());
+        }
+        let mut mode: u32 = 0;
+        if GetConsoleMode(handle, &mut mode) == 0 {
+            // Stdin isn't a console (redirected to a pipe/file). That is
+            // not an error for our purposes; the byte reader still works.
+            return Ok(());
+        }
+        // Clear ENABLE_LINE_INPUT (2), ENABLE_ECHO_INPUT (4) and
+        // ENABLE_PROCESSED_INPUT (1) — same flags crossterm clears for
+        // raw mode — and add the VT / mouse / window-resize bits.
+        const ENABLE_LINE_INPUT: u32 = 0x0002;
+        const ENABLE_ECHO_INPUT: u32 = 0x0004;
+        const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
+        let new_mode = (mode & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT))
+            | ENABLE_VIRTUAL_TERMINAL_INPUT
+            | ENABLE_MOUSE_INPUT
+            | ENABLE_WINDOW_INPUT
+            | ENABLE_EXTENDED_FLAGS;
+        if SetConsoleMode(handle, new_mode) == 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+/// Walk the process tree rooted at `child_pid` and return the deepest
+/// descendant (preferring the most recently created one) as the
+/// "foreground" approximation. Windows has no notion of a foreground
+/// process group attached to a PTY, so we treat the youngest leaf as the
+/// active agent — that matches what users observe when they run e.g.
+/// `claude` inside cmd.exe.
+pub fn foreground_job(child_pid: u32) -> Option<ForegroundJob> {
+    if child_pid == 0 {
+        return None;
+    }
+    let snapshot = process_snapshot();
+    let active = pick_active_descendant(&snapshot, child_pid)?;
+    let entry = snapshot.iter().find(|e| e.pid == active)?;
+    Some(ForegroundJob {
+        process_group_id: active,
+        processes: vec![ForegroundProcess {
+            pid: entry.pid,
+            name: entry.name.clone(),
+            argv0: Some(entry.name.clone()),
+            cmdline: None,
+        }],
+    })
+}
+
+pub fn foreground_process_group_id(child_pid: u32) -> Option<u32> {
+    if child_pid == 0 {
+        return None;
+    }
+    let snapshot = process_snapshot();
+    pick_active_descendant(&snapshot, child_pid)
+}
+
+#[derive(Clone)]
+struct ProcessEntry {
+    pid: u32,
+    parent_pid: u32,
+    name: String,
+}
+
+fn process_snapshot() -> Vec<ProcessEntry> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    let mut out = Vec::new();
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot.is_null() || snapshot as isize == -1 {
+            return out;
+        }
+        let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                let raw = wide_to_string(&entry.szExeFile);
+                // `identify_agent` matches against bare executable stems
+                // ("claude", "codex"), not the `.exe`-suffixed names that
+                // Toolhelp32 returns. Strip the extension here so Unix
+                // and Windows agree on the comparison key.
+                let name = strip_exe_suffix(&raw).to_string();
+                out.push(ProcessEntry {
+                    pid: entry.th32ProcessID,
+                    parent_pid: entry.th32ParentProcessID,
+                    name,
+                });
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+    }
+    out
+}
+
+fn wide_to_string(buf: &[u16]) -> String {
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    String::from_utf16_lossy(&buf[..len])
+}
+
+fn strip_exe_suffix(name: &str) -> &str {
+    if name.len() > 4 && name[name.len() - 4..].eq_ignore_ascii_case(".exe") {
+        &name[..name.len() - 4]
+    } else {
+        name
+    }
+}
+
+/// Walk descendants of `root` breadth-first, returning the deepest leaf
+/// that isn't `root` itself. When several leaves exist at the same depth
+/// the higher PID wins as a cheap "most recently spawned" proxy.
+fn pick_active_descendant(snapshot: &[ProcessEntry], root: u32) -> Option<u32> {
+    let mut frontier = vec![root];
+    let mut best: Option<u32> = None;
+    let mut best_depth = 0usize;
+    let mut depth = 0usize;
+    while !frontier.is_empty() {
+        let mut next = Vec::new();
+        for &pid in &frontier {
+            let children: Vec<u32> = snapshot
+                .iter()
+                .filter(|e| e.parent_pid == pid && e.pid != pid)
+                .map(|e| e.pid)
+                .collect();
+            if children.is_empty() && pid != root {
+                if depth > best_depth || (depth == best_depth && best.is_some_and(|b| pid > b)) {
+                    best = Some(pid);
+                    best_depth = depth;
+                }
+            } else {
+                next.extend(children);
+            }
+        }
+        frontier = next;
+        depth += 1;
+        if depth > 16 {
+            // Defensive cap; real shell trees rarely exceed a handful of
+            // levels.
+            break;
+        }
+    }
+    best
+}
+
+/// Best-effort cwd resolution is unavailable without extra deps; callers
+/// already tolerate None and fall back to the parent process cwd.
+pub fn process_cwd(_pid: u32) -> Option<PathBuf> {
+    None
+}
+
+pub fn session_processes(_child_pid: u32) -> Vec<u32> {
+    Vec::new()
+}
+
+/// Terminate the requested processes. Windows has no SIGHUP/SIGTERM; we
+/// approximate with `taskkill /F /PID` which is reliable across consoles.
+pub fn signal_processes(pids: &[u32], signal: Signal) {
+    let force = matches!(signal, Signal::Kill | Signal::Terminate);
+    for &pid in pids {
+        if pid == 0 {
+            continue;
+        }
+        let mut cmd = Command::new("taskkill");
+        if force {
+            cmd.arg("/F");
+        }
+        cmd.arg("/PID")
+            .arg(pid.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let _ = cmd.status();
+    }
+}
+
+/// Probe whether a PID is live by asking the OS via `tasklist`.
+pub fn process_exists(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let output = Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH", "/FO", "CSV"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output();
+    match output {
+        Ok(out) => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            text.contains(&format!("\"{pid}\""))
+        }
+        Err(_) => false,
+    }
+}
+
+/// Pipe the payload through `clip.exe`, the built-in Windows clipboard helper.
+pub fn write_clipboard(bytes: &[u8]) -> bool {
+    use std::io::Write;
+    let mut child = match Command::new("clip")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => return false,
+    };
+    let Some(mut stdin) = child.stdin.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return false;
+    };
+    if stdin.write_all(bytes).is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+        return false;
+    }
+    drop(stdin);
+    child.wait().map(|s| s.success()).unwrap_or(false)
+}
+
+/// Native toast notifications require an AppUserModelID and WinRT bindings;
+/// no-op for now so callers gracefully fall back to in-app indicators.
+pub fn show_desktop_notification(_title: &str, _body: Option<&str>) -> std::io::Result<bool> {
+    Ok(false)
+}
+
+/// Unused on Windows but kept to mirror the Unix module signature.
+#[allow(dead_code)]
+fn clipboard_commands() -> Vec<ClipboardCommand> {
+    Vec::new()
+}

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -1,3 +1,4 @@
+#[cfg(not(windows))]
 use std::io::Read;
 
 use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -134,6 +135,7 @@ pub(crate) fn events_require_host_surface_redraw(events: &[RawInputEvent]) -> bo
         .any(|event| matches!(event, RawInputEvent::OuterFocusGained))
 }
 
+#[cfg(not(windows))]
 pub fn spawn_input_reader() -> mpsc::Receiver<RawInputEvent> {
     let (tx, rx) = mpsc::channel(256);
 
@@ -162,6 +164,65 @@ pub fn spawn_input_reader() -> mpsc::Receiver<RawInputEvent> {
     rx
 }
 
+/// Windows console doesn't deliver mouse/key events as bytes through
+/// stdin reads — they arrive as `INPUT_RECORD` structures and need
+/// `ReadConsoleInput`. crossterm already abstracts that, so we use its
+/// blocking `event::read()` and translate the parsed events into our
+/// `RawInputEvent` shape instead of running the byte parser.
+#[cfg(windows)]
+pub fn spawn_input_reader() -> mpsc::Receiver<RawInputEvent> {
+    use crossterm::event::{self, Event};
+
+    let (tx, rx) = mpsc::channel(256);
+
+    std::thread::spawn(move || loop {
+        match event::read() {
+            Ok(Event::Key(key)) => {
+                if matches!(key.kind, crossterm::event::KeyEventKind::Release) {
+                    // crossterm reports release events on Windows; the rest
+                    // of the input pipeline only consumes Press/Repeat.
+                    continue;
+                }
+                let mapped = RawInputEvent::Key(TerminalKey::from(key));
+                if tx.blocking_send(mapped).is_err() {
+                    break;
+                }
+            }
+            Ok(Event::Mouse(mouse)) => {
+                if tx.blocking_send(RawInputEvent::Mouse(mouse)).is_err() {
+                    break;
+                }
+            }
+            Ok(Event::Paste(text)) => {
+                if tx.blocking_send(RawInputEvent::Paste(text)).is_err() {
+                    break;
+                }
+            }
+            Ok(Event::FocusGained) => {
+                if tx.blocking_send(RawInputEvent::OuterFocusGained).is_err() {
+                    break;
+                }
+            }
+            Ok(Event::FocusLost) => {
+                if tx.blocking_send(RawInputEvent::OuterFocusLost).is_err() {
+                    break;
+                }
+            }
+            Ok(Event::Resize(_, _)) => {
+                // Resize is handled separately via the render loop's size
+                // query; nothing to forward here.
+            }
+            Err(err) => {
+                tracing::warn!(?err, "crossterm event read failed; stopping reader");
+                break;
+            }
+        }
+    });
+
+    rx
+}
+
+#[allow(dead_code)]
 fn drain_buffer(buffer: &mut Vec<u8>, tx: &mpsc::Sender<RawInputEvent>) {
     for bytes in drain_complete_input_bytes(buffer) {
         let Some((event, _consumed)) = extract_one_event(&bytes) else {
@@ -172,6 +233,7 @@ fn drain_buffer(buffer: &mut Vec<u8>, tx: &mpsc::Sender<RawInputEvent>) {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn drain_complete_input_bytes(buffer: &mut Vec<u8>) -> Vec<Vec<u8>> {
     let mut chunks = Vec::new();
 
@@ -183,6 +245,7 @@ pub(crate) fn drain_complete_input_bytes(buffer: &mut Vec<u8>) -> Vec<Vec<u8>> {
     chunks
 }
 
+#[allow(dead_code)]
 fn flush_incomplete_buffer(buffer: &mut Vec<u8>, tx: &mpsc::Sender<RawInputEvent>) {
     if let Some(bytes) = flush_incomplete_input_bytes(buffer) {
         if bytes.as_slice() == [ESC] {
@@ -200,6 +263,10 @@ fn flush_incomplete_buffer(buffer: &mut Vec<u8>, tx: &mpsc::Sender<RawInputEvent
     }
 }
 
+// Exercised by `client::input` and the byte-reader path on Unix; on Windows the
+// reader uses `crossterm::event::read()` and never sees a partial buffer, so
+// this helper is only reached from the tests below.
+#[allow(dead_code)]
 pub(crate) fn flush_incomplete_input_bytes(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
     if buffer.is_empty() {
         return None;
@@ -246,6 +313,7 @@ fn stdin_read_ready<R: AsRawFd>(_reader: &R, _timeout_ms: i32) -> Option<bool> {
 }
 
 #[cfg(not(unix))]
+#[allow(dead_code)]
 fn stdin_read_ready<R>(_reader: &R, _timeout_ms: i32) -> Option<bool> {
     None
 }
@@ -336,6 +404,9 @@ fn first_complete_utf8_char_len(buffer: &[u8]) -> Option<usize> {
     Some(width)
 }
 
+// Only reachable through `flush_incomplete_input_bytes`; that helper is
+// dead on the Windows event-driven reader, so silence the lint there.
+#[allow(dead_code)]
 fn starts_with_incomplete_utf8_char(buffer: &[u8]) -> bool {
     match std::str::from_utf8(buffer) {
         Ok(_) => false,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{self, IsTerminal, Write as _};
-use std::os::unix::net::{UnixListener, UnixStream};
+use crate::platform::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
@@ -776,11 +776,20 @@ fn local_forward_socket_path(target: &str, session_name: &str) -> PathBuf {
 }
 
 fn fits_unix_socket_path(path: &Path) -> bool {
-    use std::os::unix::ffi::OsStrExt;
     // sun_path is byte-limited: 104 bytes on macOS, 108 on Linux. Reserve
     // 1 byte for the trailing NUL and use the smaller cap for portability.
+    // Windows AF_UNIX uses the same struct but tolerates longer paths; the
+    // same cap stays safe.
     const MAX: usize = 103;
-    path.as_os_str().as_bytes().len() <= MAX
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_os_str().as_bytes().len() <= MAX
+    }
+    #[cfg(not(unix))]
+    {
+        path.as_os_str().as_encoded_bytes().len() <= MAX
+    }
 }
 
 fn short_socket_hash(target: &str, session: &str) -> String {
@@ -812,6 +821,7 @@ fn sanitize_path_component(input: &str) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn bridge_socket_is_user_only() {
         use std::os::unix::fs::PermissionsExt;
@@ -968,8 +978,15 @@ mod tests {
     }
 
     fn socket_path_byte_len(path: &Path) -> usize {
-        use std::os::unix::ffi::OsStrExt;
-        path.as_os_str().as_bytes().len()
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            path.as_os_str().as_bytes().len()
+        }
+        #[cfg(not(unix))]
+        {
+            path.as_os_str().as_encoded_bytes().len()
+        }
     }
 
     #[test]

--- a/src/server/autodetect.rs
+++ b/src/server/autodetect.rs
@@ -9,12 +9,12 @@
 //! (escape hatch for users who want the traditional single-process behavior).
 
 use std::io;
-use std::os::unix::net::UnixStream;
-use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
+
+use crate::platform::net::UnixStream;
 
 use tracing::{info, warn};
 
@@ -145,12 +145,9 @@ pub fn spawn_server_daemon() -> io::Result<u32> {
 
 fn build_server_daemon_command(exe: PathBuf) -> Command {
     let mut command = Command::new(&exe);
+    command.arg("server");
+    crate::platform::host::detach_daemon_command(&mut command);
     command
-        .arg("server")
-        // Create a new process group so the server survives the parent's exit
-        // and doesn't receive SIGHUP when the client's terminal closes.
-        .process_group(0)
-        // Redirect stdio to /dev/null
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -230,7 +227,9 @@ pub fn auto_detect_launch() -> io::Result<()> {
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+// These integration tests reach into the live socket path layout and assume
+// Unix semantics for process-group detachment; keep them unix-only for now.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::ffi::OsStr;

--- a/src/server/client_transport.rs
+++ b/src/server/client_transport.rs
@@ -5,7 +5,7 @@
 //! `HeadlessServer`.
 
 use std::io::{self, Write};
-use std::os::unix::net::UnixStream;
+use crate::platform::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -418,6 +418,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn handshake_negotiates_terminal_ansi_encoding() {
         let (mut client_stream, server_stream) = UnixStream::pair().expect("socket pair");
@@ -486,6 +487,7 @@ mod tests {
             .expect("handshake thread result");
     }
 
+    #[cfg(unix)]
     #[test]
     fn client_read_loop_rejects_oversized_input() {
         let (mut client_stream, server_stream) = UnixStream::pair().expect("socket pair");

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -17,7 +17,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::os::unix::net::UnixListener;
+use crate::platform::net::UnixListener;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -2233,7 +2233,10 @@ fn init_logging() {
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+// Headless server tests bind UnixListeners directly and exercise
+// `prepare_socket_path` against live Unix sockets; gate them to unix until
+// the equivalent named-pipe helpers exist.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/src/server/protocol.rs
+++ b/src/server/protocol.rs
@@ -1390,6 +1390,10 @@ mod tests {
 
     // ---- Unix socketpair integration test ----
 
+    // `socketpair` is a Unix-only primitive; the test stays gated to that
+    // family. The framing code itself is exercised by the platform-agnostic
+    // round-trip tests above.
+    #[cfg(unix)]
     #[test]
     fn framing_over_unix_socketpair() {
         use std::os::unix::net::UnixStream;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,5 @@
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixStream;
+use crate::platform::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -296,7 +296,10 @@ fn normalize_name(name: &str) -> Result<Option<String>, String> {
     Ok(Some(name.to_string()))
 }
 
-#[cfg(test)]
+// Session tests use hardcoded /tmp paths and bind raw UnixListeners; keep
+// them unix-only until the Windows config-dir layout and pipe-based stubs
+// land.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::sync::{Mutex, OnceLock};

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
-use std::os::unix::net::UnixStream;
+use crate::platform::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -828,7 +828,8 @@ fn platform_target() -> (&'static str, &'static str) {
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+// Update path tests rely on /tmp sockets and Unix file modes; gate to unix.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::os::unix::net::UnixListener;


### PR DESCRIPTION
Adds Windows (`x86_64-pc-windows-msvc`) as a build and runtime target alongside the existing Linux and macOS support. The TUI, persistent server / thin client, JSON API, agent detection, mouse, keyboard, and clipboard all work; only Unix-specific test helpers (raw `UnixStream::pair()`, file-mode checks) remain gated to `cfg(unix)`.

Verified end-to-end on Windows 11 26200 inside Windows Terminal + PowerShell 7:

- `herdr.exe --version`, `--help`, `status server` round-trip the JSON API.
- `herdr.exe` launches the TUI, spawns a workspace, splits panes, attaches a `cmd.exe` PTY via ConPTY.
- Running `claude` inside a pane registers in the sidebar with the right `Agent` state.
- Mouse click + drag, Ctrl+B prefix bindings, paste, focus events all reach the server.
- `ctrl+b q` detach, attach reconnect via `herdr.exe`, server survives the client.

## Build

Windows builds require **zig 0.15.2** in PATH (the vendored `libghostty-vt` pins that version):

```powershell
$env:PATH = "C:\path\to\zig-x86_64-windows-0.15.2;$env:PATH"
cargo build --release
```

## Limitations / follow-ups (intentionally out of scope)

- Process command-line introspection on Windows would need `NtQueryInformationProcess` + PEB walking; without it, wrapped agents launched as `node /path/to/codex` show as `node` rather than `codex`. Bare-name agents (`claude`, `codex`, `droid`, ...) detect correctly.
- ConPTY child output has known higher per-byte latency than POSIX PTYs because conhost re-renders the child's stream — that's a Microsoft constraint, not a herdr layer.
- The skipped Unix-only tests should grow Windows equivalents using AF_UNIX listener pairs + Windows ACL checks; not addressed here to keep the diff focused.

## Test plan

- [x] `cargo build` on `x86_64-pc-windows-msvc` is warning-free.
- [x] `cargo build` on `x86_64-unknown-linux-gnu` still compiles (no regressions in the Unix path; only added cfg arms and platform helpers).
- [x] `herdr.exe status server` returns `not running` cleanly when no server is up.
- [x] `herdr.exe server` binds AF_UNIX sockets under `%APPDATA%\herdr-dev\`.
- [x] `herdr.exe` launches the TUI, prefix bindings work, panes spawn shells via ConPTY, agent classifier picks up `claude` in a pane.
- [ ] Linux / macOS smoke test by a maintainer with the existing CI matrix.