### PR TITLE
build: skip unused libghostty-vt xcframework

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,7 +60,8 @@ fn main() {
         .arg(format!("-Doptimize={optimize}"))
         .arg(format!("-Dsimd={simd}"))
         .arg(format!("-Dtarget={zig_target}"))
-        .arg(format!("-Dversion-string={version_string}"));
+        .arg(format!("-Dversion-string={version_string}"))
+        .arg("-Demit-xcframework=false");
     if let Ok(system_dir) = env::var("LIBGHOSTTY_VT_ZIG_SYSTEM_DIR") {
         command.arg("--system").arg(system_dir);
     }


### PR DESCRIPTION
Summary:
- pass `-Demit-xcframework=false` when `build.rs` invokes the vendored `libghostty-vt` Zig build for Cargo
- avoid producing an unused macOS xcframework artifact during source package builds

Validation:
- `ZIG=/opt/homebrew/opt/zig@0.15/bin/zig just check`

Refs:
- #284
- Homebrew/homebrew-core#283413
