### PR TITLE
Fix horizontal split border gap

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -470,10 +470,39 @@ fn split_rect(area: Rect, direction: Direction, ratio: f32) -> (Rect, Rect) {
         Direction::Vertical => {
             let first_h = ((area.height as f32) * ratio).round() as u16;
             let second_h = area.height.saturating_sub(first_h);
+            let second_y = if first_h > 0 && second_h > 0 {
+                area.y + first_h - 1
+            } else {
+                area.y + first_h
+            };
             (
                 Rect::new(area.x, area.y, area.width, first_h),
-                Rect::new(area.x, area.y + first_h, area.width, second_h),
+                Rect::new(area.x, second_y, area.width, second_h),
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vertical_split_shares_one_border_row() {
+        let area = Rect::new(0, 0, 80, 20);
+        let (top, bottom) = split_rect(area, Direction::Vertical, 0.5);
+
+        assert_eq!(top, Rect::new(0, 0, 80, 10));
+        assert_eq!(bottom, Rect::new(0, 9, 80, 10));
+        assert_eq!(top.y + top.height - 1, bottom.y);
+    }
+
+    #[test]
+    fn vertical_split_does_not_underflow_empty_first_rect() {
+        let area = Rect::new(0, 0, 80, 0);
+        let (top, bottom) = split_rect(area, Direction::Vertical, 0.5);
+
+        assert_eq!(top, Rect::new(0, 0, 80, 0));
+        assert_eq!(bottom, Rect::new(0, 0, 80, 0));
     }
 }


### PR DESCRIPTION
Fixes #271.\n\nTop/bottom pane splits currently render with two divider rows because each adjacent pane draws a full border in its own rectangle. This makes horizontal splits look much more widely spaced than vertical splits.\n\nThis adjusts vertical split geometry so the bottom pane starts one row earlier when both panes are non-empty, letting the two panes share one divider row.\n\nAlso adds unit coverage for the shared divider row and the zero-height underflow case.\n\nTesting:\n- \n-  *(fails in this environment before tests run: vendored libghostty-vt requires Zig v0.15.2, but system Zig is v0.16.0)*