### PR TITLE
Support 16-bit terminal themes

### DIFF
--- a/docs/next/CONFIGURATION.md
+++ b/docs/next/CONFIGURATION.md
@@ -216,7 +216,7 @@ command = "notify-send herdr 'custom command ran'"
 
 ## theme
 
-herdr ships with 17 built-in color themes. set one in config:
+herdr ships with 18 built-in color themes. set one in config:
 
 ```toml
 [theme]
@@ -229,6 +229,7 @@ name = "tokyo-night"
 |------|-------------|
 | `catppuccin` | soft pastel mocha palette (default) |
 | `catppuccin-latte` | light catppuccin palette |
+| `terminal` | use your terminal's 16-color ANSI palette |
 | `tokyo-night` | blue-purple aesthetic |
 | `tokyo-night-day` | light tokyo night palette |
 | `dracula` | purple/pink/green classic |

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -137,7 +137,7 @@ not a gui window, not a web dashboard, not electron. herdr runs inside whatever 
 - **tabs** — first-class in the socket api and cli
 - **mouse-native** — click panes/tabs/workspaces/agents, drag borders, select text to copy, right-click menus; not keyboard-only
 - **notifications** — sounds and toasts for background events; tab-aware suppression
-- **17 built-in themes** — catppuccin, tokyo night, gruvbox, one, solarized, kanagawa, rosé pine, vesper, and light variants for the main palettes
+- **18 built-in themes** — catppuccin, terminal, tokyo night, gruvbox, one, solarized, kanagawa, rosé pine, vesper, and light variants for the main palettes
 - **session persistence** — pane processes survive client detach; sessions restore after full restart
 
 ## agents can use herdr too

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -121,6 +121,28 @@ impl Palette {
         }
     }
 
+    /// Terminal 16-color theme.
+    pub fn terminal() -> Self {
+        Self {
+            accent: Color::Blue,
+            panel_bg: Color::Reset,
+            surface0: Color::Reset,
+            surface1: Color::DarkGray,
+            surface_dim: Color::DarkGray,
+            overlay0: Color::Gray,
+            overlay1: Color::White,
+            text: Color::Reset,
+            subtext0: Color::Gray,
+            mauve: Color::Gray,
+            green: Color::Green,
+            yellow: Color::Yellow,
+            red: Color::LightRed,
+            blue: Color::Blue,
+            teal: Color::Cyan,
+            peach: Color::Yellow,
+        }
+    }
+
     /// Tokyo Night — blue-purple aesthetic.
     pub fn tokyo_night() -> Self {
         Self {
@@ -456,6 +478,7 @@ impl Palette {
         match name.to_lowercase().replace([' ', '_'], "-").as_str() {
             "catppuccin" | "catppuccin-mocha" => Some(Self::catppuccin()),
             "catppuccin-latte" | "latte" | "light" => Some(Self::catppuccin_latte()),
+            "terminal" => Some(Self::terminal()),
             "tokyo-night" | "tokyonight" => Some(Self::tokyo_night()),
             "tokyo-night-day" | "tokyo-day" | "tokyonight-day" => Some(Self::tokyo_night_day()),
             "dracula" => Some(Self::dracula()),
@@ -615,6 +638,7 @@ impl SettingsSection {
 pub const THEME_NAMES: &[&str] = &[
     "catppuccin",
     "catppuccin-latte",
+    "terminal",
     "tokyo-night",
     "tokyo-night-day",
     "dracula",

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 ///
 /// ```toml
 /// [theme]
-/// name = "tokyo-night"  # built-in: catppuccin, tokyo-night, dracula, nord, etc.
+/// name = "tokyo-night"  # built-in: catppuccin, terminal, dracula, nord, etc.
 ///
 /// [theme.custom]        # override individual tokens on top of the base
 /// accent = "#f5c2e7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,8 +61,9 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # onboarding = true
 
 [theme]
-# Built-in themes: catppuccin, tokyo-night, dracula, nord, gruvbox,
-#                  one-dark, solarized, kanagawa, rose-pine, vesper
+# Built-in themes: catppuccin, terminal, tokyo-night, dracula, nord,
+#                  gruvbox, one-dark, solarized, kanagawa, rose-pine,
+#                  vesper
 # name = "catppuccin"
 
 # Override individual color tokens on top of the base theme.

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
@@ -293,10 +293,7 @@ pub(super) fn render_panes(app: &AppState, frame: &mut Frame, area: Rect) {
                 for y in inner.y..inner.y + inner.height {
                     for x in inner.x..inner.x + inner.width {
                         let cell = &mut buf[(x, y)];
-                        let style = cell.style();
-                        let fg = style.fg.unwrap_or(Color::White);
-                        let dimmed_fg = dim_color(fg);
-                        cell.set_style(style.fg(dimmed_fg));
+                        cell.set_style(cell.style().add_modifier(Modifier::DIM));
                     }
                 }
             }
@@ -310,30 +307,6 @@ pub(super) fn render_panes(app: &AppState, frame: &mut Frame, area: Rect) {
                 &app.palette,
             );
         }
-    }
-}
-
-/// Render selection highlight for a pane by inverting fg/bg colors.
-/// Reduce a color's brightness by blending it toward black.
-fn dim_color(color: Color) -> Color {
-    match color {
-        Color::Rgb(r, g, b) => Color::Rgb(r / 3, g / 3, b / 3),
-        Color::White => Color::DarkGray,
-        Color::Gray => Color::DarkGray,
-        Color::DarkGray => Color::Rgb(30, 30, 30),
-        Color::Red => Color::Rgb(60, 0, 0),
-        Color::Green => Color::Rgb(0, 60, 0),
-        Color::Yellow => Color::Rgb(60, 60, 0),
-        Color::Blue => Color::Rgb(0, 0, 60),
-        Color::Magenta => Color::Rgb(60, 0, 60),
-        Color::Cyan => Color::Rgb(0, 60, 60),
-        Color::LightRed => Color::Rgb(80, 30, 30),
-        Color::LightGreen => Color::Rgb(30, 80, 30),
-        Color::LightYellow => Color::Rgb(80, 80, 30),
-        Color::LightBlue => Color::Rgb(30, 30, 80),
-        Color::LightMagenta => Color::Rgb(80, 30, 80),
-        Color::LightCyan => Color::Rgb(30, 80, 80),
-        _ => Color::DarkGray,
     }
 }
 


### PR DESCRIPTION
refs #140

Add a built-in terminal theme that uses only terminal colors instead of RGB values.

This also fixes a (presumed) bug where `dim_color` was crushing colors in navigation mode.

Video attached (with green accent color)

https://github.com/user-attachments/assets/68badf40-1a92-4d0d-a418-656b34fa4035