### PR TITLE
feat: add cycle_layout keybind for preset pane layouts

### DIFF
--- a/docs/next/CONFIGURATION.md
+++ b/docs/next/CONFIGURATION.md
@@ -106,6 +106,7 @@ rename_pane = ""        # optional, unset by default
 edit_scrollback = ""    # optional, opens focused pane scrollback in $EDITOR
 zoom = "f"               # legacy alias: fullscreen
 resize_mode = "r"
+cycle_layout = "space"
 toggle_sidebar = "b"
 previous_workspace = "ctrl+alt+["
 next_workspace = "ctrl+alt+]"
@@ -155,6 +156,7 @@ agents = ""     # optional; follows visible agent panel order
 | `edit_scrollback` | unset | open the focused pane's retained scrollback in `$EDITOR` inside a temporary zoomed pane |
 | `zoom` | `f` | zoom focused pane; legacy alias: `fullscreen` |
 | `resize_mode` | `r` | enter or leave resize mode |
+| `cycle_layout` | `space` | cycle through preset pane layouts (even-horizontal, even-vertical, main-vertical, main-horizontal, tiled) |
 | `toggle_sidebar` | `b` | collapse or expand the sidebar |
 
 `edit_scrollback` writes the focused pane's retained plain-text scrollback to a temporary file, opens `${EDITOR:-vi}` on that file in a temporary zoomed pane, then removes the file when the editor exits.

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -567,6 +567,18 @@ impl AppState {
         }
     }
 
+    pub fn cycle_layout(&mut self) {
+        if let Some(tab) = self
+            .active
+            .and_then(|i| self.workspaces.get_mut(i))
+            .and_then(|ws| ws.active_tab_mut())
+        {
+            let main = tab.layout.focused();
+            tab.layout.cycle_layout(main);
+            self.mark_session_dirty();
+        }
+    }
+
     pub fn cycle_pane(&mut self, reverse: bool) {
         if let Some(tab) = self
             .active

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -488,6 +488,7 @@ pub(crate) enum NavigateAction {
     EditScrollback,
     Zoom,
     EnterResizeMode,
+    CycleLayout,
     ToggleSidebar,
     ReloadConfig,
     OpenNotificationTarget,
@@ -615,6 +616,9 @@ fn navigate_action_for_key(state: &AppState, key: &KeyEvent) -> Option<NavigateA
     }
     if key_matches(key, kb.resize_mode.0, kb.resize_mode.1) {
         return Some(NavigateAction::EnterResizeMode);
+    }
+    if key_matches(key, kb.cycle_layout.0, kb.cycle_layout.1) {
+        return Some(NavigateAction::CycleLayout);
     }
     if key_matches(key, kb.toggle_sidebar.0, kb.toggle_sidebar.1) {
         return Some(NavigateAction::ToggleSidebar);
@@ -750,6 +754,10 @@ pub(super) fn execute_navigate_action(state: &mut AppState, action: NavigateActi
             leave_navigate_mode(state);
         }
         NavigateAction::EnterResizeMode => state.mode = Mode::Resize,
+        NavigateAction::CycleLayout => {
+            state.cycle_layout();
+            leave_navigate_mode(state);
+        }
         NavigateAction::ToggleSidebar => {
             state.sidebar_collapsed = !state.sidebar_collapsed;
             leave_navigate_mode(state);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1223,6 +1223,8 @@ impl AppState {
                 zoom_label: "f".into(),
                 resize_mode: (KeyCode::Char('r'), KeyModifiers::empty()),
                 resize_mode_label: "r".into(),
+                cycle_layout: (KeyCode::Char(' '), KeyModifiers::empty()),
+                cycle_layout_label: "space".into(),
                 toggle_sidebar: (KeyCode::Char('b'), KeyModifiers::empty()),
                 toggle_sidebar_label: "b".into(),
                 custom_commands: Vec::new(),

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -115,6 +115,8 @@ pub struct Keybinds {
     pub zoom_label: String,
     pub resize_mode: (KeyCode, KeyModifiers),
     pub resize_mode_label: String,
+    pub cycle_layout: (KeyCode, KeyModifiers),
+    pub cycle_layout_label: String,
     pub toggle_sidebar: (KeyCode, KeyModifiers),
     pub toggle_sidebar_label: String,
     pub custom_commands: Vec<CustomCommandKeybind>,
@@ -374,6 +376,14 @@ impl Config {
                 &self.keys.resize_mode,
                 "r",
                 (KeyCode::Char('r'), KeyModifiers::empty()),
+                &mut diagnostics,
+            ),
+            required_binding(
+                BindingScope::Navigate,
+                "keys.cycle_layout",
+                &self.keys.cycle_layout,
+                "space",
+                (KeyCode::Char(' '), KeyModifiers::empty()),
                 &mut diagnostics,
             ),
             required_binding(
@@ -795,8 +805,10 @@ impl Config {
             zoom_label: bindings[7].label.clone(),
             resize_mode: bindings[8].value,
             resize_mode_label: bindings[8].label.clone(),
-            toggle_sidebar: bindings[9].value,
-            toggle_sidebar_label: bindings[9].label.clone(),
+            cycle_layout: bindings[9].value,
+            cycle_layout_label: bindings[9].label.clone(),
+            toggle_sidebar: bindings[10].value,
+            toggle_sidebar_label: bindings[10].label.clone(),
             custom_commands,
         };
 

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -124,6 +124,9 @@ pub struct KeysConfig {
     pub zoom: String,
     /// Enter resize mode. Default: "r"
     pub resize_mode: String,
+    /// Cycle through preset pane layouts (even-horizontal, even-vertical,
+    /// main-vertical, main-horizontal, tiled). Default: "space"
+    pub cycle_layout: String,
     /// Toggle sidebar collapse. Default: "b"
     pub toggle_sidebar: String,
     /// Optional indexed shortcuts expanded over number keys 1-9.
@@ -213,6 +216,7 @@ impl Default for KeysConfig {
             close_pane: "x".into(),
             zoom: "f".into(),
             resize_mode: "r".into(),
+            cycle_layout: "space".into(),
             toggle_sidebar: "b".into(),
             indexed: IndexedKeysConfig::default(),
             command: Vec::new(),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -60,6 +60,29 @@ pub enum NavDirection {
     Down,
 }
 
+/// Preset layout shapes for auto-layout cycling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutKind {
+    EvenHorizontal,
+    EvenVertical,
+    MainVertical,
+    MainHorizontal,
+    Tiled,
+}
+
+impl LayoutKind {
+    /// The next layout in the cycle (wraps around).
+    pub fn next(self) -> Self {
+        match self {
+            Self::EvenHorizontal => Self::EvenVertical,
+            Self::EvenVertical => Self::MainVertical,
+            Self::MainVertical => Self::MainHorizontal,
+            Self::MainHorizontal => Self::Tiled,
+            Self::Tiled => Self::EvenHorizontal,
+        }
+    }
+}
+
 /// A node in the BSP tree. Public for serialization.
 pub enum Node {
     Pane(PaneId),
@@ -75,6 +98,9 @@ pub enum Node {
 pub struct TileLayout {
     root: Node,
     focus: PaneId,
+    /// Last preset layout applied via [`apply_layout`] / [`cycle_layout`].
+    /// Not persisted — resets to `None` on restore.
+    last_layout: Option<LayoutKind>,
 }
 
 impl TileLayout {
@@ -86,6 +112,7 @@ impl TileLayout {
             Self {
                 root: Node::Pane(root_id),
                 focus: root_id,
+                last_layout: None,
             },
             root_id,
         )
@@ -249,9 +276,47 @@ impl TileLayout {
     }
 
     /// Reconstruct a layout from a saved tree.
-    /// Reconstruct a layout from a saved tree.
     pub fn from_saved(root: Node, focus: PaneId) -> Self {
-        Self { root, focus }
+        Self {
+            root,
+            focus,
+            last_layout: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn current_layout(&self) -> Option<LayoutKind> {
+        self.last_layout
+    }
+
+    /// Rebuild the BSP tree into the given preset. Preserves the set of pane
+    /// IDs and the focused pane; only the tree structure and ratios change.
+    ///
+    /// For `MainVertical` / `MainHorizontal`, `main` becomes the large pane.
+    /// For other kinds, `main` is unused but kept for a uniform call site.
+    pub fn apply_layout(&mut self, kind: LayoutKind, main: PaneId) {
+        let ids = self.pane_ids();
+        if ids.len() <= 1 {
+            // Nothing to restructure, but remember the kind so cycling progresses.
+            self.last_layout = Some(kind);
+            return;
+        }
+        let main = if ids.contains(&main) {
+            main
+        } else {
+            self.focus
+        };
+        self.root = build_layout(&ids, kind, main);
+        self.last_layout = Some(kind);
+    }
+
+    /// Apply the next preset in the cycle. Returns the applied kind.
+    pub fn cycle_layout(&mut self, main: PaneId) -> LayoutKind {
+        let next = self
+            .last_layout
+            .map_or(LayoutKind::EvenHorizontal, LayoutKind::next);
+        self.apply_layout(next, main);
+        next
     }
 }
 
@@ -475,5 +540,319 @@ fn split_rect(area: Rect, direction: Direction, ratio: f32) -> (Rect, Rect) {
                 Rect::new(area.x, area.y + first_h, area.width, second_h),
             )
         }
+    }
+}
+
+// --- Preset layout builders ---
+
+fn build_layout(ids: &[PaneId], kind: LayoutKind, main: PaneId) -> Node {
+    debug_assert!(!ids.is_empty(), "build_layout called with empty pane list");
+    match kind {
+        LayoutKind::EvenHorizontal => build_even_chain(ids, Direction::Horizontal),
+        LayoutKind::EvenVertical => build_even_chain(ids, Direction::Vertical),
+        LayoutKind::MainVertical => build_main(ids, main, Direction::Horizontal),
+        LayoutKind::MainHorizontal => build_main(ids, main, Direction::Vertical),
+        LayoutKind::Tiled => build_tiled(ids),
+    }
+}
+
+/// Build a left-leaning chain of equal-sized panes along `direction`. The
+/// split at depth `k` uses ratio `1 / (n - k)`, so each cell ends up the same
+/// fraction of the total.
+fn build_even_chain(ids: &[PaneId], direction: Direction) -> Node {
+    let n = ids.len();
+    debug_assert!(n >= 1);
+    if n == 1 {
+        return Node::Pane(ids[0]);
+    }
+    let mut node = Node::Pane(ids[n - 1]);
+    for (i, id) in ids[..n - 1].iter().enumerate().rev() {
+        let remaining = n - i;
+        node = Node::Split {
+            direction,
+            ratio: 1.0 / remaining as f32,
+            first: Box::new(Node::Pane(*id)),
+            second: Box::new(node),
+        };
+    }
+    node
+}
+
+/// Main pane on one side, even chain of the rest on the other side.
+/// `outer` is the direction of the top-level split:
+///   - `Horizontal` → main on the left, rest stacked vertically on the right
+///     (i.e. `MainVertical`)
+///   - `Vertical` → main on top, rest side-by-side horizontally below
+///     (i.e. `MainHorizontal`)
+fn build_main(ids: &[PaneId], main: PaneId, outer: Direction) -> Node {
+    let rest: Vec<PaneId> = ids.iter().copied().filter(|id| *id != main).collect();
+    if rest.is_empty() {
+        return Node::Pane(main);
+    }
+    let chain_direction = match outer {
+        Direction::Horizontal => Direction::Vertical,
+        Direction::Vertical => Direction::Horizontal,
+    };
+    let rest_node = build_even_chain(&rest, chain_direction);
+    Node::Split {
+        direction: outer,
+        ratio: 0.5,
+        first: Box::new(Node::Pane(main)),
+        second: Box::new(rest_node),
+    }
+}
+
+/// Grid layout: roughly `ceil(sqrt(n))` columns. The first `n % cols` columns
+/// hold one extra pane than the rest, so panes are distributed as evenly as
+/// possible.
+fn build_tiled(ids: &[PaneId]) -> Node {
+    let n = ids.len();
+    debug_assert!(n >= 1);
+    if n == 1 {
+        return Node::Pane(ids[0]);
+    }
+    let cols = (n as f32).sqrt().ceil() as usize;
+    let base = n / cols;
+    let extras = n % cols;
+
+    // Partition ids into columns, each column gets `base + 1` if its index < extras.
+    let mut columns: Vec<Vec<PaneId>> = Vec::with_capacity(cols);
+    let mut cursor = 0;
+    for col in 0..cols {
+        let take = base + if col < extras { 1 } else { 0 };
+        columns.push(ids[cursor..cursor + take].to_vec());
+        cursor += take;
+    }
+
+    // Build a left-leaning chain of columns. Each column's "width" is
+    // proportional to the number of panes it holds, so cells stay roughly
+    // square — but for predictability we just give each column equal width
+    // (matches tmux behavior).
+    let mut node = build_even_chain(&columns[cols - 1], Direction::Vertical);
+    for (i, col_ids) in columns[..cols - 1].iter().enumerate().rev() {
+        let remaining = cols - i;
+        node = Node::Split {
+            direction: Direction::Horizontal,
+            ratio: 1.0 / remaining as f32,
+            first: Box::new(build_even_chain(col_ids, Direction::Vertical)),
+            second: Box::new(node),
+        };
+    }
+    node
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn make_panes(n: usize) -> Vec<PaneId> {
+        (0..n).map(|_| PaneId::alloc()).collect()
+    }
+
+    fn layout_with_panes(n: usize) -> (TileLayout, Vec<PaneId>) {
+        assert!(n >= 1);
+        let ids = make_panes(n);
+        // Build a degenerate left-leaning vertical chain to get the layout
+        // into a non-canonical state, so apply_layout has work to do.
+        let mut node = Node::Pane(ids[n - 1]);
+        for id in ids[..n - 1].iter().rev() {
+            node = Node::Split {
+                direction: Direction::Vertical,
+                ratio: 0.3,
+                first: Box::new(Node::Pane(*id)),
+                second: Box::new(node),
+            };
+        }
+        let layout = TileLayout::from_saved(node, ids[0]);
+        (layout, ids)
+    }
+
+    fn pane_id_set(layout: &TileLayout) -> HashSet<PaneId> {
+        layout.pane_ids().into_iter().collect()
+    }
+
+    fn assert_root_split(node: &Node, expected: Direction) {
+        match node {
+            Node::Split { direction, .. } => assert_eq!(*direction, expected),
+            Node::Pane(_) => panic!("expected split at root, got pane"),
+        }
+    }
+
+    #[test]
+    fn cycle_layout_advances_through_all_five_then_wraps() {
+        let (mut layout, _ids) = layout_with_panes(4);
+        let main = layout.focused();
+        let kinds = [
+            LayoutKind::EvenHorizontal,
+            LayoutKind::EvenVertical,
+            LayoutKind::MainVertical,
+            LayoutKind::MainHorizontal,
+            LayoutKind::Tiled,
+            LayoutKind::EvenHorizontal, // wraps
+        ];
+        for expected in kinds {
+            let applied = layout.cycle_layout(main);
+            assert_eq!(applied, expected);
+            assert_eq!(layout.current_layout(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn apply_layout_preserves_pane_ids_and_focus() {
+        for kind in [
+            LayoutKind::EvenHorizontal,
+            LayoutKind::EvenVertical,
+            LayoutKind::MainVertical,
+            LayoutKind::MainHorizontal,
+            LayoutKind::Tiled,
+        ] {
+            for n in [2usize, 3, 4, 5, 9] {
+                let (mut layout, ids) = layout_with_panes(n);
+                let before = pane_id_set(&layout);
+                let focus = layout.focused();
+                layout.apply_layout(kind, focus);
+                assert_eq!(
+                    pane_id_set(&layout),
+                    before,
+                    "{kind:?} n={n} must preserve pane id set"
+                );
+                assert_eq!(
+                    layout.focused(),
+                    focus,
+                    "{kind:?} n={n} must preserve focus"
+                );
+                assert_eq!(layout.pane_count(), n);
+                assert!(ids.iter().all(|id| layout.pane_ids().contains(id)));
+            }
+        }
+    }
+
+    #[test]
+    fn even_horizontal_root_is_horizontal() {
+        let (mut layout, _) = layout_with_panes(4);
+        layout.apply_layout(LayoutKind::EvenHorizontal, layout.focused());
+        assert_root_split(layout.root(), Direction::Horizontal);
+    }
+
+    #[test]
+    fn even_vertical_root_is_vertical() {
+        let (mut layout, _) = layout_with_panes(4);
+        layout.apply_layout(LayoutKind::EvenVertical, layout.focused());
+        assert_root_split(layout.root(), Direction::Vertical);
+    }
+
+    #[test]
+    fn main_vertical_puts_main_on_left() {
+        let (mut layout, ids) = layout_with_panes(4);
+        let main = ids[2];
+        layout.apply_layout(LayoutKind::MainVertical, main);
+        match layout.root() {
+            Node::Split {
+                direction,
+                ratio,
+                first,
+                ..
+            } => {
+                assert_eq!(*direction, Direction::Horizontal);
+                assert!((*ratio - 0.5).abs() < 1e-6);
+                match first.as_ref() {
+                    Node::Pane(id) => assert_eq!(*id, main),
+                    _ => panic!("main pane should be a leaf at first child"),
+                }
+            }
+            _ => panic!("MainVertical root must be a split"),
+        }
+    }
+
+    #[test]
+    fn main_horizontal_puts_main_on_top() {
+        let (mut layout, ids) = layout_with_panes(4);
+        let main = ids[1];
+        layout.apply_layout(LayoutKind::MainHorizontal, main);
+        match layout.root() {
+            Node::Split {
+                direction, first, ..
+            } => {
+                assert_eq!(*direction, Direction::Vertical);
+                match first.as_ref() {
+                    Node::Pane(id) => assert_eq!(*id, main),
+                    _ => panic!("main pane should be a leaf at first child"),
+                }
+            }
+            _ => panic!("MainHorizontal root must be a split"),
+        }
+    }
+
+    #[test]
+    fn even_horizontal_produces_equal_widths() {
+        let (mut layout, _) = layout_with_panes(5);
+        layout.apply_layout(LayoutKind::EvenHorizontal, layout.focused());
+        let area = Rect::new(0, 0, 100, 20);
+        let panes = layout.panes(area);
+        assert_eq!(panes.len(), 5);
+        // Each pane should be ~20 cols wide; allow ±1 for rounding.
+        for p in &panes {
+            assert!(
+                (p.rect.width as i32 - 20).abs() <= 1,
+                "expected ~20 cols, got {} (rect={:?})",
+                p.rect.width,
+                p.rect
+            );
+            assert_eq!(p.rect.height, 20);
+        }
+    }
+
+    #[test]
+    fn tiled_distributes_panes_into_grid() {
+        let (mut layout, _) = layout_with_panes(4);
+        layout.apply_layout(LayoutKind::Tiled, layout.focused());
+        let panes = layout.panes(Rect::new(0, 0, 100, 100));
+        assert_eq!(panes.len(), 4);
+        // For n=4, cols=2, each column has 2 rows: a 2×2 grid.
+        // Each cell should be ~50×50.
+        for p in &panes {
+            assert!((p.rect.width as i32 - 50).abs() <= 1);
+            assert!((p.rect.height as i32 - 50).abs() <= 1);
+        }
+    }
+
+    #[test]
+    fn tiled_handles_uneven_pane_count() {
+        // n=5 → cols=ceil(sqrt(5))=3, base=1, extras=2.
+        // Columns hold [2, 2, 1] panes.
+        let (mut layout, _) = layout_with_panes(5);
+        layout.apply_layout(LayoutKind::Tiled, layout.focused());
+        let panes = layout.panes(Rect::new(0, 0, 99, 100));
+        assert_eq!(panes.len(), 5);
+        // All panes should be non-empty.
+        for p in &panes {
+            assert!(p.rect.width > 0 && p.rect.height > 0);
+        }
+    }
+
+    #[test]
+    fn single_pane_layout_is_noop_but_advances_cycle_state() {
+        let ids = make_panes(1);
+        let mut layout = TileLayout::from_saved(Node::Pane(ids[0]), ids[0]);
+        layout.apply_layout(LayoutKind::Tiled, ids[0]);
+        assert_eq!(layout.pane_count(), 1);
+        assert_eq!(layout.current_layout(), Some(LayoutKind::Tiled));
+        // Cycling from Tiled should give EvenHorizontal.
+        let next = layout.cycle_layout(ids[0]);
+        assert_eq!(next, LayoutKind::EvenHorizontal);
+    }
+
+    #[test]
+    fn from_saved_resets_layout_state() {
+        let (mut layout, _) = layout_with_panes(3);
+        layout.apply_layout(LayoutKind::Tiled, layout.focused());
+        assert_eq!(layout.current_layout(), Some(LayoutKind::Tiled));
+
+        // Round-trip through from_saved (simulating persistence reload).
+        let focus = layout.focused();
+        let root = std::mem::replace(&mut layout.root, Node::Pane(PaneId::from_raw(0)));
+        let restored = TileLayout::from_saved(root, focus);
+        assert_eq!(restored.current_layout(), None);
     }
 }

--- a/src/ui/keybind_help.rs
+++ b/src/ui/keybind_help.rs
@@ -110,6 +110,7 @@ pub(super) fn keybind_help_groups(
         ),
         (kb.zoom_label.clone(), "zoom pane"),
         (kb.resize_mode_label.clone(), "resize mode"),
+        (kb.cycle_layout_label.clone(), "cycle layout"),
         (kb.toggle_sidebar_label.clone(), "toggle sidebar"),
         (
             optional_keybind_label(&kb.focus_pane_left_label),


### PR DESCRIPTION
Adds a navigate-mode keybind (default `space`) that cycles the active tab's panes through five preset layouts, similar to tmux's `prefix + space`.