### PR TITLE
feat: support placeholders in [worktrees].directory for sibling layouts

### DIFF
--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -89,6 +89,12 @@ directory = "{repo_parent}/{repo_name}.worktrees"
 
 With this config, a repo at `~/foo/bar` gets worktrees at `~/foo/bar.worktrees/<branch-slug>`. When the template contains `{repo_name}` or `{repo_root}`, Herdr drops the implicit `<repo>/` segment so the path doesn't double up.
 
+A few caveats:
+
+- `{repo_root}` and `{repo_parent}` are the paths Git reports for the source repo, with symlinks resolved. If you open a symlink such as `~/foo/bar` that points at `~/work/projects/bar`, `{repo_parent}` will be `~/work/projects`, not `~/foo`.
+- `directory = "{repo_root}/.worktrees"` places checkouts inside the source repo's working tree. Add the chosen folder (e.g. `.worktrees/`) to `.gitignore` or `.git/info/exclude` so Git doesn't show the worktrees as untracked changes.
+- Unknown placeholders (e.g. `{repo_nam}` typos) and an empty `directory` are surfaced as config diagnostics on startup.
+
 Worktree actions are available from Git workspace rows. `New worktree` creates a branch and checkout, opens it as a new Herdr workspace, and groups it under the source workspace. `Open worktree...` lists existing Git worktree checkouts for that repo; choosing an already-open checkout focuses it, and choosing a closed checkout opens it in the same group.
 
 Grouped worktrees still behave like normal Herdr workspaces: they can be focused, renamed, closed, and contain their own tabs and panes. The parent row is the original workspace. Closing the parent row closes the whole Herdr group, but it does not delete checkout folders or branches.

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -74,7 +74,20 @@ Set the root directory Herdr uses for Git worktree checkouts created from the si
 directory = "~/.herdr/worktrees"
 ```
 
-Herdr creates checkouts under `<directory>/<repo>/<branch-slug>`. For sibling-style checkouts, set this to a directory such as `~/Projects/herdr-worktrees`.
+By default Herdr creates checkouts under `<directory>/<repo>/<branch-slug>`. The `directory` value also accepts the following placeholders, substituted per source repo:
+
+- `{repo_root}` — absolute path of the source repo, e.g. `/home/me/foo/bar`
+- `{repo_parent}` — parent directory of the source repo, e.g. `/home/me/foo`
+- `{repo_name}` — basename of the source repo, e.g. `bar`
+
+For a true sibling-folder layout next to each repo, use `{repo_name}` in the template:
+
+```toml
+[worktrees]
+directory = "{repo_parent}/{repo_name}.worktrees"
+```
+
+With this config, a repo at `~/foo/bar` gets worktrees at `~/foo/bar.worktrees/<branch-slug>`. When the template contains `{repo_name}` or `{repo_root}`, Herdr drops the implicit `<repo>/` segment so the path doesn't double up.
 
 Worktree actions are available from Git workspace rows. `New worktree` creates a branch and checkout, opens it as a new Herdr workspace, and groups it under the source workspace. `Open worktree...` lists existing Git worktree checkouts for that repo; choosing an already-open checkout focuses it, and choosing a closed checkout opens it in the same group.
 

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -89,11 +89,10 @@ directory = "{repo_parent}/{repo_name}.worktrees"
 
 With this config, a repo at `~/foo/bar` gets worktrees at `~/foo/bar.worktrees/<branch-slug>`. When the template contains `{repo_name}` or `{repo_root}`, Herdr drops the implicit `<repo>/` segment so the path doesn't double up.
 
-A few caveats:
+Two caveats:
 
-- `{repo_root}` and `{repo_parent}` are the paths Git reports for the source repo, with symlinks resolved. If you open a symlink such as `~/foo/bar` that points at `~/work/projects/bar`, `{repo_parent}` will be `~/work/projects`, not `~/foo`.
-- `directory = "{repo_root}/.worktrees"` places checkouts inside the source repo's working tree. Add the chosen folder (e.g. `.worktrees/`) to `.gitignore` or `.git/info/exclude` so Git doesn't show the worktrees as untracked changes.
-- Unknown placeholders (e.g. `{repo_nam}` typos) and an empty `directory` are surfaced as config diagnostics on startup.
+- `{repo_root}` and `{repo_parent}` use Git's reported repo path, with symlinks resolved.
+- `directory = "{repo_root}/.worktrees"` puts checkouts inside the working tree — add the folder to `.gitignore` so Git doesn't list them as untracked.
 
 Worktree actions are available from Git workspace rows. `New worktree` creates a branch and checkout, opens it as a new Herdr workspace, and groups it under the source workspace. `Open worktree...` lists existing Git worktree checkouts for that repo; choosing an already-open checkout focuses it, and choosing a closed checkout opens it in the same group.
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1018,6 +1018,7 @@ impl App {
         }
 
         if !invalid_section("worktrees") {
+            diagnostics.extend(config.worktrees.diagnostics());
             self.state.worktree_directory = config.worktrees.directory.clone();
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1731,6 +1731,31 @@ mod tests {
     }
 
     #[test]
+    fn reload_config_surfaces_worktree_template_diagnostic_and_still_applies_value() {
+        let _guard = config_env_lock().lock().unwrap();
+        let path = temp_config_path("reload-config-worktree-template-diag");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[worktrees]\ndirectory = \"~/wt/{repo_nam}\"\n").unwrap();
+        std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
+
+        let mut app = test_app();
+        let report = app.reload_config();
+
+        assert_eq!(report.status, crate::config::ConfigReloadStatus::Partial);
+        // Warn-only: the (typo'd) template still gets applied. The diagnostic is
+        // surfaced separately so the user can see and fix it.
+        assert_eq!(app.state.worktree_directory, "~/wt/{repo_nam}");
+        assert!(app
+            .state
+            .config_diagnostic
+            .as_deref()
+            .is_some_and(|message| message.contains("{repo_nam}")));
+
+        std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
     fn settings_save_toast_delivery_persists_then_applies_live_config() {
         let _guard = config_env_lock().lock().unwrap();
         let path = temp_config_path("settings-save-toast-delivery");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -327,7 +327,7 @@ impl App {
             (18, 36)
         });
 
-        let worktree_directory = crate::worktree::expand_tilde_path(&config.worktrees.directory);
+        let worktree_directory = config.worktrees.directory.clone();
 
         info!(
             pane_scrollback_limit_bytes = config.advanced.scrollback_limit_bytes,
@@ -1018,8 +1018,7 @@ impl App {
         }
 
         if !invalid_section("worktrees") {
-            self.state.worktree_directory =
-                crate::worktree::expand_tilde_path(&config.worktrees.directory);
+            self.state.worktree_directory = config.worktrees.directory.clone();
         }
 
         if !invalid_section("theme") {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1013,7 +1013,10 @@ pub struct AppState {
     pub worktree_create: Option<WorktreeCreateState>,
     pub worktree_open: Option<WorktreeOpenState>,
     pub worktree_remove: Option<WorktreeRemoveState>,
-    pub worktree_directory: std::path::PathBuf,
+    /// Raw `[worktrees].directory` template from config. Per-repo placeholder
+    /// resolution happens at worktree-creation time via
+    /// `crate::worktree::default_checkout_path`.
+    pub worktree_directory: String,
     pub collapsed_space_keys: std::collections::HashSet<String>,
     pub request_complete_onboarding: bool,
     pub name_input: String,
@@ -1299,7 +1302,7 @@ impl AppState {
             worktree_create: None,
             worktree_open: None,
             worktree_remove: None,
-            worktree_directory: std::path::PathBuf::from("/tmp/herdr-worktrees"),
+            worktree_directory: "/tmp/herdr-worktrees".to_string(),
             collapsed_space_keys: std::collections::HashSet::new(),
             request_complete_onboarding: false,
             name_input: String::new(),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1013,9 +1013,8 @@ pub struct AppState {
     pub worktree_create: Option<WorktreeCreateState>,
     pub worktree_open: Option<WorktreeOpenState>,
     pub worktree_remove: Option<WorktreeRemoveState>,
-    /// Raw `[worktrees].directory` template from config. Per-repo placeholder
-    /// resolution happens at worktree-creation time via
-    /// `crate::worktree::default_checkout_path`.
+    /// Raw `[worktrees].directory` template. Per-repo placeholders are resolved
+    /// at worktree-creation time, not here.
     pub worktree_directory: String,
     pub collapsed_space_keys: std::collections::HashSet<String>,
     pub request_complete_onboarding: bool,

--- a/src/app/worktrees.rs
+++ b/src/app/worktrees.rs
@@ -94,6 +94,7 @@ impl App {
         let branch = crate::worktree::generated_branch_slug(seed);
         let checkout_path = crate::worktree::default_checkout_path(
             &self.state.worktree_directory,
+            &space.repo_root,
             &repo_name,
             &branch,
         );
@@ -420,6 +421,7 @@ impl App {
         create.branch = self.state.name_input.clone();
         create.checkout_path = crate::worktree::default_checkout_path(
             &self.state.worktree_directory,
+            &create.source_repo_root,
             &create.repo_name,
             &create.branch,
         );
@@ -444,6 +446,7 @@ impl App {
         self.state.name_input = branch.clone();
         create.checkout_path = crate::worktree::default_checkout_path(
             &self.state.worktree_directory,
+            &create.source_repo_root,
             &create.repo_name,
             &branch,
         );
@@ -833,7 +836,7 @@ mod tests {
     #[test]
     fn sync_worktree_branch_updates_derived_path() {
         let mut app = app_for_worktree_tests();
-        app.state.worktree_directory = std::path::PathBuf::from("/w");
+        app.state.worktree_directory = "/w".to_string();
         app.state.name_input = "issue/137".into();
         app.state.worktree_create = Some(WorktreeCreateState {
             source_workspace_id: "source".into(),
@@ -864,9 +867,11 @@ mod tests {
         let repo = create_committed_repo("app-worktree-add-repo");
         let worktree_root = unique_temp_path("app-worktree-add-root");
         let branch = "worktree/app-worker";
-        let checkout = crate::worktree::default_checkout_path(&worktree_root, "herdr", branch);
+        let worktree_root_str = worktree_root.display().to_string();
+        let checkout =
+            crate::worktree::default_checkout_path(&worktree_root_str, &repo, "herdr", branch);
         let mut app = app_for_worktree_tests();
-        app.state.worktree_directory = worktree_root.clone();
+        app.state.worktree_directory = worktree_root_str.clone();
         app.state.name_input = branch.into();
         app.state.worktree_create = Some(WorktreeCreateState {
             source_workspace_id: "source".into(),
@@ -926,9 +931,11 @@ mod tests {
 
         let worktree_root = unique_temp_path("app-worktree-add-from-source-root");
         let branch = "worktree/from-source";
-        let checkout = crate::worktree::default_checkout_path(&worktree_root, "herdr", branch);
+        let worktree_root_str = worktree_root.display().to_string();
+        let checkout =
+            crate::worktree::default_checkout_path(&worktree_root_str, &repo, "herdr", branch);
         let mut app = app_for_worktree_tests();
-        app.state.worktree_directory = worktree_root.clone();
+        app.state.worktree_directory = worktree_root_str.clone();
         app.state.name_input = branch.into();
         app.state.worktree_create = Some(WorktreeCreateState {
             source_workspace_id: "source".into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ impl Config {
             .into_iter()
             .chain(keybind_diags)
             .chain(self.ui.sound.diagnostics())
+            .chain(self.worktrees.diagnostics())
             .collect()
     }
 

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -236,6 +236,12 @@ pub struct WorktreesConfig {
     pub directory: String,
 }
 
+impl WorktreesConfig {
+    pub fn diagnostics(&self) -> Vec<String> {
+        crate::worktree::template_diagnostics(&self.directory)
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct UiConfig {
@@ -533,6 +539,22 @@ directory = "~/Projects/herdr-worktrees"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.worktrees.directory, "~/Projects/herdr-worktrees");
+    }
+
+    #[test]
+    fn collect_diagnostics_surfaces_worktrees_template_problems() {
+        // Guards the chain wiring in Config::collect_diagnostics; a future refactor
+        // that drops `self.worktrees.diagnostics()` would otherwise silently regress.
+        let toml = r#"
+[worktrees]
+directory = "~/wt/{repo_nam}"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        let diagnostics = config.collect_diagnostics();
+        assert!(
+            diagnostics.iter().any(|d| d.contains("{repo_nam}")),
+            "expected worktrees diagnostic in {diagnostics:?}",
+        );
     }
 
     #[test]

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -222,17 +222,8 @@ pub struct IndexedKeysConfig {
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct WorktreesConfig {
-    /// Template for the root directory under which Herdr creates worktree
-    /// checkouts. Supports `~` and the placeholders `{repo_root}`,
-    /// `{repo_parent}`, and `{repo_name}` (substituted per source repo at
-    /// worktree-creation time).
-    ///
-    /// Layout:
-    /// * Default (no placeholders): `<directory>/<repo_name>/<branch-slug>`
-    /// * Templates containing `{repo_name}` or `{repo_root}` drop the implicit
-    ///   `<repo_name>/` segment, so e.g.
-    ///   `directory = "{repo_parent}/{repo_name}.worktrees"` produces a
-    ///   sibling-folder layout: `<parent>/<repo>.worktrees/<branch-slug>`.
+    /// Root directory for worktree checkouts. Supports `~` and the
+    /// `{repo_root}`, `{repo_parent}`, `{repo_name}` placeholders.
     pub directory: String,
 }
 

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -222,7 +222,17 @@ pub struct IndexedKeysConfig {
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct WorktreesConfig {
-    /// Root directory under which Herdr creates <repo>/<branch-slug> checkouts.
+    /// Template for the root directory under which Herdr creates worktree
+    /// checkouts. Supports `~` and the placeholders `{repo_root}`,
+    /// `{repo_parent}`, and `{repo_name}` (substituted per source repo at
+    /// worktree-creation time).
+    ///
+    /// Layout:
+    /// * Default (no placeholders): `<directory>/<repo_name>/<branch-slug>`
+    /// * Templates containing `{repo_name}` or `{repo_root}` drop the implicit
+    ///   `<repo_name>/` segment, so e.g.
+    ///   `directory = "{repo_parent}/{repo_name}.worktrees"` produces a
+    ///   sibling-folder layout: `<parent>/<repo>.worktrees/<branch-slug>`.
     pub directory: String,
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -72,20 +72,9 @@ pub(crate) fn canonical_or_original(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-/// Resolve the `[worktrees].directory` template into a concrete root path for
-/// a specific source repo.
-///
-/// Supported placeholders:
-///   `{repo_root}`   — absolute path of the source repo (e.g. `/home/me/foo/bar`)
-///   `{repo_parent}` — parent directory of the source repo (e.g. `/home/me/foo`)
-///   `{repo_name}`   — basename of the source repo (e.g. `bar`)
-///
-/// Returns the resolved root and whether the template referenced `{repo_name}`
-/// or `{repo_root}` — when it did, [`default_checkout_path`] skips the implicit
-/// `<repo_name>/` segment so paths don't double up (e.g. a template of
-/// `{repo_parent}/{repo_name}.worktrees` resolves to
-/// `<parent>/<repo>.worktrees/<branch-slug>`, not
-/// `<parent>/<repo>.worktrees/<repo>/<branch-slug>`).
+/// Expands `~` and `{repo_root}`/`{repo_parent}`/`{repo_name}` in `template`.
+/// The bool is true when the template already encodes the repo name (via
+/// `{repo_name}` or `{repo_root}`) so callers can skip appending it again.
 pub(crate) fn resolve_worktree_root(
     template: &str,
     repo_root: &Path,
@@ -99,11 +88,7 @@ pub(crate) fn resolve_worktree_root(
         return (expand_tilde_path(template), false);
     }
 
-    // `Path::parent()` returns paths without a trailing `/` for normal paths,
-    // but returns `Some("/")` for paths like "/foo" and `None` for "/" itself.
-    // For the "/" case (whether falling back from `None` or returned as the
-    // parent of a top-level repo), substitute "" so `{repo_parent}/wt` becomes
-    // `/wt` rather than `//wt` in user-visible logs.
+    // Avoid "//wt" when {repo_parent} resolves to the filesystem root.
     let repo_parent = repo_root.parent().unwrap_or_else(|| Path::new("/"));
     let repo_parent_str = if repo_parent == Path::new("/") {
         String::new()
@@ -119,10 +104,8 @@ pub(crate) fn resolve_worktree_root(
     (expand_tilde_path(&expanded), has_repo_name || has_repo_root)
 }
 
-/// Validate a `[worktrees].directory` template, returning user-facing
-/// diagnostics for problems Herdr can detect without knowing a specific repo:
-/// an empty/whitespace value, or `{...}` tokens that aren't one of the
-/// supported placeholders (`{repo_root}`, `{repo_parent}`, `{repo_name}`).
+/// Static diagnostics for `[worktrees].directory`: empty value or unknown
+/// `{...}` placeholders. Per-repo errors are not detectable here.
 pub(crate) fn template_diagnostics(template: &str) -> Vec<String> {
     let mut diagnostics = Vec::new();
 
@@ -491,9 +474,7 @@ prunable stale
 
     #[test]
     fn default_checkout_path_with_repo_parent_and_name_creates_sibling_layout() {
-        // Sibling layout: {repo_parent}/{repo_name}.worktrees lives next to the source repo.
-        // Because the template references {repo_name}, the implicit <repo>/ segment is
-        // dropped to avoid `.../bar.worktrees/bar/<branch>`.
+        // {repo_name} in template ⇒ implicit <repo>/ segment is dropped.
         assert_eq!(
             default_checkout_path(
                 "{repo_parent}/{repo_name}.worktrees",
@@ -561,8 +542,6 @@ prunable stale
 
     #[test]
     fn resolve_worktree_root_substitutes_empty_for_root_parent_to_avoid_double_slash() {
-        // /foo has parent /, which would naively yield "//wt". {repo_parent}
-        // substitutes to "" in that case so the result displays as "/wt".
         let (root, _) = resolve_worktree_root("{repo_parent}/wt", Path::new("/foo"), "foo");
         assert_eq!(root.display().to_string(), "/wt");
     }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -72,8 +72,59 @@ pub(crate) fn canonical_or_original(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-pub(crate) fn default_checkout_path(root: &Path, repo_name: &str, branch: &str) -> PathBuf {
-    root.join(repo_name).join(branch_to_path_slug(branch))
+/// Resolve the `[worktrees].directory` template into a concrete root path for
+/// a specific source repo.
+///
+/// Supported placeholders:
+///   `{repo_root}`   — absolute path of the source repo (e.g. `/home/me/foo/bar`)
+///   `{repo_parent}` — parent directory of the source repo (e.g. `/home/me/foo`)
+///   `{repo_name}`   — basename of the source repo (e.g. `bar`)
+///
+/// Returns the resolved root and whether the template referenced `{repo_name}`
+/// or `{repo_root}` — when it did, [`default_checkout_path`] skips the implicit
+/// `<repo_name>/` segment so paths don't double up (e.g. a template of
+/// `{repo_parent}/{repo_name}.worktrees` resolves to
+/// `<parent>/<repo>.worktrees/<branch-slug>`, not
+/// `<parent>/<repo>.worktrees/<repo>/<branch-slug>`).
+pub(crate) fn resolve_worktree_root(
+    template: &str,
+    repo_root: &Path,
+    repo_name: &str,
+) -> (PathBuf, bool) {
+    let has_repo_name = template.contains("{repo_name}");
+    let has_repo_root = template.contains("{repo_root}");
+    let has_repo_parent = template.contains("{repo_parent}");
+
+    if !has_repo_name && !has_repo_root && !has_repo_parent {
+        return (expand_tilde_path(template), false);
+    }
+
+    let repo_parent = repo_root
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("/"));
+
+    let expanded = template
+        .replace("{repo_root}", &repo_root.display().to_string())
+        .replace("{repo_parent}", &repo_parent.display().to_string())
+        .replace("{repo_name}", repo_name);
+
+    (expand_tilde_path(&expanded), has_repo_name || has_repo_root)
+}
+
+pub(crate) fn default_checkout_path(
+    template: &str,
+    repo_root: &Path,
+    repo_name: &str,
+    branch: &str,
+) -> PathBuf {
+    let (root, repo_already_in_root) = resolve_worktree_root(template, repo_root, repo_name);
+    let base = if repo_already_in_root {
+        root
+    } else {
+        root.join(repo_name)
+    };
+    base.join(branch_to_path_slug(branch))
 }
 
 pub(crate) fn build_worktree_remove_command(
@@ -362,12 +413,101 @@ prunable stale
     fn default_checkout_path_appends_repo_and_branch_slug() {
         assert_eq!(
             default_checkout_path(
-                Path::new("/home/me/.herdr/worktrees"),
+                "/home/me/.herdr/worktrees",
+                Path::new("/home/me/code/herdr"),
                 "herdr",
                 "worktree/brave-river",
             ),
             PathBuf::from("/home/me/.herdr/worktrees/herdr/worktree-brave-river")
         );
+    }
+
+    #[test]
+    fn default_checkout_path_expands_tilde_in_legacy_template() {
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", "/home/me");
+        assert_eq!(
+            default_checkout_path(
+                "~/.herdr/worktrees",
+                Path::new("/home/me/code/herdr"),
+                "herdr",
+                "main",
+            ),
+            PathBuf::from("/home/me/.herdr/worktrees/herdr/main")
+        );
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+    }
+
+    #[test]
+    fn default_checkout_path_with_repo_parent_and_name_creates_sibling_layout() {
+        // Sibling layout: {repo_parent}/{repo_name}.worktrees lives next to the source repo.
+        // Because the template references {repo_name}, the implicit <repo>/ segment is
+        // dropped to avoid `.../bar.worktrees/bar/<branch>`.
+        assert_eq!(
+            default_checkout_path(
+                "{repo_parent}/{repo_name}.worktrees",
+                Path::new("/home/me/foo/bar"),
+                "bar",
+                "issue/137",
+            ),
+            PathBuf::from("/home/me/foo/bar.worktrees/issue-137")
+        );
+    }
+
+    #[test]
+    fn default_checkout_path_with_repo_root_nests_inside_repo() {
+        // {repo_root} also drops the implicit <repo>/ segment.
+        assert_eq!(
+            default_checkout_path(
+                "{repo_root}/.worktrees",
+                Path::new("/home/me/foo/bar"),
+                "bar",
+                "feature/x",
+            ),
+            PathBuf::from("/home/me/foo/bar/.worktrees/feature-x")
+        );
+    }
+
+    #[test]
+    fn default_checkout_path_with_only_repo_parent_keeps_repo_segment() {
+        // {repo_parent} alone does NOT include the repo name, so the implicit
+        // <repo>/ segment is preserved (matches legacy <root>/<repo>/<branch> shape).
+        assert_eq!(
+            default_checkout_path(
+                "{repo_parent}/shared-worktrees",
+                Path::new("/home/me/foo/bar"),
+                "bar",
+                "feature/x",
+            ),
+            PathBuf::from("/home/me/foo/shared-worktrees/bar/feature-x")
+        );
+    }
+
+    #[test]
+    fn resolve_worktree_root_signals_when_repo_name_is_in_template() {
+        let (root, repo_already_in_root) = resolve_worktree_root(
+            "{repo_parent}/{repo_name}.worktrees",
+            Path::new("/home/me/foo/bar"),
+            "bar",
+        );
+        assert_eq!(root, PathBuf::from("/home/me/foo/bar.worktrees"));
+        assert!(repo_already_in_root);
+
+        let (root, repo_already_in_root) =
+            resolve_worktree_root("/w", Path::new("/home/me/foo/bar"), "bar");
+        assert_eq!(root, PathBuf::from("/w"));
+        assert!(!repo_already_in_root);
+    }
+
+    #[test]
+    fn resolve_worktree_root_handles_repo_at_filesystem_root() {
+        // `parent()` returns None for /, but we should still produce something sane.
+        let (root, _) = resolve_worktree_root("{repo_parent}/wt", Path::new("/"), "");
+        assert_eq!(root, PathBuf::from("//wt"));
     }
 
     #[test]

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -516,19 +516,50 @@ prunable stale
     }
 
     #[test]
-    fn resolve_worktree_root_signals_when_repo_name_is_in_template() {
-        let (root, repo_already_in_root) = resolve_worktree_root(
-            "{repo_parent}/{repo_name}.worktrees",
-            Path::new("/home/me/foo/bar"),
-            "bar",
+    fn default_checkout_path_expands_tilde_after_substituting_placeholders() {
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", "/home/me");
+        // ~ in the template, {repo_name} present (so implicit segment is dropped).
+        assert_eq!(
+            default_checkout_path(
+                "~/wt/{repo_name}",
+                Path::new("/home/me/code/herdr"),
+                "herdr",
+                "feature/x",
+            ),
+            PathBuf::from("/home/me/wt/herdr/feature-x"),
         );
-        assert_eq!(root, PathBuf::from("/home/me/foo/bar.worktrees"));
-        assert!(repo_already_in_root);
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+    }
 
-        let (root, repo_already_in_root) =
-            resolve_worktree_root("/w", Path::new("/home/me/foo/bar"), "bar");
-        assert_eq!(root, PathBuf::from("/w"));
-        assert!(!repo_already_in_root);
+    #[test]
+    fn default_checkout_path_handles_placeholder_inside_literal_segment() {
+        assert_eq!(
+            default_checkout_path(
+                "/wt/prefix-{repo_name}-suffix",
+                Path::new("/home/me/code/herdr"),
+                "herdr",
+                "main",
+            ),
+            PathBuf::from("/wt/prefix-herdr-suffix/main"),
+        );
+    }
+
+    #[test]
+    fn default_checkout_path_replaces_every_occurrence_of_a_placeholder() {
+        assert_eq!(
+            default_checkout_path(
+                "/wt/{repo_name}/old/{repo_name}",
+                Path::new("/home/me/code/herdr"),
+                "herdr",
+                "main",
+            ),
+            PathBuf::from("/wt/herdr/old/herdr/main"),
+        );
     }
 
     #[test]
@@ -560,9 +591,47 @@ prunable stale
     }
 
     #[test]
+    fn template_diagnostics_reports_every_unknown_placeholder() {
+        let diagnostics = template_diagnostics("{repo_nam}/{repo_par}/{repo_root}");
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics.iter().any(|d| d.contains("{repo_nam}")));
+        assert!(diagnostics.iter().any(|d| d.contains("{repo_par}")));
+    }
+
+    #[test]
+    fn template_diagnostics_flags_doubled_braces_as_unknown_placeholder() {
+        // Greedy `}` matching means `{{repo_name}}` parses as `{{repo_name}` and
+        // is flagged as unknown. Pin the behavior so a future fix is intentional.
+        let diagnostics = template_diagnostics("/wt/{{repo_name}}");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("{{repo_name}"));
+    }
+
+    #[test]
+    fn template_diagnostics_flags_empty_and_whitespace_braces() {
+        assert_eq!(template_diagnostics("/wt/{}/x").len(), 1);
+        assert_eq!(template_diagnostics("/wt/{ }/x").len(), 1);
+    }
+
+    #[test]
     fn template_diagnostics_accepts_all_known_placeholders() {
         assert!(template_diagnostics("{repo_parent}/{repo_name}.worktrees/{repo_root}").is_empty());
         assert!(template_diagnostics("~/.herdr/worktrees").is_empty());
+        // Lock in that every accepted placeholder is also substituted by
+        // resolve_worktree_root: a rename in one without the other would
+        // pass the diagnostic check but leave `{...}` literally on disk.
+        let (root, _) = resolve_worktree_root(
+            "{repo_parent}|{repo_name}|{repo_root}",
+            Path::new("/home/me/code/herdr"),
+            "herdr",
+        );
+        let rendered = root.display().to_string();
+        assert!(
+            !rendered.contains('{'),
+            "unsubstituted placeholder in {rendered:?}"
+        );
+        assert!(rendered.contains("/home/me/code"));
+        assert!(rendered.contains("herdr"));
     }
 
     #[test]

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -99,17 +99,64 @@ pub(crate) fn resolve_worktree_root(
         return (expand_tilde_path(template), false);
     }
 
-    let repo_parent = repo_root
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("/"));
+    // `Path::parent()` returns paths without a trailing `/` for normal paths,
+    // but returns `Some("/")` for paths like "/foo" and `None` for "/" itself.
+    // For the "/" case (whether falling back from `None` or returned as the
+    // parent of a top-level repo), substitute "" so `{repo_parent}/wt` becomes
+    // `/wt` rather than `//wt` in user-visible logs.
+    let repo_parent = repo_root.parent().unwrap_or_else(|| Path::new("/"));
+    let repo_parent_str = if repo_parent == Path::new("/") {
+        String::new()
+    } else {
+        repo_parent.display().to_string()
+    };
 
     let expanded = template
         .replace("{repo_root}", &repo_root.display().to_string())
-        .replace("{repo_parent}", &repo_parent.display().to_string())
+        .replace("{repo_parent}", &repo_parent_str)
         .replace("{repo_name}", repo_name);
 
     (expand_tilde_path(&expanded), has_repo_name || has_repo_root)
+}
+
+/// Validate a `[worktrees].directory` template, returning user-facing
+/// diagnostics for problems Herdr can detect without knowing a specific repo:
+/// an empty/whitespace value, or `{...}` tokens that aren't one of the
+/// supported placeholders (`{repo_root}`, `{repo_parent}`, `{repo_name}`).
+pub(crate) fn template_diagnostics(template: &str) -> Vec<String> {
+    let mut diagnostics = Vec::new();
+
+    if template.trim().is_empty() {
+        diagnostics.push(
+            "worktrees.directory is empty; worktree checkouts will be created relative to \
+             Herdr's working directory. Set a path such as `~/.herdr/worktrees`."
+                .to_string(),
+        );
+        return diagnostics;
+    }
+
+    const KNOWN: &[&str] = &["{repo_root}", "{repo_parent}", "{repo_name}"];
+    let mut cursor = template;
+    while let Some(open) = cursor.find('{') {
+        let rest = &cursor[open..];
+        let Some(close_offset) = rest.find('}') else {
+            diagnostics.push(format!(
+                "worktrees.directory contains an unclosed `{{` near `{rest}`; supported \
+                 placeholders are `{{repo_root}}`, `{{repo_parent}}`, `{{repo_name}}`."
+            ));
+            break;
+        };
+        let token = &rest[..=close_offset];
+        if !KNOWN.contains(&token) {
+            diagnostics.push(format!(
+                "worktrees.directory contains unknown placeholder `{token}`; supported \
+                 placeholders are `{{repo_root}}`, `{{repo_parent}}`, `{{repo_name}}`."
+            ));
+        }
+        cursor = &rest[close_offset + 1..];
+    }
+
+    diagnostics
 }
 
 pub(crate) fn default_checkout_path(
@@ -505,9 +552,45 @@ prunable stale
 
     #[test]
     fn resolve_worktree_root_handles_repo_at_filesystem_root() {
-        // `parent()` returns None for /, but we should still produce something sane.
+        // `parent()` returns None for /, so {repo_parent} substitutes to "".
+        // Asserting on display().to_string() (not PathBuf equality, which would
+        // silently normalize //wt == /wt) ensures user-visible logs are clean.
         let (root, _) = resolve_worktree_root("{repo_parent}/wt", Path::new("/"), "");
-        assert_eq!(root, PathBuf::from("//wt"));
+        assert_eq!(root.display().to_string(), "/wt");
+    }
+
+    #[test]
+    fn resolve_worktree_root_substitutes_empty_for_root_parent_to_avoid_double_slash() {
+        // /foo has parent /, which would naively yield "//wt". {repo_parent}
+        // substitutes to "" in that case so the result displays as "/wt".
+        let (root, _) = resolve_worktree_root("{repo_parent}/wt", Path::new("/foo"), "foo");
+        assert_eq!(root.display().to_string(), "/wt");
+    }
+
+    #[test]
+    fn template_diagnostics_flags_empty_and_whitespace_templates() {
+        assert!(!template_diagnostics("").is_empty());
+        assert!(!template_diagnostics("   ").is_empty());
+    }
+
+    #[test]
+    fn template_diagnostics_flags_unknown_placeholders() {
+        let diagnostics = template_diagnostics("~/wt/{repo_nam}");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("{repo_nam}"));
+    }
+
+    #[test]
+    fn template_diagnostics_accepts_all_known_placeholders() {
+        assert!(template_diagnostics("{repo_parent}/{repo_name}.worktrees/{repo_root}").is_empty());
+        assert!(template_diagnostics("~/.herdr/worktrees").is_empty());
+    }
+
+    #[test]
+    fn template_diagnostics_flags_unclosed_open_brace() {
+        let diagnostics = template_diagnostics("~/wt/{repo_name");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("unclosed"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #261.

## Summary

Add `{repo_root}`, `{repo_parent}`, and `{repo_name}` placeholders to `[worktrees].directory` so worktree checkouts can live anywhere relative to each source repo — most usefully, in a sibling folder next to each repo:

\`\`\`toml
[worktrees]
directory = \"{repo_parent}/{repo_name}.worktrees\"
\`\`\`

A repo at `~/foo/bar` now gets worktrees at `~/foo/bar.worktrees/<branch-slug>`.

**Default behavior is unchanged.** A literal `directory` (no placeholders) still produces `<directory>/<repo>/<branch-slug>` exactly as before, so existing user configs see no path differences.

## How it works

- Placeholders are substituted per source repo at worktree-creation time (not at config load), so one `directory` value can serve repos under different parents.
- When the template includes `{repo_name}` or `{repo_root}`, the implicit `<repo_name>/` segment is dropped to avoid path doubling (e.g. `~/foo/bar.worktrees/<branch>`, not `~/foo/bar.worktrees/bar/<branch>`). `{repo_parent}` alone keeps the segment (it's treated like a legacy multi-repo root that happens to live next to the parent).
- `~` expansion runs after placeholder substitution, so `~/wt/{repo_name}` works.

## Diagnostics

Bad templates surface as user diagnostics at both startup and live config reload (mirrors the existing `ui.sound.diagnostics()` chain), rather than being silently treated as literal directory segments:

- Empty / whitespace `directory`
- Unknown placeholders, e.g. `{repo_nam}` typo — every typo in the template is reported, not just the first
- Unclosed `{`

The template still gets applied (warn-only) so the user sees the warning and can fix the config without restarting.

## Docs

Updated `docs/next/website/src/content/docs/configuration.mdx` with the placeholder list and two caveats (symlink resolution via `git rev-parse --show-toplevel`, and the `.gitignore` reminder when using `{repo_root}/.worktrees`).

## Test plan

- [x] `cargo test -- --test-threads=1` → 1330 passed, 0 failed.
- [x] `cargo clippy --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Manual: built locally, configured `directory = \"{repo_parent}/{repo_name}.worktrees\"`, created a worktree via `prefix+shift+g` — landed at `~/.../<repo>.worktrees/<slug>` as expected.

New tests cover, in `src/worktree.rs`:

- Legacy literal layout (`<root>/<repo>/<branch>`) unchanged.
- `{repo_parent}/{repo_name}.worktrees` produces sibling layout; implicit segment dropped.
- `{repo_root}/.worktrees` nests inside the repo; implicit segment dropped.
- `{repo_parent}/shared-worktrees` (no `{repo_name}`/`{repo_root}`) keeps the implicit `<repo>/` segment.
- `~` + placeholder combined (`~/wt/{repo_name}`).
- Placeholder inside literal segment (`prefix-{repo_name}-suffix`).
- Same placeholder repeated (`{repo_name}/old/{repo_name}`).
- Edge: repo at filesystem root (`/`) — no `//path`.
- Edge: repo at `/foo` whose parent is `/` — no `//path`. Asserts on `display().to_string()` rather than `PathBuf` equality (which normalizes `//` and would hide bugs).
- Diagnostics: empty/whitespace template, unknown placeholder (single + multi-typo), unclosed `{`, doubled `{{repo_name}}`, `{}` and `{ }`, accepts all known placeholders + verifies they're all actually substituted.

In `src/config/model.rs`:

- Chains `WorktreesConfig::diagnostics()` into `Config::collect_diagnostics()` and tests that wiring (so a refactor dropping the chain doesn't silently regress startup diagnostics).

In `src/app/mod.rs`:

- End-to-end `reload_config` integration test: typo'd template fed via TOML produces a `ConfigReloadStatus::Partial` report, the diagnostic reaches `state.config_diagnostic`, and the value still applies (warn-only).

## Notes for review

- I considered a separate `layout = \"sibling\"` mode field as an alternative API. Went with placeholders because they're strictly more expressive (any user-defined relative layout, not just sibling) and don't require a new enum to maintain. Easy to switch if you'd prefer the mode approach — the change is contained to `src/worktree.rs` and `src/config/model.rs`.
- The `worktree_directory` field on `AppState` changed type from `PathBuf` (resolved) to `String` (raw template), since per-repo resolution now happens at use time. Verified that no socket-API response or snapshot serializes this field, so the type change is purely internal.
- The new diagnostic surfacing at config reload follows the same shape as `ui.sound.diagnostics()` extension at `apply_live_config`.

Reference branch: https://github.com/ZainRizvi/herdr/tree/worktree-directory-template