### PR TITLE
feat(experimental): add reveal_hidden_cursor_for_cjk_ime opt-in for CJK IME tracking

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added update badges on the sidebar menu, settings menu item, and integrations settings tab when installed integrations are outdated.
 - Added `terminal.default_shell` to choose the executable used for new interactive panes. When unset, Herdr still falls back to `$SHELL`, then `/bin/sh`. (#196)
 - Added native Kiro CLI detection with idle and working state heuristics. (#185)
+- Added `experimental.reveal_hidden_cursor_for_cjk_ime = false` (opt-in), `experimental.cjk_ime_agents = []` (optional allow-list), and `experimental.cjk_ime_cursor_shape = "steady_block"` to expose the focused pane's cursor anchor to the outer terminal even when the pane requested `?25l`, restoring macOS IME candidate-window tracking for TUIs that paint their own cursor (Claude Code, pi, codex). When `cjk_ime_agents` is non-empty, the reveal applies only to focused panes whose detected agent matches one of the listed names. When the pane reports no cursor position, the anchor falls back to the pane's top-left so a stable IME hint is always available. Trade-off when enabled: an extra hardware cursor may appear in the outer terminal for apps that hide the cursor without painting a replacement. (#149)
 
 ### Fixed
 - Keybinding conflict warnings now stay visible and show one readable yellow row per conflicting binding.

--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added `experimental.reveal_hidden_cursor_for_cjk_ime = false` (opt-in), `experimental.cjk_ime_agents = []` (optional allow-list), and `experimental.cjk_ime_cursor_shape = "steady_block"` to expose the focused pane's cursor anchor to the outer terminal even when the pane requested `?25l`, restoring macOS IME candidate-window tracking for TUIs that paint their own cursor (Claude Code, pi, codex). When `cjk_ime_agents` is non-empty, the reveal applies only to focused panes whose detected agent matches one of the listed names. When the pane reports no cursor position, the anchor falls back to the pane's top-left so a stable IME hint is always available. Trade-off when enabled: an extra hardware cursor may appear in the outer terminal for apps that hide the cursor without painting a replacement. (#149, thanks @ChihGodlee)
+
 ### Fixed
 - `herdr --remote` now offers to restart the remote server after installing or replacing a remote binary, or when the running server version differs, even if the client/server protocol is still compatible.
 
@@ -14,7 +17,6 @@
 - Added update badges on the sidebar menu, settings menu item, and integrations settings tab when installed integrations are outdated.
 - Added `terminal.default_shell` to choose the executable used for new interactive panes. When unset, Herdr still falls back to `$SHELL`, then `/bin/sh`. (#196)
 - Added native Kiro CLI detection with idle and working state heuristics. (#185)
-- Added `experimental.reveal_hidden_cursor_for_cjk_ime = false` (opt-in), `experimental.cjk_ime_agents = []` (optional allow-list), and `experimental.cjk_ime_cursor_shape = "steady_block"` to expose the focused pane's cursor anchor to the outer terminal even when the pane requested `?25l`, restoring macOS IME candidate-window tracking for TUIs that paint their own cursor (Claude Code, pi, codex). When `cjk_ime_agents` is non-empty, the reveal applies only to focused panes whose detected agent matches one of the listed names. When the pane reports no cursor position, the anchor falls back to the pane's top-left so a stable IME hint is always available. Trade-off when enabled: an extra hardware cursor may appear in the outer terminal for apps that hide the cursor without painting a replacement. (#149)
 
 ### Fixed
 - Keybinding conflict warnings now stay visible and show one readable yellow row per conflicting binding.

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -284,6 +284,29 @@ kitty_graphics = false
 
 Leave this off unless you are testing terminal image behavior.
 
+## IME cursor tracking
+
+When the focused pane hides its cursor and paints its own — common in AI-agent TUIs like Claude Code, pi, and codex — macOS native input methods stop tracking the candidate window position because the outer terminal stops reporting the cursor.
+
+Set `reveal_hidden_cursor_for_cjk_ime = true` to expose the focused pane's cursor anchor to the outer terminal regardless of the pane's `?25l` request:
+
+```toml
+[experimental]
+reveal_hidden_cursor_for_cjk_ime = false
+cjk_ime_agents = []
+cjk_ime_cursor_shape = "steady_block"
+```
+
+When enabled, the cursor stays visible at the focused pane's reported position. If the pane reports no cursor position, the anchor falls back to the pane's top-left so a stable IME hint is always available.
+
+`cjk_ime_agents` is an optional allow-list. When empty, the reveal applies to any focused pane. When non-empty, the reveal only applies if the focused pane's detected agent matches one of the listed names — useful to enable the reveal only for AI-agent TUIs that paint their own cursor while leaving plain shells untouched. Accepted names: `pi`, `claude`, `codex`, `gemini`, `cursor`, `cline`, `opencode`, `copilot`, `kimi`, `kiro`, `droid`, `amp`, `grok`, `hermes`. Unknown names are ignored.
+
+`cjk_ime_cursor_shape` controls the DECSCUSR shape rendered for the IME anchor. Accepted values: `block`, `steady_block` (default), `underline`, `steady_underline`, `bar`, `steady_bar`.
+
+Hot-reloads through the existing `[experimental]` block.
+
+The trade-off when enabled: an extra hardware cursor is visible in the outer terminal for apps that hide the cursor without painting a replacement (vim normal mode, etc.). Pair the reveal with `cjk_ime_agents` to scope it to specific TUIs.
+
 ## Environment variables
 
 | Variable | Purpose |

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -299,7 +299,7 @@ cjk_ime_cursor_shape = "steady_block"
 
 When enabled, the cursor stays visible at the focused pane's reported position. If the pane reports no cursor position, the anchor falls back to the pane's top-left so a stable IME hint is always available.
 
-`cjk_ime_agents` is an optional allow-list. When empty, the reveal applies to any focused pane. When non-empty, the reveal only applies if the focused pane's detected agent matches one of the listed names — useful to enable the reveal only for AI-agent TUIs that paint their own cursor while leaving plain shells untouched. Accepted names: `pi`, `claude`, `codex`, `gemini`, `cursor`, `cline`, `opencode`, `copilot`, `kimi`, `kiro`, `droid`, `amp`, `grok`, `hermes`. Unknown names are ignored.
+`cjk_ime_agents` is an optional allow-list. When empty, the reveal applies to any focused pane. When non-empty, the reveal only applies if the focused pane's detected agent matches one of the listed names — useful to enable the reveal only for AI-agent TUIs that paint their own cursor while leaving plain shells untouched. Accepted names: `pi`, `claude`, `codex`, `gemini`, `cursor`, `cline`, `opencode`, `copilot`, `kimi`, `kiro`, `droid`, `amp`, `grok`, `hermes`. Unknown names are ignored; if the list contains no valid names, the reveal does not apply.
 
 `cjk_ime_cursor_shape` controls the DECSCUSR shape rendered for the IME anchor. Accepted values: `block`, `steady_block` (default), `underline`, `steady_underline`, `bar`, `steady_bar`.
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -153,6 +153,21 @@ fn agent_panel_scope_from_config(
     }
 }
 
+/// Parse the configured agent name list into a deduplicated set of `Agent`
+/// values. Unknown agent names are silently dropped so a typo cannot disable
+/// other valid entries.
+fn parse_cjk_ime_agents(names: &[String]) -> Vec<crate::detect::Agent> {
+    let mut out = Vec::with_capacity(names.len());
+    for name in names {
+        if let Some(agent) = crate::detect::parse_agent_label(name) {
+            if !out.contains(&agent) {
+                out.push(agent);
+            }
+        }
+    }
+    out
+}
+
 /// Resolve the palette from config: base theme + optional custom overrides.
 fn resolve_palette(config: &crate::config::Config) -> state::Palette {
     resolve_palette_with_legacy_accent(config, true)
@@ -412,6 +427,9 @@ impl App {
             confirm_close: config.ui.confirm_close,
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
+            reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
+            cjk_ime_agents: parse_cjk_ime_agents(&config.experimental.cjk_ime_agents),
+            cjk_ime_cursor_shape: config.experimental.cjk_ime_cursor_shape.to_decscusr(),
             kitty_graphics_enabled: config.experimental.kitty_graphics,
             default_shell: config.terminal.default_shell.clone(),
             pane_scrollback_limit_bytes: config.advanced.scrollback_limit_bytes,
@@ -887,6 +905,11 @@ impl App {
             if was_kitty_graphics_enabled && !config.experimental.kitty_graphics {
                 let _ = crate::kitty_graphics::clear_all_host_graphics();
             }
+            self.state.reveal_hidden_cursor_for_cjk_ime =
+                config.experimental.reveal_hidden_cursor_for_cjk_ime;
+            self.state.cjk_ime_agents = parse_cjk_ime_agents(&config.experimental.cjk_ime_agents);
+            self.state.cjk_ime_cursor_shape =
+                config.experimental.cjk_ime_cursor_shape.to_decscusr();
         }
 
         if !invalid_section("advanced") {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -428,6 +428,7 @@ impl App {
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
             reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
+            cjk_ime_agent_filter_configured: !config.experimental.cjk_ime_agents.is_empty(),
             cjk_ime_agents: parse_cjk_ime_agents(&config.experimental.cjk_ime_agents),
             cjk_ime_cursor_shape: config.experimental.cjk_ime_cursor_shape.to_decscusr(),
             kitty_graphics_enabled: config.experimental.kitty_graphics,
@@ -907,6 +908,8 @@ impl App {
             }
             self.state.reveal_hidden_cursor_for_cjk_ime =
                 config.experimental.reveal_hidden_cursor_for_cjk_ime;
+            self.state.cjk_ime_agent_filter_configured =
+                !config.experimental.cjk_ime_agents.is_empty();
             self.state.cjk_ime_agents = parse_cjk_ime_agents(&config.experimental.cjk_ime_agents);
             self.state.cjk_ime_cursor_shape =
                 config.experimental.cjk_ime_cursor_shape.to_decscusr();

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -965,6 +965,14 @@ pub struct AppState {
     pub confirm_close: bool,
     pub prompt_new_tab_name: bool,
     pub show_agent_labels_on_pane_borders: bool,
+    /// Expose the focused pane's cursor anchor to the outer terminal even when
+    /// the pane requested `?25l`. See `[experimental] reveal_hidden_cursor_for_cjk_ime`.
+    pub reveal_hidden_cursor_for_cjk_ime: bool,
+    /// Restrict cursor reveal to focused panes whose detected agent matches
+    /// one of these. Empty means apply to any focused pane.
+    pub cjk_ime_agents: Vec<crate::detect::Agent>,
+    /// DECSCUSR shape parameter (1–6) for the IME anchor cursor.
+    pub cjk_ime_cursor_shape: u8,
     pub kitty_graphics_enabled: bool,
     pub default_shell: String,
     pub pane_scrollback_limit_bytes: usize,
@@ -1224,6 +1232,9 @@ impl AppState {
             confirm_close: true,
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
+            reveal_hidden_cursor_for_cjk_ime: false,
+            cjk_ime_agents: Vec::new(),
+            cjk_ime_cursor_shape: 2, // steady_block
             kitty_graphics_enabled: false,
             default_shell: String::new(),
             pane_scrollback_limit_bytes: crate::config::DEFAULT_SCROLLBACK_LIMIT_BYTES,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -969,7 +969,8 @@ pub struct AppState {
     /// the pane requested `?25l`. See `[experimental] reveal_hidden_cursor_for_cjk_ime`.
     pub reveal_hidden_cursor_for_cjk_ime: bool,
     /// Restrict cursor reveal to focused panes whose detected agent matches
-    /// one of these. Empty means apply to any focused pane.
+    /// one of these. When false, apply to any focused pane.
+    pub cjk_ime_agent_filter_configured: bool,
     pub cjk_ime_agents: Vec<crate::detect::Agent>,
     /// DECSCUSR shape parameter (1–6) for the IME anchor cursor.
     pub cjk_ime_cursor_shape: u8,
@@ -1233,6 +1234,7 @@ impl AppState {
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
             reveal_hidden_cursor_for_cjk_ime: false,
+            cjk_ime_agent_filter_configured: false,
             cjk_ime_agents: Vec::new(),
             cjk_ime_cursor_shape: 2, // steady_block
             kitty_graphics_enabled: false,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -209,6 +209,33 @@ pub struct UiConfig {
     pub sound: SoundConfig,
 }
 
+/// Cursor shape (DECSCUSR) used for the forced IME anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImeCursorShape {
+    Block,
+    #[default]
+    SteadyBlock,
+    Underline,
+    SteadyUnderline,
+    Bar,
+    SteadyBar,
+}
+
+impl ImeCursorShape {
+    /// Convert to DECSCUSR parameter (1–6).
+    pub fn to_decscusr(self) -> u8 {
+        match self {
+            Self::Block => 1,
+            Self::SteadyBlock => 2,
+            Self::Underline => 3,
+            Self::SteadyUnderline => 4,
+            Self::Bar => 5,
+            Self::SteadyBar => 6,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct AdvancedConfig {
@@ -224,6 +251,27 @@ pub struct ExperimentalConfig {
     pub allow_nested: bool,
     /// Experimental local Kitty graphics rendering for attached clients. Default: false.
     pub kitty_graphics: bool,
+    /// Expose the focused pane's cursor anchor to the outer terminal even when
+    /// the pane requested `?25l`, so macOS native input methods keep tracking
+    /// the candidate window when TUIs paint their own cursor (Claude Code, pi,
+    /// codex, etc.). Default: false.
+    ///
+    /// When the pane reports no cursor position, falls back to the pane's
+    /// top-left so a stable IME anchor is always available.
+    ///
+    /// Trade-off when enabled: an extra hardware cursor will be visible in the
+    /// outer terminal for apps that hide the cursor without painting a
+    /// replacement (vim normal mode, etc.). See #149.
+    pub reveal_hidden_cursor_for_cjk_ime: bool,
+    /// Restrict `reveal_hidden_cursor_for_cjk_ime` to focused panes whose
+    /// detected agent matches one of these names (case-insensitive). Empty
+    /// list means apply to any focused pane. Unknown agent names are ignored.
+    /// Accepted names: pi, claude, codex, gemini, cursor, cline, opencode,
+    /// copilot, kimi, kiro, droid, amp, grok, hermes. Default: empty.
+    pub cjk_ime_agents: Vec<String>,
+    /// Cursor shape rendered for the IME anchor when
+    /// `reveal_hidden_cursor_for_cjk_ime` is enabled. Default: "steady_block".
+    pub cjk_ime_cursor_shape: ImeCursorShape,
 }
 
 impl Default for KeysConfig {
@@ -378,6 +426,54 @@ prompt_new_tab_name = false
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert!(!config.ui.prompt_new_tab_name);
+    }
+
+    #[test]
+    fn reveal_hidden_cursor_for_cjk_ime_default_off_and_parse() {
+        let default_config = Config::default();
+        assert!(!default_config.experimental.reveal_hidden_cursor_for_cjk_ime);
+
+        let toml = r#"
+[experimental]
+reveal_hidden_cursor_for_cjk_ime = true
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.experimental.reveal_hidden_cursor_for_cjk_ime);
+    }
+
+    #[test]
+    fn cjk_ime_cursor_shape_default_steady_block_and_parse() {
+        let default_config = Config::default();
+        assert_eq!(
+            default_config.experimental.cjk_ime_cursor_shape,
+            ImeCursorShape::SteadyBlock
+        );
+
+        let toml = r#"
+[experimental]
+cjk_ime_cursor_shape = "bar"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.experimental.cjk_ime_cursor_shape,
+            ImeCursorShape::Bar
+        );
+    }
+
+    #[test]
+    fn cjk_ime_agents_default_empty_and_parse() {
+        let default_config = Config::default();
+        assert!(default_config.experimental.cjk_ime_agents.is_empty());
+
+        let toml = r#"
+[experimental]
+cjk_ime_agents = ["claude", "codex"]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.experimental.cjk_ime_agents,
+            vec!["claude".to_string(), "codex".to_string()]
+        );
     }
 
     #[test]

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -265,7 +265,8 @@ pub struct ExperimentalConfig {
     pub reveal_hidden_cursor_for_cjk_ime: bool,
     /// Restrict `reveal_hidden_cursor_for_cjk_ime` to focused panes whose
     /// detected agent matches one of these names (case-insensitive). Empty
-    /// list means apply to any focused pane. Unknown agent names are ignored.
+    /// list means apply to any focused pane. Unknown agent names are ignored;
+    /// if the list contains no valid names, the reveal does not apply.
     /// Accepted names: pi, claude, codex, gemini, cursor, cline, opencode,
     /// copilot, kimi, kiro, droid, amp, grok, hermes. Default: empty.
     pub cjk_ime_agents: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,19 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Experimental local Kitty graphics rendering for attached clients.
 # Requires a Kitty graphics-compatible outer terminal.
 # kitty_graphics = false
+# Expose the focused pane's cursor to the outer terminal so macOS input
+# methods keep tracking the candidate window when TUIs paint their own
+# cursor (Claude Code, pi, codex). Trade-off: extra cursor visible for
+# apps that hide it without painting a replacement (vim normal mode, etc.).
+# reveal_hidden_cursor_for_cjk_ime = false
+# Optional allow-list: only reveal for focused panes whose detected agent
+# matches one of these names. Empty means apply to any focused pane.
+# Accepted: pi, claude, codex, gemini, cursor, cline, opencode, copilot,
+# kimi, kiro, droid, amp, grok, hermes.
+# cjk_ime_agents = []
+# Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.
+# Values: block, steady_block (default), underline, steady_underline, bar, steady_bar.
+# cjk_ime_cursor_shape = "steady_block"
 
 [advanced]
 # Maximum scrollback buffer size in bytes retained per pane terminal.

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,7 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # reveal_hidden_cursor_for_cjk_ime = false
 # Optional allow-list: only reveal for focused panes whose detected agent
 # matches one of these names. Empty means apply to any focused pane.
+# If the list contains no valid names, the reveal does not apply.
 # Accepted: pi, claude, codex, gemini, cursor, cline, opencode, copilot,
 # kimi, kiro, droid, amp, grok, hermes.
 # cjk_ime_agents = []

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -2685,6 +2685,149 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn virtual_render_exposes_hidden_pane_cursor_when_reveal_hidden_for_cjk_ime() {
+        let mut state = AppState::test_new();
+        state.reveal_hidden_cursor_for_cjk_ime = true;
+        let mut ws = crate::workspace::Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        ws.insert_test_runtime(
+            pane_id,
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(20, 5, b"left\x1b[?25l"),
+        );
+
+        state.workspaces = vec![ws];
+        state.active = Some(0);
+        state.selected = 0;
+        state.mode = crate::app::Mode::Terminal;
+
+        let area = Rect::new(0, 0, 80, 24);
+        let (_buffer, cursor) =
+            crate::server::render_stream::render_virtual(&mut state, area, true);
+        let pane = state
+            .view
+            .pane_infos
+            .iter()
+            .find(|info| info.id == pane_id)
+            .expect("focused pane info");
+
+        assert_eq!(
+            cursor,
+            Some(CursorState {
+                x: pane.inner_rect.x + 4,
+                y: pane.inner_rect.y,
+                visible: true,
+                shape: state.cjk_ime_cursor_shape,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn virtual_render_keeps_cursor_hidden_when_scrolled_back_even_with_reveal_hidden_for_cjk_ime(
+    ) {
+        let mut state = AppState::test_new();
+        state.reveal_hidden_cursor_for_cjk_ime = true;
+        let mut ws = crate::workspace::Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        let mut bytes = Vec::new();
+        for line in 0..80 {
+            bytes.extend_from_slice(format!("line {line:02}\r\n").as_bytes());
+        }
+        let runtime =
+            crate::terminal::TerminalRuntime::test_with_scrollback_bytes(20, 5, 4096, &bytes);
+        ws.insert_test_runtime(pane_id, runtime);
+
+        state.workspaces = vec![ws];
+        state.active = Some(0);
+        state.selected = 0;
+        state.mode = crate::app::Mode::Terminal;
+
+        let area = Rect::new(0, 0, 80, 24);
+        let _ = crate::server::render_stream::render_virtual(&mut state, area, true);
+        let runtime = state
+            .runtime_for_pane(pane_id)
+            .expect("pane runtime after initial render");
+        runtime.scroll_up(6);
+        assert!(crate::ui::pane_is_scrolled_back(runtime));
+
+        let (_buffer, cursor) =
+            crate::server::render_stream::render_virtual(&mut state, area, true);
+
+        assert!(
+            cursor.as_ref().is_none_or(|cursor| !cursor.visible),
+            "scrolled-back focused pane should keep the cursor hidden even when reveal_hidden_cursor_for_cjk_ime is true; got {cursor:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn virtual_render_fallback_cursor_when_viewport_none_and_reveal_hidden_for_cjk_ime() {
+        let mut state = AppState::test_new();
+        state.reveal_hidden_cursor_for_cjk_ime = true;
+        let mut ws = crate::workspace::Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        // Feed only ?25l with no prior cursor movement — exercises the fallback
+        // path for TUIs whose viewport has no cursor position.
+        ws.insert_test_runtime(
+            pane_id,
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(20, 5, b"\x1b[?25l"),
+        );
+
+        state.workspaces = vec![ws];
+        state.active = Some(0);
+        state.selected = 0;
+        state.mode = crate::app::Mode::Terminal;
+
+        let area = Rect::new(0, 0, 80, 24);
+        let (_buffer, cursor) =
+            crate::server::render_stream::render_virtual(&mut state, area, true);
+        let pane = state
+            .view
+            .pane_infos
+            .iter()
+            .find(|info| info.id == pane_id)
+            .expect("focused pane info");
+
+        assert_eq!(
+            cursor,
+            Some(CursorState {
+                x: pane.inner_rect.x,
+                y: pane.inner_rect.y,
+                visible: true,
+                shape: state.cjk_ime_cursor_shape,
+            }),
+            "fallback should anchor at pane top-left with the configured shape",
+        );
+    }
+
+    #[tokio::test]
+    async fn virtual_render_skips_reveal_when_focused_pane_has_no_detected_agent() {
+        let mut state = AppState::test_new();
+        state.reveal_hidden_cursor_for_cjk_ime = true;
+        // Filter only Claude, but the test pane has no detected agent, so the
+        // reveal must not apply.
+        state.cjk_ime_agents = vec![crate::detect::Agent::Claude];
+        let mut ws = crate::workspace::Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        ws.insert_test_runtime(
+            pane_id,
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(20, 5, b"left\x1b[?25l"),
+        );
+
+        state.workspaces = vec![ws];
+        state.active = Some(0);
+        state.selected = 0;
+        state.mode = crate::app::Mode::Terminal;
+
+        let area = Rect::new(0, 0, 80, 24);
+        let (_buffer, cursor) =
+            crate::server::render_stream::render_virtual(&mut state, area, true);
+
+        assert!(
+            cursor.as_ref().is_none_or(|cursor| !cursor.visible),
+            "agent filter should suppress reveal when the focused pane's detected agent is not on the list; got {cursor:?}",
+        );
+    }
+
+    #[tokio::test]
     async fn virtual_render_omits_focused_pane_cursor_while_mobile_switcher_open() {
         let mut state = AppState::test_new();
         let mut ws = crate::workspace::Workspace::test_new("test");

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -2804,6 +2804,7 @@ mod tests {
         state.reveal_hidden_cursor_for_cjk_ime = true;
         // Filter only Claude, but the test pane has no detected agent, so the
         // reveal must not apply.
+        state.cjk_ime_agent_filter_configured = true;
         state.cjk_ime_agents = vec![crate::detect::Agent::Claude];
         let mut ws = crate::workspace::Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
@@ -2824,6 +2825,34 @@ mod tests {
         assert!(
             cursor.as_ref().is_none_or(|cursor| !cursor.visible),
             "agent filter should suppress reveal when the focused pane's detected agent is not on the list; got {cursor:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn virtual_render_skips_reveal_when_agent_filter_has_no_valid_entries() {
+        let mut state = AppState::test_new();
+        state.reveal_hidden_cursor_for_cjk_ime = true;
+        state.cjk_ime_agent_filter_configured = true;
+        state.cjk_ime_agents = Vec::new();
+        let mut ws = crate::workspace::Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
+        ws.insert_test_runtime(
+            pane_id,
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(20, 5, b"left\x1b[?25l"),
+        );
+
+        state.workspaces = vec![ws];
+        state.active = Some(0);
+        state.selected = 0;
+        state.mode = crate::app::Mode::Terminal;
+
+        let area = Rect::new(0, 0, 80, 24);
+        let (_buffer, cursor) =
+            crate::server::render_stream::render_virtual(&mut state, area, true);
+
+        assert!(
+            cursor.as_ref().is_none_or(|cursor| !cursor.visible),
+            "agent filter with no valid entries should suppress reveal; got {cursor:?}",
         );
     }
 

--- a/src/server/render_stream.rs
+++ b/src/server/render_stream.rs
@@ -322,11 +322,54 @@ fn focused_terminal_cursor(app_state: &AppState) -> Option<CursorState> {
         .iter()
         .find(|info| info.is_focused)?;
     let rt = app_state.runtime_for_pane_in_workspace(ws_idx, info.id)?;
-    let cursor = rt.cursor_state(info.inner_rect, true)?;
-    Some(CursorState {
-        x: cursor.x,
-        y: cursor.y,
-        visible: cursor.visible && !crate::ui::pane_is_scrolled_back(rt),
-        shape: cursor.shape,
-    })
+    let scrolled_back = crate::ui::pane_is_scrolled_back(rt);
+
+    // Determine whether the IME-anchor reveal applies to this focused pane.
+    // The master switch must be on, and either no agent filter is configured
+    // (apply to any pane) or the focused pane's detected agent matches the
+    // allow-list.
+    let reveal = app_state.reveal_hidden_cursor_for_cjk_ime
+        && (app_state.cjk_ime_agents.is_empty() || {
+            let detected = app_state
+                .workspaces
+                .get(ws_idx)
+                .and_then(|ws| ws.terminal_id(info.id))
+                .and_then(|tid| app_state.terminals.get(tid))
+                .and_then(|t| t.detected_agent);
+            detected.is_some_and(|agent| app_state.cjk_ime_agents.contains(&agent))
+        });
+
+    if let Some(cursor) = rt.cursor_state(info.inner_rect, true) {
+        // When the reveal applies, expose the cursor anchor regardless of the
+        // pane's `?25l` request so macOS IMEs keep tracking the candidate
+        // window when TUIs paint their own cursor. Scrollback suppression
+        // still applies.
+        let visible = if reveal {
+            !scrolled_back
+        } else {
+            cursor.visible && !scrolled_back
+        };
+        Some(CursorState {
+            x: cursor.x,
+            y: cursor.y,
+            visible,
+            shape: if reveal && visible {
+                app_state.cjk_ime_cursor_shape
+            } else {
+                cursor.shape
+            },
+        })
+    } else if reveal && !scrolled_back {
+        // cursor_state() returned None — the viewport has no cursor position
+        // (can happen with complex TUIs). Fall back to the pane's top-left so
+        // the outer terminal still exposes a cursor anchor for IME tracking.
+        Some(CursorState {
+            x: info.inner_rect.x,
+            y: info.inner_rect.y,
+            visible: true,
+            shape: app_state.cjk_ime_cursor_shape,
+        })
+    } else {
+        None
+    }
 }

--- a/src/server/render_stream.rs
+++ b/src/server/render_stream.rs
@@ -327,9 +327,9 @@ fn focused_terminal_cursor(app_state: &AppState) -> Option<CursorState> {
     // Determine whether the IME-anchor reveal applies to this focused pane.
     // The master switch must be on, and either no agent filter is configured
     // (apply to any pane) or the focused pane's detected agent matches the
-    // allow-list.
+    // allow-list. A configured list with no valid entries reveals nothing.
     let reveal = app_state.reveal_hidden_cursor_for_cjk_ime
-        && (app_state.cjk_ime_agents.is_empty() || {
+        && (!app_state.cjk_ime_agent_filter_configured || {
             let detected = app_state
                 .workspaces
                 .get(ws_idx)


### PR DESCRIPTION
Refs #149.

## Summary

When a focused pane requests `?25l` (cursor hidden) but paints its own cursor — common in AI-agent TUIs like Claude Code, pi, and codex — macOS native input methods stop tracking the candidate-window position. CJK users (Chinese / Japanese / Korean) cannot see the candidate window follow as they type.

This PR adds an opt-in `[experimental]` flag plus a per-agent allow-list and a configurable cursor shape:

```toml
[experimental]
reveal_hidden_cursor_for_cjk_ime = false   # opt-in master switch (default off)
cjk_ime_agents = ["claude"]                # optional allow-list (default empty = any pane)
cjk_ime_cursor_shape = "steady_block"      # DECSCUSR shape for the revealed cursor
```

When the master switch is on, `focused_terminal_cursor` (`src/server/render_stream.rs`) returns `visible: true` for the focused pane regardless of the pane's hidden-cursor request, so both `write_host_cursor_state` and `write_ime_anchor_cursor_state` (`src/client/blit.rs`) emit `?25h` + `CUP` and the OS terminal reports the position to the IME. Default `false` preserves the behavior set in `2c95071` byte-for-byte.

## Behavior matrix

| Master switch | Allow-list | Focused pane's detected agent | Reveal applies? |
|---|---|---|---|
| false | (any) | (any) | ❌ no (current default behavior) |
| true | `[]` (empty) | (any) | ✅ yes (apply to any pane) |
| true | `["claude"]` | None | ❌ no |
| true | `["claude"]` | Claude | ✅ yes |
| true | `["claude"]` | Codex | ❌ no |

The allow-list lets users enable the workaround only for AI-agent TUIs that paint their own cursor, leaving plain shells and other programs untouched. Accepted names: `pi`, `claude`, `codex`, `gemini`, `cursor`, `cline`, `opencode`, `copilot`, `kimi`, `kiro`, `droid`, `amp`, `grok`, `hermes`. Unknown names are silently ignored so a typo cannot disable other valid entries.

## None-fallback (required for the feature to work in practice)

Manual testing surfaced an edge case: `cursor_state()` (`src/pane/terminal.rs:528`) calls `render_state.cursor_viewport().ok()??`, which returns `None` for some TUIs (Claude Code among them). Without a fallback, the original visibility short-circuit never executes and the cursor stays hidden. When the reveal applies and `cursor_state()` returns `None`, this PR falls back to the pane's `inner_rect` top-left so a stable IME anchor is always available. Scrollback still suppresses the reveal in both branches.

## Trade-off (when enabled)

A hardware cursor is visible in the outer terminal for apps that hide the cursor without painting a replacement (vim normal mode, etc.). The `cjk_ime_agents` allow-list is the recommended mitigation: scope the reveal to AI-agent TUIs only.

## Files touched

- `src/config/model.rs` — `ExperimentalConfig` adds 3 fields; `ImeCursorShape` enum (6 variants) with `to_decscusr` mapping; 3 parse tests
- `src/app/state.rs` — flat fields on `AppState` (`reveal_hidden_cursor_for_cjk_ime`, `cjk_ime_agents`, `cjk_ime_cursor_shape`)
- `src/app/mod.rs` — `parse_cjk_ime_agents` helper; initial wiring + hot-reload through the existing `[experimental]` block
- `src/server/render_stream.rs` — visibility + shape short-circuit, agent filter, None fallback
- `src/server/headless.rs` — 4 new tests
- `src/main.rs` — commented example in the embedded default config
- `docs/next/CHANGELOG.md` — Unreleased / Added entry
- `docs/next/website/src/content/docs/configuration.mdx` — new "IME cursor tracking" section after Kitty graphics

`src/client/blit.rs` is intentionally untouched — the visibility flip is upstream of the blit code.

## Tests

| Test | Verifies |
|---|---|
| `reveal_hidden_cursor_for_cjk_ime_default_off_and_parse` | Default `false`; `[experimental]` TOML parses |
| `cjk_ime_cursor_shape_default_steady_block_and_parse` | Default `SteadyBlock`; alternate shape parses |
| `cjk_ime_agents_default_empty_and_parse` | Default empty; `["claude", "codex"]` parses |
| `virtual_render_preserves_hidden_focused_pane_cursor_position` *(existing, regression)* | Default off + `?25l` → `visible: false` (byte-equivalent) |
| `virtual_render_exposes_hidden_pane_cursor_when_reveal_hidden_for_cjk_ime` | Master on + `?25l` → `visible: true`, configured shape |
| `virtual_render_keeps_cursor_hidden_when_scrolled_back_even_with_reveal_hidden_for_cjk_ime` | Master on + scrollback → cursor stays hidden |
| `virtual_render_fallback_cursor_when_viewport_none_and_reveal_hidden_for_cjk_ime` | Master on + `cursor_state()` returns None → anchored at pane top-left, configured shape |
| `virtual_render_skips_reveal_when_focused_pane_has_no_detected_agent` | Master on + `cjk_ime_agents = ["claude"]` + no detected agent → reveal does NOT apply |

Existing IME input regressions remain green; default-off path is byte-equivalent to current master.

## Manual verification

Built `aarch64-apple-darwin` via the fork's `Build artifacts (manual)` workflow and tested on macOS 26.5 with the system Pinyin IME against Claude Code:

- Default config (flag off): candidate window stuck at startup position, does not follow as I type — reproduces the original bug.
- `reveal_hidden_cursor_for_cjk_ime = true`, `cjk_ime_agents = ["claude"]`, `cjk_ime_cursor_shape = "steady_block"`: cursor visible in outer terminal at the focused pane's reported position, candidate window tracks the cursor as I type.
- Switching focus to a plain shell pane (no detected agent): the extra outer-terminal cursor disappears, confirming the agent filter scopes the reveal correctly.
- Disabling the master switch: returns to the anchored-at-start behavior.
- Scrolling back inside the Claude Code pane: cursor anchor goes away as expected.

Happy to record a short clip if helpful.

## Notes for review

- Hot-reload follows the established pattern of `kitty_graphics` in the same `if !invalid_section("experimental")` block in `src/app/mod.rs`.
- I added a single line under "Unreleased / Added" in `docs/next/CHANGELOG.md`. CONTRIBUTING.md says contributors don't need to edit the changelog and that maintainers prepare it during release review — happy to drop that line if you'd rather curate it yourself.
- No protocol changes, no new keybinds, no new UI surfaces.
- Single conventional commit, no Change-Id or amend trailers.