### PR TITLE
feat: add Copy and Paste to pane right-click context menu

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -798,6 +798,28 @@ impl AppState {
         self.selection = None;
         self.selection_autoscroll = None;
     }
+
+    pub fn copy_visible_selection(
+        &mut self,
+        terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+    ) {
+        let sel = match &self.selection {
+            Some(sel) if sel.is_visible() => sel.clone(),
+            _ => return,
+        };
+        let ws_idx = match self.active {
+            Some(i) if self.workspaces.get(i).is_some() => i,
+            _ => return,
+        };
+        let text = self
+            .runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, sel.pane_id)
+            .and_then(|rt| rt.extract_selection(&sel));
+        if let Some(text) = text {
+            if !text.is_empty() {
+                self.request_clipboard_write = Some(text.into_bytes());
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2221,5 +2243,14 @@ mod tests {
         assert_eq!(state.request_remove_linked_worktree, None);
         assert_eq!(state.workspaces.len(), 1);
         assert_eq!(state.workspaces[0].display_name(), "selected");
+    }
+
+    #[test]
+    fn copy_visible_selection_is_noop_when_no_selection() {
+        let mut state = app_with_workspaces(&["test"]);
+        state.selection = None;
+        let runtimes = crate::terminal::TerminalRuntimeRegistry::new();
+        state.copy_visible_selection(&runtimes);
+        assert!(state.request_clipboard_write.is_none(), "no-op when no selection");
     }
 }

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -505,7 +505,12 @@ pub(super) fn apply_context_menu_action(
     idx: usize,
 ) {
     let item = menu.items().get(idx).copied();
-    match (menu.kind, item) {
+    if item.as_ref().is_some_and(|i| !i.enabled) {
+        leave_modal(state);
+        return;
+    }
+    let label = item.map(|i| i.label);
+    match (menu.kind, label) {
         (ContextMenuKind::GitWorkspace { ws_idx, .. }, Some("New worktree")) => {
             state.request_new_linked_worktree = Some(ws_idx);
             leave_modal(state);

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -626,6 +626,10 @@ pub(super) fn apply_context_menu_action(
             state.copy_visible_selection(terminal_runtimes);
             state.mode = Mode::Terminal;
         }
+        (ContextMenuKind::Pane { .. }, Some("Paste")) => {
+            state.request_clipboard_paste = true;
+            state.mode = Mode::Terminal;
+        }
         _ => leave_modal(state),
     }
 }

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -622,6 +622,10 @@ pub(super) fn apply_context_menu_action(
                 Mode::Navigate
             };
         }
+        (ContextMenuKind::Pane { .. }, Some("Copy")) => {
+            state.copy_visible_selection(terminal_runtimes);
+            state.mode = Mode::Terminal;
+        }
         _ => leave_modal(state),
     }
 }

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -638,12 +638,21 @@ pub(crate) fn handle_context_menu_key(
         }
         KeyCode::Up => {
             if let Some(menu) = &mut state.context_menu {
-                menu.list.move_prev();
+                let items = menu.items();
+                let start = menu.list.highlighted;
+                if let Some(idx) = (0..start).rev().find(|&i| items.get(i).is_some_and(|it| it.enabled)) {
+                    menu.list.highlighted = idx;
+                }
             }
         }
         KeyCode::Down => {
             if let Some(menu) = &mut state.context_menu {
-                menu.list.move_next(menu.items().len());
+                let items = menu.items();
+                let start = menu.list.highlighted;
+                let count = items.len();
+                if let Some(idx) = (start + 1..count).find(|&i| items.get(i).is_some_and(|it| it.enabled)) {
+                    menu.list.highlighted = idx;
+                }
             }
         }
         KeyCode::Enter => {
@@ -1143,5 +1152,57 @@ mod tests {
 
         assert!(state.workspaces.is_empty());
         assert_eq!(state.mode, Mode::Navigate);
+    }
+
+    #[test]
+    fn down_key_skips_disabled_context_menu_item() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.mode = Mode::ContextMenu;
+        state.context_menu = Some(ContextMenuState {
+            kind: ContextMenuKind::Pane {
+                pane_id: crate::layout::PaneId::from_raw(0),
+                has_manual_label: false,
+                has_selection: false,
+            },
+            x: 0,
+            y: 0,
+            list: MenuListState::new(0),
+        });
+        handle_context_menu_key(
+            &mut state,
+            &mut crate::terminal::TerminalRuntimeRegistry::new(),
+            KeyEvent::new(
+                KeyCode::Down,
+                KeyModifiers::empty(),
+            ),
+        );
+        // Copy(0) is disabled; Down from 0 should land on Paste(1)
+        assert_eq!(state.context_menu.as_ref().unwrap().list.highlighted, 1);
+    }
+
+    #[test]
+    fn up_key_from_paste_skips_disabled_copy() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.mode = Mode::ContextMenu;
+        state.context_menu = Some(ContextMenuState {
+            kind: ContextMenuKind::Pane {
+                pane_id: crate::layout::PaneId::from_raw(0),
+                has_manual_label: false,
+                has_selection: false,
+            },
+            x: 0,
+            y: 0,
+            list: MenuListState::new(1), // start at Paste
+        });
+        handle_context_menu_key(
+            &mut state,
+            &mut crate::terminal::TerminalRuntimeRegistry::new(),
+            KeyEvent::new(
+                KeyCode::Up,
+                KeyModifiers::empty(),
+            ),
+        );
+        // Up from Paste(1) → Copy(0) is disabled → stay at 1
+        assert_eq!(state.context_menu.as_ref().unwrap().list.highlighted, 1);
     }
 }

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -968,17 +968,15 @@ impl AppState {
                         .selection
                         .as_ref()
                         .is_some_and(|s| s.pane_id == info.id && s.is_visible());
-                    let kind = ContextMenuKind::Pane {
-                        pane_id: info.id,
-                        has_manual_label,
-                        has_selection,
-                    };
-                    let initial_idx = {
-                        let tmp = ContextMenuState { kind: kind.clone(), x: 0, y: 0, list: MenuListState::new(0) };
-                        tmp.items().iter().position(|i| i.enabled).unwrap_or(0)
-                    };
+                    // Copy is always at index 0, Paste is at index 1. If Copy is disabled (no selection),
+                    // start highlighting at Paste (index 1).
+                    let initial_idx = if has_selection { 0 } else { 1 };
                     self.context_menu = Some(ContextMenuState {
-                        kind,
+                        kind: ContextMenuKind::Pane {
+                            pane_id: info.id,
+                            has_manual_label,
+                            has_selection,
+                        },
                         x: mouse.column,
                         y: mouse.row,
                         list: MenuListState::new(initial_idx),

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -963,6 +963,7 @@ impl AppState {
                         kind: ContextMenuKind::Pane {
                             pane_id: info.id,
                             has_manual_label,
+                            has_selection: false,
                         },
                         x: mouse.column,
                         y: mouse.row,
@@ -1998,10 +1999,11 @@ mod tests {
             kind: ContextMenuKind::Pane {
                 pane_id,
                 has_manual_label: false,
+                has_selection: false,
             },
             x: 2,
             y: 2,
-            list: MenuListState::new(1),
+            list: MenuListState::new(3),
         });
         app.state.mode = Mode::ContextMenu;
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -1076,7 +1076,7 @@ impl AppState {
         let max_item_w = menu
             .items()
             .iter()
-            .map(|item| item.len() as u16)
+            .map(|item| item.label.len() as u16)
             .max()
             .unwrap_or(0);
         let menu_w = (max_item_w + 4).max(14).min(screen.width.max(1));

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -875,7 +875,12 @@ impl AppState {
             MouseEventKind::Moved if self.mode == Mode::ContextMenu => {
                 let hovered = self.context_menu_item_at(mouse.column, mouse.row);
                 if let Some(menu) = &mut self.context_menu {
-                    menu.list.hover(hovered);
+                    if let Some(idx) = hovered {
+                        let items = menu.items();
+                        if items.get(idx).is_some_and(|i| i.enabled) {
+                            menu.list.hover(Some(idx));
+                        }
+                    }
                 }
             }
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -964,15 +964,24 @@ impl AppState {
                         .and_then(|pane| self.terminals.get(&pane.attached_terminal_id))
                         .and_then(|terminal| terminal.manual_label.as_ref())
                         .is_some();
+                    let has_selection = self
+                        .selection
+                        .as_ref()
+                        .is_some_and(|s| s.pane_id == info.id && s.is_visible());
+                    let kind = ContextMenuKind::Pane {
+                        pane_id: info.id,
+                        has_manual_label,
+                        has_selection,
+                    };
+                    let initial_idx = {
+                        let tmp = ContextMenuState { kind: kind.clone(), x: 0, y: 0, list: MenuListState::new(0) };
+                        tmp.items().iter().position(|i| i.enabled).unwrap_or(0)
+                    };
                     self.context_menu = Some(ContextMenuState {
-                        kind: ContextMenuKind::Pane {
-                            pane_id: info.id,
-                            has_manual_label,
-                            has_selection: false,
-                        },
+                        kind,
                         x: mouse.column,
                         y: mouse.row,
-                        list: MenuListState::new(0),
+                        list: MenuListState::new(initial_idx),
                     });
                     self.mode = Mode::ContextMenu;
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1154,6 +1154,45 @@ impl App {
                 crate::raw_input::RawInputEvent::Unsupported => {}
             }
         }
+
+        if let Some(content) = self.state.request_clipboard_write.take() {
+            if self
+                .event_tx
+                .try_send(AppEvent::ClipboardWrite { content })
+                .is_err()
+            {
+                tracing::warn!("failed to queue clipboard write event");
+            }
+        }
+        if self.state.request_clipboard_paste {
+            self.state.request_clipboard_paste = false;
+            if let Some(text) = crate::platform::read_clipboard_text() {
+                if !text.is_empty() {
+                    if let Some(active) = self.state.active {
+                        if let Some(ws) = self.state.workspaces.get(active) {
+                            if let Some(focused) = ws.focused_pane_id() {
+                                if let Some(runtime) = self.state.runtime_for_pane_in_workspace(
+                                    &self.terminal_runtimes,
+                                    active,
+                                    focused,
+                                ) {
+                                    let bytes = if runtime
+                                        .input_state()
+                                        .map(|s| s.bracketed_paste)
+                                        .unwrap_or(false)
+                                    {
+                                        format!("\x1b[200~{text}\x1b[201~")
+                                    } else {
+                                        text
+                                    };
+                                    let _ = runtime.try_send_bytes(bytes::Bytes::from(bytes));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Handles a key event in non-terminal mode for the headless server.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -375,6 +375,7 @@ impl App {
             request_reload_config: false,
             request_client_sound_config_reload: false,
             request_clipboard_write: None,
+            request_clipboard_paste: false,
             creating_new_tab: false,
             requested_new_tab_name: None,
             rename_pane_target: None,

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -120,9 +120,21 @@ impl App {
             }
             crate::raw_input::RawInputEvent::Unsupported => false,
         };
+        if let Some(content) = self.state.request_clipboard_write.take() {
+            if self
+                .event_tx
+                .try_send(crate::events::AppEvent::ClipboardWrite { content })
+                .is_err()
+            {
+                tracing::warn!("failed to queue clipboard write event");
+            }
+        }
         if self.state.request_clipboard_paste {
             self.state.request_clipboard_paste = false;
-            if let Some(text) = crate::platform::read_clipboard_text() {
+            let text = tokio::task::spawn_blocking(crate::platform::read_clipboard_text)
+                .await
+                .unwrap_or(None);
+            if let Some(text) = text {
                 if !text.is_empty() {
                     self.handle_paste(text).await;
                     changed = true;

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -63,7 +63,7 @@ impl App {
         &mut self,
         event: crate::raw_input::RawInputEvent,
     ) -> bool {
-        let changed = match event {
+        let mut changed = match event {
             crate::raw_input::RawInputEvent::Key(key) => {
                 let key_id = repeat_key_identity(&key);
                 match key.kind {
@@ -124,6 +124,7 @@ impl App {
             self.state.request_clipboard_paste = false;
             if let Some(text) = crate::platform::read_clipboard_text() {
                 self.handle_paste(text).await;
+                changed = true;
             }
         }
 

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -123,8 +123,10 @@ impl App {
         if self.state.request_clipboard_paste {
             self.state.request_clipboard_paste = false;
             if let Some(text) = crate::platform::read_clipboard_text() {
-                self.handle_paste(text).await;
-                changed = true;
+                if !text.is_empty() {
+                    self.handle_paste(text).await;
+                    changed = true;
+                }
             }
         }
 

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -120,6 +120,13 @@ impl App {
             }
             crate::raw_input::RawInputEvent::Unsupported => false,
         };
+        if self.state.request_clipboard_paste {
+            self.state.request_clipboard_paste = false;
+            if let Some(text) = crate::platform::read_clipboard_text() {
+                self.handle_paste(text).await;
+            }
+        }
+
         self.shutdown_detached_terminal_runtimes();
         changed
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1045,6 +1045,7 @@ pub struct AppState {
     /// Set when UI interaction requested a clipboard write that must be
     /// handled by the outer App/event loop instead of directly from AppState.
     pub request_clipboard_write: Option<Vec<u8>>,
+    pub request_clipboard_paste: bool,
     pub creating_new_tab: bool,
     pub requested_new_tab_name: Option<String>,
     pub rename_pane_target: Option<PaneId>,
@@ -1330,6 +1331,7 @@ impl AppState {
             request_reload_config: false,
             request_client_sound_config_reload: false,
             request_clipboard_write: None,
+            request_clipboard_paste: false,
             creating_new_tab: false,
             requested_new_tab_name: None,
             rename_pane_target: None,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -867,6 +867,7 @@ pub enum ContextMenuKind {
     Pane {
         pane_id: PaneId,
         has_manual_label: bool,
+        has_selection: bool,
     },
 }
 
@@ -934,8 +935,11 @@ impl ContextMenuState {
             ],
             ContextMenuKind::Pane {
                 has_manual_label: true,
+                has_selection,
                 ..
             } => vec![
+                if has_selection { MenuItem::active("Copy") } else { MenuItem::disabled("Copy") },
+                MenuItem::active("Paste"),
                 MenuItem::active("Rename pane"),
                 MenuItem::active("Clear pane name"),
                 MenuItem::active("Split vertical"),
@@ -945,8 +949,11 @@ impl ContextMenuState {
             ],
             ContextMenuKind::Pane {
                 has_manual_label: false,
+                has_selection,
                 ..
             } => vec![
+                if has_selection { MenuItem::active("Copy") } else { MenuItem::disabled("Copy") },
+                MenuItem::active("Paste"),
                 MenuItem::active("Rename pane"),
                 MenuItem::active("Split vertical"),
                 MenuItem::active("Split horizontal"),
@@ -1583,5 +1590,40 @@ mod tests {
         let items = menu.items();
         assert!(items.iter().all(|i| i.enabled), "tab menu items should all be enabled");
         assert!(items.iter().any(|i| i.label == "New tab"));
+    }
+
+    #[test]
+    fn pane_menu_has_copy_enabled_when_selection_exists() {
+        let menu = ContextMenuState {
+            kind: ContextMenuKind::Pane {
+                pane_id: crate::layout::PaneId::from_raw(0),
+                has_manual_label: false,
+                has_selection: true,
+            },
+            x: 0,
+            y: 0,
+            list: MenuListState::new(0),
+        };
+        let items = menu.items();
+        let copy = items.iter().find(|i| i.label == "Copy").expect("Copy item missing");
+        let paste = items.iter().find(|i| i.label == "Paste").expect("Paste item missing");
+        assert!(copy.enabled, "Copy should be enabled when has_selection=true");
+        assert!(paste.enabled, "Paste should always be enabled");
+    }
+
+    #[test]
+    fn pane_menu_has_copy_disabled_when_no_selection() {
+        let menu = ContextMenuState {
+            kind: ContextMenuKind::Pane {
+                pane_id: crate::layout::PaneId::from_raw(0),
+                has_manual_label: false,
+                has_selection: false,
+            },
+            x: 0,
+            y: 0,
+            list: MenuListState::new(0),
+        };
+        let copy = menu.items().into_iter().find(|i| i.label == "Copy").expect("Copy item missing");
+        assert!(!copy.enabled, "Copy should be disabled when has_selection=false");
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1045,6 +1045,8 @@ pub struct AppState {
     /// Set when UI interaction requested a clipboard write that must be
     /// handled by the outer App/event loop instead of directly from AppState.
     pub request_clipboard_write: Option<Vec<u8>>,
+    /// Set when the pane context menu Paste action fires; drained by the
+    /// async event loop which calls handle_paste with the clipboard contents.
     pub request_clipboard_paste: bool,
     pub creating_new_tab: bool,
     pub requested_new_tab_name: Option<String>,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -834,7 +834,22 @@ pub(crate) struct TabPressState {
     pub start_row: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MenuItem {
+    pub label: &'static str,
+    pub enabled: bool,
+}
+
+impl MenuItem {
+    pub fn active(label: &'static str) -> Self {
+        Self { label, enabled: true }
+    }
+
+    pub fn disabled(label: &'static str) -> Self {
+        Self { label, enabled: false }
+    }
+}
+
 pub enum ContextMenuKind {
     Workspace {
         ws_idx: usize,
@@ -864,63 +879,79 @@ pub struct ContextMenuState {
 }
 
 impl ContextMenuState {
-    pub fn items(&self) -> &'static [&'static str] {
+    pub fn items(&self) -> Vec<MenuItem> {
         match self.kind {
-            ContextMenuKind::Workspace { .. } => &["Rename", "Close"],
+            ContextMenuKind::Workspace { .. } => vec![
+                MenuItem::active("Rename"),
+                MenuItem::active("Close"),
+            ],
             ContextMenuKind::GitWorkspace {
                 is_linked_worktree: false,
                 has_worktree_children: false,
                 ..
-            } => &["Rename", "Close", "New worktree", "Open worktree..."],
+            } => vec![
+                MenuItem::active("Rename"),
+                MenuItem::active("Close"),
+                MenuItem::active("New worktree"),
+                MenuItem::active("Open worktree..."),
+            ],
             ContextMenuKind::GitWorkspace {
                 is_linked_worktree: true,
                 ..
-            } => &["Rename", "Close", "Delete worktree checkout..."],
+            } => vec![
+                MenuItem::active("Rename"),
+                MenuItem::active("Close"),
+                MenuItem::active("Delete worktree checkout..."),
+            ],
             ContextMenuKind::GitWorkspace {
                 is_linked_worktree: false,
                 has_worktree_children: true,
                 collapsed: true,
                 ..
-            } => &[
-                "Rename",
-                "Close group",
-                "New worktree",
-                "Open worktree...",
-                "Expand",
+            } => vec![
+                MenuItem::active("Rename"),
+                MenuItem::active("Close group"),
+                MenuItem::active("New worktree"),
+                MenuItem::active("Open worktree..."),
+                MenuItem::active("Expand"),
             ],
             ContextMenuKind::GitWorkspace {
                 is_linked_worktree: false,
                 has_worktree_children: true,
                 collapsed: false,
                 ..
-            } => &[
-                "Rename",
-                "Close group",
-                "New worktree",
-                "Open worktree...",
-                "Collapse",
+            } => vec![
+                MenuItem::active("Rename"),
+                MenuItem::active("Close group"),
+                MenuItem::active("New worktree"),
+                MenuItem::active("Open worktree..."),
+                MenuItem::active("Collapse"),
             ],
-            ContextMenuKind::Tab { .. } => &["New tab", "Rename", "Close"],
+            ContextMenuKind::Tab { .. } => vec![
+                MenuItem::active("New tab"),
+                MenuItem::active("Rename"),
+                MenuItem::active("Close"),
+            ],
             ContextMenuKind::Pane {
                 has_manual_label: true,
                 ..
-            } => &[
-                "Rename pane",
-                "Clear pane name",
-                "Split vertical",
-                "Split horizontal",
-                "Zoom",
-                "Close pane",
+            } => vec![
+                MenuItem::active("Rename pane"),
+                MenuItem::active("Clear pane name"),
+                MenuItem::active("Split vertical"),
+                MenuItem::active("Split horizontal"),
+                MenuItem::active("Zoom"),
+                MenuItem::active("Close pane"),
             ],
             ContextMenuKind::Pane {
                 has_manual_label: false,
                 ..
-            } => &[
-                "Rename pane",
-                "Split vertical",
-                "Split horizontal",
-                "Zoom",
-                "Close pane",
+            } => vec![
+                MenuItem::active("Rename pane"),
+                MenuItem::active("Split vertical"),
+                MenuItem::active("Split horizontal"),
+                MenuItem::active("Zoom"),
+                MenuItem::active("Close pane"),
             ],
         }
     }
@@ -1490,8 +1521,8 @@ mod tests {
         };
 
         assert_eq!(
-            menu.items(),
-            &["Rename", "Close", "Delete worktree checkout..."]
+            menu.items().iter().map(|i| i.label).collect::<Vec<_>>(),
+            vec!["Rename", "Close", "Delete worktree checkout..."]
         );
     }
 
@@ -1510,8 +1541,8 @@ mod tests {
         };
 
         assert_eq!(
-            menu.items(),
-            &["Rename", "Close", "New worktree", "Open worktree..."]
+            menu.items().iter().map(|i| i.label).collect::<Vec<_>>(),
+            vec!["Rename", "Close", "New worktree", "Open worktree..."]
         );
     }
 
@@ -1530,8 +1561,8 @@ mod tests {
         };
 
         assert_eq!(
-            menu.items(),
-            &[
+            menu.items().iter().map(|i| i.label).collect::<Vec<_>>(),
+            vec![
                 "Rename",
                 "Close group",
                 "New worktree",
@@ -1539,5 +1570,18 @@ mod tests {
                 "Collapse"
             ]
         );
+    }
+
+    #[test]
+    fn context_menu_items_returns_menu_items() {
+        let menu = ContextMenuState {
+            kind: ContextMenuKind::Tab { ws_idx: 0, tab_idx: 0 },
+            x: 0,
+            y: 0,
+            list: MenuListState::new(0),
+        };
+        let items = menu.items();
+        assert!(items.iter().all(|i| i.enabled), "tab menu items should all be enabled");
+        assert!(items.iter().any(|i| i.label == "New tab"));
     }
 }

--- a/src/platform/fallback.rs
+++ b/src/platform/fallback.rs
@@ -36,6 +36,11 @@ pub fn write_clipboard(_bytes: &[u8]) -> bool {
 }
 
 /// Unsupported platform stub.
+pub fn read_clipboard_text() -> Option<String> {
+    None
+}
+
+/// Unsupported platform stub.
 pub fn read_clipboard_image() -> Option<ClipboardImage> {
     None
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -160,6 +160,37 @@ pub fn write_clipboard(bytes: &[u8]) -> bool {
     false
 }
 
+pub fn read_clipboard_text() -> Option<String> {
+    if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+        if let Some(text) = run_read_command("wl-paste", &["--no-newline"]) {
+            return Some(text);
+        }
+    }
+    if std::env::var_os("DISPLAY").is_some() {
+        if let Some(text) = run_read_command("xclip", &["-selection", "clipboard", "-o"]) {
+            return Some(text);
+        }
+        if let Some(text) = run_read_command("xsel", &["--clipboard", "--output"]) {
+            return Some(text);
+        }
+    }
+    None
+}
+
+fn run_read_command(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if output.status.success() {
+        String::from_utf8(output.stdout).ok()
+    } else {
+        None
+    }
+}
+
 pub fn read_clipboard_image() -> Option<ClipboardImage> {
     for (mime, extension) in [
         ("image/png", "png"),
@@ -417,5 +448,16 @@ mod tests {
         let args = std::fs::read_to_string(&path).expect("args file");
         let _ = std::fs::remove_file(&path);
         assert_eq!(args, "--\n-danger\nbody\n");
+    }
+
+    #[test]
+    fn read_clipboard_text_returns_none_when_no_display() {
+        let _guard = env_lock().lock().unwrap();
+        unsafe {
+            std::env::remove_var("WAYLAND_DISPLAY");
+            std::env::remove_var("DISPLAY");
+        }
+        let result = read_clipboard_text();
+        assert!(result.is_none());
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -207,6 +207,19 @@ pub fn write_clipboard(bytes: &[u8]) -> bool {
     )
 }
 
+pub fn read_clipboard_text() -> Option<String> {
+    let output = Command::new("pbpaste")
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if output.status.success() {
+        String::from_utf8(output.stdout).ok()
+    } else {
+        None
+    }
+}
+
 pub fn read_clipboard_image() -> Option<ClipboardImage> {
     let path = std::env::temp_dir().join(format!(
         "herdr-clipboard-image-{}-{}.png",

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -220,10 +220,16 @@ pub(super) fn render_context_menu(app: &AppState, frame: &mut Frame) {
     let items: Vec<ListItem> = menu
         .items()
         .iter()
-        .map(|item| ListItem::new(Line::from(*item)))
+        .map(|item| {
+            let style = if item.enabled {
+                Style::default().fg(p.text)
+            } else {
+                Style::default().fg(p.overlay0)
+            };
+            ListItem::new(Line::from(Span::styled(item.label, style)))
+        })
         .collect();
     let list = List::new(items)
-        .style(Style::default().fg(p.text))
         .highlight_style(
             Style::default()
                 .bg(p.accent)


### PR DESCRIPTION
## Summary

- Adds **Copy** and **Paste** items to the pane right-click context menu
- Copy is always visible but dimmed/unselectable when no text is selected; enabled when a selection exists
- Paste is always enabled and injects clipboard contents into the focused pane

## Implementation

**`MenuItem` type** (`src/app/state.rs`) — replaces `&'static str` in the context menu `items()` API with `MenuItem { label, enabled }` so individual items can be disabled without removing them from the list. All existing menus (Workspace, GitWorkspace, Tab) continue to work unchanged — their items are all `enabled: true`.

**`has_selection` on `ContextMenuKind::Pane`** — snapshotted at right-click time from the active `Selection` (checks `pane_id` matches and `is_visible()`). The initial highlight lands on Copy when a selection exists, Paste otherwise.

**Keyboard nav skips disabled items** — Up/Down and hover skip disabled entries; Enter/click on a disabled item is a no-op.

**`copy_visible_selection`** (`src/app/actions.rs`) — reads the visible selection from the pane's terminal runtime and queues a clipboard write via `request_clipboard_write`. Works on completed selections and does not clear the selection afterward.

**`read_clipboard_text`** (`src/platform/linux.rs`, `src/platform/macos.rs`, `src/platform/fallback.rs`) — mirrors the existing `write_clipboard` platform function. Linux: `wl-paste --no-newline` (Wayland) → `xclip` → `xsel`. macOS: `pbpaste`. Fallback: `None`.

**`request_clipboard_paste` flag** (`src/app/state.rs`) — follows the existing deferred-flag pattern. In the monolithic path, drained in `handle_raw_input_event` using `spawn_blocking` so a slow clipboard tool can't stall the tokio runtime. In the headless server path, drained at the end of `route_client_events` using the same inline paste logic as `RawInputEvent::Paste`.

**Drain on all input paths** — `request_clipboard_write` is now drained in both `handle_raw_input_event` (catches keyboard-driven Copy) and `route_client_events` (headless), in addition to the existing drain in `handle_mouse`.

## Test Plan

- [ ] Drag to select text in a pane → right-click → Copy is bright; click it → text on system clipboard
- [ ] Right-click with no selection → Copy is dimmed; Up arrow stays on Paste; Enter on Copy is a no-op
- [ ] Copy text to clipboard outside herdr → right-click in pane → Paste → text injected at cursor
- [ ] Keyboard: navigate context menu with arrow keys → Enter on Copy/Paste works correctly
- [ ] Existing context menu items (Rename, Split, Zoom, Close) unaffected
- [ ] All 1370 unit/integration tests pass (`cargo test`)