### PR TITLE
docs: add homebrew install notes

### DIFF
--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -25,6 +25,12 @@ workspaces, tabs, panes. mouse-native: click, drag, split. every agent at a glan
 curl -fsSL https://herdr.dev/install.sh | sh
 ```
 
+or install with homebrew:
+
+```bash
+brew install herdr
+```
+
 or download the binary from [releases](https://github.com/ogulcancelik/herdr/releases). requires linux or macos.
 
 ### update

--- a/docs/next/website/src/content/docs/install.mdx
+++ b/docs/next/website/src/content/docs/install.mdx
@@ -15,6 +15,14 @@ curl -fsSL https://herdr.dev/install.sh | sh
 
 The installer downloads the right release binary for your platform and places it on your PATH.
 
+## Install with Homebrew
+
+If you already use Homebrew:
+
+```bash
+brew install herdr
+```
+
 ## Verify
 
 Start Herdr:


### PR DESCRIPTION
Summary:
- add Homebrew install notes to the next-release README
- add Homebrew install notes to the staged website install docs

Validation:
- `ZIG=/opt/homebrew/opt/zig@0.15/bin/zig just check`

References:
- Homebrew/homebrew-core#283413
- #286
