### PR TITLE
fix: preserve shift enter newline

### DIFF
--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -67,6 +67,19 @@ impl App {
         let pane_id = ws.focused_pane_id()?;
         let rt = self.state.runtime_for_pane_in_workspace(ws_idx, pane_id)?;
 
+        if key_event.code == KeyCode::Enter
+            && key_event
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::SHIFT)
+        {
+            rt.scroll_reset();
+            return Some(PreparedPaneInput {
+                ws_idx,
+                pane_id,
+                bytes: Bytes::from(vec![b'\n']),
+            });
+        }
+
         // Intercept plain PageUp/PageDown presses for pane scrollback when the
         // focused pane doesn't handle its own scrolling (e.g., a plain shell
         // with mouse off). Modified page keys are pane shortcuts, and release
@@ -510,6 +523,32 @@ mod tests {
 
         let bytes = rx.try_recv().unwrap();
         assert_eq!(bytes.as_ref(), b"\x1b\x7f");
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn shift_enter_forwards_line_feed_to_focused_pane() {
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let pane_infos = ws.tabs[0].layout.panes(Rect::new(0, 0, 80, 24));
+        let info = pane_infos[0].clone();
+        let (runtime, mut rx) = crate::pane::PaneRuntime::test_with_channel(
+            info.inner_rect.width,
+            info.inner_rect.height,
+        );
+        ws.tabs[0].runtimes.insert(pane_id, runtime);
+
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.pane_infos = pane_infos;
+
+        app.handle_terminal_key_headless(TerminalKey::new(KeyCode::Enter, KeyModifiers::SHIFT));
+
+        let bytes = rx.try_recv().unwrap();
+        assert_eq!(bytes.as_ref(), b"\n");
         assert!(rx.try_recv().is_err());
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -234,20 +234,23 @@ fn setup_terminal_with_capabilities(
         execute!(io::stdout(), DisableMouseCapture)?;
     }
 
-    // tmux doesn't understand kitty keyboard protocol push.
-    // Enable modifyOtherKeys mode 2 for tmux only for the full app client.
-    let in_tmux = enable_client_protocols && std::env::var("TMUX").is_ok();
-    if in_tmux {
+    // Some terminals do not report modified Enter through Kitty keyboard
+    // enhancement alone. modifyOtherKeys mode 2 makes Shift+Enter arrive as
+    // CSI u (\e[13;2u) instead of collapsing to plain Enter (\r).
+    let modify_other_keys_enabled = enable_client_protocols;
+    if modify_other_keys_enabled {
         io::stdout().write_all(b"\x1b[>4;2m")?;
         io::stdout().flush()?;
     }
 
-    Ok(TerminalGuard { in_tmux })
+    Ok(TerminalGuard {
+        modify_other_keys_enabled,
+    })
 }
 
 /// Guard that restores the terminal when dropped.
 struct TerminalGuard {
-    in_tmux: bool,
+    modify_other_keys_enabled: bool,
 }
 
 fn write_terminal_restore_postlude(writer: &mut impl io::Write) -> io::Result<()> {
@@ -264,11 +267,11 @@ fn set_mouse_capture(enabled: bool) -> io::Result<()> {
     }
 }
 
-fn restore_terminal_state(in_tmux: bool) {
+fn restore_terminal_state(modify_other_keys_enabled: bool) {
     let _ = clear_received_kitty_graphics(&mut io::stdout());
 
     // Reset modifyOtherKeys if we enabled it.
-    if in_tmux {
+    if modify_other_keys_enabled {
         let _ = io::stdout().write_all(b"\x1b[>4;0m");
         let _ = io::stdout().flush();
     }
@@ -286,7 +289,7 @@ fn restore_terminal_state(in_tmux: bool) {
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        restore_terminal_state(self.in_tmux);
+        restore_terminal_state(self.modify_other_keys_enabled);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write as _};
 
 use crossterm::event::{
     DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
@@ -455,15 +455,10 @@ fn main() -> io::Result<()> {
         Err(err) => return Err(err),
     };
 
-    let in_tmux = std::env::var("TMUX").is_ok();
-
     let original_hook = std::panic::take_hook();
-    let panic_in_tmux = in_tmux;
     std::panic::set_hook(Box::new(move |info| {
         tracing::error!("PANIC: {info}");
-        if panic_in_tmux {
-            let _ = std::io::Write::write_all(&mut io::stdout(), b"\x1b[>4;0m");
-        }
+        let _ = std::io::Write::write_all(&mut io::stdout(), b"\x1b[>4;0m");
         if crate::kitty_graphics::is_enabled() {
             let _ = crate::kitty_graphics::clear_all_host_graphics();
         }
@@ -505,14 +500,11 @@ fn main() -> io::Result<()> {
             PushKeyboardEnhancementFlags(crate::input::ime_compatible_keyboard_enhancement_flags())
         )?;
 
-        // tmux doesn't understand kitty keyboard protocol push (\e[>1u).
-        // It uses modifyOtherKeys mode to send CSI u sequences for modified keys.
-        // Enable modifyOtherKeys mode 2 so tmux sends Shift+Enter as \e[13;2u etc.
-        if in_tmux {
-            use std::io::Write;
-            std::io::stdout().write_all(b"\x1b[>4;2m")?;
-            std::io::stdout().flush()?;
-        }
+        // Some terminals do not report modified Enter through Kitty keyboard
+        // enhancement alone. modifyOtherKeys mode 2 makes Shift+Enter arrive as
+        // CSI u (\e[13;2u) instead of collapsing to plain Enter (\r).
+        io::stdout().write_all(b"\x1b[>4;2m")?;
+        io::stdout().flush()?;
 
         let startup_release_notes = crate::release_notes::load_pending_for_current_version();
 
@@ -526,12 +518,9 @@ fn main() -> io::Result<()> {
         );
         let result = app.run(&mut terminal).await;
 
-        // Reset modifyOtherKeys if we enabled it
-        if in_tmux {
-            use std::io::Write;
-            std::io::stdout().write_all(b"\x1b[>4;0m")?;
-            std::io::stdout().flush()?;
-        }
+        // Reset modifyOtherKeys if we enabled it.
+        io::stdout().write_all(b"\x1b[>4;0m")?;
+        io::stdout().flush()?;
 
         if crate::kitty_graphics::is_enabled() {
             crate::kitty_graphics::clear_all_host_graphics()?;


### PR DESCRIPTION
## Summary
- enable modifyOtherKeys mode 2 for full Herdr clients so terminals can report Shift+Enter distinctly
- forward parsed Shift+Enter to the focused pane as LF instead of CR
- add a regression test for Shift+Enter forwarding

## Testing
- cargo fmt --check
- manual local test in WezTerm: Shift+Enter inserts newlines and plain Enter submits

## Notes
This avoids requiring users to add a custom WezTerm keybinding when their terminal supports modifyOtherKeys.

refs: #168 