### PR TITLE
feat: add nix flake, dev shell, and home-manager module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 /.pi/todos
 /.pi/issues
 /.pi/cache
+
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -293,6 +293,60 @@ cargo build --release
 ./target/release/herdr
 ```
 
+### nix
+
+build or run directly:
+
+```bash
+nix run github:ogulcancelik/herdr
+nix build github:ogulcancelik/herdr
+./result/bin/herdr
+```
+
+dev shell with all dependencies (rust, zig, cargo-nextest, just):
+
+```bash
+nix develop github:ogulcancelik/herdr
+```
+
+install to your profile:
+
+```bash
+nix profile install github:ogulcancelik/herdr
+```
+
+#### home manager
+
+add the flake input and import the module:
+
+```nix
+# flake.nix
+inputs.herdr.url = "github:ogulcancelik/herdr";
+```
+
+```nix
+# home.nix
+imports = [ inputs.herdr.homeManagerModules.herdr ];
+
+programs.herdr = {
+  enable = true;
+
+  # default: installs the latest GitHub release binary
+  # to build from source instead, override the package:
+  # package = inputs.herdr.packages.''${pkgs.system}.default;
+
+  # optional: configure herdr via nix (generates ~/.config/herdr/config.toml)
+  settings = {
+    theme.name = "catppuccin";
+    terminal.default_shell = "${pkgs.zsh}/bin/zsh";
+    ui.sidebar_width = 26;
+  };
+
+  # shell integration for zsh, bash, fish (enabled by default when the shell is enabled)
+  shellIntegration.enable = true;
+};
+```
+
 ## testing
 
 ```bash

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/inclyc/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,136 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687265871,
+        "narHash": "sha256-P8AOiQk/XN8/ia4289hDHlTfWB70cRQ5pc9GRfmEdpc=",
+        "owner": "inclyc",
+        "repo": "flake-compat",
+        "rev": "70e56389c58bbd300d11778913b255477ebbae22",
+        "type": "github"
+      },
+      "original": {
+        "owner": "inclyc",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779506148,
+        "narHash": "sha256-OffE5yuMrSW71zIJNLvtl9MCO6WTAHEjlFPUCvkd/QM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d9973e2ab49747fada06ebbe26cda27eb0220cf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "herdr — terminal workspace manager for AI coding agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    crane.url = "github:ipetkov/crane";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-compat = {
+      url = "github:inclyc/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      imports = [
+        inputs.treefmt-nix.flakeModule
+        ./nix/modules/packages.nix
+        ./nix/modules/overlays.nix
+        ./nix/modules/devshells.nix
+        ./nix/modules/treefmt.nix
+        ./nix/modules/hm-module.nix
+      ];
+    };
+
+  nixConfig = {
+    # Uncomment and fill in after creating the cache on cachix.org:
+    # extra-substituters = [ "https://herdr.cachix.org" ];
+    # extra-trusted-public-keys = [ "herdr.cachix.org-1:YOUR_PUBLIC_KEY_HERE" ];
+  };
+}

--- a/nix/modules/devshells.nix
+++ b/nix/modules/devshells.nix
@@ -1,0 +1,29 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { system, pkgs, ... }:
+    let
+      rustBin = inputs.rust-overlay.lib.mkRustBin { } pkgs;
+      rustToolchain = rustBin.stable.latest.default;
+    in
+    {
+      devShells.default = pkgs.mkShell {
+        name = "herdr-dev";
+
+        packages = with pkgs; [
+          rustToolchain
+          cargo-nextest
+          just
+          zig_0_15
+          cmake
+          ninja
+          pkg-config
+        ];
+
+        env = {
+          LIBGHOSTTY_VT_OPTIMIZE = "Debug";
+          LIBGHOSTTY_VT_SIMD = "true";
+        };
+      };
+    };
+}

--- a/nix/modules/hm-module.nix
+++ b/nix/modules/hm-module.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  flake.homeManagerModules.herdr = import ./hm/herdr.nix;
+}

--- a/nix/modules/hm/herdr.nix
+++ b/nix/modules/hm/herdr.nix
@@ -1,0 +1,127 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.herdr;
+  tomlFormat = pkgs.formats.toml { };
+
+  # Fetch the latest release binary from GitHub.
+  # Automatically picks the right platform.
+  # Update version + hashes when a new release is published:
+  #   nix-prefetch-url https://github.com/ogulcancelik/herdr/releases/download/v<VERSION>/herdr-linux-x86_64
+  herdr-version = "0.6.1";
+  herdr-release =
+    let
+      arch = if pkgs.stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64";
+      os =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "macos"
+        else
+          "linux";
+      hashes = {
+        x86_64-linux = "sha256-gatwYkmHXbNFcp32Q31yYV0PaQnoNYw2gDvPPfE6up4=";
+        aarch64-linux = "sha256-COQTNDaBcK2oXQYwD3FJgx/7VsCPB9z0nII/vyKsAKM=";
+        x86_64-darwin = "sha256-ZVf4+i6En8onpzn9r4FpchjhClD3Ew2c1L/lI8LxiK4=";
+        aarch64-darwin = "sha256-GG+JoD3rgBHhaYEUcQ+0kXlWK5h21S/q7Fysu3Zd0co=";
+      };
+      system = pkgs.stdenv.hostPlatform.system;
+    in
+    pkgs.stdenv.mkDerivation {
+      pname = "herdr";
+      version = herdr-version;
+      src = pkgs.fetchurl {
+        url = "https://github.com/ogulcancelik/herdr/releases/download/v${herdr-version}/herdr-${os}-${arch}";
+        hash = hashes.${system} or (throw "herdr: no pre-built binary for ${system}");
+      };
+      phases = [ "installPhase" ];
+      installPhase = ''
+        mkdir -p $out/bin
+        cp $src $out/bin/herdr
+        chmod +x $out/bin/herdr
+      '';
+    };
+in
+{
+  options.programs.herdr = {
+    enable = lib.mkEnableOption "herdr";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = herdr-release;
+      defaultText = lib.literalExpression "herdr from GitHub releases (latest)";
+      description = ''
+        The herdr package to use. Defaults to the latest GitHub release binary.
+        To build from source instead, use the flake overlay:
+
+            programs.herdr.package = inputs.herdr.packages.''${system}.default;
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        theme.name = "catppuccin";
+        terminal.default_shell = "${pkgs.zsh}/bin/zsh";
+        terminal.new_cwd = "follow";
+        ui.sidebar_width = 26;
+        ui.mouse_capture = true;
+        keys.prefix = "ctrl+b";
+        keys.new_tab = "prefix+c";
+        keys.new_workspace = "prefix+shift+n";
+      };
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/herdr/config.toml`.
+        See <https://herdr.dev> for all options.
+      '';
+    };
+
+    shellIntegration = {
+      enable = lib.mkEnableOption "herdr shell integration" // {
+        default = true;
+      };
+
+      bash = {
+        enable = lib.mkEnableOption "herdr bash integration" // {
+          default = config.programs.bash.enable;
+        };
+      };
+
+      zsh = {
+        enable = lib.mkEnableOption "herdr zsh integration" // {
+          default = config.programs.zsh.enable;
+        };
+      };
+
+      fish = {
+        enable = lib.mkEnableOption "herdr fish integration" // {
+          default = config.programs.fish.enable;
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."herdr/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "herdr-config" cfg.settings;
+    };
+
+    programs.bash.initExtra = lib.mkIf (cfg.shellIntegration.enable && cfg.shellIntegration.bash.enable) ''
+      eval "$(herdr integration shell bash 2>/dev/null || true)"
+    '';
+
+    programs.zsh.initExtra = lib.mkIf (cfg.shellIntegration.enable && cfg.shellIntegration.zsh.enable) ''
+      eval "$(herdr integration shell zsh 2>/dev/null || true)"
+    '';
+
+    programs.fish.shellInit = lib.mkIf (cfg.shellIntegration.enable && cfg.shellIntegration.fish.enable) ''
+      herdr integration shell fish 2>/dev/null | source
+    '';
+  };
+}

--- a/nix/modules/overlays.nix
+++ b/nix/modules/overlays.nix
@@ -1,0 +1,6 @@
+{ inputs, ... }:
+{
+  flake.overlays.default = final: prev: {
+    herdr = inputs.self.packages.${prev.system}.default;
+  };
+}

--- a/nix/modules/packages.nix
+++ b/nix/modules/packages.nix
@@ -1,0 +1,20 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { system, ... }:
+    let
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
+      rustBin = inputs.rust-overlay.lib.mkRustBin { } pkgs;
+      rustToolchain = rustBin.stable.latest.default;
+      craneLib = inputs.crane.mkLib pkgs;
+      herdr-pkg = pkgs.callPackage ../package.nix {
+        crane = craneLib;
+        inherit rustToolchain;
+      };
+    in
+    {
+      packages = {
+        default = herdr-pkg;
+      };
+    };
+}

--- a/nix/modules/treefmt.nix
+++ b/nix/modules/treefmt.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  perSystem =
+    { ... }:
+    {
+      treefmt = {
+        programs.nixfmt.enable = true;
+      };
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  crane,
+  rustToolchain,
+  optimize ? "release",
+}:
+let
+  craneLib = crane.overrideToolchain rustToolchain;
+
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = lib.fileset.unions [
+      ../src
+      ../assets
+      ../vendor
+      ../build.rs
+      ../Cargo.toml
+      ../Cargo.lock
+    ];
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly {
+    inherit src;
+  };
+in
+craneLib.buildPackage {
+  inherit src cargoArtifacts;
+
+  meta = {
+    description = "Terminal workspace manager for AI coding agents";
+    homepage = "https://herdr.dev";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "herdr";
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/inclyc/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
## What

Adds Nix support so users can install, develop, and configure herdr through Nix flakes and home-manager.

### Flake outputs

| Output | Description |
|--------|-------------|
| `packages.<system>.default` | Build herdr from source (crane + rust-overlay) |
| `devShells.<system>.default` | Dev environment with rust, zig, cargo-nextest, just |
| `overlays.default` | Exposes `pkgs.herdr` via flake overlay |
| `homeManagerModules.herdr` | Home-manager module with settings + shell integration |
| `checks` | treefmt (nixfmt) |

### Home-manager module

```nix
programs.herdr = {
  enable = true;
  # default: installs latest GitHub release binary
  # build from source: package = inputs.herdr.packages.${pkgs.system}.default;

  settings = {
    theme.name = "catppuccin";
    terminal.default_shell = "${pkgs.zsh}/bin/zsh";
  };

  shellIntegration.enable = true; # zsh, bash, fish
};
```

- Default package is the pre-built release binary (no compilation needed)
- Build from source by overriding `package` with the flake overlay
- Generates `~/.config/herdr/config.toml` from Nix attrset via `pkgs.formats.toml`
- Shell integration auto-enabled for each shell that's configured in home-manager

### Quick start

```bash
nix run github:ogulcancelik/herdr           # run without installing
nix develop github:ogulcancelik/herdr        # dev shell
nix profile install github:ogulcancelik/herdr # install to profile
```

### Files

| File | Purpose |
|------|---------|
| `flake.nix` | Flake entry point (flake-parts, crane, rust-overlay, treefmt-nix) |
| `nix/package.nix` | Crane-based Rust build derivation |
| `nix/modules/packages.nix` | Package outputs |
| `nix/modules/overlays.nix` | Flake overlay |
| `nix/modules/devshells.nix` | Dev shell |
| `nix/modules/treefmt.nix` | Formatter (nixfmt only) |
| `nix/modules/hm-module.nix` | Exposes home-manager module as flake output |
| `nix/modules/hm/herdr.nix` | Home-manager module |
| `default.nix` / `shell.nix` | flake-compat shims |

### Notes

- Cachix config is commented out in `flake.nix` — uncomment and fill in after creating the cache
- Release hashes in the home-manager module are pinned to v0.6.1; update via `nix-prefetch-url` when a new release ships
- `treefmt` runs `nixfmt` only (no `rustfmt`) to avoid touching `src/` or `tests/`
