### PR TITLE
fix: raise AppEvent channel capacity to lift 64-pane ceiling

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -221,7 +221,7 @@ impl App {
     ) -> Self {
         let (prefix_code, prefix_mods) = config.prefix_key();
         crate::kitty_graphics::set_enabled(config.experimental.kitty_graphics);
-        let (event_tx, event_rx) = mpsc::channel::<AppEvent>(64);
+        let (event_tx, event_rx) = mpsc::channel::<AppEvent>(4096);
         let render_notify = Arc::new(Notify::new());
         let render_dirty = Arc::new(AtomicBool::new(false));
 
@@ -2627,7 +2627,7 @@ mod tests {
             AgentState::Working
         );
 
-        for i in 0..64 {
+        for i in 0..4096 {
             app.event_tx
                 .try_send(AppEvent::UpdateReady {
                     version: format!("9.9.{i}"),


### PR DESCRIPTION
## Summary
- Bumps the bounded `AppEvent` mpsc channel in `src/app/mod.rs` from capacity **64** → **4096**, removing the hard total-pane wall reported in #265.
- Updates the backpressure regression test to fill the new capacity so it still exercises the same blocked-then-drained behavior.

## Why
Every pane spawned clones this `Sender` and runs blocking producer tasks against it. Once ~64 panes were live, steady-state event traffic could saturate the 64-slot buffer faster than the UI loop drained it, blocking both existing pane readers and the spawn path for pane #65 — manifesting as "can't open a new pane / tab / workspace" once the user hit 64 total panes (8×2×4 in the report).

Fixes #265.

## Test plan
- [x] `cargo test` — 1298 unit tests + integration suites pass
- [x] `full_internal_event_queue_eventually_applies_working_to_idle_transition` still verifies backpressure at the new capacity
- [ ] Manual: open >64 panes across multiple workspaces/tabs and confirm new panes/tabs/workspaces continue to spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)