### PR TITLE
feat: Improve agents sidebar context

### DIFF
--- a/src/app/config_io.rs
+++ b/src/app/config_io.rs
@@ -1,4 +1,6 @@
 use super::App;
+use crate::app::state::{AgentViewItem, AgentViewPreferences, SpaceViewItem, SpaceViewPreferences};
+use crate::config::{AgentViewField, SpaceViewField, ViewColorPreset, ViewItem};
 
 impl App {
     pub(super) fn update_config_file<F>(&mut self, error_context: &str, update: F) -> bool
@@ -94,6 +96,30 @@ impl App {
         }
     }
 
+    pub(super) fn save_space_view_preferences(&mut self, preferences: SpaceViewPreferences) {
+        if self.update_config_file("space sidebar preferences", |content| {
+            crate::config::upsert_section_body(
+                content,
+                "ui.sidebar.spaces",
+                &space_view_config_body(&preferences),
+            )
+        }) {
+            self.apply_config_from_disk(false);
+        }
+    }
+
+    pub(super) fn save_agent_view_preferences(&mut self, preferences: AgentViewPreferences) {
+        if self.update_config_file("agent sidebar preferences", |content| {
+            crate::config::upsert_section_body(
+                content,
+                "ui.sidebar.agents",
+                &agent_view_config_body(&preferences),
+            )
+        }) {
+            self.apply_config_from_disk(false);
+        }
+    }
+
     pub(super) fn save_agent_panel_scope(&mut self, scope: crate::app::state::AgentPanelScope) {
         let value = match scope {
             crate::app::state::AgentPanelScope::CurrentWorkspace => {
@@ -113,5 +139,63 @@ impl App {
         }) {
             self.apply_config_from_disk(false);
         }
+    }
+}
+
+fn space_view_config_body(preferences: &SpaceViewPreferences) -> String {
+    view_item_lines_array(&preferences.lines, space_view_field_name)
+}
+
+fn agent_view_config_body(preferences: &AgentViewPreferences) -> String {
+    view_item_lines_array(&preferences.lines, agent_view_field_name)
+}
+
+fn view_item_lines_array<F: Copy>(
+    lines: &[Vec<ViewItem<F>>],
+    field_name: fn(F) -> &'static str,
+) -> String {
+    let mut body = String::new();
+    body.push_str("lines = [\n");
+    for line in lines {
+        body.push_str("  [\n");
+        for item in line {
+            let color = if ViewColorPreset::is_default(&item.color) {
+                String::new()
+            } else {
+                format!(", color = \"{}\"", item.color.as_str())
+            };
+            body.push_str(&format!(
+                "    {{ field = \"{}\", show = {}{} }},\n",
+                field_name(item.field),
+                item.show,
+                color
+            ));
+        }
+        body.push_str("  ],\n");
+    }
+    body.push_str("]\n");
+    body
+}
+
+fn space_view_field_name(field: SpaceViewItem) -> &'static str {
+    match field {
+        SpaceViewField::Status => "status",
+        SpaceViewField::Name => "name",
+        SpaceViewField::Branch => "branch",
+        SpaceViewField::BranchStatus => "branch_status",
+    }
+}
+
+fn agent_view_field_name(field: AgentViewItem) -> &'static str {
+    match field {
+        AgentViewField::AgentStatus => "agent_status",
+        AgentViewField::PaneName => "pane_name",
+        AgentViewField::TabName => "tab_name",
+        AgentViewField::SpaceName => "space_name",
+        AgentViewField::Status => "status",
+        AgentViewField::Time => "time",
+        AgentViewField::CustomStatus => "custom_status",
+        AgentViewField::AgentName => "agent_name",
+        AgentViewField::RightAlignment => "right_alignment",
     }
 }

--- a/src/app/config_io.rs
+++ b/src/app/config_io.rs
@@ -1,6 +1,8 @@
 use super::App;
-use crate::app::state::{AgentViewItem, AgentViewPreferences, SpaceViewItem, SpaceViewPreferences};
-use crate::config::{AgentViewField, SpaceViewField, ViewColorPreset, ViewItem};
+use crate::app::state::{
+    SidebarAgentItem, SidebarAgentPreferences, SidebarSpaceItem, SidebarSpacePreferences,
+};
+use crate::config::{SidebarAgentField, SidebarColorPreset, SidebarItem, SidebarSpaceField};
 
 impl App {
     pub(super) fn update_config_file<F>(&mut self, error_context: &str, update: F) -> bool
@@ -24,7 +26,18 @@ impl App {
             }
         }
 
-        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => {
+                crate::logging::config_write_failed(&path, error_context, &err.to_string());
+                self.state.config_diagnostic =
+                    Some(format!("failed to save {error_context}: {err}"));
+                self.config_diagnostic_deadline =
+                    Some(std::time::Instant::now() + std::time::Duration::from_secs(5));
+                return false;
+            }
+        };
         let new_content = update(&content);
         if let Err(err) = std::fs::write(&path, new_content) {
             crate::logging::config_write_failed(&path, error_context, &err.to_string());
@@ -96,28 +109,40 @@ impl App {
         }
     }
 
-    pub(super) fn save_space_view_preferences(&mut self, preferences: SpaceViewPreferences) {
-        if self.update_config_file("space sidebar preferences", |content| {
+    pub(super) fn save_sidebar_space_preferences(
+        &mut self,
+        preferences: SidebarSpacePreferences,
+    ) -> bool {
+        let saved = self.update_config_file("space sidebar preferences", |content| {
             crate::config::upsert_section_body(
                 content,
                 "ui.sidebar.spaces",
-                &space_view_config_body(&preferences),
+                &space_sidebar_config_body(&preferences),
             )
-        }) {
-            self.apply_config_from_disk(false);
+        });
+        if saved {
+            let report = self.apply_config_from_disk(false);
+            return report.status == crate::config::ConfigReloadStatus::Applied;
         }
+        false
     }
 
-    pub(super) fn save_agent_view_preferences(&mut self, preferences: AgentViewPreferences) {
-        if self.update_config_file("agent sidebar preferences", |content| {
+    pub(super) fn save_sidebar_agent_preferences(
+        &mut self,
+        preferences: SidebarAgentPreferences,
+    ) -> bool {
+        let saved = self.update_config_file("agent sidebar preferences", |content| {
             crate::config::upsert_section_body(
                 content,
                 "ui.sidebar.agents",
-                &agent_view_config_body(&preferences),
+                &agent_sidebar_config_body(&preferences),
             )
-        }) {
-            self.apply_config_from_disk(false);
+        });
+        if saved {
+            let report = self.apply_config_from_disk(false);
+            return report.status == crate::config::ConfigReloadStatus::Applied;
         }
+        false
     }
 
     pub(super) fn save_agent_panel_scope(&mut self, scope: crate::app::state::AgentPanelScope) {
@@ -142,16 +167,16 @@ impl App {
     }
 }
 
-fn space_view_config_body(preferences: &SpaceViewPreferences) -> String {
-    view_item_lines_array(&preferences.lines, space_view_field_name)
+fn space_sidebar_config_body(preferences: &SidebarSpacePreferences) -> String {
+    sidebar_item_lines_array(&preferences.lines, sidebar_space_field_name)
 }
 
-fn agent_view_config_body(preferences: &AgentViewPreferences) -> String {
-    view_item_lines_array(&preferences.lines, agent_view_field_name)
+fn agent_sidebar_config_body(preferences: &SidebarAgentPreferences) -> String {
+    sidebar_item_lines_array(&preferences.lines, sidebar_agent_field_name)
 }
 
-fn view_item_lines_array<F: Copy>(
-    lines: &[Vec<ViewItem<F>>],
+fn sidebar_item_lines_array<F: Copy>(
+    lines: &[Vec<SidebarItem<F>>],
     field_name: fn(F) -> &'static str,
 ) -> String {
     let mut body = String::new();
@@ -159,7 +184,7 @@ fn view_item_lines_array<F: Copy>(
     for line in lines {
         body.push_str("  [\n");
         for item in line {
-            let color = if ViewColorPreset::is_default(&item.color) {
+            let color = if SidebarColorPreset::is_default(&item.color) {
                 String::new()
             } else {
                 format!(", color = \"{}\"", item.color.as_str())
@@ -177,25 +202,25 @@ fn view_item_lines_array<F: Copy>(
     body
 }
 
-fn space_view_field_name(field: SpaceViewItem) -> &'static str {
+fn sidebar_space_field_name(field: SidebarSpaceItem) -> &'static str {
     match field {
-        SpaceViewField::Status => "status",
-        SpaceViewField::Name => "name",
-        SpaceViewField::Branch => "branch",
-        SpaceViewField::BranchStatus => "branch_status",
+        SidebarSpaceField::Status => "status",
+        SidebarSpaceField::Name => "name",
+        SidebarSpaceField::Branch => "branch",
+        SidebarSpaceField::BranchStatus => "branch_status",
     }
 }
 
-fn agent_view_field_name(field: AgentViewItem) -> &'static str {
+fn sidebar_agent_field_name(field: SidebarAgentItem) -> &'static str {
     match field {
-        AgentViewField::AgentStatus => "agent_status",
-        AgentViewField::PaneName => "pane_name",
-        AgentViewField::TabName => "tab_name",
-        AgentViewField::SpaceName => "space_name",
-        AgentViewField::Status => "status",
-        AgentViewField::Time => "time",
-        AgentViewField::CustomStatus => "custom_status",
-        AgentViewField::AgentName => "agent_name",
-        AgentViewField::RightAlignment => "right_alignment",
+        SidebarAgentField::AgentStatus => "agent_status",
+        SidebarAgentField::PaneName => "pane_name",
+        SidebarAgentField::TabName => "tab_name",
+        SidebarAgentField::SpaceName => "space_name",
+        SidebarAgentField::Status => "status",
+        SidebarAgentField::Time => "time",
+        SidebarAgentField::CustomStatus => "custom_status",
+        SidebarAgentField::AgentName => "agent_name",
+        SidebarAgentField::RightAlignment => "right_alignment",
     }
 }

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -213,6 +213,22 @@ impl App {
                     SettingsAction::SavePaneHistory(enabled) => {
                         self.save_pane_history_persistence(enabled)
                     }
+                    SettingsAction::SaveSidebarSpace {
+                        previous,
+                        preferences,
+                    } => {
+                        if !self.save_sidebar_space_preferences(preferences) {
+                            self.state.sidebar_space = previous;
+                        }
+                    }
+                    SettingsAction::SaveSidebarAgent {
+                        previous,
+                        preferences,
+                    } => {
+                        if !self.save_sidebar_agent_preferences(preferences) {
+                            self.state.sidebar_agent = previous;
+                        }
+                    }
                     SettingsAction::InstallRecommendedIntegrations => {
                         self.install_recommended_integrations()
                     }

--- a/src/app/input/settings.rs
+++ b/src/app/input/settings.rs
@@ -3,7 +3,12 @@ use ratatui::layout::Rect;
 
 use crate::{
     app::{
-        state::{AppState, SettingsSection, THEME_NAMES},
+        state::{
+            ordered_sidebar_agent_items, ordered_sidebar_space_items, AppState, SettingsSection,
+            SidebarAgentItem, SidebarAgentPreferences, SidebarConfigGroup, SidebarLine,
+            SidebarSpaceItem, SidebarSpacePreferences, SIDEBAR_AGENT_ITEMS, SIDEBAR_SPACE_ITEMS,
+            THEME_NAMES,
+        },
         App, Mode,
     },
     config::ToastDelivery,
@@ -18,6 +23,14 @@ pub(super) enum SettingsAction {
     SaveToastDelivery(ToastDelivery),
     SaveAgentBorderLabels(bool),
     SavePaneHistory(bool),
+    SaveSidebarSpace {
+        previous: SidebarSpacePreferences,
+        preferences: SidebarSpacePreferences,
+    },
+    SaveSidebarAgent {
+        previous: SidebarAgentPreferences,
+        preferences: SidebarAgentPreferences,
+    },
     InstallRecommendedIntegrations,
 }
 
@@ -34,6 +47,22 @@ impl App {
                 }
                 SettingsAction::SavePaneHistory(enabled) => {
                     self.save_pane_history_persistence(enabled)
+                }
+                SettingsAction::SaveSidebarSpace {
+                    previous,
+                    preferences,
+                } => {
+                    if !self.save_sidebar_space_preferences(preferences) {
+                        self.state.sidebar_space = previous;
+                    }
+                }
+                SettingsAction::SaveSidebarAgent {
+                    previous,
+                    preferences,
+                } => {
+                    if !self.save_sidebar_agent_preferences(preferences) {
+                        self.state.sidebar_agent = previous;
+                    }
                 }
                 SettingsAction::InstallRecommendedIntegrations => {
                     self.install_recommended_integrations()
@@ -75,6 +104,334 @@ fn toast_delivery_for_index(idx: usize) -> ToastDelivery {
         1 => ToastDelivery::Herdr,
         2 => ToastDelivery::Terminal,
         _ => ToastDelivery::System,
+    }
+}
+
+fn sidebar_config_row_count(group: SidebarConfigGroup) -> usize {
+    match group {
+        SidebarConfigGroup::Spaces => SIDEBAR_SPACE_ITEMS.len(),
+        SidebarConfigGroup::Agents => SIDEBAR_AGENT_ITEMS.len(),
+    }
+}
+
+fn sidebar_space_settings_lines(
+    preferences: &SidebarSpacePreferences,
+) -> impl Iterator<Item = SidebarLine> {
+    (0..SidebarConfigGroup::Spaces.settings_line_count(preferences.lines.len()))
+        .map(SidebarLine::from_index)
+}
+
+fn sidebar_agent_settings_lines(
+    preferences: &SidebarAgentPreferences,
+) -> impl Iterator<Item = SidebarLine> {
+    (0..SidebarConfigGroup::Agents.settings_line_count(preferences.lines.len()))
+        .map(SidebarLine::from_index)
+}
+
+fn sidebar_config_row_offsets(state: &AppState) -> Vec<(usize, u16)> {
+    let mut rows = Vec::new();
+    let mut offset = 0;
+    match state.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => {
+            let ordered = ordered_sidebar_space_items(&state.sidebar_space);
+            for line in sidebar_space_settings_lines(&state.sidebar_space) {
+                offset += 1;
+                let start_len = rows.len();
+                for (idx, _) in ordered
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(_, item)| item.line(&state.sidebar_space) == line)
+                {
+                    rows.push((idx, offset));
+                    offset += 1;
+                }
+                if rows.len() == start_len {
+                    offset += 1;
+                }
+            }
+        }
+        SidebarConfigGroup::Agents => {
+            let ordered = ordered_sidebar_agent_items(&state.sidebar_agent);
+            for line in sidebar_agent_settings_lines(&state.sidebar_agent) {
+                offset += 1;
+                let start_len = rows.len();
+                for (idx, _) in ordered
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(_, item)| item.line(&state.sidebar_agent) == line)
+                {
+                    rows.push((idx, offset));
+                    offset += 1;
+                }
+                if rows.len() == start_len {
+                    offset += 1;
+                }
+            }
+        }
+    }
+    rows
+}
+
+fn selected_sidebar_space_item(state: &AppState) -> Option<SidebarSpaceItem> {
+    ordered_sidebar_space_items(&state.sidebar_space)
+        .get(state.settings.list.selected)
+        .copied()
+}
+
+fn selected_sidebar_agent_item(state: &AppState) -> Option<SidebarAgentItem> {
+    ordered_sidebar_agent_items(&state.sidebar_agent)
+        .get(state.settings.list.selected)
+        .copied()
+}
+
+fn normalize_sidebar_space_orders(preferences: &mut SidebarSpacePreferences) {
+    for line in sidebar_space_settings_lines(preferences) {
+        let mut items: Vec<_> = SIDEBAR_SPACE_ITEMS
+            .iter()
+            .copied()
+            .filter(|item| item.line(preferences) == line)
+            .collect();
+        items.sort_by_key(|item| (item.order(preferences), item.default_index()));
+        for (order, item) in items.into_iter().enumerate() {
+            item.set_order(preferences, order as u8);
+        }
+    }
+}
+
+fn normalize_sidebar_agent_orders(preferences: &mut SidebarAgentPreferences) {
+    for line in sidebar_agent_settings_lines(preferences) {
+        let mut items: Vec<_> = SIDEBAR_AGENT_ITEMS
+            .iter()
+            .copied()
+            .filter(|item| item.line(preferences) == line)
+            .collect();
+        items.sort_by_key(|item| (item.order(preferences), item.default_index()));
+        for (order, item) in items.into_iter().enumerate() {
+            item.set_order(preferences, order as u8);
+        }
+    }
+}
+
+fn selected_sidebar_space_index(
+    preferences: &SidebarSpacePreferences,
+    selected: SidebarSpaceItem,
+) -> usize {
+    ordered_sidebar_space_items(preferences)
+        .iter()
+        .position(|item| *item == selected)
+        .unwrap_or(0)
+}
+
+fn selected_sidebar_agent_index(
+    preferences: &SidebarAgentPreferences,
+    selected: SidebarAgentItem,
+) -> usize {
+    ordered_sidebar_agent_items(preferences)
+        .iter()
+        .position(|item| *item == selected)
+        .unwrap_or(0)
+}
+
+fn sidebar_space_line_end_order(preferences: &SidebarSpacePreferences, line: SidebarLine) -> u8 {
+    SIDEBAR_SPACE_ITEMS
+        .iter()
+        .copied()
+        .filter(|item| item.line(preferences) == line)
+        .filter_map(|item| item.order(preferences).checked_add(1))
+        .max()
+        .unwrap_or(0)
+}
+
+fn sidebar_space_item_at_order(
+    preferences: &SidebarSpacePreferences,
+    line: SidebarLine,
+    order: u8,
+) -> Option<SidebarSpaceItem> {
+    SIDEBAR_SPACE_ITEMS
+        .iter()
+        .copied()
+        .find(|item| item.line(preferences) == line && item.order(preferences) == order)
+}
+
+fn sidebar_agent_line_end_order(preferences: &SidebarAgentPreferences, line: SidebarLine) -> u8 {
+    SIDEBAR_AGENT_ITEMS
+        .iter()
+        .copied()
+        .filter(|item| item.line(preferences) == line)
+        .filter_map(|item| item.order(preferences).checked_add(1))
+        .max()
+        .unwrap_or(0)
+}
+
+fn sidebar_agent_item_at_order(
+    preferences: &SidebarAgentPreferences,
+    line: SidebarLine,
+    order: u8,
+) -> Option<SidebarAgentItem> {
+    SIDEBAR_AGENT_ITEMS
+        .iter()
+        .copied()
+        .find(|item| item.line(preferences) == line && item.order(preferences) == order)
+}
+
+fn move_sidebar_space_item_to_line(
+    preferences: &mut SidebarSpacePreferences,
+    item: SidebarSpaceItem,
+    line: SidebarLine,
+    order: u8,
+) {
+    item.set_line(preferences, line);
+    item.set_order(preferences, order);
+}
+
+fn move_sidebar_agent_item_to_line(
+    preferences: &mut SidebarAgentPreferences,
+    item: SidebarAgentItem,
+    line: SidebarLine,
+    order: u8,
+) {
+    item.set_line(preferences, line);
+    item.set_order(preferences, order);
+}
+
+fn toggle_sidebar_config_item(state: &mut AppState) -> Option<SettingsAction> {
+    match state.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => {
+            let item = selected_sidebar_space_item(state)?;
+            let previous = state.sidebar_space.clone();
+            let mut preferences = previous.clone();
+            let enabled = !item.enabled(&preferences);
+            item.set_enabled(&mut preferences, enabled);
+            state.sidebar_space = preferences.clone();
+            Some(SettingsAction::SaveSidebarSpace {
+                previous,
+                preferences,
+            })
+        }
+        SidebarConfigGroup::Agents => {
+            let item = selected_sidebar_agent_item(state)?;
+            let previous = state.sidebar_agent.clone();
+            let mut preferences = previous.clone();
+            let enabled = !item.enabled(&preferences);
+            item.set_enabled(&mut preferences, enabled);
+            state.sidebar_agent = preferences.clone();
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences,
+            })
+        }
+    }
+}
+
+fn cycle_sidebar_config_item_color(state: &mut AppState) -> Option<SettingsAction> {
+    match state.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => {
+            let item = selected_sidebar_space_item(state)?;
+            let previous = state.sidebar_space.clone();
+            let mut preferences = previous.clone();
+            let next_color = item.color(&preferences).next();
+            item.set_color(&mut preferences, next_color);
+            state.sidebar_space = preferences.clone();
+            Some(SettingsAction::SaveSidebarSpace {
+                previous,
+                preferences,
+            })
+        }
+        SidebarConfigGroup::Agents => {
+            let item = selected_sidebar_agent_item(state)?;
+            let previous = state.sidebar_agent.clone();
+            let mut preferences = previous.clone();
+            let next_color = item.color(&preferences).next();
+            item.set_color(&mut preferences, next_color);
+            state.sidebar_agent = preferences.clone();
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences,
+            })
+        }
+    }
+}
+
+fn reorder_selected_sidebar_item(state: &mut AppState, delta: i8) -> Option<SettingsAction> {
+    match state.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => {
+            let item = selected_sidebar_space_item(state)?;
+            let previous = state.sidebar_space.clone();
+            let mut preferences = previous.clone();
+            let item_line = item.line(&preferences);
+            let item_order = item.order(&preferences);
+            let line_count =
+                SidebarConfigGroup::Spaces.settings_line_count(preferences.lines.len());
+            if delta < 0 && item_order > 0 {
+                let target_order = item_order.saturating_sub(1);
+                let target = sidebar_space_item_at_order(&preferences, item_line, target_order)?;
+                item.set_order(&mut preferences, target_order);
+                target.set_order(&mut preferences, item_order);
+            } else if delta > 0
+                && item_order + 1 < sidebar_space_line_end_order(&preferences, item_line)
+            {
+                let target_order = item_order.saturating_add(1);
+                let target = sidebar_space_item_at_order(&preferences, item_line, target_order)?;
+                item.set_order(&mut preferences, target_order);
+                target.set_order(&mut preferences, item_order);
+            } else if delta < 0 && item_line.index() > 0 {
+                let target_line = SidebarLine::from_index(item_line.index() - 1);
+                let insert_order = sidebar_space_line_end_order(&preferences, target_line);
+                move_sidebar_space_item_to_line(&mut preferences, item, target_line, insert_order);
+            } else if delta > 0 && item_line.index() + 1 < line_count {
+                let target_line = SidebarLine::from_index(item_line.index() + 1);
+                move_sidebar_space_item_to_line(&mut preferences, item, target_line, 0);
+            } else {
+                return None;
+            }
+            normalize_sidebar_space_orders(&mut preferences);
+            state.settings.list.selected = selected_sidebar_space_index(&preferences, item);
+            state.sidebar_space = preferences.clone();
+            Some(SettingsAction::SaveSidebarSpace {
+                previous,
+                preferences,
+            })
+        }
+        SidebarConfigGroup::Agents => {
+            let item = selected_sidebar_agent_item(state)?;
+            let previous = state.sidebar_agent.clone();
+            let mut preferences = previous.clone();
+            let item_line = item.line(&preferences);
+            let item_order = item.order(&preferences);
+            let line_count =
+                SidebarConfigGroup::Agents.settings_line_count(preferences.lines.len());
+            if delta < 0 && item_order > 0 {
+                let target_order = item_order.saturating_sub(1);
+                let target = sidebar_agent_item_at_order(&preferences, item_line, target_order)?;
+                item.set_order(&mut preferences, target_order);
+                target.set_order(&mut preferences, item_order);
+            } else if delta > 0
+                && item_order + 1 < sidebar_agent_line_end_order(&preferences, item_line)
+            {
+                let target_order = item_order.saturating_add(1);
+                let target = sidebar_agent_item_at_order(&preferences, item_line, target_order)?;
+                item.set_order(&mut preferences, target_order);
+                target.set_order(&mut preferences, item_order);
+            } else if delta < 0 && item_line.index() > 0 {
+                let target_line = SidebarLine::from_index(item_line.index() - 1);
+                let insert_order = sidebar_agent_line_end_order(&preferences, target_line);
+                move_sidebar_agent_item_to_line(&mut preferences, item, target_line, insert_order);
+            } else if delta > 0 && item_line.index() + 1 < line_count {
+                let target_line = SidebarLine::from_index(item_line.index() + 1);
+                move_sidebar_agent_item_to_line(&mut preferences, item, target_line, 0);
+            } else {
+                return None;
+            }
+            normalize_sidebar_agent_orders(&mut preferences);
+            state.settings.list.selected = selected_sidebar_agent_index(&preferences, item);
+            state.sidebar_agent = preferences.clone();
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences,
+            })
+        }
     }
 }
 
@@ -216,8 +573,76 @@ pub(super) fn update_settings_state(state: &mut AppState, key: KeyEvent) -> Opti
                 state.settings.list.selected = toast_delivery_index(state.toast_delivery());
             }
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
+                state.settings.section = SettingsSection::Sidebar;
+                state.settings.list.selected = 0;
+                state.settings.sidebar_config_group = SidebarConfigGroup::Spaces;
+                state.settings.sidebar_config_editing = false;
+            }
+            _ => {
+                if let Some(super::modal::ModalAction::Close) =
+                    super::modal::modal_action_from_key(&key, super::modal::SETTINGS_ACTIONS)
+                {
+                    cancel_settings(state);
+                }
+            }
+        },
+        SettingsSection::Sidebar => match key.code {
+            KeyCode::BackTab => {
+                state.settings.section = SettingsSection::PaneLabels;
+                state.settings.list.selected = usize::from(!state.agent_border_labels_enabled());
+                state.settings.sidebar_config_editing = false;
+            }
+            KeyCode::Tab => {
                 state.settings.section = SettingsSection::Integrations;
                 state.settings.list.selected = 0;
+                state.settings.sidebar_config_editing = false;
+            }
+            KeyCode::Enter if state.settings.sidebar_config_editing => {
+                state.settings.sidebar_config_editing = false;
+            }
+            KeyCode::Up | KeyCode::Char('k') if state.settings.sidebar_config_editing => {
+                return reorder_selected_sidebar_item(state, -1);
+            }
+            KeyCode::Down | KeyCode::Char('j') if state.settings.sidebar_config_editing => {
+                return reorder_selected_sidebar_item(state, 1);
+            }
+            KeyCode::Char(' ') if state.settings.sidebar_config_editing => {}
+            KeyCode::Char('c') => {
+                return cycle_sidebar_config_item_color(state);
+            }
+            KeyCode::Up | KeyCode::Char('k') => state.settings.list.move_prev(),
+            KeyCode::Down | KeyCode::Char('j') => {
+                state.settings.list.move_next(sidebar_config_row_count(
+                    state.settings.sidebar_config_group,
+                ));
+            }
+            KeyCode::Left | KeyCode::Char('h') | KeyCode::Right | KeyCode::Char('l')
+                if state.settings.sidebar_config_editing => {}
+            KeyCode::Left | KeyCode::Char('h') => {
+                state.settings.sidebar_config_group =
+                    state.settings.sidebar_config_group.previous();
+                state.settings.list.selected = 0;
+                state.settings.sidebar_config_editing = false;
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                state.settings.sidebar_config_group = state.settings.sidebar_config_group.next();
+                state.settings.list.selected = 0;
+                state.settings.sidebar_config_editing = false;
+            }
+            KeyCode::Enter => match state.settings.sidebar_config_group {
+                SidebarConfigGroup::Spaces => {
+                    if selected_sidebar_space_item(state).is_some() {
+                        state.settings.sidebar_config_editing = true;
+                    }
+                }
+                SidebarConfigGroup::Agents => {
+                    if selected_sidebar_agent_item(state).is_some() {
+                        state.settings.sidebar_config_editing = true;
+                    }
+                }
+            },
+            KeyCode::Char(' ') => {
+                return toggle_sidebar_config_item(state);
             }
             _ => {
                 if let Some(super::modal::ModalAction::Close) =
@@ -228,6 +653,12 @@ pub(super) fn update_settings_state(state: &mut AppState, key: KeyEvent) -> Opti
             }
         },
         SettingsSection::Experiments => match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                state.settings.list.move_prev();
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                state.settings.list.move_next(1);
+            }
             KeyCode::Enter | KeyCode::Char(' ') => {
                 return Some(SettingsAction::SavePaneHistory(
                     !state.pane_history_persistence_enabled(),
@@ -254,8 +685,10 @@ pub(super) fn update_settings_state(state: &mut AppState, key: KeyEvent) -> Opti
                 return Some(SettingsAction::InstallRecommendedIntegrations);
             }
             KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h') => {
-                state.settings.section = SettingsSection::PaneLabels;
-                state.settings.list.selected = usize::from(!state.agent_border_labels_enabled());
+                state.settings.section = SettingsSection::Sidebar;
+                state.settings.list.selected = 0;
+                state.settings.sidebar_config_group = SidebarConfigGroup::Spaces;
+                state.settings.sidebar_config_editing = false;
             }
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
                 state.settings.section = SettingsSection::Experiments;
@@ -285,15 +718,25 @@ pub(crate) fn open_settings_at(state: &mut AppState, section: SettingsSection) {
         SettingsSection::Sound => usize::from(!state.sound_enabled()),
         SettingsSection::Toast => toast_delivery_index(state.toast_delivery()),
         SettingsSection::PaneLabels => usize::from(!state.agent_border_labels_enabled()),
+        SettingsSection::Sidebar => {
+            state.settings.sidebar_config_group = SidebarConfigGroup::Spaces;
+            0
+        }
         SettingsSection::Experiments => 0,
         SettingsSection::Integrations => 0,
     };
+    state.settings.sidebar_config_editing = false;
     state.mode = Mode::Settings;
 }
 
 impl AppState {
     fn settings_popup_rect(&self) -> Rect {
-        crate::ui::centered_popup_rect(self.screen_rect(), 76, 22).unwrap_or_default()
+        crate::ui::centered_popup_rect(
+            self.screen_rect(),
+            crate::ui::SETTINGS_POPUP_WIDTH,
+            crate::ui::SETTINGS_POPUP_HEIGHT,
+        )
+        .unwrap_or_default()
     }
 
     fn settings_inner_rect(&self) -> Rect {
@@ -375,6 +818,13 @@ impl AppState {
                     None
                 }
             }
+            SettingsSection::Sidebar => {
+                let list_y = area.y + 3;
+                let offset = row.checked_sub(list_y)?;
+                sidebar_config_row_offsets(self)
+                    .into_iter()
+                    .find_map(|(idx, row_offset)| (row_offset == offset).then_some(idx))
+            }
             SettingsSection::Experiments => {
                 let list_y = area.y + 3;
                 (row == list_y).then_some(0)
@@ -394,6 +844,11 @@ impl AppState {
                         SettingsSection::Toast => toast_delivery_index(self.toast_delivery()),
                         SettingsSection::PaneLabels => {
                             usize::from(!self.agent_border_labels_enabled())
+                        }
+                        SettingsSection::Sidebar => {
+                            self.settings.sidebar_config_group = SidebarConfigGroup::Spaces;
+                            self.settings.sidebar_config_editing = false;
+                            0
                         }
                         SettingsSection::Experiments => 0,
                         SettingsSection::Integrations => 0,
@@ -418,6 +873,10 @@ impl AppState {
                         SettingsSection::PaneLabels => {
                             let enabled = idx == 0;
                             Some(SettingsAction::SaveAgentBorderLabels(enabled))
+                        }
+                        SettingsSection::Sidebar => {
+                            self.settings.sidebar_config_editing = false;
+                            toggle_sidebar_config_item(self)
                         }
                         SettingsSection::Experiments => Some(SettingsAction::SavePaneHistory(
                             !self.pane_history_persistence_enabled(),
@@ -524,9 +983,474 @@ mod tests {
     }
 
     #[test]
+    fn settings_popup_rect_uses_wide_settings_modal() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.view.sidebar_rect = Rect::new(0, 0, 30, 40);
+        state.view.terminal_area = Rect::new(30, 0, 90, 40);
+
+        let popup = state.settings_popup_rect();
+
+        assert_eq!(popup.width, crate::ui::SETTINGS_POPUP_WIDTH);
+        assert_eq!(popup.height, crate::ui::SETTINGS_POPUP_HEIGHT);
+    }
+
+    #[test]
+    fn settings_sidebar_config_switches_groups_and_toggles_agents_time() {
+        let mut state = state_with_workspaces(&["test"]);
+        crate::app::state::SidebarAgentItem::Time.set_enabled(&mut state.sidebar_agent, true);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        assert_eq!(
+            state.settings.sidebar_config_group,
+            crate::app::state::SidebarConfigGroup::Agents
+        );
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.list.selected, 1);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.list.selected, 2);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.list.selected, 3);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.list.selected, 4);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.list.selected, 5);
+
+        let previous = state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::Time.set_enabled(&mut expected, false);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_agent, expected);
+        assert_eq!(state.mode, Mode::Settings);
+    }
+
+    #[test]
+    fn settings_sidebar_config_toggles_spaces_status() {
+        let mut state = state_with_workspaces(&["test"]);
+        crate::app::state::SidebarSpaceItem::Status.set_enabled(&mut state.sidebar_space, false);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+
+        let previous = state.sidebar_space.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarSpaceItem::Status.set_enabled(&mut expected, true);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarSpace {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_space, expected);
+        assert_eq!(state.mode, Mode::Settings);
+    }
+
+    #[test]
+    fn settings_sidebar_config_c_cycles_selected_item_color() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+
+        let previous = state.sidebar_space.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarSpaceItem::Status
+            .set_color(&mut expected, crate::config::SidebarColorPreset::Muted);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarSpace {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_space, expected);
+    }
+
+    #[test]
+    fn settings_sidebar_enter_starts_and_stops_item_editing() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, None);
+        assert!(state.settings.sidebar_config_editing);
+
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, None);
+        assert!(!state.settings.sidebar_config_editing);
+        assert_eq!(state.mode, Mode::Settings);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_space_does_not_toggle_selected_item() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let expected = state.sidebar_space.clone();
+
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, None);
+        assert_eq!(state.sidebar_space, expected);
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_left_right_does_not_change_item_line() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        state.settings.list.selected = 1;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, None);
+        assert_eq!(
+            crate::app::state::SidebarAgentItem::PaneName.line(&state.sidebar_agent),
+            crate::app::state::SidebarLine::First
+        );
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_up_down_reorders_agents_within_line() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        state.settings.list.selected = 2;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let previous = state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::TabName.set_order(&mut expected, 1);
+        crate::app::state::SidebarAgentItem::PaneName.set_order(&mut expected, 2);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_agent, expected);
+        assert_eq!(state.mode, Mode::Settings);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_down_moves_agent_item_between_line_groups() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        state.settings.list.selected = 3;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let previous = state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::SpaceName
+            .set_line(&mut expected, crate::app::state::SidebarLine::Second);
+        crate::app::state::SidebarAgentItem::SpaceName.set_order(&mut expected, 0);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_agent, expected);
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_up_moves_agent_item_to_previous_line_without_swap() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        state.settings.list.selected = 4;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let previous = state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::Status
+            .set_line(&mut expected, crate::app::state::SidebarLine::First);
+        crate::app::state::SidebarAgentItem::Status.set_order(&mut expected, 4);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_agent, expected);
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_down_moves_agent_item_to_third_line() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        state.settings.list.selected = 8;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let previous = state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::AgentName
+            .set_line(&mut expected, crate::app::state::SidebarLine::Extra(2));
+        crate::app::state::SidebarAgentItem::AgentName.set_order(&mut expected, 0);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_agent, expected);
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_down_moves_space_item_into_empty_next_line() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.sidebar_space.lines = vec![
+            crate::app::state::SIDEBAR_SPACE_ITEMS
+                .into_iter()
+                .map(crate::config::SidebarItem::visible)
+                .collect(),
+            Vec::new(),
+        ];
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        state.settings.list.selected = 3;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let previous = state.sidebar_space.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarSpaceItem::BranchStatus
+            .set_line(&mut expected, crate::app::state::SidebarLine::Second);
+        crate::app::state::SidebarSpaceItem::BranchStatus.set_order(&mut expected, 0);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarSpace {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_space, expected);
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_up_moves_agent_item_into_empty_previous_line() {
+        let mut state = state_with_workspaces(&["test"]);
+        for item in crate::app::state::SIDEBAR_AGENT_ITEMS {
+            item.set_line(
+                &mut state.sidebar_agent,
+                crate::app::state::SidebarLine::Second,
+            );
+        }
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Right, KeyModifiers::empty()),
+        );
+        state.settings.list.selected = 0;
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let previous = state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::AgentStatus
+            .set_line(&mut expected, crate::app::state::SidebarLine::First);
+        crate::app::state::SidebarAgentItem::AgentStatus.set_order(&mut expected, 0);
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(state.sidebar_agent, expected);
+        assert!(state.settings.sidebar_config_editing);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_up_on_first_item_is_noop() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        // selected = 0 (first space item, line 0, order 0).
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let before_space = state.sidebar_space.clone();
+        let before_agent = state.sidebar_agent.clone();
+        let before_selected = state.settings.list.selected;
+
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Up, KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, None, "Up on first item must be a no-op");
+        assert_eq!(state.sidebar_space, before_space);
+        assert_eq!(state.sidebar_agent, before_agent);
+        assert_eq!(state.settings.list.selected, before_selected);
+    }
+
+    #[test]
+    fn settings_sidebar_edit_down_on_last_item_is_noop() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Sidebar);
+        let last_index = sidebar_config_row_count(crate::app::state::SidebarConfigGroup::Spaces)
+            .saturating_sub(1);
+        state.settings.list.selected = last_index;
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+        let before_space = state.sidebar_space.clone();
+        let before_agent = state.sidebar_agent.clone();
+        let before_selected = state.settings.list.selected;
+
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, None, "Down on last item must be a no-op");
+        assert_eq!(state.sidebar_space, before_space);
+        assert_eq!(state.sidebar_agent, before_agent);
+        assert_eq!(state.settings.list.selected, before_selected);
+    }
+
+    #[test]
     fn settings_tab_cycle_places_experiments_last() {
         let mut state = state_with_workspaces(&["test"]);
         open_settings_at(&mut state, SettingsSection::PaneLabels);
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.section, SettingsSection::Sidebar);
 
         update_settings_state(
             &mut state,
@@ -557,6 +1481,12 @@ mod tests {
             KeyEvent::new(KeyCode::BackTab, KeyModifiers::empty()),
         );
         assert_eq!(state.settings.section, SettingsSection::Integrations);
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::BackTab, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.section, SettingsSection::Sidebar);
     }
 
     #[test]
@@ -604,6 +1534,37 @@ mod tests {
 
         assert_eq!(action, Some(SettingsAction::SavePaneHistory(true)));
         assert_eq!(app.state.settings.list.selected, 0);
+    }
+
+    #[test]
+    fn settings_mouse_click_toggles_sidebar_agent_right_align_row() {
+        let mut app = app_for_mouse_test();
+        app.state.view.sidebar_rect = Rect::new(0, 0, 26, 40);
+        app.state.view.terminal_area = Rect::new(26, 0, 100, 40);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.state.sidebar_agent, true);
+        open_settings_at(&mut app.state, SettingsSection::Sidebar);
+        app.state.settings.sidebar_config_group = crate::app::state::SidebarConfigGroup::Agents;
+
+        let area = app.state.settings_content_rect();
+        let previous = app.state.sidebar_agent.clone();
+        let mut expected = previous.clone();
+        crate::app::state::SidebarAgentItem::RightAlignment.set_enabled(&mut expected, false);
+        let action = app.state.handle_settings_mouse(mouse(
+            MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            area.x + 2,
+            area.y + 12,
+        ));
+
+        assert_eq!(
+            action,
+            Some(SettingsAction::SaveSidebarAgent {
+                previous,
+                preferences: expected.clone(),
+            })
+        );
+        assert_eq!(app.state.sidebar_agent, expected);
+        assert_eq!(app.state.settings.list.selected, 7);
     }
 
     #[test]

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -455,23 +455,30 @@ impl AppState {
             detail_area,
             crate::ui::should_show_scrollbar(metrics),
         );
-        if body.height < 2 || row < body.y || row >= body.y + body.height {
+        let entry_rows = crate::ui::agent_panel_entry_row_count(self);
+        if entry_rows == 0
+            || body.height < entry_rows
+            || row < body.y
+            || row >= body.y + body.height
+        {
             return None;
         }
 
         let mut row_y = body.y;
+        let body_bottom = body.y.saturating_add(body.height);
         for detail in crate::ui::agent_panel_entries(self)
             .into_iter()
             .skip(self.agent_panel_scroll)
         {
-            if row_y.saturating_add(1) >= body.y + body.height {
+            let row_end = row_y.saturating_add(entry_rows);
+            if row_end > body_bottom {
                 break;
             }
-            if row == row_y || row == row_y + 1 {
+            if row >= row_y && row < row_end {
                 return Some((detail.ws_idx, detail.tab_idx, detail.pane_id));
             }
-            row_y = row_y.saturating_add(2);
-            if row_y < body.y + body.height {
+            row_y = row_end;
+            if row_y < body_bottom {
                 row_y = row_y.saturating_add(1);
             }
         }
@@ -488,7 +495,7 @@ mod tests {
 
     use super::super::{app_for_mouse_test, capture_snapshot, mouse, unique_temp_path};
     use crate::{
-        app::state::{AgentPanelScope, DragTarget, Mode},
+        app::state::{AgentPanelScope, DragTarget, Mode, SidebarAgentItem},
         detect::Agent,
         workspace::Workspace,
     };
@@ -782,6 +789,108 @@ mod tests {
         assert_eq!(
             app.state.workspaces[1].tabs[0].layout.focused(),
             second_pane
+        );
+    }
+
+    #[test]
+    fn agent_detail_hit_test_uses_one_configured_row_per_entry() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        for (ws_idx, pane_id, agent) in
+            [(0, first_pane, Agent::Pi), (1, second_pane, Agent::Claude)]
+        {
+            let terminal_id = app.state.workspaces[ws_idx].tabs[0].panes[&pane_id]
+                .attached_terminal_id
+                .clone();
+            app.state
+                .terminals
+                .get_mut(&terminal_id)
+                .unwrap()
+                .detected_agent = Some(agent);
+        }
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+        app.state.sidebar_agent.lines = vec![vec![crate::config::SidebarItem::visible(
+            SidebarAgentItem::AgentStatus,
+        )]];
+
+        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+            app.state.view.sidebar_rect,
+            app.state.sidebar_section_split,
+        );
+        let body = crate::ui::agent_panel_body_rect(detail_area, false);
+
+        let target = app
+            .state
+            .agent_detail_target_at(body.y + 2)
+            .expect("second one-line entry should be hittable");
+
+        assert_eq!(target, (1, 0, second_pane));
+    }
+
+    #[test]
+    fn agent_detail_hit_test_uses_three_configured_rows_per_entry() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        for (ws_idx, pane_id, agent) in
+            [(0, first_pane, Agent::Pi), (1, second_pane, Agent::Claude)]
+        {
+            let terminal_id = app.state.workspaces[ws_idx].tabs[0].panes[&pane_id]
+                .attached_terminal_id
+                .clone();
+            app.state
+                .terminals
+                .get_mut(&terminal_id)
+                .unwrap()
+                .detected_agent = Some(agent);
+        }
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+        app.state.sidebar_agent.lines = vec![
+            vec![crate::config::SidebarItem::visible(
+                SidebarAgentItem::AgentStatus,
+            )],
+            vec![crate::config::SidebarItem::visible(
+                SidebarAgentItem::Status,
+            )],
+            vec![crate::config::SidebarItem::visible(
+                SidebarAgentItem::AgentName,
+            )],
+        ];
+
+        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+            app.state.view.sidebar_rect,
+            app.state.sidebar_section_split,
+        );
+        let body = crate::ui::agent_panel_body_rect(detail_area, false);
+
+        assert_eq!(
+            app.state
+                .agent_detail_target_at(body.y + 2)
+                .expect("third row of first entry should be hittable"),
+            (0, 0, first_pane)
+        );
+        assert_eq!(
+            app.state
+                .agent_detail_target_at(body.y + 4)
+                .expect("second three-line entry should start after separator"),
+            (1, 0, second_pane)
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -486,8 +486,8 @@ impl App {
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
             pane_history_persistence: config.experimental.pane_history,
-            space_view: config.ui.sidebar.spaces.clone(),
-            agent_view: config.ui.sidebar.agents.clone(),
+            sidebar_space: config.ui.sidebar.spaces.clone(),
+            sidebar_agent: config.ui.sidebar.agents.clone(),
             reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
             cjk_ime_agent_filter_configured: !config.experimental.cjk_ime_agents.is_empty(),
             cjk_ime_agents: parse_cjk_ime_agents(&config.experimental.cjk_ime_agents),
@@ -511,6 +511,8 @@ impl App {
             settings: state::SettingsState {
                 section: state::SettingsSection::Theme,
                 list: state::SelectionListState::new(0),
+                sidebar_config_group: state::SidebarConfigGroup::default(),
+                sidebar_config_editing: false,
                 original_palette: None,
                 original_theme: None,
             },
@@ -1094,8 +1096,8 @@ impl App {
                 self.state.agent_panel_scope =
                     agent_panel_scope_from_config(config.ui.agent_panel_scope);
                 self.state.agent_panel_scroll = 0;
-                self.state.space_view = config.ui.sidebar.spaces.clone();
-                self.state.agent_view = config.ui.sidebar.agents.clone();
+                self.state.sidebar_space = config.ui.sidebar.spaces.clone();
+                self.state.sidebar_agent = config.ui.sidebar.agents.clone();
                 self.state.accent = crate::config::parse_color(&config.ui.accent);
                 if !self.state.local_sound_playback && self.state.sound != config.ui.sound {
                     self.state.request_client_config_reload = true;
@@ -1997,40 +1999,142 @@ mod tests {
     }
 
     #[test]
-    fn settings_save_sidebar_view_config_persists_then_applies_live_config() {
+    fn settings_save_sidebar_config_persists_then_applies_live_config() {
         let _guard = config_env_lock().lock().unwrap();
-        let path = temp_config_path("settings-save-sidebar-view-config");
+        let path = temp_config_path("settings-save-sidebar-config");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, "onboarding = false\n").unwrap();
         std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
 
         let mut app = test_app();
-        assert!(state::SpaceViewItem::BranchStatus.enabled(&app.state.space_view));
-        assert!(state::AgentViewItem::Time.enabled(&app.state.agent_view));
+        assert!(state::SidebarSpaceItem::BranchStatus.enabled(&app.state.sidebar_space));
+        assert!(state::SidebarAgentItem::Time.enabled(&app.state.sidebar_agent));
 
-        let mut space_view = app.state.space_view.clone();
-        state::SpaceViewItem::BranchStatus.set_enabled(&mut space_view, false);
-        app.save_space_view_preferences(space_view);
-        let mut agent_view = app.state.agent_view.clone();
-        state::AgentViewItem::Time.set_enabled(&mut agent_view, false);
-        state::AgentViewItem::Time.set_color(&mut agent_view, crate::config::ViewColorPreset::Cool);
-        app.save_agent_view_preferences(agent_view);
+        let mut sidebar_space = app.state.sidebar_space.clone();
+        state::SidebarSpaceItem::BranchStatus.set_enabled(&mut sidebar_space, false);
+        app.save_sidebar_space_preferences(sidebar_space);
+        let mut sidebar_agent = app.state.sidebar_agent.clone();
+        state::SidebarAgentItem::Time.set_enabled(&mut sidebar_agent, false);
+        state::SidebarAgentItem::Time
+            .set_color(&mut sidebar_agent, crate::config::SidebarColorPreset::Cool);
+        app.save_sidebar_agent_preferences(sidebar_agent);
 
-        assert!(!state::SpaceViewItem::BranchStatus.enabled(&app.state.space_view));
-        assert!(!state::AgentViewItem::Time.enabled(&app.state.agent_view));
+        assert!(!state::SidebarSpaceItem::BranchStatus.enabled(&app.state.sidebar_space));
+        assert!(!state::SidebarAgentItem::Time.enabled(&app.state.sidebar_agent));
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("[ui.sidebar.spaces]"));
         assert!(content.contains("lines = ["));
         assert!(content.contains(r#"{ field = "branch_status", show = false }"#));
-        assert!(!content.contains("line_first"));
-        assert!(!content.contains("line_second"));
-        assert!(!content.contains("show_branch_status"));
-        assert!(!content.contains("branch_status_line"));
         assert!(content.contains("[ui.sidebar.agents]"));
         assert!(content.contains(r#"{ field = "time", show = false, color = "cool" }"#));
-        assert!(!content.contains("show_time"));
-        assert!(!content.contains("time_line"));
         assert!(app.state.config_diagnostic.is_none());
+
+        std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn save_sidebar_preferences_round_trips_non_default_layout_structurally() {
+        let _guard = config_env_lock().lock().unwrap();
+        let path = temp_config_path("sidebar-round-trip-structural");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "onboarding = false\n").unwrap();
+        std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
+
+        let mut app = test_app();
+
+        // Deliberately non-default: three lines, reordered items, and a
+        // non-default color preset.
+        let original_agent = crate::config::SidebarAgentsConfig {
+            lines: vec![
+                vec![
+                    crate::config::SidebarItem::visible(crate::config::SidebarAgentField::PaneName),
+                    crate::config::SidebarItem::visible(
+                        crate::config::SidebarAgentField::AgentStatus,
+                    ),
+                ],
+                vec![
+                    crate::config::SidebarItem::visible(crate::config::SidebarAgentField::TabName),
+                    crate::config::SidebarItem::visible(
+                        crate::config::SidebarAgentField::SpaceName,
+                    ),
+                    crate::config::SidebarItem {
+                        field: crate::config::SidebarAgentField::CustomStatus,
+                        show: false,
+                        color: crate::config::SidebarColorPreset::Warm,
+                    },
+                ],
+                vec![
+                    crate::config::SidebarItem::visible(crate::config::SidebarAgentField::Status),
+                    crate::config::SidebarItem::visible(crate::config::SidebarAgentField::Time),
+                    crate::config::SidebarItem::visible(
+                        crate::config::SidebarAgentField::RightAlignment,
+                    ),
+                    crate::config::SidebarItem::visible(
+                        crate::config::SidebarAgentField::AgentName,
+                    ),
+                ],
+            ],
+        };
+
+        app.save_sidebar_agent_preferences(original_agent.clone());
+
+        assert_eq!(
+            app.state.sidebar_agent.lines, original_agent.lines,
+            "structural round-trip: lines must match exactly",
+        );
+        assert!(app.state.config_diagnostic.is_none());
+
+        std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn settings_sidebar_save_failure_rolls_back_live_preview() {
+        let _guard = config_env_lock().lock().unwrap();
+        let path = temp_config_path("settings-sidebar-save-failure");
+        std::fs::create_dir_all(&path).unwrap();
+        std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
+
+        let mut app = test_app();
+        crate::app::input::open_settings_at(&mut app.state, state::SettingsSection::Sidebar);
+        let previous = app.state.sidebar_space.clone();
+
+        app.handle_settings_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()));
+
+        assert_eq!(app.state.sidebar_space, previous);
+        assert!(app
+            .state
+            .config_diagnostic
+            .as_deref()
+            .is_some_and(|message| message.contains("failed to save space sidebar preferences")));
+
+        std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn settings_sidebar_reload_failure_rolls_back_live_preview() {
+        let _guard = config_env_lock().lock().unwrap();
+        let path = temp_config_path("settings-sidebar-reload-failure");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[keys\n").unwrap();
+        std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
+
+        let mut app = test_app();
+        crate::app::input::open_settings_at(&mut app.state, state::SettingsSection::Sidebar);
+        let previous = app.state.sidebar_space.clone();
+
+        app.handle_settings_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::empty()));
+
+        assert_eq!(app.state.sidebar_space, previous);
+        assert!(app
+            .state
+            .config_diagnostic
+            .as_deref()
+            .is_some_and(|message| message.contains("config parse error")));
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("[ui.sidebar.spaces]"));
 
         std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);
         let _ = std::fs::remove_dir_all(path.parent().unwrap());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -486,6 +486,8 @@ impl App {
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
             pane_history_persistence: config.experimental.pane_history,
+            space_view: config.ui.sidebar.spaces.clone(),
+            agent_view: config.ui.sidebar.agents.clone(),
             reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
             cjk_ime_agent_filter_configured: !config.experimental.cjk_ime_agents.is_empty(),
             cjk_ime_agents: parse_cjk_ime_agents(&config.experimental.cjk_ime_agents),
@@ -1092,6 +1094,8 @@ impl App {
                 self.state.agent_panel_scope =
                     agent_panel_scope_from_config(config.ui.agent_panel_scope);
                 self.state.agent_panel_scroll = 0;
+                self.state.space_view = config.ui.sidebar.spaces.clone();
+                self.state.agent_view = config.ui.sidebar.agents.clone();
                 self.state.accent = crate::config::parse_color(&config.ui.accent);
                 if !self.state.local_sound_playback && self.state.sound != config.ui.sound {
                     self.state.request_client_config_reload = true;
@@ -1986,6 +1990,46 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("[experimental]"));
         assert!(content.contains("pane_history = true"));
+        assert!(app.state.config_diagnostic.is_none());
+
+        std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn settings_save_sidebar_view_config_persists_then_applies_live_config() {
+        let _guard = config_env_lock().lock().unwrap();
+        let path = temp_config_path("settings-save-sidebar-view-config");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "onboarding = false\n").unwrap();
+        std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
+
+        let mut app = test_app();
+        assert!(state::SpaceViewItem::BranchStatus.enabled(&app.state.space_view));
+        assert!(state::AgentViewItem::Time.enabled(&app.state.agent_view));
+
+        let mut space_view = app.state.space_view.clone();
+        state::SpaceViewItem::BranchStatus.set_enabled(&mut space_view, false);
+        app.save_space_view_preferences(space_view);
+        let mut agent_view = app.state.agent_view.clone();
+        state::AgentViewItem::Time.set_enabled(&mut agent_view, false);
+        state::AgentViewItem::Time.set_color(&mut agent_view, crate::config::ViewColorPreset::Cool);
+        app.save_agent_view_preferences(agent_view);
+
+        assert!(!state::SpaceViewItem::BranchStatus.enabled(&app.state.space_view));
+        assert!(!state::AgentViewItem::Time.enabled(&app.state.agent_view));
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("[ui.sidebar.spaces]"));
+        assert!(content.contains("lines = ["));
+        assert!(content.contains(r#"{ field = "branch_status", show = false }"#));
+        assert!(!content.contains("line_first"));
+        assert!(!content.contains("line_second"));
+        assert!(!content.contains("show_branch_status"));
+        assert!(!content.contains("branch_status_line"));
+        assert!(content.contains("[ui.sidebar.agents]"));
+        assert!(content.contains(r#"{ field = "time", show = false, color = "cool" }"#));
+        assert!(!content.contains("show_time"));
+        assert!(!content.contains("time_line"));
         assert!(app.state.config_diagnostic.is_none());
 
         std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    AgentViewField, AgentsViewConfig, Keybinds, NewTerminalCwdConfig, SoundConfig, SpaceViewField,
-    SpacesViewConfig, ToastConfig, ToastDelivery, ViewColorPreset, ViewItem,
+    Keybinds, NewTerminalCwdConfig, SidebarAgentField, SidebarAgentsConfig, SidebarColorPreset,
+    SidebarItem, SidebarSpaceField, SidebarSpacesConfig, SoundConfig, ToastConfig, ToastDelivery,
 };
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::{Direction, Rect};
@@ -81,13 +81,13 @@ pub struct Palette {
 }
 
 impl Palette {
-    pub(crate) fn view_color(&self, preset: ViewColorPreset, default: Color) -> Color {
+    pub(crate) fn sidebar_color(&self, preset: SidebarColorPreset, default: Color) -> Color {
         match preset {
-            ViewColorPreset::Default => default,
-            ViewColorPreset::Muted => self.overlay1,
-            ViewColorPreset::Accent => self.accent,
-            ViewColorPreset::Cool => self.teal,
-            ViewColorPreset::Warm => self.peach,
+            SidebarColorPreset::Default => default,
+            SidebarColorPreset::Muted => self.overlay1,
+            SidebarColorPreset::Accent => self.accent,
+            SidebarColorPreset::Cool => self.teal,
+            SidebarColorPreset::Warm => self.peach,
         }
     }
 
@@ -724,13 +724,13 @@ pub enum AgentPanelScope {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ViewLine {
+pub enum SidebarLine {
     First,
     Second,
     Extra(usize),
 }
 
-impl ViewLine {
+impl SidebarLine {
     pub(crate) fn from_index(index: usize) -> Self {
         match index {
             0 => Self::First,
@@ -762,19 +762,19 @@ impl ViewLine {
     }
 }
 
-pub type SpaceViewPreferences = SpacesViewConfig;
-pub type AgentViewPreferences = AgentsViewConfig;
-pub(crate) use crate::config::AgentViewField as AgentViewItem;
-pub(crate) use crate::config::SpaceViewField as SpaceViewItem;
+pub type SidebarSpacePreferences = SidebarSpacesConfig;
+pub type SidebarAgentPreferences = SidebarAgentsConfig;
+pub(crate) use crate::config::SidebarAgentField as SidebarAgentItem;
+pub(crate) use crate::config::SidebarSpaceField as SidebarSpaceItem;
 
-pub(crate) const SPACE_VIEW_ITEMS: [SpaceViewItem; 4] = [
-    SpaceViewItem::Status,
-    SpaceViewItem::Name,
-    SpaceViewItem::Branch,
-    SpaceViewItem::BranchStatus,
+pub(crate) const SIDEBAR_SPACE_ITEMS: [SidebarSpaceItem; 4] = [
+    SidebarSpaceItem::Status,
+    SidebarSpaceItem::Name,
+    SidebarSpaceItem::Branch,
+    SidebarSpaceItem::BranchStatus,
 ];
 
-impl SpaceViewField {
+impl SidebarSpaceField {
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Status => "space status",
@@ -793,84 +793,93 @@ impl SpaceViewField {
         }
     }
 
-    pub(crate) fn enabled(self, view: &SpaceViewPreferences) -> bool {
-        space_view_entry(view, self).show
+    pub(crate) fn enabled(self, preferences: &SidebarSpacePreferences) -> bool {
+        sidebar_space_entry(preferences, self).show
     }
 
-    pub(crate) fn set_enabled(self, view: &mut SpaceViewPreferences, enabled: bool) {
-        if let Some(entry) = space_view_entry_mut(view, self) {
+    pub(crate) fn set_enabled(self, preferences: &mut SidebarSpacePreferences, enabled: bool) {
+        if let Some(entry) = sidebar_space_entry_mut(preferences, self) {
             entry.show = enabled;
         } else {
             let line = self.default_line();
-            let entry = ViewItem::new(self, enabled);
-            space_view_line_mut(view, line).push(entry);
+            let entry = SidebarItem::new(self, enabled);
+            sidebar_space_line_mut(preferences, line).push(entry);
         }
     }
 
-    pub(crate) fn color(self, view: &SpaceViewPreferences) -> ViewColorPreset {
-        space_view_entry(view, self).color
+    pub(crate) fn color(self, preferences: &SidebarSpacePreferences) -> SidebarColorPreset {
+        sidebar_space_entry(preferences, self).color
     }
 
-    pub(crate) fn set_color(self, view: &mut SpaceViewPreferences, color: ViewColorPreset) {
-        if let Some(entry) = space_view_entry_mut(view, self) {
+    pub(crate) fn set_color(
+        self,
+        preferences: &mut SidebarSpacePreferences,
+        color: SidebarColorPreset,
+    ) {
+        if let Some(entry) = sidebar_space_entry_mut(preferences, self) {
             entry.color = color;
         } else {
             let line = self.default_line();
-            let entry = ViewItem {
+            let entry = SidebarItem {
                 color,
-                ..ViewItem::visible(self)
+                ..SidebarItem::visible(self)
             };
-            space_view_line_mut(view, line).push(entry);
+            sidebar_space_line_mut(preferences, line).push(entry);
         }
     }
 
-    pub(crate) fn line(self, view: &SpaceViewPreferences) -> ViewLine {
-        view.lines
+    pub(crate) fn line(self, preferences: &SidebarSpacePreferences) -> SidebarLine {
+        preferences
+            .lines
             .iter()
             .position(|line| line.iter().any(|entry| entry.field == self))
-            .map(ViewLine::from_index)
+            .map(SidebarLine::from_index)
             .unwrap_or_else(|| self.default_line())
     }
 
-    pub(crate) fn set_line(self, view: &mut SpaceViewPreferences, line: ViewLine) {
-        let entry = remove_space_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
-        space_view_line_mut(view, line).push(entry);
+    pub(crate) fn set_line(self, preferences: &mut SidebarSpacePreferences, line: SidebarLine) {
+        let entry = remove_sidebar_space_item(preferences, self)
+            .unwrap_or_else(|| SidebarItem::visible(self));
+        sidebar_space_line_mut(preferences, line).push(entry);
     }
 
-    pub(crate) fn order(self, view: &SpaceViewPreferences) -> u8 {
-        space_view_line(view, self.line(view))
+    pub(crate) fn order(self, preferences: &SidebarSpacePreferences) -> u8 {
+        sidebar_space_line(preferences, self.line(preferences))
             .iter()
             .position(|entry| entry.field == self)
             .map(|idx| idx as u8)
             .unwrap_or_else(|| self.default_index())
     }
 
-    pub(crate) fn set_order(self, view: &mut SpaceViewPreferences, order: u8) {
-        let line = self.line(view);
-        let entry = remove_space_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
-        let target = space_view_line_mut(view, line);
+    pub(crate) fn set_order(self, preferences: &mut SidebarSpacePreferences, order: u8) {
+        let line = self.line(preferences);
+        let entry = remove_sidebar_space_item(preferences, self)
+            .unwrap_or_else(|| SidebarItem::visible(self));
+        let target = sidebar_space_line_mut(preferences, line);
         let index = usize::from(order).min(target.len());
         target.insert(index, entry);
     }
 
-    fn default_line(self) -> ViewLine {
+    fn default_line(self) -> SidebarLine {
         match self {
-            Self::Status | Self::Name => ViewLine::First,
-            Self::Branch | Self::BranchStatus => ViewLine::Second,
+            Self::Status | Self::Name => SidebarLine::First,
+            Self::Branch | Self::BranchStatus => SidebarLine::Second,
         }
     }
 }
 
-pub(crate) fn ordered_space_view_items(view: &SpaceViewPreferences) -> Vec<SpaceViewItem> {
+pub(crate) fn ordered_sidebar_space_items(
+    preferences: &SidebarSpacePreferences,
+) -> Vec<SidebarSpaceItem> {
     let mut items = Vec::new();
-    for line in &view.lines {
+    for line in &preferences.lines {
         for entry in line {
             if !items.contains(&entry.field) {
                 items.push(entry.field);
             }
         }
     }
-    for item in SPACE_VIEW_ITEMS {
+    for item in SIDEBAR_SPACE_ITEMS {
         if !items.contains(&item) {
             items.push(item);
         }
@@ -878,19 +887,19 @@ pub(crate) fn ordered_space_view_items(view: &SpaceViewPreferences) -> Vec<Space
     items
 }
 
-pub(crate) const AGENT_VIEW_PLACEMENT_ITEMS: [AgentViewItem; 9] = [
-    AgentViewItem::AgentStatus,
-    AgentViewItem::PaneName,
-    AgentViewItem::TabName,
-    AgentViewItem::SpaceName,
-    AgentViewItem::Status,
-    AgentViewItem::Time,
-    AgentViewItem::CustomStatus,
-    AgentViewItem::RightAlignment,
-    AgentViewItem::AgentName,
+pub(crate) const SIDEBAR_AGENT_ITEMS: [SidebarAgentItem; 9] = [
+    SidebarAgentItem::AgentStatus,
+    SidebarAgentItem::PaneName,
+    SidebarAgentItem::TabName,
+    SidebarAgentItem::SpaceName,
+    SidebarAgentItem::Status,
+    SidebarAgentItem::Time,
+    SidebarAgentItem::CustomStatus,
+    SidebarAgentItem::RightAlignment,
+    SidebarAgentItem::AgentName,
 ];
 
-impl AgentViewField {
+impl SidebarAgentField {
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::AgentStatus => "agent status",
@@ -919,91 +928,100 @@ impl AgentViewField {
         }
     }
 
-    pub(crate) fn enabled(self, view: &AgentViewPreferences) -> bool {
-        agent_view_entry(view, self).show
+    pub(crate) fn enabled(self, preferences: &SidebarAgentPreferences) -> bool {
+        sidebar_agent_entry(preferences, self).show
     }
 
-    pub(crate) fn set_enabled(self, view: &mut AgentViewPreferences, enabled: bool) {
-        if let Some(entry) = agent_view_entry_mut(view, self) {
+    pub(crate) fn set_enabled(self, preferences: &mut SidebarAgentPreferences, enabled: bool) {
+        if let Some(entry) = sidebar_agent_entry_mut(preferences, self) {
             entry.show = enabled;
         } else {
             let line = self.default_line();
-            let entry = ViewItem::new(self, enabled);
-            agent_view_line_mut(view, line).push(entry);
+            let entry = SidebarItem::new(self, enabled);
+            sidebar_agent_line_mut(preferences, line).push(entry);
         }
     }
 
-    pub(crate) fn color(self, view: &AgentViewPreferences) -> ViewColorPreset {
-        agent_view_entry(view, self).color
+    pub(crate) fn color(self, preferences: &SidebarAgentPreferences) -> SidebarColorPreset {
+        sidebar_agent_entry(preferences, self).color
     }
 
-    pub(crate) fn set_color(self, view: &mut AgentViewPreferences, color: ViewColorPreset) {
-        if let Some(entry) = agent_view_entry_mut(view, self) {
+    pub(crate) fn set_color(
+        self,
+        preferences: &mut SidebarAgentPreferences,
+        color: SidebarColorPreset,
+    ) {
+        if let Some(entry) = sidebar_agent_entry_mut(preferences, self) {
             entry.color = color;
         } else {
             let line = self.default_line();
-            let entry = ViewItem {
+            let entry = SidebarItem {
                 color,
-                ..ViewItem::visible(self)
+                ..SidebarItem::visible(self)
             };
-            agent_view_line_mut(view, line).push(entry);
+            sidebar_agent_line_mut(preferences, line).push(entry);
         }
     }
 
-    pub(crate) fn line(self, view: &AgentViewPreferences) -> Option<ViewLine> {
-        Some(
-            view.lines
-                .iter()
-                .position(|line| line.iter().any(|entry| entry.field == self))
-                .map(ViewLine::from_index)
-                .unwrap_or_else(|| self.default_line()),
-        )
+    pub(crate) fn line(self, preferences: &SidebarAgentPreferences) -> SidebarLine {
+        preferences
+            .lines
+            .iter()
+            .position(|line| line.iter().any(|entry| entry.field == self))
+            .map(SidebarLine::from_index)
+            .unwrap_or_else(|| self.default_line())
     }
 
-    pub(crate) fn set_line(self, view: &mut AgentViewPreferences, line: ViewLine) {
-        let entry = remove_agent_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
-        agent_view_line_mut(view, line).push(entry);
+    pub(crate) fn set_line(self, preferences: &mut SidebarAgentPreferences, line: SidebarLine) {
+        let entry = remove_sidebar_agent_item(preferences, self)
+            .unwrap_or_else(|| SidebarItem::visible(self));
+        sidebar_agent_line_mut(preferences, line).push(entry);
     }
 
-    pub(crate) fn order(self, view: &AgentViewPreferences) -> Option<u8> {
-        let line = self.line(view)?;
-        agent_view_line(view, line)
+    pub(crate) fn order(self, preferences: &SidebarAgentPreferences) -> u8 {
+        let line = self.line(preferences);
+        sidebar_agent_line(preferences, line)
             .iter()
             .position(|entry| entry.field == self)
             .map(|idx| idx as u8)
-            .or_else(|| Some(self.default_index()))
+            .unwrap_or_else(|| self.default_index())
     }
 
-    pub(crate) fn set_order(self, view: &mut AgentViewPreferences, order: u8) {
-        let line = self.line(view).unwrap_or_else(|| self.default_line());
-        let entry = remove_agent_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
-        let target = agent_view_line_mut(view, line);
+    pub(crate) fn set_order(self, preferences: &mut SidebarAgentPreferences, order: u8) {
+        let line = self.line(preferences);
+        let entry = remove_sidebar_agent_item(preferences, self)
+            .unwrap_or_else(|| SidebarItem::visible(self));
+        let target = sidebar_agent_line_mut(preferences, line);
         let index = usize::from(order).min(target.len());
         target.insert(index, entry);
     }
 
-    fn default_line(self) -> ViewLine {
+    fn default_line(self) -> SidebarLine {
         match self {
-            Self::AgentStatus | Self::PaneName | Self::TabName | Self::SpaceName => ViewLine::First,
+            Self::AgentStatus | Self::PaneName | Self::TabName | Self::SpaceName => {
+                SidebarLine::First
+            }
             Self::Status
             | Self::Time
             | Self::CustomStatus
             | Self::RightAlignment
-            | Self::AgentName => ViewLine::Second,
+            | Self::AgentName => SidebarLine::Second,
         }
     }
 }
 
-pub(crate) fn ordered_agent_view_items(view: &AgentViewPreferences) -> Vec<AgentViewItem> {
+pub(crate) fn ordered_sidebar_agent_items(
+    preferences: &SidebarAgentPreferences,
+) -> Vec<SidebarAgentItem> {
     let mut items = Vec::new();
-    for line in &view.lines {
+    for line in &preferences.lines {
         for entry in line {
             if !items.contains(&entry.field) {
                 items.push(entry.field);
             }
         }
     }
-    for item in AGENT_VIEW_PLACEMENT_ITEMS {
+    for item in SIDEBAR_AGENT_ITEMS {
         if !items.contains(&item) {
             items.push(item);
         }
@@ -1011,47 +1029,56 @@ pub(crate) fn ordered_agent_view_items(view: &AgentViewPreferences) -> Vec<Agent
     items
 }
 
-fn space_view_line(view: &SpaceViewPreferences, line: ViewLine) -> &[ViewItem<SpaceViewField>] {
-    view.lines
+fn sidebar_space_line(
+    preferences: &SidebarSpacePreferences,
+    line: SidebarLine,
+) -> &[SidebarItem<SidebarSpaceField>] {
+    preferences
+        .lines
         .get(line.index())
         .map(Vec::as_slice)
         .unwrap_or(&[])
 }
 
-fn space_view_line_mut(
-    view: &mut SpaceViewPreferences,
-    line: ViewLine,
-) -> &mut Vec<ViewItem<SpaceViewField>> {
-    while view.lines.len() <= line.index() {
-        view.lines.push(Vec::new());
+fn sidebar_space_line_mut(
+    preferences: &mut SidebarSpacePreferences,
+    line: SidebarLine,
+) -> &mut Vec<SidebarItem<SidebarSpaceField>> {
+    while preferences.lines.len() <= line.index() {
+        preferences.lines.push(Vec::new());
     }
-    &mut view.lines[line.index()]
+    &mut preferences.lines[line.index()]
 }
 
-fn space_view_entry(view: &SpaceViewPreferences, item: SpaceViewItem) -> ViewItem<SpaceViewField> {
-    view.lines
+fn sidebar_space_entry(
+    preferences: &SidebarSpacePreferences,
+    item: SidebarSpaceItem,
+) -> SidebarItem<SidebarSpaceField> {
+    preferences
+        .lines
         .iter()
         .flatten()
         .find(|entry| entry.field == item)
         .copied()
-        .unwrap_or_else(|| ViewItem::visible(item))
+        .unwrap_or_else(|| SidebarItem::new(item, false))
 }
 
-fn space_view_entry_mut(
-    view: &mut SpaceViewPreferences,
-    item: SpaceViewItem,
-) -> Option<&mut ViewItem<SpaceViewField>> {
-    view.lines
+fn sidebar_space_entry_mut(
+    preferences: &mut SidebarSpacePreferences,
+    item: SidebarSpaceItem,
+) -> Option<&mut SidebarItem<SidebarSpaceField>> {
+    preferences
+        .lines
         .iter_mut()
         .flatten()
         .find(|entry| entry.field == item)
 }
 
-fn remove_space_view_item(
-    view: &mut SpaceViewPreferences,
-    item: SpaceViewItem,
-) -> Option<ViewItem<SpaceViewField>> {
-    for line in &mut view.lines {
+fn remove_sidebar_space_item(
+    preferences: &mut SidebarSpacePreferences,
+    item: SidebarSpaceItem,
+) -> Option<SidebarItem<SidebarSpaceField>> {
+    for line in &mut preferences.lines {
         if let Some(index) = line.iter().position(|entry| entry.field == item) {
             return Some(line.remove(index));
         }
@@ -1059,47 +1086,56 @@ fn remove_space_view_item(
     None
 }
 
-fn agent_view_line(view: &AgentViewPreferences, line: ViewLine) -> &[ViewItem<AgentViewField>] {
-    view.lines
+fn sidebar_agent_line(
+    preferences: &SidebarAgentPreferences,
+    line: SidebarLine,
+) -> &[SidebarItem<SidebarAgentField>] {
+    preferences
+        .lines
         .get(line.index())
         .map(Vec::as_slice)
         .unwrap_or(&[])
 }
 
-fn agent_view_line_mut(
-    view: &mut AgentViewPreferences,
-    line: ViewLine,
-) -> &mut Vec<ViewItem<AgentViewField>> {
-    while view.lines.len() <= line.index() {
-        view.lines.push(Vec::new());
+fn sidebar_agent_line_mut(
+    preferences: &mut SidebarAgentPreferences,
+    line: SidebarLine,
+) -> &mut Vec<SidebarItem<SidebarAgentField>> {
+    while preferences.lines.len() <= line.index() {
+        preferences.lines.push(Vec::new());
     }
-    &mut view.lines[line.index()]
+    &mut preferences.lines[line.index()]
 }
 
-fn agent_view_entry(view: &AgentViewPreferences, item: AgentViewItem) -> ViewItem<AgentViewField> {
-    view.lines
+fn sidebar_agent_entry(
+    preferences: &SidebarAgentPreferences,
+    item: SidebarAgentItem,
+) -> SidebarItem<SidebarAgentField> {
+    preferences
+        .lines
         .iter()
         .flatten()
         .find(|entry| entry.field == item)
         .copied()
-        .unwrap_or_else(|| ViewItem::visible(item))
+        .unwrap_or_else(|| SidebarItem::new(item, false))
 }
 
-fn agent_view_entry_mut(
-    view: &mut AgentViewPreferences,
-    item: AgentViewItem,
-) -> Option<&mut ViewItem<AgentViewField>> {
-    view.lines
+fn sidebar_agent_entry_mut(
+    preferences: &mut SidebarAgentPreferences,
+    item: SidebarAgentItem,
+) -> Option<&mut SidebarItem<SidebarAgentField>> {
+    preferences
+        .lines
         .iter_mut()
         .flatten()
         .find(|entry| entry.field == item)
 }
 
-fn remove_agent_view_item(
-    view: &mut AgentViewPreferences,
-    item: AgentViewItem,
-) -> Option<ViewItem<AgentViewField>> {
-    for line in &mut view.lines {
+fn remove_sidebar_agent_item(
+    preferences: &mut SidebarAgentPreferences,
+    item: SidebarAgentItem,
+) -> Option<SidebarItem<SidebarAgentField>> {
+    for line in &mut preferences.lines {
         if let Some(index) = line.iter().position(|entry| entry.field == item) {
             return Some(line.remove(index));
         }
@@ -1108,13 +1144,15 @@ fn remove_agent_view_item(
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum ViewConfigGroup {
+pub enum SidebarConfigGroup {
     #[default]
     Spaces,
     Agents,
 }
 
-impl ViewConfigGroup {
+impl SidebarConfigGroup {
+    const ALL: [Self; 2] = [Self::Spaces, Self::Agents];
+
     pub fn label(self) -> &'static str {
         match self {
             Self::Spaces => "spaces",
@@ -1130,17 +1168,19 @@ impl ViewConfigGroup {
     }
 
     pub fn previous(self) -> Self {
-        match self {
-            Self::Spaces => Self::Agents,
-            Self::Agents => Self::Spaces,
-        }
+        let index = Self::ALL
+            .iter()
+            .position(|group| *group == self)
+            .unwrap_or(0);
+        Self::ALL[(index + Self::ALL.len() - 1) % Self::ALL.len()]
     }
 
     pub fn next(self) -> Self {
-        match self {
-            Self::Spaces => Self::Agents,
-            Self::Agents => Self::Spaces,
-        }
+        let index = Self::ALL
+            .iter()
+            .position(|group| *group == self)
+            .unwrap_or(0);
+        Self::ALL[(index + 1) % Self::ALL.len()]
     }
 }
 
@@ -1155,6 +1195,7 @@ pub enum SettingsSection {
     Sound,
     Toast,
     PaneLabels,
+    Sidebar,
     Experiments,
     Integrations,
 }
@@ -1165,6 +1206,7 @@ impl SettingsSection {
         Self::Sound,
         Self::Toast,
         Self::PaneLabels,
+        Self::Sidebar,
         Self::Integrations,
         Self::Experiments,
     ];
@@ -1175,6 +1217,7 @@ impl SettingsSection {
             Self::Sound => "sound",
             Self::Toast => "toasts",
             Self::PaneLabels => "pane labels",
+            Self::Sidebar => "sidebar",
             Self::Experiments => "experiments",
             Self::Integrations => "integrations",
         }
@@ -1260,6 +1303,10 @@ pub struct SettingsState {
     pub section: SettingsSection,
     /// Selected item index within the current section.
     pub list: SelectionListState,
+    /// Active subgroup inside Settings > sidebar.
+    pub sidebar_config_group: SidebarConfigGroup,
+    /// Whether Settings > sidebar is editing line/order for the selected row.
+    pub sidebar_config_editing: bool,
     /// The palette before opening settings (for cancel/restore).
     pub original_palette: Option<Palette>,
     /// The theme name before opening settings.
@@ -1562,8 +1609,8 @@ pub struct AppState {
     pub prompt_new_tab_name: bool,
     pub show_agent_labels_on_pane_borders: bool,
     pub pane_history_persistence: bool,
-    pub space_view: SpaceViewPreferences,
-    pub agent_view: AgentViewPreferences,
+    pub sidebar_space: SidebarSpacePreferences,
+    pub sidebar_agent: SidebarAgentPreferences,
     /// Expose the focused pane's cursor anchor to the outer terminal even when
     /// the pane requested `?25l`. See `[experimental] reveal_hidden_cursor_for_cjk_ime`.
     pub reveal_hidden_cursor_for_cjk_ime: bool,
@@ -1865,8 +1912,8 @@ impl AppState {
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
             pane_history_persistence: false,
-            space_view: SpaceViewPreferences::default(),
-            agent_view: AgentViewPreferences::default(),
+            sidebar_space: SidebarSpacePreferences::default(),
+            sidebar_agent: SidebarAgentPreferences::default(),
             reveal_hidden_cursor_for_cjk_ime: false,
             cjk_ime_agent_filter_configured: false,
             cjk_ime_agents: Vec::new(),
@@ -1889,6 +1936,8 @@ impl AppState {
             settings: SettingsState {
                 section: SettingsSection::Theme,
                 list: SelectionListState::new(0),
+                sidebar_config_group: SidebarConfigGroup::default(),
+                sidebar_config_editing: false,
                 original_palette: None,
                 original_theme: None,
             },
@@ -1985,6 +2034,23 @@ mod tests {
             KeyCode::Char('b'),
             KeyModifiers::SHIFT,
         ));
+    }
+
+    #[test]
+    fn omitted_sidebar_items_are_treated_as_disabled() {
+        let spaces = SidebarSpacePreferences {
+            lines: vec![vec![SidebarItem::visible(SidebarSpaceItem::Name)]],
+        };
+        let agents = SidebarAgentPreferences {
+            lines: vec![vec![SidebarItem::visible(SidebarAgentItem::Status)]],
+        };
+
+        assert!(SidebarSpaceItem::Name.enabled(&spaces));
+        assert!(!SidebarSpaceItem::Branch.enabled(&spaces));
+        assert_eq!(SidebarSpaceItem::Branch.line(&spaces), SidebarLine::Second);
+        assert!(SidebarAgentItem::Status.enabled(&agents));
+        assert!(!SidebarAgentItem::Time.enabled(&agents));
+        assert_eq!(SidebarAgentItem::Time.line(&agents), SidebarLine::Second);
     }
 
     #[test]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,4 +1,7 @@
-use crate::config::{Keybinds, NewTerminalCwdConfig, SoundConfig, ToastConfig, ToastDelivery};
+use crate::config::{
+    AgentViewField, AgentsViewConfig, Keybinds, NewTerminalCwdConfig, SoundConfig, SpaceViewField,
+    SpacesViewConfig, ToastConfig, ToastDelivery, ViewColorPreset, ViewItem,
+};
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::{Direction, Rect};
 use ratatui::style::Color;
@@ -78,6 +81,16 @@ pub struct Palette {
 }
 
 impl Palette {
+    pub(crate) fn view_color(&self, preset: ViewColorPreset, default: Color) -> Color {
+        match preset {
+            ViewColorPreset::Default => default,
+            ViewColorPreset::Muted => self.overlay1,
+            ViewColorPreset::Accent => self.accent,
+            ViewColorPreset::Cool => self.teal,
+            ViewColorPreset::Warm => self.peach,
+        }
+    }
+
     /// Catppuccin Mocha — the default.
     pub fn catppuccin() -> Self {
         Self {
@@ -710,6 +723,427 @@ pub enum AgentPanelScope {
     AllWorkspaces,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewLine {
+    First,
+    Second,
+    Extra(usize),
+}
+
+impl ViewLine {
+    pub(crate) fn from_index(index: usize) -> Self {
+        match index {
+            0 => Self::First,
+            1 => Self::Second,
+            extra => Self::Extra(extra),
+        }
+    }
+
+    pub(crate) fn index(self) -> usize {
+        match self {
+            Self::First => 0,
+            Self::Second => 1,
+            Self::Extra(index) => index,
+        }
+    }
+
+    pub(crate) fn label(self) -> String {
+        let number = self.index() + 1;
+        let suffix = match number % 100 {
+            11..=13 => "th",
+            _ => match number % 10 {
+                1 => "st",
+                2 => "nd",
+                3 => "rd",
+                _ => "th",
+            },
+        };
+        format!("{number}{suffix} line")
+    }
+}
+
+pub type SpaceViewPreferences = SpacesViewConfig;
+pub type AgentViewPreferences = AgentsViewConfig;
+pub(crate) use crate::config::AgentViewField as AgentViewItem;
+pub(crate) use crate::config::SpaceViewField as SpaceViewItem;
+
+pub(crate) const SPACE_VIEW_ITEMS: [SpaceViewItem; 4] = [
+    SpaceViewItem::Status,
+    SpaceViewItem::Name,
+    SpaceViewItem::Branch,
+    SpaceViewItem::BranchStatus,
+];
+
+impl SpaceViewField {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Status => "space status",
+            Self::Name => "space name",
+            Self::Branch => "space branch",
+            Self::BranchStatus => "space branch status",
+        }
+    }
+
+    pub(crate) fn default_index(self) -> u8 {
+        match self {
+            Self::Status => 0,
+            Self::Name => 1,
+            Self::Branch => 2,
+            Self::BranchStatus => 3,
+        }
+    }
+
+    pub(crate) fn enabled(self, view: &SpaceViewPreferences) -> bool {
+        space_view_entry(view, self).show
+    }
+
+    pub(crate) fn set_enabled(self, view: &mut SpaceViewPreferences, enabled: bool) {
+        if let Some(entry) = space_view_entry_mut(view, self) {
+            entry.show = enabled;
+        } else {
+            let line = self.default_line();
+            let entry = ViewItem::new(self, enabled);
+            space_view_line_mut(view, line).push(entry);
+        }
+    }
+
+    pub(crate) fn color(self, view: &SpaceViewPreferences) -> ViewColorPreset {
+        space_view_entry(view, self).color
+    }
+
+    pub(crate) fn set_color(self, view: &mut SpaceViewPreferences, color: ViewColorPreset) {
+        if let Some(entry) = space_view_entry_mut(view, self) {
+            entry.color = color;
+        } else {
+            let line = self.default_line();
+            let entry = ViewItem {
+                color,
+                ..ViewItem::visible(self)
+            };
+            space_view_line_mut(view, line).push(entry);
+        }
+    }
+
+    pub(crate) fn line(self, view: &SpaceViewPreferences) -> ViewLine {
+        view.lines
+            .iter()
+            .position(|line| line.iter().any(|entry| entry.field == self))
+            .map(ViewLine::from_index)
+            .unwrap_or_else(|| self.default_line())
+    }
+
+    pub(crate) fn set_line(self, view: &mut SpaceViewPreferences, line: ViewLine) {
+        let entry = remove_space_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
+        space_view_line_mut(view, line).push(entry);
+    }
+
+    pub(crate) fn order(self, view: &SpaceViewPreferences) -> u8 {
+        space_view_line(view, self.line(view))
+            .iter()
+            .position(|entry| entry.field == self)
+            .map(|idx| idx as u8)
+            .unwrap_or_else(|| self.default_index())
+    }
+
+    pub(crate) fn set_order(self, view: &mut SpaceViewPreferences, order: u8) {
+        let line = self.line(view);
+        let entry = remove_space_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
+        let target = space_view_line_mut(view, line);
+        let index = usize::from(order).min(target.len());
+        target.insert(index, entry);
+    }
+
+    fn default_line(self) -> ViewLine {
+        match self {
+            Self::Status | Self::Name => ViewLine::First,
+            Self::Branch | Self::BranchStatus => ViewLine::Second,
+        }
+    }
+}
+
+pub(crate) fn ordered_space_view_items(view: &SpaceViewPreferences) -> Vec<SpaceViewItem> {
+    let mut items = Vec::new();
+    for line in &view.lines {
+        for entry in line {
+            if !items.contains(&entry.field) {
+                items.push(entry.field);
+            }
+        }
+    }
+    for item in SPACE_VIEW_ITEMS {
+        if !items.contains(&item) {
+            items.push(item);
+        }
+    }
+    items
+}
+
+pub(crate) const AGENT_VIEW_PLACEMENT_ITEMS: [AgentViewItem; 9] = [
+    AgentViewItem::AgentStatus,
+    AgentViewItem::PaneName,
+    AgentViewItem::TabName,
+    AgentViewItem::SpaceName,
+    AgentViewItem::Status,
+    AgentViewItem::Time,
+    AgentViewItem::CustomStatus,
+    AgentViewItem::RightAlignment,
+    AgentViewItem::AgentName,
+];
+
+impl AgentViewField {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::AgentStatus => "agent status",
+            Self::PaneName => "agent pane name",
+            Self::TabName => "agent tab name",
+            Self::SpaceName => "space name",
+            Self::Status => "status text",
+            Self::Time => "agent time",
+            Self::CustomStatus => "custom status",
+            Self::AgentName => "agent name",
+            Self::RightAlignment => "right-alignment",
+        }
+    }
+
+    pub(crate) fn default_index(self) -> u8 {
+        match self {
+            Self::AgentStatus => 0,
+            Self::PaneName => 1,
+            Self::TabName => 2,
+            Self::SpaceName => 3,
+            Self::Status => 4,
+            Self::Time => 5,
+            Self::CustomStatus => 6,
+            Self::RightAlignment => 7,
+            Self::AgentName => 8,
+        }
+    }
+
+    pub(crate) fn enabled(self, view: &AgentViewPreferences) -> bool {
+        agent_view_entry(view, self).show
+    }
+
+    pub(crate) fn set_enabled(self, view: &mut AgentViewPreferences, enabled: bool) {
+        if let Some(entry) = agent_view_entry_mut(view, self) {
+            entry.show = enabled;
+        } else {
+            let line = self.default_line();
+            let entry = ViewItem::new(self, enabled);
+            agent_view_line_mut(view, line).push(entry);
+        }
+    }
+
+    pub(crate) fn color(self, view: &AgentViewPreferences) -> ViewColorPreset {
+        agent_view_entry(view, self).color
+    }
+
+    pub(crate) fn set_color(self, view: &mut AgentViewPreferences, color: ViewColorPreset) {
+        if let Some(entry) = agent_view_entry_mut(view, self) {
+            entry.color = color;
+        } else {
+            let line = self.default_line();
+            let entry = ViewItem {
+                color,
+                ..ViewItem::visible(self)
+            };
+            agent_view_line_mut(view, line).push(entry);
+        }
+    }
+
+    pub(crate) fn line(self, view: &AgentViewPreferences) -> Option<ViewLine> {
+        Some(
+            view.lines
+                .iter()
+                .position(|line| line.iter().any(|entry| entry.field == self))
+                .map(ViewLine::from_index)
+                .unwrap_or_else(|| self.default_line()),
+        )
+    }
+
+    pub(crate) fn set_line(self, view: &mut AgentViewPreferences, line: ViewLine) {
+        let entry = remove_agent_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
+        agent_view_line_mut(view, line).push(entry);
+    }
+
+    pub(crate) fn order(self, view: &AgentViewPreferences) -> Option<u8> {
+        let line = self.line(view)?;
+        agent_view_line(view, line)
+            .iter()
+            .position(|entry| entry.field == self)
+            .map(|idx| idx as u8)
+            .or_else(|| Some(self.default_index()))
+    }
+
+    pub(crate) fn set_order(self, view: &mut AgentViewPreferences, order: u8) {
+        let line = self.line(view).unwrap_or_else(|| self.default_line());
+        let entry = remove_agent_view_item(view, self).unwrap_or_else(|| ViewItem::visible(self));
+        let target = agent_view_line_mut(view, line);
+        let index = usize::from(order).min(target.len());
+        target.insert(index, entry);
+    }
+
+    fn default_line(self) -> ViewLine {
+        match self {
+            Self::AgentStatus | Self::PaneName | Self::TabName | Self::SpaceName => ViewLine::First,
+            Self::Status
+            | Self::Time
+            | Self::CustomStatus
+            | Self::RightAlignment
+            | Self::AgentName => ViewLine::Second,
+        }
+    }
+}
+
+pub(crate) fn ordered_agent_view_items(view: &AgentViewPreferences) -> Vec<AgentViewItem> {
+    let mut items = Vec::new();
+    for line in &view.lines {
+        for entry in line {
+            if !items.contains(&entry.field) {
+                items.push(entry.field);
+            }
+        }
+    }
+    for item in AGENT_VIEW_PLACEMENT_ITEMS {
+        if !items.contains(&item) {
+            items.push(item);
+        }
+    }
+    items
+}
+
+fn space_view_line(view: &SpaceViewPreferences, line: ViewLine) -> &[ViewItem<SpaceViewField>] {
+    view.lines
+        .get(line.index())
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+fn space_view_line_mut(
+    view: &mut SpaceViewPreferences,
+    line: ViewLine,
+) -> &mut Vec<ViewItem<SpaceViewField>> {
+    while view.lines.len() <= line.index() {
+        view.lines.push(Vec::new());
+    }
+    &mut view.lines[line.index()]
+}
+
+fn space_view_entry(view: &SpaceViewPreferences, item: SpaceViewItem) -> ViewItem<SpaceViewField> {
+    view.lines
+        .iter()
+        .flatten()
+        .find(|entry| entry.field == item)
+        .copied()
+        .unwrap_or_else(|| ViewItem::visible(item))
+}
+
+fn space_view_entry_mut(
+    view: &mut SpaceViewPreferences,
+    item: SpaceViewItem,
+) -> Option<&mut ViewItem<SpaceViewField>> {
+    view.lines
+        .iter_mut()
+        .flatten()
+        .find(|entry| entry.field == item)
+}
+
+fn remove_space_view_item(
+    view: &mut SpaceViewPreferences,
+    item: SpaceViewItem,
+) -> Option<ViewItem<SpaceViewField>> {
+    for line in &mut view.lines {
+        if let Some(index) = line.iter().position(|entry| entry.field == item) {
+            return Some(line.remove(index));
+        }
+    }
+    None
+}
+
+fn agent_view_line(view: &AgentViewPreferences, line: ViewLine) -> &[ViewItem<AgentViewField>] {
+    view.lines
+        .get(line.index())
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+fn agent_view_line_mut(
+    view: &mut AgentViewPreferences,
+    line: ViewLine,
+) -> &mut Vec<ViewItem<AgentViewField>> {
+    while view.lines.len() <= line.index() {
+        view.lines.push(Vec::new());
+    }
+    &mut view.lines[line.index()]
+}
+
+fn agent_view_entry(view: &AgentViewPreferences, item: AgentViewItem) -> ViewItem<AgentViewField> {
+    view.lines
+        .iter()
+        .flatten()
+        .find(|entry| entry.field == item)
+        .copied()
+        .unwrap_or_else(|| ViewItem::visible(item))
+}
+
+fn agent_view_entry_mut(
+    view: &mut AgentViewPreferences,
+    item: AgentViewItem,
+) -> Option<&mut ViewItem<AgentViewField>> {
+    view.lines
+        .iter_mut()
+        .flatten()
+        .find(|entry| entry.field == item)
+}
+
+fn remove_agent_view_item(
+    view: &mut AgentViewPreferences,
+    item: AgentViewItem,
+) -> Option<ViewItem<AgentViewField>> {
+    for line in &mut view.lines {
+        if let Some(index) = line.iter().position(|entry| entry.field == item) {
+            return Some(line.remove(index));
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ViewConfigGroup {
+    #[default]
+    Spaces,
+    Agents,
+}
+
+impl ViewConfigGroup {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Spaces => "spaces",
+            Self::Agents => "agents",
+        }
+    }
+
+    pub(crate) fn settings_line_count(self, configured_line_count: usize) -> usize {
+        configured_line_count.max(match self {
+            Self::Spaces => 2,
+            Self::Agents => 3,
+        })
+    }
+
+    pub fn previous(self) -> Self {
+        match self {
+            Self::Spaces => Self::Agents,
+            Self::Agents => Self::Spaces,
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Spaces => Self::Agents,
+            Self::Agents => Self::Spaces,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Settings UI state
 // ---------------------------------------------------------------------------
@@ -1128,6 +1562,8 @@ pub struct AppState {
     pub prompt_new_tab_name: bool,
     pub show_agent_labels_on_pane_borders: bool,
     pub pane_history_persistence: bool,
+    pub space_view: SpaceViewPreferences,
+    pub agent_view: AgentViewPreferences,
     /// Expose the focused pane's cursor anchor to the outer terminal even when
     /// the pane requested `?25l`. See `[experimental] reveal_hidden_cursor_for_cjk_ime`.
     pub reveal_hidden_cursor_for_cjk_ime: bool,
@@ -1429,6 +1865,8 @@ impl AppState {
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
             pane_history_persistence: false,
+            space_view: SpaceViewPreferences::default(),
+            agent_view: AgentViewPreferences::default(),
             reveal_hidden_cursor_for_cjk_ime: false,
             cjk_ime_agent_filter_configured: false,
             cjk_ime_agents: Vec::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,9 +18,10 @@ pub use self::{
         IndexedKeybind, Keybinds, LiveKeybindConfig,
     },
     model::{
-        validated_sidebar_bounds, AgentPanelScopeConfig, AgentViewField, AgentsViewConfig, Config,
-        ConfigReloadReport, ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, SpaceViewField,
-        SpacesViewConfig, ToastConfig, ToastDelivery, ViewColorPreset, ViewItem,
+        validated_sidebar_bounds, AgentPanelScopeConfig, Config, ConfigReloadReport,
+        ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, SidebarAgentField,
+        SidebarAgentsConfig, SidebarColorPreset, SidebarItem, SidebarSpaceField,
+        SidebarSpacesConfig, ToastConfig, ToastDelivery,
     },
     sound::SoundConfig,
     theme::{parse_color, CustomThemeColors, ThemeConfig},

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,8 @@ mod theme;
 pub use self::{
     io::{
         config_diagnostic_summary, config_dir, config_path, load_live_config,
-        remove_keybinding_config_sections, remove_section_key, state_dir, upsert_section_bool,
-        upsert_section_value,
+        remove_keybinding_config_sections, remove_section_key, state_dir, upsert_section_body,
+        upsert_section_bool, upsert_section_value,
     },
     keybinds::{
         format_key_combo, normalize_key_combo, terminal_key_matches_combo, ActionKeybinds,
@@ -18,8 +18,9 @@ pub use self::{
         IndexedKeybind, Keybinds, LiveKeybindConfig,
     },
     model::{
-        validated_sidebar_bounds, AgentPanelScopeConfig, Config, ConfigReloadReport,
-        ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, ToastConfig, ToastDelivery,
+        validated_sidebar_bounds, AgentPanelScopeConfig, AgentViewField, AgentsViewConfig, Config,
+        ConfigReloadReport, ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, SpaceViewField,
+        SpacesViewConfig, ToastConfig, ToastDelivery, ViewColorPreset, ViewItem,
     },
     sound::SoundConfig,
     theme::{parse_color, CustomThemeColors, ThemeConfig},

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -314,8 +314,14 @@ pub fn remove_section_key(content: &str, section: &str, key: &str) -> String {
     result.join("\n") + "\n"
 }
 
+/// Replace the inline body of `[<section>]` with `body`.
+///
+/// Nested subsections (`[<section>.<child>]`) are preserved verbatim. Duplicate
+/// target section headers are preserved too, with a warning, because removing
+/// malformed user config silently is riskier than surfacing it.
 pub fn upsert_section_body(content: &str, section: &str, body: &str) -> String {
     let header = format!("[{section}]");
+    let nested_prefix = format!("[{section}.");
     let lines: Vec<&str> = content.lines().collect();
     let mut result = Vec::new();
     let mut i = 0;
@@ -326,15 +332,35 @@ pub fn upsert_section_body(content: &str, section: &str, body: &str) -> String {
         let trimmed = line.trim();
 
         if trimmed == header {
+            if replaced {
+                warn!(
+                    section = section,
+                    "upsert_section_body found duplicate [{section}] header; preserving it verbatim",
+                );
+                result.push(line.to_string());
+                i += 1;
+                continue;
+            }
             replaced = true;
             result.push(header.clone());
             result.extend(body.trim_end().lines().map(str::to_string));
             i += 1;
+            let mut copying_nested = false;
             while i < lines.len() {
                 let current = lines[i];
                 let current_trimmed = current.trim();
-                if current_trimmed.starts_with('[') && current_trimmed.ends_with(']') {
+                let is_header = current_trimmed.starts_with('[') && current_trimmed.ends_with(']');
+                if is_header {
+                    if current_trimmed.starts_with(&nested_prefix) {
+                        copying_nested = true;
+                        result.push(current.to_string());
+                        i += 1;
+                        continue;
+                    }
                     break;
+                }
+                if copying_nested {
+                    result.push(current.to_string());
                 }
                 i += 1;
             }
@@ -498,6 +524,37 @@ mod tests {
     }
 
     #[test]
+    fn upsert_section_body_replaces_managed_body_and_preserves_following_sections() {
+        let content = r#"[ui.sidebar.spaces]
+# managed comments are replaced with the generated body
+lines = []
+[ui.sidebar.spaces.colors]
+accent = "cyan"
+[ui.sidebar.agents]
+lines = []
+"#;
+
+        let updated = upsert_section_body(
+            content,
+            "ui.sidebar.spaces",
+            r#"lines = [
+  [{ field = "name", show = true }],
+]"#,
+        );
+
+        assert!(updated.contains(
+            r#"[ui.sidebar.spaces]
+lines = [
+  [{ field = "name", show = true }],
+]
+[ui.sidebar.spaces.colors]
+accent = "cyan""#
+        ));
+        assert!(updated.contains("[ui.sidebar.agents]\nlines = []"));
+        assert!(!updated.contains("managed comments"));
+    }
+
+    #[test]
     fn config_diagnostic_summary_keeps_multiple_warnings_visible() {
         let diagnostics = vec![
             "one".to_string(),
@@ -568,5 +625,108 @@ mouse_capture = false
         let (updated, removed) = remove_keybinding_config_sections(content);
         assert!(!removed);
         assert_eq!(updated, content);
+    }
+
+    #[test]
+    fn upsert_section_body_appends_section_when_missing_in_empty_content() {
+        let updated = upsert_section_body("", "ui.sidebar.spaces", "lines = []\n");
+        let parsed: toml::Value = toml::from_str(&updated).expect("output must parse as TOML");
+        assert!(updated.contains("[ui.sidebar.spaces]"));
+        assert!(updated.contains("lines = []"));
+        assert!(parsed.get("ui").is_some());
+    }
+
+    #[test]
+    fn upsert_section_body_appends_section_when_content_lacks_trailing_newline() {
+        let content = "[ui]\nmouse_capture = true";
+        let updated = upsert_section_body(content, "ui.sidebar.agents", "lines = [[]]\n");
+        assert!(updated.contains("mouse_capture = true"));
+        assert!(updated.contains("[ui.sidebar.agents]"));
+        assert!(toml::from_str::<toml::Value>(&updated).is_ok());
+    }
+
+    #[test]
+    fn upsert_section_body_replaces_existing_section_truncates_old_body() {
+        let content = "\
+[ui.sidebar.agents]
+lines = [[ { field = \"agent_status\", show = true } ]]
+old_extra_key = 42
+
+[ui.toast]
+delivery = \"off\"
+";
+        let new_body = "lines = [[ { field = \"agent_status\", show = false } ]]\n";
+        let updated = upsert_section_body(content, "ui.sidebar.agents", new_body);
+        assert!(!updated.contains("old_extra_key"));
+        assert!(updated.contains(r#"{ field = "agent_status", show = false }"#));
+        assert!(updated.contains("[ui.toast]"));
+        assert!(updated.contains("delivery = \"off\""));
+        assert!(toml::from_str::<toml::Value>(&updated).is_ok());
+    }
+
+    #[test]
+    fn upsert_section_body_replaces_section_that_extends_to_eof() {
+        let content = "[ui]\nmouse_capture = true\n\n[ui.sidebar.spaces]\nlines = []\n";
+        let updated = upsert_section_body(
+            content,
+            "ui.sidebar.spaces",
+            "lines = [[ { field = \"status\", show = false } ]]\n",
+        );
+        assert!(updated.contains("mouse_capture = true"));
+        assert!(updated.contains(r#"{ field = "status", show = false }"#));
+        assert!(toml::from_str::<toml::Value>(&updated).is_ok());
+    }
+
+    #[test]
+    fn upsert_section_body_preserves_following_section_verbatim() {
+        let following = "[ui.toast]\ndelivery = \"terminal\"\n# user comment line\n";
+        let content = format!("[ui.sidebar.spaces]\nlines = []\n{following}");
+        let updated = upsert_section_body(
+            &content,
+            "ui.sidebar.spaces",
+            "lines = [[ { field = \"name\", show = true } ]]\n",
+        );
+        assert!(updated.contains(following.trim_end()));
+    }
+
+    #[test]
+    fn upsert_section_body_is_idempotent_on_repeated_calls() {
+        let body = "lines = [[ { field = \"agent_status\", show = true } ]]\n";
+        let once = upsert_section_body("[ui]\nmouse_capture = true\n", "ui.sidebar.agents", body);
+        let twice = upsert_section_body(&once, "ui.sidebar.agents", body);
+        assert_eq!(
+            once, twice,
+            "upsert_section_body must be idempotent for the same body",
+        );
+    }
+
+    #[test]
+    fn upsert_section_body_preserves_nested_subsections_of_target() {
+        let content = "\
+[ui]
+mouse_capture = true
+sidebar_width = 30
+
+[ui.sidebar.spaces]
+lines = [[ { field = \"status\", show = true } ]]
+
+[ui.sidebar.agents]
+lines = [[ { field = \"agent_status\", show = true } ]]
+
+[ui.toast]
+delivery = \"off\"
+";
+        let updated =
+            upsert_section_body(content, "ui", "mouse_capture = false\naccent = \"blue\"\n");
+        assert!(updated.contains("mouse_capture = false"));
+        assert!(updated.contains("accent = \"blue\""));
+        assert!(!updated.contains("sidebar_width = 30"));
+        assert!(updated.contains("[ui.sidebar.spaces]"));
+        assert!(updated.contains(r#"{ field = "status", show = true }"#));
+        assert!(updated.contains("[ui.sidebar.agents]"));
+        assert!(updated.contains(r#"{ field = "agent_status", show = true }"#));
+        assert!(updated.contains("[ui.toast]"));
+        assert!(updated.contains("delivery = \"off\""));
+        assert!(toml::from_str::<toml::Value>(&updated).is_ok());
     }
 }

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -314,6 +314,48 @@ pub fn remove_section_key(content: &str, section: &str, key: &str) -> String {
     result.join("\n") + "\n"
 }
 
+pub fn upsert_section_body(content: &str, section: &str, body: &str) -> String {
+    let header = format!("[{section}]");
+    let lines: Vec<&str> = content.lines().collect();
+    let mut result = Vec::new();
+    let mut i = 0;
+    let mut replaced = false;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+
+        if trimmed == header {
+            replaced = true;
+            result.push(header.clone());
+            result.extend(body.trim_end().lines().map(str::to_string));
+            i += 1;
+            while i < lines.len() {
+                let current = lines[i];
+                let current_trimmed = current.trim();
+                if current_trimmed.starts_with('[') && current_trimmed.ends_with(']') {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        result.push(line.to_string());
+        i += 1;
+    }
+
+    if !replaced {
+        if !result.is_empty() && !result.last().is_some_and(|line| line.trim().is_empty()) {
+            result.push(String::new());
+        }
+        result.push(header);
+        result.extend(body.trim_end().lines().map(str::to_string));
+    }
+
+    result.join("\n") + "\n"
+}
+
 pub fn remove_keybinding_config_sections(content: &str) -> (String, bool) {
     let mut result = Vec::new();
     let mut removed = false;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -287,13 +287,13 @@ pub struct UiConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct SidebarConfig {
-    pub spaces: SpacesViewConfig,
-    pub agents: AgentsViewConfig,
+    pub spaces: SidebarSpacesConfig,
+    pub agents: SidebarAgentsConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SpaceViewField {
+pub enum SidebarSpaceField {
     Status,
     Name,
     Branch,
@@ -302,7 +302,7 @@ pub enum SpaceViewField {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum AgentViewField {
+pub enum SidebarAgentField {
     AgentStatus,
     PaneName,
     TabName,
@@ -316,7 +316,7 @@ pub enum AgentViewField {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ViewColorPreset {
+pub enum SidebarColorPreset {
     #[default]
     Default,
     Muted,
@@ -325,7 +325,7 @@ pub enum ViewColorPreset {
     Warm,
 }
 
-impl ViewColorPreset {
+impl SidebarColorPreset {
     pub fn is_default(color: &Self) -> bool {
         matches!(*color, Self::Default)
     }
@@ -352,30 +352,30 @@ impl ViewColorPreset {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct SpacesViewConfig {
-    pub lines: Vec<Vec<ViewItem<SpaceViewField>>>,
+pub struct SidebarSpacesConfig {
+    pub lines: Vec<Vec<SidebarItem<SidebarSpaceField>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct AgentsViewConfig {
-    pub lines: Vec<Vec<ViewItem<AgentViewField>>>,
+pub struct SidebarAgentsConfig {
+    pub lines: Vec<Vec<SidebarItem<SidebarAgentField>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-pub struct ViewItem<F> {
+pub struct SidebarItem<F> {
     pub field: F,
     #[serde(default = "default_true")]
     pub show: bool,
-    #[serde(default, skip_serializing_if = "ViewColorPreset::is_default")]
-    pub color: ViewColorPreset,
+    #[serde(default, skip_serializing_if = "SidebarColorPreset::is_default")]
+    pub color: SidebarColorPreset,
 }
 
-impl<F> ViewItem<F> {
+impl<F> SidebarItem<F> {
     pub const fn new(field: F, show: bool) -> Self {
         Self {
             field,
             show,
-            color: ViewColorPreset::Default,
+            color: SidebarColorPreset::Default,
         }
     }
 
@@ -388,90 +388,173 @@ fn default_true() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
-struct RawSpacesViewConfig {
-    lines: Option<Vec<Vec<ViewItem<SpaceViewField>>>>,
+struct RawSidebarItem {
+    field: Option<String>,
+    show: bool,
+    color: Option<String>,
+}
+
+impl Default for RawSidebarItem {
+    fn default() -> Self {
+        Self {
+            field: None,
+            show: true,
+            color: None,
+        }
+    }
+}
+
+impl RawSidebarItem {
+    fn into_item<F>(self, parse_field: fn(&str) -> Option<F>) -> Option<SidebarItem<F>> {
+        Some(SidebarItem {
+            field: parse_field(self.field.as_deref()?)?,
+            show: self.show,
+            color: parse_sidebar_color(self.color.as_deref()),
+        })
+    }
+}
+
+fn parse_sidebar_color(value: Option<&str>) -> SidebarColorPreset {
+    match value {
+        Some("muted") => SidebarColorPreset::Muted,
+        Some("accent") => SidebarColorPreset::Accent,
+        Some("cool") => SidebarColorPreset::Cool,
+        Some("warm") => SidebarColorPreset::Warm,
+        _ => SidebarColorPreset::Default,
+    }
+}
+
+fn parse_sidebar_space_field(value: &str) -> Option<SidebarSpaceField> {
+    match value {
+        "status" => Some(SidebarSpaceField::Status),
+        "name" => Some(SidebarSpaceField::Name),
+        "branch" => Some(SidebarSpaceField::Branch),
+        "branch_status" => Some(SidebarSpaceField::BranchStatus),
+        _ => None,
+    }
+}
+
+fn parse_sidebar_agent_field(value: &str) -> Option<SidebarAgentField> {
+    match value {
+        "agent_status" => Some(SidebarAgentField::AgentStatus),
+        "pane_name" => Some(SidebarAgentField::PaneName),
+        "tab_name" => Some(SidebarAgentField::TabName),
+        "space_name" => Some(SidebarAgentField::SpaceName),
+        "status" => Some(SidebarAgentField::Status),
+        "time" => Some(SidebarAgentField::Time),
+        "custom_status" => Some(SidebarAgentField::CustomStatus),
+        "agent_name" => Some(SidebarAgentField::AgentName),
+        "right_alignment" => Some(SidebarAgentField::RightAlignment),
+        _ => None,
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
-struct RawAgentsViewConfig {
-    lines: Option<Vec<Vec<ViewItem<AgentViewField>>>>,
+struct RawSidebarSpacesConfig {
+    lines: Option<Vec<Vec<RawSidebarItem>>>,
 }
 
-impl<'de> Deserialize<'de> for SpacesViewConfig {
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+struct RawSidebarAgentsConfig {
+    lines: Option<Vec<Vec<RawSidebarItem>>>,
+}
+
+impl<'de> Deserialize<'de> for SidebarSpacesConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let raw = RawSpacesViewConfig::deserialize(deserializer)?;
+        let raw = RawSidebarSpacesConfig::deserialize(deserializer)?;
         Ok(raw.into_config())
     }
 }
 
-impl<'de> Deserialize<'de> for AgentsViewConfig {
+impl<'de> Deserialize<'de> for SidebarAgentsConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let raw = RawAgentsViewConfig::deserialize(deserializer)?;
+        let raw = RawSidebarAgentsConfig::deserialize(deserializer)?;
         Ok(raw.into_config())
     }
 }
 
-impl RawSpacesViewConfig {
-    fn into_config(self) -> SpacesViewConfig {
-        let mut config = SpacesViewConfig::default();
-        apply_space_lines_override(&mut config, self.lines);
-        config
+impl RawSidebarSpacesConfig {
+    fn into_config(self) -> SidebarSpacesConfig {
+        self.lines
+            .map(|lines| SidebarSpacesConfig {
+                lines: normalize_sidebar_space_lines(raw_sidebar_lines(
+                    lines,
+                    parse_sidebar_space_field,
+                )),
+            })
+            .unwrap_or_default()
     }
 }
 
-impl RawAgentsViewConfig {
-    fn into_config(self) -> AgentsViewConfig {
-        let mut config = AgentsViewConfig::default();
-        apply_agent_lines_override(&mut config, self.lines);
-        config
+impl RawSidebarAgentsConfig {
+    fn into_config(self) -> SidebarAgentsConfig {
+        self.lines
+            .map(|lines| SidebarAgentsConfig {
+                lines: normalize_sidebar_agent_lines(raw_sidebar_lines(
+                    lines,
+                    parse_sidebar_agent_field,
+                )),
+            })
+            .unwrap_or_default()
     }
 }
 
-fn apply_space_lines_override(
-    config: &mut SpacesViewConfig,
-    lines: Option<Vec<Vec<ViewItem<SpaceViewField>>>>,
-) {
-    let Some(lines) = lines else {
-        return;
-    };
-    config.lines = normalize_space_lines(lines);
+fn raw_sidebar_lines<F>(
+    lines: Vec<Vec<RawSidebarItem>>,
+    parse_field: fn(&str) -> Option<F>,
+) -> Vec<Vec<SidebarItem<F>>> {
+    lines
+        .into_iter()
+        .map(|line| {
+            line.into_iter()
+                .filter_map(|item| item.into_item(parse_field))
+                .collect()
+        })
+        .collect()
 }
 
-fn apply_agent_lines_override(
-    config: &mut AgentsViewConfig,
-    lines: Option<Vec<Vec<ViewItem<AgentViewField>>>>,
-) {
-    let Some(lines) = lines else {
-        return;
-    };
-    config.lines = normalize_agent_lines(lines);
+fn normalize_sidebar_space_lines(
+    lines: Vec<Vec<SidebarItem<SidebarSpaceField>>>,
+) -> Vec<Vec<SidebarItem<SidebarSpaceField>>> {
+    normalize_sidebar_lines(lines)
 }
 
-fn normalize_space_lines(
-    lines: Vec<Vec<ViewItem<SpaceViewField>>>,
-) -> Vec<Vec<ViewItem<SpaceViewField>>> {
-    normalize_view_lines(lines, &SPACE_VIEW_DEFAULT_ITEMS)
+fn normalize_sidebar_agent_lines(
+    lines: Vec<Vec<SidebarItem<SidebarAgentField>>>,
+) -> Vec<Vec<SidebarItem<SidebarAgentField>>> {
+    let mut seen = Vec::new();
+    let mut normalized = Vec::new();
+    for line in lines {
+        let mut normalized_line = Vec::new();
+        for item in line {
+            if item.field == SidebarAgentField::RightAlignment {
+                normalized_line.push(item);
+                continue;
+            }
+            if seen.contains(&item.field) {
+                continue;
+            }
+            seen.push(item.field);
+            normalized_line.push(item);
+        }
+        normalized.push(normalized_line);
+    }
+    normalized
 }
 
-fn normalize_agent_lines(
-    lines: Vec<Vec<ViewItem<AgentViewField>>>,
-) -> Vec<Vec<ViewItem<AgentViewField>>> {
-    normalize_view_lines(lines, &AGENT_VIEW_DEFAULT_ITEMS)
-}
-
-fn normalize_view_lines<F: Copy + Eq>(
-    lines: Vec<Vec<ViewItem<F>>>,
-    default_items: &[(usize, F)],
-) -> Vec<Vec<ViewItem<F>>> {
+fn normalize_sidebar_lines<F: Copy + Eq>(
+    lines: Vec<Vec<SidebarItem<F>>>,
+) -> Vec<Vec<SidebarItem<F>>> {
     let mut seen = Vec::new();
     let mut normalized = Vec::new();
     for line in lines {
@@ -485,47 +568,7 @@ fn normalize_view_lines<F: Copy + Eq>(
         }
         normalized.push(normalized_line);
     }
-    append_missing_view_items(&mut normalized, &mut seen, default_items);
     normalized
-}
-
-const SPACE_VIEW_DEFAULT_ITEMS: [(usize, SpaceViewField); 4] = [
-    (0, SpaceViewField::Status),
-    (0, SpaceViewField::Name),
-    (1, SpaceViewField::Branch),
-    (1, SpaceViewField::BranchStatus),
-];
-
-const AGENT_VIEW_DEFAULT_ITEMS: [(usize, AgentViewField); 9] = [
-    (0, AgentViewField::AgentStatus),
-    (0, AgentViewField::PaneName),
-    (0, AgentViewField::TabName),
-    (0, AgentViewField::SpaceName),
-    (1, AgentViewField::Status),
-    (1, AgentViewField::Time),
-    (1, AgentViewField::CustomStatus),
-    (1, AgentViewField::RightAlignment),
-    (1, AgentViewField::AgentName),
-];
-
-fn append_missing_view_items<F: Copy + Eq>(
-    lines: &mut Vec<Vec<ViewItem<F>>>,
-    seen: &mut Vec<F>,
-    default_items: &[(usize, F)],
-) {
-    if lines.is_empty() {
-        lines.push(Vec::new());
-    }
-    for &(line_idx, field) in default_items {
-        if seen.contains(&field) {
-            continue;
-        }
-        while lines.len() <= line_idx {
-            lines.push(Vec::new());
-        }
-        lines[line_idx].push(ViewItem::visible(field));
-        seen.push(field);
-    }
 }
 
 /// Cursor shape (DECSCUSR) used for the forced IME anchor.
@@ -681,39 +724,39 @@ impl Default for UiConfig {
     }
 }
 
-impl Default for SpacesViewConfig {
+impl Default for SidebarSpacesConfig {
     fn default() -> Self {
         Self {
             lines: vec![
                 vec![
-                    ViewItem::visible(SpaceViewField::Status),
-                    ViewItem::visible(SpaceViewField::Name),
+                    SidebarItem::visible(SidebarSpaceField::Status),
+                    SidebarItem::visible(SidebarSpaceField::Name),
                 ],
                 vec![
-                    ViewItem::visible(SpaceViewField::Branch),
-                    ViewItem::visible(SpaceViewField::BranchStatus),
+                    SidebarItem::visible(SidebarSpaceField::Branch),
+                    SidebarItem::visible(SidebarSpaceField::BranchStatus),
                 ],
             ],
         }
     }
 }
 
-impl Default for AgentsViewConfig {
+impl Default for SidebarAgentsConfig {
     fn default() -> Self {
         Self {
             lines: vec![
                 vec![
-                    ViewItem::visible(AgentViewField::AgentStatus),
-                    ViewItem::visible(AgentViewField::PaneName),
-                    ViewItem::visible(AgentViewField::TabName),
-                    ViewItem::visible(AgentViewField::SpaceName),
+                    SidebarItem::visible(SidebarAgentField::AgentStatus),
+                    SidebarItem::visible(SidebarAgentField::PaneName),
+                    SidebarItem::visible(SidebarAgentField::TabName),
+                    SidebarItem::visible(SidebarAgentField::SpaceName),
                 ],
                 vec![
-                    ViewItem::visible(AgentViewField::Status),
-                    ViewItem::visible(AgentViewField::Time),
-                    ViewItem::visible(AgentViewField::CustomStatus),
-                    ViewItem::visible(AgentViewField::RightAlignment),
-                    ViewItem::visible(AgentViewField::AgentName),
+                    SidebarItem::visible(SidebarAgentField::Status),
+                    SidebarItem::visible(SidebarAgentField::Time),
+                    SidebarItem::visible(SidebarAgentField::CustomStatus),
+                    SidebarItem::visible(SidebarAgentField::RightAlignment),
+                    SidebarItem::visible(SidebarAgentField::AgentName),
                 ],
             ],
         }
@@ -1085,18 +1128,18 @@ pane_history = true
     }
 
     #[test]
-    fn sidebar_view_config_defaults_to_lines_array_and_parses_variable_line_count() {
+    fn sidebar_config_defaults_to_lines_array_and_parses_variable_line_count() {
         let default = Config::default();
         assert_eq!(
             default.ui.sidebar.spaces.lines,
             vec![
                 vec![
-                    ViewItem::visible(SpaceViewField::Status),
-                    ViewItem::visible(SpaceViewField::Name),
+                    SidebarItem::visible(SidebarSpaceField::Status),
+                    SidebarItem::visible(SidebarSpaceField::Name),
                 ],
                 vec![
-                    ViewItem::visible(SpaceViewField::Branch),
-                    ViewItem::visible(SpaceViewField::BranchStatus),
+                    SidebarItem::visible(SidebarSpaceField::Branch),
+                    SidebarItem::visible(SidebarSpaceField::BranchStatus),
                 ],
             ]
         );
@@ -1104,17 +1147,17 @@ pane_history = true
             default.ui.sidebar.agents.lines,
             vec![
                 vec![
-                    ViewItem::visible(AgentViewField::AgentStatus),
-                    ViewItem::visible(AgentViewField::PaneName),
-                    ViewItem::visible(AgentViewField::TabName),
-                    ViewItem::visible(AgentViewField::SpaceName),
+                    SidebarItem::visible(SidebarAgentField::AgentStatus),
+                    SidebarItem::visible(SidebarAgentField::PaneName),
+                    SidebarItem::visible(SidebarAgentField::TabName),
+                    SidebarItem::visible(SidebarAgentField::SpaceName),
                 ],
                 vec![
-                    ViewItem::visible(AgentViewField::Status),
-                    ViewItem::visible(AgentViewField::Time),
-                    ViewItem::visible(AgentViewField::CustomStatus),
-                    ViewItem::visible(AgentViewField::RightAlignment),
-                    ViewItem::visible(AgentViewField::AgentName),
+                    SidebarItem::visible(SidebarAgentField::Status),
+                    SidebarItem::visible(SidebarAgentField::Time),
+                    SidebarItem::visible(SidebarAgentField::CustomStatus),
+                    SidebarItem::visible(SidebarAgentField::RightAlignment),
+                    SidebarItem::visible(SidebarAgentField::AgentName),
                 ],
             ]
         );
@@ -1153,41 +1196,41 @@ lines = [
             config.ui.sidebar.spaces.lines,
             vec![
                 vec![
-                    ViewItem {
-                        field: SpaceViewField::Name,
+                    SidebarItem {
+                        field: SidebarSpaceField::Name,
                         show: false,
-                        color: ViewColorPreset::Muted,
+                        color: SidebarColorPreset::Muted,
                     },
-                    ViewItem::visible(SpaceViewField::Branch),
+                    SidebarItem::visible(SidebarSpaceField::Branch),
                 ],
                 vec![
-                    ViewItem::visible(SpaceViewField::Status),
-                    ViewItem::new(SpaceViewField::BranchStatus, false),
+                    SidebarItem::visible(SidebarSpaceField::Status),
+                    SidebarItem::new(SidebarSpaceField::BranchStatus, false),
                 ],
             ]
         );
         assert_eq!(
             config.ui.sidebar.agents.lines,
             vec![vec![
-                ViewItem::visible(AgentViewField::AgentStatus),
-                ViewItem::visible(AgentViewField::PaneName),
-                ViewItem::visible(AgentViewField::TabName),
-                ViewItem::visible(AgentViewField::SpaceName),
-                ViewItem::new(AgentViewField::Status, false),
-                ViewItem::new(AgentViewField::Time, false),
-                ViewItem {
-                    field: AgentViewField::CustomStatus,
+                SidebarItem::visible(SidebarAgentField::AgentStatus),
+                SidebarItem::visible(SidebarAgentField::PaneName),
+                SidebarItem::visible(SidebarAgentField::TabName),
+                SidebarItem::visible(SidebarAgentField::SpaceName),
+                SidebarItem::new(SidebarAgentField::Status, false),
+                SidebarItem::new(SidebarAgentField::Time, false),
+                SidebarItem {
+                    field: SidebarAgentField::CustomStatus,
                     show: false,
-                    color: ViewColorPreset::Warm,
+                    color: SidebarColorPreset::Warm,
                 },
-                ViewItem::visible(AgentViewField::RightAlignment),
-                ViewItem::visible(AgentViewField::AgentName),
+                SidebarItem::visible(SidebarAgentField::RightAlignment),
+                SidebarItem::visible(SidebarAgentField::AgentName),
             ],]
         );
     }
 
     #[test]
-    fn sidebar_view_config_preserves_three_configured_lines() {
+    fn sidebar_config_preserves_three_configured_lines() {
         let toml = r#"
 [ui.sidebar.agents]
 lines = [
@@ -1214,69 +1257,102 @@ lines = [
         assert_eq!(
             config.ui.sidebar.agents.lines[2],
             vec![
-                ViewItem::visible(AgentViewField::RightAlignment),
-                ViewItem::visible(AgentViewField::AgentName),
+                SidebarItem::visible(SidebarAgentField::RightAlignment),
+                SidebarItem::visible(SidebarAgentField::AgentName),
             ]
         );
     }
 
     #[test]
-    fn sidebar_view_config_flat_keys_do_not_override_lines_array() {
+    fn sidebar_config_ignores_invalid_items_without_rejecting_ui() {
         let toml = r#"
-[ui.sidebar.spaces]
-show_status = false
-status_line = "second"
-status_order = 2
-show_name = true
-name_line = "first"
-name_order = 0
-show_branch = false
-branch_line = "first"
-branch_order = 1
-show_branch_status = true
-branch_status_line = "second"
-branch_status_order = 0
+[ui]
+mouse_capture = false
 
 [ui.sidebar.agents]
-show_agent_status = false
-agent_status_line = "second"
-agent_status_order = 3
-show_pane_name = false
-pane_name_line = "second"
-pane_name_order = 1
-show_tab_name = true
-tab_name_line = "first"
-tab_name_order = 0
-show_space_name = false
-space_name_line = "first"
-space_name_order = 2
-show_status = false
-status_line = "second"
-status_order = 0
-show_time = false
-time_line = "first"
-time_order = 1
-show_agent_name = true
-agent_name_line = "second"
-agent_name_order = 4
-right_align_agent = true
-right_align_line = "second"
-right_align_order = 3
+lines = [
+  [
+    { field = "not_a_field", show = true },
+    { field = "time", show = true, color = "not_a_color" },
+  ],
+]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert!(!config.ui.mouse_capture);
+        let time = config
+            .ui
+            .sidebar
+            .agents
+            .lines
+            .iter()
+            .flatten()
+            .find(|item| item.field == SidebarAgentField::Time)
+            .copied();
+        assert_eq!(time, Some(SidebarItem::visible(SidebarAgentField::Time)));
+    }
+
+    #[test]
+    fn sidebar_config_preserves_omitted_items() {
+        let toml = r#"
+[ui.sidebar.spaces]
+lines = [
+  [
+    { field = "name", show = true },
+  ],
+]
+
+[ui.sidebar.agents]
+lines = [
+  [
+    { field = "status", show = true },
+  ],
+]
 "#;
         let config: Config = toml::from_str(toml).unwrap();
 
         assert_eq!(
             config.ui.sidebar.spaces.lines,
-            SpacesViewConfig::default().lines
+            vec![vec![SidebarItem::visible(SidebarSpaceField::Name)]]
         );
         assert_eq!(
             config.ui.sidebar.agents.lines,
-            AgentsViewConfig::default().lines
+            vec![vec![SidebarItem::visible(SidebarAgentField::Status)]]
         );
     }
 
     #[test]
-    fn sidebar_view_config_accepts_all_fields_on_one_line() {
+    fn sidebar_agent_config_preserves_per_line_right_alignment_markers() {
+        let toml = r#"
+[ui.sidebar.agents]
+lines = [
+  [
+    { field = "right_alignment", show = true },
+    { field = "agent_name", show = true },
+  ],
+  [
+    { field = "status", show = true },
+  ],
+  [
+    { field = "right_alignment", show = true },
+    { field = "time", show = true },
+  ],
+]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(
+            config.ui.sidebar.agents.lines[0][0],
+            SidebarItem::visible(SidebarAgentField::RightAlignment)
+        );
+        assert_eq!(
+            config.ui.sidebar.agents.lines[2][0],
+            SidebarItem::visible(SidebarAgentField::RightAlignment)
+        );
+    }
+
+    #[test]
+    fn sidebar_config_accepts_all_fields_on_one_line() {
         let toml = r#"
 [ui.sidebar.spaces]
 lines = [
@@ -1308,24 +1384,24 @@ lines = [
         assert_eq!(
             config.ui.sidebar.spaces.lines,
             vec![vec![
-                ViewItem::visible(SpaceViewField::Status),
-                ViewItem::visible(SpaceViewField::Name),
-                ViewItem::visible(SpaceViewField::Branch),
-                ViewItem::visible(SpaceViewField::BranchStatus),
+                SidebarItem::visible(SidebarSpaceField::Status),
+                SidebarItem::visible(SidebarSpaceField::Name),
+                SidebarItem::visible(SidebarSpaceField::Branch),
+                SidebarItem::visible(SidebarSpaceField::BranchStatus),
             ],]
         );
         assert_eq!(
             config.ui.sidebar.agents.lines,
             vec![vec![
-                ViewItem::visible(AgentViewField::AgentStatus),
-                ViewItem::visible(AgentViewField::PaneName),
-                ViewItem::visible(AgentViewField::TabName),
-                ViewItem::visible(AgentViewField::SpaceName),
-                ViewItem::visible(AgentViewField::Status),
-                ViewItem::visible(AgentViewField::Time),
-                ViewItem::visible(AgentViewField::CustomStatus),
-                ViewItem::visible(AgentViewField::RightAlignment),
-                ViewItem::visible(AgentViewField::AgentName),
+                SidebarItem::visible(SidebarAgentField::AgentStatus),
+                SidebarItem::visible(SidebarAgentField::PaneName),
+                SidebarItem::visible(SidebarAgentField::TabName),
+                SidebarItem::visible(SidebarAgentField::SpaceName),
+                SidebarItem::visible(SidebarAgentField::Status),
+                SidebarItem::visible(SidebarAgentField::Time),
+                SidebarItem::visible(SidebarAgentField::CustomStatus),
+                SidebarItem::visible(SidebarAgentField::RightAlignment),
+                SidebarItem::visible(SidebarAgentField::AgentName),
             ],]
         );
     }
@@ -1375,5 +1451,22 @@ scrollback_lines = 12345
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.advanced.scrollback_limit_bytes, 12345);
+    }
+
+    #[test]
+    fn color_preset_next_cycles_through_all_variants() {
+        let cycle = [
+            SidebarColorPreset::Default,
+            SidebarColorPreset::Muted,
+            SidebarColorPreset::Accent,
+            SidebarColorPreset::Cool,
+            SidebarColorPreset::Warm,
+        ];
+        let mut current = cycle[0];
+        for expected_next in cycle.iter().skip(1).chain(std::iter::once(&cycle[0])) {
+            current = current.next();
+            assert_eq!(&current, expected_next);
+        }
+        assert_eq!(current, SidebarColorPreset::Default);
     }
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -280,6 +280,252 @@ pub struct UiConfig {
     pub toast: ToastConfig,
     /// Play sounds when agents change state in background workspaces.
     pub sound: SoundConfig,
+    /// Sidebar navigation display preferences.
+    pub sidebar: SidebarConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct SidebarConfig {
+    pub spaces: SpacesViewConfig,
+    pub agents: AgentsViewConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpaceViewField {
+    Status,
+    Name,
+    Branch,
+    BranchStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentViewField {
+    AgentStatus,
+    PaneName,
+    TabName,
+    SpaceName,
+    Status,
+    Time,
+    CustomStatus,
+    AgentName,
+    RightAlignment,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ViewColorPreset {
+    #[default]
+    Default,
+    Muted,
+    Accent,
+    Cool,
+    Warm,
+}
+
+impl ViewColorPreset {
+    pub fn is_default(color: &Self) -> bool {
+        matches!(*color, Self::Default)
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Default => Self::Muted,
+            Self::Muted => Self::Accent,
+            Self::Accent => Self::Cool,
+            Self::Cool => Self::Warm,
+            Self::Warm => Self::Default,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Muted => "muted",
+            Self::Accent => "accent",
+            Self::Cool => "cool",
+            Self::Warm => "warm",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpacesViewConfig {
+    pub lines: Vec<Vec<ViewItem<SpaceViewField>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentsViewConfig {
+    pub lines: Vec<Vec<ViewItem<AgentViewField>>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ViewItem<F> {
+    pub field: F,
+    #[serde(default = "default_true")]
+    pub show: bool,
+    #[serde(default, skip_serializing_if = "ViewColorPreset::is_default")]
+    pub color: ViewColorPreset,
+}
+
+impl<F> ViewItem<F> {
+    pub const fn new(field: F, show: bool) -> Self {
+        Self {
+            field,
+            show,
+            color: ViewColorPreset::Default,
+        }
+    }
+
+    pub const fn visible(field: F) -> Self {
+        Self::new(field, true)
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+struct RawSpacesViewConfig {
+    lines: Option<Vec<Vec<ViewItem<SpaceViewField>>>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+struct RawAgentsViewConfig {
+    lines: Option<Vec<Vec<ViewItem<AgentViewField>>>>,
+}
+
+impl<'de> Deserialize<'de> for SpacesViewConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawSpacesViewConfig::deserialize(deserializer)?;
+        Ok(raw.into_config())
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentsViewConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawAgentsViewConfig::deserialize(deserializer)?;
+        Ok(raw.into_config())
+    }
+}
+
+impl RawSpacesViewConfig {
+    fn into_config(self) -> SpacesViewConfig {
+        let mut config = SpacesViewConfig::default();
+        apply_space_lines_override(&mut config, self.lines);
+        config
+    }
+}
+
+impl RawAgentsViewConfig {
+    fn into_config(self) -> AgentsViewConfig {
+        let mut config = AgentsViewConfig::default();
+        apply_agent_lines_override(&mut config, self.lines);
+        config
+    }
+}
+
+fn apply_space_lines_override(
+    config: &mut SpacesViewConfig,
+    lines: Option<Vec<Vec<ViewItem<SpaceViewField>>>>,
+) {
+    let Some(lines) = lines else {
+        return;
+    };
+    config.lines = normalize_space_lines(lines);
+}
+
+fn apply_agent_lines_override(
+    config: &mut AgentsViewConfig,
+    lines: Option<Vec<Vec<ViewItem<AgentViewField>>>>,
+) {
+    let Some(lines) = lines else {
+        return;
+    };
+    config.lines = normalize_agent_lines(lines);
+}
+
+fn normalize_space_lines(
+    lines: Vec<Vec<ViewItem<SpaceViewField>>>,
+) -> Vec<Vec<ViewItem<SpaceViewField>>> {
+    normalize_view_lines(lines, &SPACE_VIEW_DEFAULT_ITEMS)
+}
+
+fn normalize_agent_lines(
+    lines: Vec<Vec<ViewItem<AgentViewField>>>,
+) -> Vec<Vec<ViewItem<AgentViewField>>> {
+    normalize_view_lines(lines, &AGENT_VIEW_DEFAULT_ITEMS)
+}
+
+fn normalize_view_lines<F: Copy + Eq>(
+    lines: Vec<Vec<ViewItem<F>>>,
+    default_items: &[(usize, F)],
+) -> Vec<Vec<ViewItem<F>>> {
+    let mut seen = Vec::new();
+    let mut normalized = Vec::new();
+    for line in lines {
+        let mut normalized_line = Vec::new();
+        for item in line {
+            if seen.contains(&item.field) {
+                continue;
+            }
+            seen.push(item.field);
+            normalized_line.push(item);
+        }
+        normalized.push(normalized_line);
+    }
+    append_missing_view_items(&mut normalized, &mut seen, default_items);
+    normalized
+}
+
+const SPACE_VIEW_DEFAULT_ITEMS: [(usize, SpaceViewField); 4] = [
+    (0, SpaceViewField::Status),
+    (0, SpaceViewField::Name),
+    (1, SpaceViewField::Branch),
+    (1, SpaceViewField::BranchStatus),
+];
+
+const AGENT_VIEW_DEFAULT_ITEMS: [(usize, AgentViewField); 9] = [
+    (0, AgentViewField::AgentStatus),
+    (0, AgentViewField::PaneName),
+    (0, AgentViewField::TabName),
+    (0, AgentViewField::SpaceName),
+    (1, AgentViewField::Status),
+    (1, AgentViewField::Time),
+    (1, AgentViewField::CustomStatus),
+    (1, AgentViewField::RightAlignment),
+    (1, AgentViewField::AgentName),
+];
+
+fn append_missing_view_items<F: Copy + Eq>(
+    lines: &mut Vec<Vec<ViewItem<F>>>,
+    seen: &mut Vec<F>,
+    default_items: &[(usize, F)],
+) {
+    if lines.is_empty() {
+        lines.push(Vec::new());
+    }
+    for &(line_idx, field) in default_items {
+        if seen.contains(&field) {
+            continue;
+        }
+        while lines.len() <= line_idx {
+            lines.push(Vec::new());
+        }
+        lines[line_idx].push(ViewItem::visible(field));
+        seen.push(field);
+    }
 }
 
 /// Cursor shape (DECSCUSR) used for the forced IME anchor.
@@ -430,6 +676,46 @@ impl Default for UiConfig {
             accent: "cyan".into(),
             toast: ToastConfig::default(),
             sound: SoundConfig::default(),
+            sidebar: SidebarConfig::default(),
+        }
+    }
+}
+
+impl Default for SpacesViewConfig {
+    fn default() -> Self {
+        Self {
+            lines: vec![
+                vec![
+                    ViewItem::visible(SpaceViewField::Status),
+                    ViewItem::visible(SpaceViewField::Name),
+                ],
+                vec![
+                    ViewItem::visible(SpaceViewField::Branch),
+                    ViewItem::visible(SpaceViewField::BranchStatus),
+                ],
+            ],
+        }
+    }
+}
+
+impl Default for AgentsViewConfig {
+    fn default() -> Self {
+        Self {
+            lines: vec![
+                vec![
+                    ViewItem::visible(AgentViewField::AgentStatus),
+                    ViewItem::visible(AgentViewField::PaneName),
+                    ViewItem::visible(AgentViewField::TabName),
+                    ViewItem::visible(AgentViewField::SpaceName),
+                ],
+                vec![
+                    ViewItem::visible(AgentViewField::Status),
+                    ViewItem::visible(AgentViewField::Time),
+                    ViewItem::visible(AgentViewField::CustomStatus),
+                    ViewItem::visible(AgentViewField::RightAlignment),
+                    ViewItem::visible(AgentViewField::AgentName),
+                ],
+            ],
         }
     }
 }
@@ -796,6 +1082,252 @@ pane_history = true
         let config: Config = toml::from_str(toml).unwrap();
 
         assert!(config.experimental.pane_history);
+    }
+
+    #[test]
+    fn sidebar_view_config_defaults_to_lines_array_and_parses_variable_line_count() {
+        let default = Config::default();
+        assert_eq!(
+            default.ui.sidebar.spaces.lines,
+            vec![
+                vec![
+                    ViewItem::visible(SpaceViewField::Status),
+                    ViewItem::visible(SpaceViewField::Name),
+                ],
+                vec![
+                    ViewItem::visible(SpaceViewField::Branch),
+                    ViewItem::visible(SpaceViewField::BranchStatus),
+                ],
+            ]
+        );
+        assert_eq!(
+            default.ui.sidebar.agents.lines,
+            vec![
+                vec![
+                    ViewItem::visible(AgentViewField::AgentStatus),
+                    ViewItem::visible(AgentViewField::PaneName),
+                    ViewItem::visible(AgentViewField::TabName),
+                    ViewItem::visible(AgentViewField::SpaceName),
+                ],
+                vec![
+                    ViewItem::visible(AgentViewField::Status),
+                    ViewItem::visible(AgentViewField::Time),
+                    ViewItem::visible(AgentViewField::CustomStatus),
+                    ViewItem::visible(AgentViewField::RightAlignment),
+                    ViewItem::visible(AgentViewField::AgentName),
+                ],
+            ]
+        );
+
+        let toml = r#"
+[ui.sidebar.spaces]
+lines = [
+  [
+    { field = "name", show = false, color = "muted" },
+    { field = "branch", show = true },
+  ],
+  [
+    { field = "status", show = true },
+    { field = "branch_status", show = false },
+  ],
+]
+
+[ui.sidebar.agents]
+lines = [
+  [
+    { field = "agent_status", show = true },
+    { field = "pane_name", show = true },
+    { field = "tab_name", show = true },
+    { field = "space_name", show = true },
+    { field = "status", show = false },
+    { field = "time", show = false },
+    { field = "custom_status", show = false, color = "warm" },
+    { field = "right_alignment", show = true },
+    { field = "agent_name", show = true },
+  ],
+]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(
+            config.ui.sidebar.spaces.lines,
+            vec![
+                vec![
+                    ViewItem {
+                        field: SpaceViewField::Name,
+                        show: false,
+                        color: ViewColorPreset::Muted,
+                    },
+                    ViewItem::visible(SpaceViewField::Branch),
+                ],
+                vec![
+                    ViewItem::visible(SpaceViewField::Status),
+                    ViewItem::new(SpaceViewField::BranchStatus, false),
+                ],
+            ]
+        );
+        assert_eq!(
+            config.ui.sidebar.agents.lines,
+            vec![vec![
+                ViewItem::visible(AgentViewField::AgentStatus),
+                ViewItem::visible(AgentViewField::PaneName),
+                ViewItem::visible(AgentViewField::TabName),
+                ViewItem::visible(AgentViewField::SpaceName),
+                ViewItem::new(AgentViewField::Status, false),
+                ViewItem::new(AgentViewField::Time, false),
+                ViewItem {
+                    field: AgentViewField::CustomStatus,
+                    show: false,
+                    color: ViewColorPreset::Warm,
+                },
+                ViewItem::visible(AgentViewField::RightAlignment),
+                ViewItem::visible(AgentViewField::AgentName),
+            ],]
+        );
+    }
+
+    #[test]
+    fn sidebar_view_config_preserves_three_configured_lines() {
+        let toml = r#"
+[ui.sidebar.agents]
+lines = [
+  [
+    { field = "agent_status", show = true },
+    { field = "pane_name", show = true },
+    { field = "tab_name", show = true },
+  ],
+  [
+    { field = "space_name", show = true },
+    { field = "status", show = true },
+    { field = "time", show = true },
+    { field = "custom_status", show = true },
+  ],
+  [
+    { field = "right_alignment", show = true },
+    { field = "agent_name", show = true },
+  ],
+]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.ui.sidebar.agents.lines.len(), 3);
+        assert_eq!(
+            config.ui.sidebar.agents.lines[2],
+            vec![
+                ViewItem::visible(AgentViewField::RightAlignment),
+                ViewItem::visible(AgentViewField::AgentName),
+            ]
+        );
+    }
+
+    #[test]
+    fn sidebar_view_config_flat_keys_do_not_override_lines_array() {
+        let toml = r#"
+[ui.sidebar.spaces]
+show_status = false
+status_line = "second"
+status_order = 2
+show_name = true
+name_line = "first"
+name_order = 0
+show_branch = false
+branch_line = "first"
+branch_order = 1
+show_branch_status = true
+branch_status_line = "second"
+branch_status_order = 0
+
+[ui.sidebar.agents]
+show_agent_status = false
+agent_status_line = "second"
+agent_status_order = 3
+show_pane_name = false
+pane_name_line = "second"
+pane_name_order = 1
+show_tab_name = true
+tab_name_line = "first"
+tab_name_order = 0
+show_space_name = false
+space_name_line = "first"
+space_name_order = 2
+show_status = false
+status_line = "second"
+status_order = 0
+show_time = false
+time_line = "first"
+time_order = 1
+show_agent_name = true
+agent_name_line = "second"
+agent_name_order = 4
+right_align_agent = true
+right_align_line = "second"
+right_align_order = 3
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(
+            config.ui.sidebar.spaces.lines,
+            SpacesViewConfig::default().lines
+        );
+        assert_eq!(
+            config.ui.sidebar.agents.lines,
+            AgentsViewConfig::default().lines
+        );
+    }
+
+    #[test]
+    fn sidebar_view_config_accepts_all_fields_on_one_line() {
+        let toml = r#"
+[ui.sidebar.spaces]
+lines = [
+  [
+    { field = "status", show = true },
+    { field = "name", show = true },
+    { field = "branch", show = true },
+    { field = "branch_status", show = true },
+  ],
+]
+
+[ui.sidebar.agents]
+lines = [
+  [
+    { field = "agent_status", show = true },
+    { field = "pane_name", show = true },
+    { field = "tab_name", show = true },
+    { field = "space_name", show = true },
+    { field = "status", show = true },
+    { field = "time", show = true },
+    { field = "custom_status", show = true },
+    { field = "right_alignment", show = true },
+    { field = "agent_name", show = true },
+  ],
+]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(
+            config.ui.sidebar.spaces.lines,
+            vec![vec![
+                ViewItem::visible(SpaceViewField::Status),
+                ViewItem::visible(SpaceViewField::Name),
+                ViewItem::visible(SpaceViewField::Branch),
+                ViewItem::visible(SpaceViewField::BranchStatus),
+            ],]
+        );
+        assert_eq!(
+            config.ui.sidebar.agents.lines,
+            vec![vec![
+                ViewItem::visible(AgentViewField::AgentStatus),
+                ViewItem::visible(AgentViewField::PaneName),
+                ViewItem::visible(AgentViewField::TabName),
+                ViewItem::visible(AgentViewField::SpaceName),
+                ViewItem::visible(AgentViewField::Status),
+                ViewItem::visible(AgentViewField::Time),
+                ViewItem::visible(AgentViewField::CustomStatus),
+                ViewItem::visible(AgentViewField::RightAlignment),
+                ViewItem::visible(AgentViewField::AgentName),
+            ],]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -724,4 +724,54 @@ mod tests {
             .iter()
             .all(|message| !message.starts_with("herdr:")));
     }
+
+    /// Every commented `# ...` line inside DEFAULT_CONFIG that parses as a TOML
+    /// statement standalone should remain valid when uncommented.
+    ///
+    /// We strip the `# ` prefix only from lines that parse as a single
+    /// valid TOML statement in isolation (assignment or section header).
+    /// Prose comments and inline-example text like `# Accepts: hex
+    /// (#rrggbb)` or `# type = "shell" runs detached in the background.`
+    /// are left as comments.
+    #[test]
+    fn default_config_template_is_valid_toml_when_uncommented() {
+        fn looks_like_toml_statement(after_strip: &str) -> bool {
+            let trimmed = after_strip.trim();
+            if trimmed.is_empty() {
+                return false;
+            }
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                return toml::from_str::<toml::Value>(trimmed).is_ok();
+            }
+            toml::from_str::<toml::Value>(&format!("{trimmed}\n")).is_ok()
+        }
+
+        let mut uncommented = String::with_capacity(DEFAULT_CONFIG.len());
+        for line in DEFAULT_CONFIG.lines() {
+            let trimmed = line.trim_start();
+            let stripped = trimmed
+                .strip_prefix("# ")
+                .or_else(|| trimmed.strip_prefix("#"));
+            match stripped {
+                Some(rest) if looks_like_toml_statement(rest) => uncommented.push_str(rest),
+                _ => uncommented.push_str(line),
+            }
+            uncommented.push('\n');
+        }
+
+        let parsed: config::Config = toml::from_str(&uncommented).unwrap_or_else(|err| {
+            panic!("uncommented DEFAULT_CONFIG must parse: {err}\n\n{uncommented}")
+        });
+        // Sound examples reference user-supplied files that aren't expected to
+        // exist on the test machine.
+        let schema_diagnostics: Vec<String> = parsed
+            .collect_diagnostics()
+            .into_iter()
+            .filter(|d| !d.contains("missing sound file:"))
+            .collect();
+        assert!(
+            schema_diagnostics.is_empty(),
+            "uncommented DEFAULT_CONFIG must produce no schema diagnostics, got {schema_diagnostics:?}",
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,37 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Accepts: hex (#89b4fa), named colors (cyan, blue, magenta), or rgb(r,g,b)
 # accent = "cyan"
 
+[ui.sidebar.spaces]
+# Optional per-item color presets: default, muted, accent, cool, warm.
+# lines = [
+#   [
+#     { field = "status", show = true },
+#     { field = "name", show = true },
+#   ],
+#   [
+#     { field = "branch", show = true },
+#     { field = "branch_status", show = true },
+#   ],
+# ]
+
+[ui.sidebar.agents]
+# Optional per-item color presets: default, muted, accent, cool, warm.
+# lines = [
+#   [
+#     { field = "agent_status", show = true },
+#     { field = "pane_name", show = true },
+#     { field = "tab_name", show = true },
+#     { field = "space_name", show = true },
+#   ],
+#   [
+#     { field = "status", show = true },
+#     { field = "time", show = true },
+#     { field = "custom_status", show = true },
+#     { field = "right_alignment", show = true },
+#     { field = "agent_name", show = true },
+#   ],
+# ]
+
 # Background notification popup delivery
 [ui.toast]
 # off = disable pop-up notifications
@@ -240,6 +271,7 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Experimental local Kitty graphics rendering for attached clients.
 # Requires a Kitty graphics-compatible outer terminal.
 # kitty_graphics = false
+# agent_panel_details was superseded by [ui.sidebar.agents] and is ignored if present.
 # Save recent pane screen history across full server restarts.
 pane_history = false
 # Expose the focused pane's cursor to the outer terminal so macOS input

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6,4 +6,4 @@ pub mod state;
 pub use id::TerminalId;
 pub use runtime::TerminalRuntime;
 pub(crate) use runtime_registry::TerminalRuntimeRegistry;
-pub use state::{EffectiveStateChange, TerminalState, TerminalStateMutation};
+pub use state::{EffectiveStateChange, TerminalState, TerminalStateMutation, WorkingDuration};

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -42,6 +42,12 @@ pub struct TerminalStateMutation {
     pub session_ref_changed: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkingDuration {
+    pub elapsed: Duration,
+    pub is_live: bool,
+}
+
 /// Pure state for a server-owned terminal.
 ///
 /// During the migration this is still one-to-one with a pane-backed PTY, but
@@ -63,6 +69,8 @@ pub struct TerminalState {
     pub agent_name: Option<String>,
     hook_report_sequences: HashMap<String, u64>,
     pub state: AgentState,
+    working_since: Option<Instant>,
+    last_working_duration: Option<Duration>,
     pub revision: u64,
     pub launch_argv: Option<Vec<String>>,
 }
@@ -85,6 +93,8 @@ impl TerminalState {
             agent_name: None,
             hook_report_sequences: HashMap::new(),
             state: AgentState::Unknown,
+            working_since: None,
+            last_working_duration: None,
             revision: 0,
             launch_argv: None,
         }
@@ -559,6 +569,26 @@ impl TerminalState {
             .and_then(|authority| authority.custom_status.as_deref())
     }
 
+    pub fn working_duration_at(&self, now: Instant) -> Option<WorkingDuration> {
+        if self.state == AgentState::Working {
+            let since = self.working_since?;
+            let elapsed = now.checked_duration_since(since).unwrap_or_default();
+            return Some(WorkingDuration {
+                elapsed,
+                is_live: true,
+            });
+        }
+
+        if self.state == AgentState::Unknown {
+            return None;
+        }
+
+        self.last_working_duration.map(|elapsed| WorkingDuration {
+            elapsed,
+            is_live: false,
+        })
+    }
+
     fn visible_blocker_overrides_hook(&self) -> bool {
         self.fallback_visible_blocker
             && self.fallback_not_older_than_hook()
@@ -683,6 +713,27 @@ impl TerminalState {
 
         if previous_agent_label == agent_label && previous_state == state {
             return None;
+        }
+
+        if previous_state != AgentState::Working && state == AgentState::Working {
+            self.working_since = if previous_state == AgentState::Blocked {
+                self.last_working_duration
+                    .and_then(|elapsed| now.checked_sub(elapsed))
+                    .or(Some(now))
+            } else {
+                Some(now)
+            };
+            self.last_working_duration = None;
+        } else if previous_state == AgentState::Working && state != AgentState::Working {
+            let elapsed = self
+                .working_since
+                .and_then(|since| now.checked_duration_since(since))
+                .unwrap_or_default();
+            self.working_since = None;
+            self.last_working_duration = (state != AgentState::Unknown).then_some(elapsed);
+        } else if state == AgentState::Unknown {
+            self.working_since = None;
+            self.last_working_duration = None;
         }
 
         self.state = state;
@@ -854,6 +905,231 @@ mod tests {
             &mut last_working,
         );
         assert_eq!(state, AgentState::Idle);
+    }
+
+    #[test]
+    fn working_duration_starts_when_effective_state_enters_working() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(12))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(12));
+        assert!(duration.is_live);
+    }
+
+    #[test]
+    fn repeated_working_reports_do_not_reset_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start + std::time::Duration::from_secs(5),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(8))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(8));
+        assert!(duration.is_live);
+    }
+
+    #[test]
+    fn leaving_working_freezes_last_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Idle,
+            false,
+            true,
+            false,
+            false,
+            start + std::time::Duration::from_secs(7),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(20))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(7));
+        assert!(!duration.is_live);
+    }
+
+    #[test]
+    fn new_working_transition_clears_stale_duration_and_restarts_timer() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Idle,
+            false,
+            true,
+            false,
+            false,
+            start + std::time::Duration::from_secs(7),
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start + std::time::Duration::from_secs(20),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(22))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(2));
+        assert!(duration.is_live);
+    }
+
+    #[test]
+    fn blocked_to_working_transition_resumes_previous_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Blocked,
+            true,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(10),
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start + std::time::Duration::from_secs(12),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(15))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(13));
+        assert!(duration.is_live);
+    }
+
+    #[test]
+    fn blocked_without_resuming_working_keeps_frozen_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Blocked,
+            true,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(10),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(30))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(10));
+        assert!(!duration.is_live);
+    }
+
+    #[test]
+    fn unknown_state_hides_stale_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            None,
+            AgentState::Unknown,
+            false,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(3),
+        );
+
+        assert_eq!(
+            terminal.working_duration_at(start + std::time::Duration::from_secs(5)),
+            None
+        );
     }
 
     #[test]

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -284,7 +284,7 @@ impl TerminalState {
         seq: Option<u64>,
         now: Instant,
     ) -> Option<TerminalStateMutation> {
-        if !self.accept_hook_report(&source, seq) {
+        if !self.hook_report_is_new(&source, seq) {
             return None;
         }
 
@@ -295,6 +295,7 @@ impl TerminalState {
         if self.known_agent_label_conflicts_with_detected_agent(&agent_label) {
             return None;
         }
+        self.record_hook_report(&source, seq);
         self.persisted_agent_session = None;
         self.hook_authority = Some(HookAuthority {
             source,
@@ -416,7 +417,7 @@ impl TerminalState {
             .is_some_and(|hook_agent| hook_agent != detected_agent)
     }
 
-    fn accept_hook_report(&mut self, source: &str, seq: Option<u64>) -> bool {
+    fn hook_report_is_new(&self, source: &str, seq: Option<u64>) -> bool {
         let Some(seq) = seq else {
             return !self.hook_report_sequences.contains_key(source);
         };
@@ -429,8 +430,14 @@ impl TerminalState {
             return false;
         }
 
-        self.hook_report_sequences.insert(source.to_string(), seq);
         true
+    }
+
+    fn record_hook_report(&mut self, source: &str, seq: Option<u64>) {
+        let Some(seq) = seq else {
+            return;
+        };
+        self.hook_report_sequences.insert(source.to_string(), seq);
     }
 
     #[cfg(test)]
@@ -454,7 +461,7 @@ impl TerminalState {
                 .map(|authority| authority.source.clone())
         });
         if let Some(source) = sequence_source.as_deref() {
-            if !self.accept_hook_report(source, seq) {
+            if !self.hook_report_is_new(source, seq) {
                 return None;
             }
         }
@@ -469,6 +476,9 @@ impl TerminalState {
             .is_some_and(|authority| source.is_none_or(|source| authority.source == source));
         if !should_clear {
             return None;
+        }
+        if let Some(source) = sequence_source.as_deref() {
+            self.record_hook_report(source, seq);
         }
         self.hook_authority = None;
         self.stale_hook_idle_since = None;
@@ -502,7 +512,7 @@ impl TerminalState {
         agent_label: &str,
         seq: Option<u64>,
     ) -> Option<TerminalStateMutation> {
-        if !self.accept_hook_report(source, seq) {
+        if !self.hook_report_is_new(source, seq) {
             return None;
         }
 
@@ -518,6 +528,7 @@ impl TerminalState {
             return None;
         }
 
+        self.record_hook_report(source, seq);
         let previous_agent_label = self.effective_agent_label().map(str::to_string);
         let previous_known_agent = self.effective_known_agent();
         let previous_state = self.state;
@@ -731,7 +742,10 @@ impl TerminalState {
                 .unwrap_or_default();
             self.working_since = None;
             self.last_working_duration = (state != AgentState::Unknown).then_some(elapsed);
-        } else if state == AgentState::Unknown {
+        } else if state == AgentState::Unknown
+            || (previous_state != AgentState::Working && state == AgentState::Blocked)
+            || (previous_state == AgentState::Blocked && state == AgentState::Idle)
+        {
             self.working_since = None;
             self.last_working_duration = None;
         }
@@ -1072,6 +1086,55 @@ mod tests {
     }
 
     #[test]
+    fn blocked_after_idle_does_not_resume_previous_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Idle,
+            false,
+            true,
+            false,
+            false,
+            start + std::time::Duration::from_secs(7),
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Blocked,
+            true,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(10),
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start + std::time::Duration::from_secs(12),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(15))
+            .unwrap();
+        assert_eq!(duration.elapsed, std::time::Duration::from_secs(3));
+        assert!(duration.is_live);
+    }
+
+    #[test]
     fn blocked_without_resuming_working_keeps_frozen_duration() {
         let mut terminal = test_terminal();
         let start = std::time::Instant::now();
@@ -1103,6 +1166,45 @@ mod tests {
     }
 
     #[test]
+    fn blocked_to_idle_clears_frozen_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Blocked,
+            true,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(10),
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Idle,
+            false,
+            true,
+            false,
+            false,
+            start + std::time::Duration::from_secs(12),
+        );
+
+        assert_eq!(
+            terminal.working_duration_at(start + std::time::Duration::from_secs(30)),
+            None
+        );
+    }
+
+    #[test]
     fn unknown_state_hides_stale_working_duration() {
         let mut terminal = test_terminal();
         let start = std::time::Instant::now();
@@ -1130,6 +1232,112 @@ mod tests {
             terminal.working_duration_at(start + std::time::Duration::from_secs(5)),
             None
         );
+    }
+
+    #[test]
+    fn idle_to_blocked_without_prior_working_keeps_no_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Idle,
+            false,
+            true,
+            false,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Blocked,
+            true,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(2),
+        );
+
+        assert_eq!(
+            terminal.working_duration_at(start + std::time::Duration::from_secs(5)),
+            None,
+            "no working session was ever observed; duration must remain None",
+        );
+    }
+
+    #[test]
+    fn blocked_to_unknown_clears_frozen_working_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Blocked,
+            true,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(10),
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            None,
+            AgentState::Unknown,
+            false,
+            false,
+            false,
+            false,
+            start + std::time::Duration::from_secs(15),
+        );
+
+        assert_eq!(
+            terminal.working_duration_at(start + std::time::Duration::from_secs(20)),
+            None,
+            "Blocked -> Unknown clears the frozen working duration",
+        );
+    }
+
+    #[test]
+    fn unknown_to_working_starts_fresh_duration() {
+        let mut terminal = test_terminal();
+        let start = std::time::Instant::now();
+
+        terminal.set_detected_state_with_screen_signals_at(
+            None,
+            AgentState::Unknown,
+            false,
+            false,
+            false,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start + std::time::Duration::from_secs(5),
+        );
+
+        let duration = terminal
+            .working_duration_at(start + std::time::Duration::from_secs(8))
+            .unwrap();
+        assert_eq!(
+            duration.elapsed,
+            std::time::Duration::from_secs(3),
+            "fresh Working epoch must start the clock from zero, not resume",
+        );
+        assert!(duration.is_live);
     }
 
     #[test]
@@ -2061,6 +2269,32 @@ mod tests {
     }
 
     #[test]
+    fn rejected_hook_report_does_not_advance_sequence() {
+        let mut terminal = test_terminal();
+        terminal.set_detected_state(Some(Agent::Codex), AgentState::Idle);
+
+        let rejected = terminal.set_hook_authority(
+            "herdr:codex".into(),
+            "claude".into(),
+            AgentState::Working,
+            None,
+            Some(20),
+        );
+        assert!(rejected.is_none());
+
+        let accepted = terminal.set_hook_authority(
+            "herdr:codex".into(),
+            "codex".into(),
+            AgentState::Working,
+            None,
+            Some(20),
+        );
+
+        assert!(accepted.is_some());
+        assert_eq!(terminal.state, AgentState::Working);
+    }
+
+    #[test]
     fn stale_release_sequence_is_ignored_for_same_source() {
         let mut terminal = test_terminal();
         terminal.set_hook_authority(
@@ -2079,6 +2313,28 @@ mod tests {
     }
 
     #[test]
+    fn rejected_release_does_not_advance_sequence() {
+        let mut terminal = test_terminal();
+        terminal.set_hook_authority(
+            "herdr:pi".into(),
+            "pi".into(),
+            AgentState::Working,
+            None,
+            Some(20),
+        );
+
+        let rejected = terminal.release_agent("herdr:pi", "codex", Some(21));
+        assert!(rejected.is_none());
+        assert!(terminal.hook_authority.is_some());
+
+        let accepted = terminal.release_agent("herdr:pi", "pi", Some(21));
+
+        assert!(accepted.is_some());
+        assert!(terminal.hook_authority.is_none());
+        assert_eq!(terminal.state, AgentState::Unknown);
+    }
+
+    #[test]
     fn stale_clear_all_sequence_is_checked_against_current_authority_source() {
         let mut terminal = test_terminal();
         terminal.set_hook_authority(
@@ -2094,6 +2350,27 @@ mod tests {
         assert!(change.is_none());
         assert_eq!(terminal.state, AgentState::Working);
         assert!(terminal.hook_authority.is_some());
+    }
+
+    #[test]
+    fn rejected_clear_does_not_advance_sequence() {
+        let mut terminal = test_terminal();
+        terminal.set_hook_authority(
+            "herdr:pi".into(),
+            "pi".into(),
+            AgentState::Working,
+            None,
+            Some(20),
+        );
+
+        let rejected = terminal.clear_hook_authority(Some("custom:pi"), Some(21));
+        assert!(rejected.is_none());
+        assert!(terminal.hook_authority.is_some());
+
+        let accepted = terminal.clear_hook_authority(Some("herdr:pi"), Some(21));
+
+        assert!(accepted.is_some());
+        assert!(terminal.hook_authority.is_none());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -59,14 +59,18 @@ pub(crate) use self::{
         open_existing_worktree_inner_rect, open_existing_worktree_visible_start,
         remove_worktree_button_rects, remove_worktree_popup_rect, rename_button_rects,
     },
-    settings::{settings_button_rects, settings_show_primary_action},
+    settings::{
+        settings_button_rects, settings_show_primary_action, SETTINGS_POPUP_HEIGHT,
+        SETTINGS_POPUP_WIDTH,
+    },
     sidebar::{
-        agent_panel_body_rect, agent_panel_entries, agent_panel_scroll_metrics,
-        agent_panel_scrollbar_rect, agent_panel_toggle_rect, collapsed_sidebar_sections,
-        collapsed_sidebar_toggle_rect, compute_workspace_card_areas, expanded_sidebar_sections,
-        normalized_workspace_scroll, sidebar_section_divider_rect, workspace_drop_indicator_row,
-        workspace_list_entries, workspace_list_rect, workspace_list_scroll_metrics,
-        workspace_list_scrollbar_rect, workspace_parent_group_state, WorkspaceListEntry,
+        agent_panel_body_rect, agent_panel_entries, agent_panel_entry_row_count,
+        agent_panel_scroll_metrics, agent_panel_scrollbar_rect, agent_panel_toggle_rect,
+        collapsed_sidebar_sections, collapsed_sidebar_toggle_rect, compute_workspace_card_areas,
+        expanded_sidebar_sections, normalized_workspace_scroll, sidebar_section_divider_rect,
+        workspace_drop_indicator_row, workspace_list_entries, workspace_list_rect,
+        workspace_list_scroll_metrics, workspace_list_scrollbar_rect, workspace_parent_group_state,
+        WorkspaceListEntry,
     },
 };
 pub(crate) use self::{

--- a/src/ui/mobile.rs
+++ b/src/ui/mobile.rs
@@ -936,10 +936,12 @@ mod tests {
             pane_id: PaneId::from_raw(1),
             primary_label: "herdr".into(),
             primary_tab_label: primary_tab_label.map(str::to_string),
+            pane_label: None,
             agent_label: agent_label.map(str::to_string),
             state: AgentState::Idle,
             seen: true,
             custom_status: None,
+            working_duration: None,
         }
     }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -11,15 +11,22 @@ use super::widgets::{
     render_action_button, render_modal_choice_list, render_panel_shell, ActionButtonSpec,
 };
 use crate::{
-    app::{state::Palette, AppState},
+    app::{
+        state::{
+            ordered_sidebar_agent_items, ordered_sidebar_space_items, Palette, SettingsSection,
+            SidebarConfigGroup, SidebarLine,
+        },
+        AppState,
+    },
     config::ToastDelivery,
 };
 
-pub(super) fn render_settings_overlay(app: &AppState, frame: &mut Frame, area: Rect) {
-    use crate::app::state::SettingsSection;
+pub(crate) const SETTINGS_POPUP_WIDTH: u16 = 96;
+pub(crate) const SETTINGS_POPUP_HEIGHT: u16 = 32;
 
+pub(super) fn render_settings_overlay(app: &AppState, frame: &mut Frame, area: Rect) {
     let p = &app.palette;
-    let Some(popup) = centered_popup_rect(area, 76, 22) else {
+    let Some(popup) = centered_popup_rect(area, SETTINGS_POPUP_WIDTH, SETTINGS_POPUP_HEIGHT) else {
         return;
     };
 
@@ -131,6 +138,9 @@ pub(super) fn render_settings_overlay(app: &AppState, frame: &mut Frame, area: R
                 app.settings.list.selected,
             );
         }
+        SettingsSection::Sidebar => {
+            render_settings_sidebar_config(app, frame, content_area);
+        }
         SettingsSection::Experiments => {
             render_settings_experiments(app, frame, content_area);
         }
@@ -169,16 +179,47 @@ pub(super) fn render_settings_overlay(app: &AppState, frame: &mut Frame, area: R
                 .add_modifier(Modifier::BOLD),
         );
 
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
+        frame.render_widget(Paragraph::new(settings_footer_hint(app)), footer_rows[0]);
+    }
+}
+
+fn settings_footer_hint(app: &AppState) -> Line<'static> {
+    let p = &app.palette;
+    if app.settings.section == SettingsSection::Sidebar {
+        if app.settings.sidebar_config_editing {
+            return Line::from(vec![
                 Span::styled(" ↑↓", Style::default().fg(p.overlay0)),
-                Span::styled(" select  ", Style::default().fg(p.overlay1)),
+                Span::styled(" reorder  ", Style::default().fg(p.overlay1)),
+                Span::styled("c", Style::default().fg(p.overlay0)),
+                Span::styled(" color  ", Style::default().fg(p.overlay1)),
+                Span::styled("enter", Style::default().fg(p.overlay0)),
+                Span::styled(" done  ", Style::default().fg(p.overlay1)),
                 Span::styled("tab", Style::default().fg(p.overlay0)),
                 Span::styled(" section", Style::default().fg(p.overlay1)),
-            ])),
-            footer_rows[0],
-        );
+            ]);
+        }
+        return Line::from(vec![
+            Span::styled(" ↑↓", Style::default().fg(p.overlay0)),
+            Span::styled(" select  ", Style::default().fg(p.overlay1)),
+            Span::styled("←→", Style::default().fg(p.overlay0)),
+            Span::styled(" group  ", Style::default().fg(p.overlay1)),
+            Span::styled("space", Style::default().fg(p.overlay0)),
+            Span::styled(" toggle  ", Style::default().fg(p.overlay1)),
+            Span::styled("c", Style::default().fg(p.overlay0)),
+            Span::styled(" color  ", Style::default().fg(p.overlay1)),
+            Span::styled("enter", Style::default().fg(p.overlay0)),
+            Span::styled(" edit  ", Style::default().fg(p.overlay1)),
+            Span::styled("tab", Style::default().fg(p.overlay0)),
+            Span::styled(" section", Style::default().fg(p.overlay1)),
+        ]);
     }
+
+    Line::from(vec![
+        Span::styled(" ↑↓", Style::default().fg(p.overlay0)),
+        Span::styled(" select  ", Style::default().fg(p.overlay1)),
+        Span::styled("tab", Style::default().fg(p.overlay0)),
+        Span::styled(" section", Style::default().fg(p.overlay1)),
+    ])
 }
 
 pub(crate) fn settings_primary_button_label(
@@ -379,6 +420,194 @@ fn render_settings_toggle(
     );
 }
 
+fn render_settings_sidebar_config(app: &AppState, frame: &mut Frame, area: Rect) {
+    let p = &app.palette;
+    let [desc_area, _, list_area] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Min(1),
+    ])
+    .areas::<3>(area);
+
+    let title = format!(
+        "{} - sidebar config",
+        app.settings.sidebar_config_group.label()
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            title,
+            Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+        ))),
+        Rect::new(desc_area.x, desc_area.y, desc_area.width, 1),
+    );
+    frame.render_widget(
+        Paragraph::new("configure sidebar navigation").style(Style::default().fg(p.overlay1)),
+        Rect::new(
+            desc_area.x,
+            desc_area.y.saturating_add(1),
+            desc_area.width,
+            1,
+        ),
+    );
+
+    let mut rows: Vec<(Line<'static>, Option<usize>, bool)> = Vec::new();
+    match app.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => {
+            let ordered = ordered_sidebar_space_items(&app.sidebar_space);
+            let line_count =
+                SidebarConfigGroup::Spaces.settings_line_count(app.sidebar_space.lines.len());
+            for line in (0..line_count).map(SidebarLine::from_index) {
+                rows.push((Line::from(format!(" {}", line.label())), None, true));
+                let start_len = rows.len();
+                for (idx, item) in ordered
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(_, item)| item.line(&app.sidebar_space) == line)
+                {
+                    let marker = if item.enabled(&app.sidebar_space) {
+                        "[✓]"
+                    } else {
+                        "[ ]"
+                    };
+                    rows.push((
+                        sidebar_config_item_row(
+                            format!("   {marker} {}", item.label()),
+                            item.color(&app.sidebar_space),
+                            p,
+                        ),
+                        Some(idx),
+                        false,
+                    ));
+                }
+                if rows.len() == start_len {
+                    rows.push((Line::from("   (empty)"), None, false));
+                }
+            }
+        }
+        SidebarConfigGroup::Agents => {
+            let ordered = ordered_sidebar_agent_items(&app.sidebar_agent);
+            let line_count =
+                SidebarConfigGroup::Agents.settings_line_count(app.sidebar_agent.lines.len());
+            for line in (0..line_count).map(SidebarLine::from_index) {
+                rows.push((Line::from(format!(" {}", line.label())), None, true));
+                let start_len = rows.len();
+                for (idx, item) in ordered
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter(|(_, item)| item.line(&app.sidebar_agent) == line)
+                {
+                    let marker = if item.enabled(&app.sidebar_agent) {
+                        "[✓]"
+                    } else {
+                        "[ ]"
+                    };
+                    rows.push((
+                        sidebar_config_item_row(
+                            format!("   {marker} {}", item.label()),
+                            item.color(&app.sidebar_agent),
+                            p,
+                        ),
+                        Some(idx),
+                        false,
+                    ));
+                }
+                if rows.len() == start_len {
+                    rows.push((Line::from("   (empty)"), None, false));
+                }
+            }
+        }
+    };
+
+    let list_bottom = list_area.y.saturating_add(list_area.height);
+    let mut rendered_rows = 0u16;
+    for (idx, (text, selected_idx, is_header)) in rows.iter().enumerate() {
+        let row = Rect::new(list_area.x, list_area.y + idx as u16, list_area.width, 1);
+        if row.y >= list_bottom {
+            break;
+        }
+        let style = if selected_idx == &Some(app.settings.list.selected) {
+            let style = Style::default()
+                .bg(p.surface0)
+                .fg(p.text)
+                .add_modifier(Modifier::BOLD);
+            if app.settings.sidebar_config_editing {
+                style.fg(p.accent)
+            } else {
+                style
+            }
+        } else if *is_header {
+            Style::default().fg(p.overlay0).add_modifier(Modifier::BOLD)
+        } else if selected_idx.is_none() {
+            Style::default().fg(p.overlay1)
+        } else {
+            Style::default().fg(p.subtext0)
+        };
+        frame.render_widget(Paragraph::new(text.clone()).style(style), row);
+        rendered_rows = rendered_rows.saturating_add(1);
+    }
+
+    if rows.len() > rendered_rows as usize {
+        return;
+    }
+
+    let demo_y = list_area.y + rendered_rows + 1;
+    if demo_y >= list_area.y + list_area.height {
+        return;
+    }
+    let demo_title = match app.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => "demo spaces",
+        SidebarConfigGroup::Agents => "demo agents",
+    };
+    frame.render_widget(
+        Paragraph::new(Span::styled(
+            demo_title,
+            Style::default().fg(p.overlay0).add_modifier(Modifier::BOLD),
+        )),
+        Rect::new(list_area.x, demo_y, list_area.width, 1),
+    );
+
+    let demo_width = match app.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => list_area.width,
+        SidebarConfigGroup::Agents => super::sidebar::settings_sidebar_agent_demo_width(app)
+            .max(1)
+            .min(list_area.width),
+    };
+    let demo_lines = match app.settings.sidebar_config_group {
+        SidebarConfigGroup::Spaces => super::sidebar::settings_sidebar_space_demo_lines(app),
+        SidebarConfigGroup::Agents => {
+            super::sidebar::settings_sidebar_agent_demo_lines(app, demo_width)
+        }
+    };
+    for (idx, line) in demo_lines.into_iter().enumerate() {
+        let y = demo_y + 1 + idx as u16;
+        if y >= list_area.y + list_area.height {
+            break;
+        }
+        frame.render_widget(
+            Paragraph::new(line),
+            Rect::new(list_area.x, y, demo_width, 1),
+        );
+    }
+}
+
+fn sidebar_config_item_row(
+    label: String,
+    color: crate::config::SidebarColorPreset,
+    p: &Palette,
+) -> Line<'static> {
+    Line::from(vec![
+        Span::raw(label),
+        Span::raw("  "),
+        Span::styled("■", Style::default().fg(p.sidebar_color(color, p.subtext0))),
+        Span::styled(
+            format!(" {}", color.as_str()),
+            Style::default().fg(p.overlay1),
+        ),
+    ])
+}
+
 fn render_settings_experiments(app: &AppState, frame: &mut Frame, area: Rect) {
     let p = &app.palette;
     let [desc_area, _, list_area] = Layout::vertical([
@@ -391,28 +620,30 @@ fn render_settings_experiments(app: &AppState, frame: &mut Frame, area: Rect) {
     super::widgets::render_modal_description(
         frame,
         desc_area,
-        "optional features that are off by default",
+        "optional and experimental behavior",
         Style::default().fg(p.overlay1),
     );
 
-    let marker = if app.pane_history_persistence_enabled() {
-        "[✓]"
-    } else {
-        "[ ]"
-    };
-    let style = if app.settings.list.selected == 0 {
-        Style::default()
-            .bg(p.surface0)
-            .fg(p.text)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(p.subtext0)
-    };
-    let row = Rect::new(list_area.x, list_area.y, list_area.width, 1);
-    frame.render_widget(
-        Paragraph::new(format!(" pane screen history {marker}")).style(style),
-        row,
-    );
+    let rows = [(
+        "pane screen history",
+        app.pane_history_persistence_enabled(),
+    )];
+    for (idx, (label, enabled)) in rows.into_iter().enumerate() {
+        let marker = if enabled { "[✓]" } else { "[ ]" };
+        let style = if app.settings.list.selected == idx {
+            Style::default()
+                .bg(p.surface0)
+                .fg(p.text)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(p.subtext0)
+        };
+        let row = Rect::new(list_area.x, list_area.y + idx as u16, list_area.width, 1);
+        frame.render_widget(
+            Paragraph::new(format!(" {label} {marker}")).style(style),
+            row,
+        );
+    }
 }
 
 #[cfg(test)]
@@ -444,14 +675,19 @@ mod tests {
             .collect::<String>();
 
         assert!(rendered.contains("pane screen history [✓]"));
+        assert!(!rendered.contains("agent panel details"));
         assert!(!rendered.contains("[x]"));
     }
 
     #[test]
-    fn experiments_pane_history_keeps_empty_checkbox_marker_when_disabled() {
+    fn sidebar_config_renders_spaces_checkbox_rows_and_demo_preview() {
         let mut app = AppState::test_new();
-        app.pane_history_persistence = false;
-        app.settings.section = SettingsSection::Experiments;
+        crate::app::state::SidebarSpaceItem::Status.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::Name.set_enabled(&mut app.sidebar_space, true);
+        crate::app::state::SidebarSpaceItem::Branch.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::BranchStatus.set_enabled(&mut app.sidebar_space, true);
+        app.settings.section = SettingsSection::Sidebar;
+        app.settings.sidebar_config_group = crate::app::state::SidebarConfigGroup::Spaces;
         app.settings.list.selected = 0;
         app.mode = Mode::Settings;
 
@@ -469,6 +705,227 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
 
-        assert!(rendered.contains("pane screen history [ ]"));
+        assert!(rendered.contains("spaces - sidebar config"));
+        assert!(rendered.contains("1st line"));
+        assert!(rendered.contains("[ ] space status"));
+        assert!(rendered.contains("■ default"));
+        assert!(rendered.contains("[✓] space name"));
+        assert!(rendered.contains("2nd line"));
+        assert!(rendered.contains("[ ] space branch"));
+        assert!(rendered.contains("[✓] space branch status"));
+        assert!(!rendered.contains("1st line 1"));
+        assert!(rendered.contains("demo spaces"));
+        assert!(rendered.contains("↑2"));
+    }
+
+    #[test]
+    fn sidebar_config_keeps_empty_line_groups_visible() {
+        let mut app = AppState::test_new();
+        for item in crate::app::state::SIDEBAR_SPACE_ITEMS {
+            item.set_line(
+                &mut app.sidebar_space,
+                crate::app::state::SidebarLine::Second,
+            );
+        }
+        app.settings.section = SettingsSection::Sidebar;
+        app.settings.sidebar_config_group = crate::app::state::SidebarConfigGroup::Spaces;
+        app.mode = Mode::Settings;
+
+        let mut terminal =
+            Terminal::new(TestBackend::new(100, 34)).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render_settings_overlay(&app, frame, Rect::new(0, 0, 100, 34)))
+            .expect("settings overlay should render");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("1st line"));
+        assert!(rendered.contains("(empty)"));
+        assert!(rendered.contains("2nd line"));
+        assert!(rendered.contains("[✓] space status"));
+        assert!(rendered.contains("[✓] space name"));
+    }
+
+    #[test]
+    fn sidebar_config_renders_agents_checkbox_rows_and_demo_preview() {
+        let mut app = AppState::test_new();
+        crate::app::state::SidebarAgentItem::PaneName.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::TabName.set_enabled(&mut app.sidebar_agent, false);
+        crate::app::state::SidebarAgentItem::SpaceName.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::AgentStatus.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::Status.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::Time.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::AgentName.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, false);
+        app.sidebar_width = 60;
+        app.view.sidebar_rect = Rect::new(0, 0, 60, 40);
+        app.settings.section = SettingsSection::Sidebar;
+        app.settings.sidebar_config_group = crate::app::state::SidebarConfigGroup::Agents;
+        app.settings.list.selected = 0;
+        app.mode = Mode::Settings;
+
+        let mut terminal =
+            Terminal::new(TestBackend::new(110, 34)).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render_settings_overlay(&app, frame, Rect::new(0, 0, 110, 34)))
+            .expect("settings overlay should render");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("agents - sidebar config"));
+        assert!(rendered.contains("1st line"));
+        assert!(rendered.contains("[✓] agent status"));
+        assert!(rendered.contains("■ default"));
+        assert!(rendered.contains("[✓] agent pane name"));
+        assert!(rendered.contains("[ ] agent tab name"));
+        assert!(rendered.contains("[✓] space name"));
+        assert!(rendered.contains("2nd line"));
+        assert!(rendered.contains("[✓] status text"));
+        assert!(rendered.contains("[✓] agent time"));
+        assert!(rendered.contains("[✓] custom status"));
+        assert!(rendered.contains("[ ] right-alignment"));
+        assert!(rendered.contains("[✓] agent name"));
+        assert!(rendered.contains("3rd line"));
+        assert!(rendered.contains("(empty)"));
+        assert!(!rendered.contains("layout"));
+        assert!(!rendered.contains("right-align agent name"));
+        assert!(!rendered.contains("1st line 1"));
+        assert!(rendered.contains("demo agents"));
+        assert!(rendered.contains("claude"));
+        assert!(rendered.contains("codex"));
+    }
+
+    #[test]
+    fn sidebar_config_agent_demo_uses_sidebar_width_for_right_alignment() {
+        let mut app = AppState::test_new();
+        app.view.sidebar_rect = Rect::new(0, 0, 26, 40);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, true);
+        app.settings.section = SettingsSection::Sidebar;
+        app.settings.sidebar_config_group = crate::app::state::SidebarConfigGroup::Agents;
+        app.mode = Mode::Settings;
+
+        let mut terminal =
+            Terminal::new(TestBackend::new(120, 36)).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render_settings_overlay(&app, frame, Rect::new(0, 0, 120, 36)))
+            .expect("settings overlay should render");
+        let buffer = terminal.backend().buffer();
+        let content = app.settings_content_rect();
+        let row = (content.y..content.y + content.height)
+            .map(|y| {
+                (0..120)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .find(|row| row.contains("working") && row.contains("claude"))
+            .expect("working claude demo row should render");
+        let claude_col = row
+            .find("claude")
+            .unwrap_or_else(|| panic!("claude should render in row: {row:?}"))
+            as u16;
+
+        let expected_right_edge = row
+            .find("working")
+            .map(|idx| idx as u16 - 2 + 26)
+            .expect("working text should render");
+        assert_eq!(claude_col + "claude".len() as u16, expected_right_edge);
+    }
+
+    #[test]
+    fn sidebar_config_footer_shows_navigation_hints() {
+        let mut app = AppState::test_new();
+        app.settings.section = SettingsSection::Sidebar;
+        app.mode = Mode::Settings;
+
+        let mut terminal =
+            Terminal::new(TestBackend::new(110, 28)).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render_settings_overlay(&app, frame, Rect::new(0, 0, 110, 28)))
+            .expect("settings overlay should render");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("←→ group"));
+        assert!(rendered.contains("enter edit"));
+        assert!(rendered.contains("space toggle"));
+        assert!(rendered.contains("c color"));
+    }
+
+    #[test]
+    fn sidebar_config_footer_shows_editing_hints() {
+        let mut app = AppState::test_new();
+        app.settings.section = SettingsSection::Sidebar;
+        app.settings.sidebar_config_editing = true;
+        app.mode = Mode::Settings;
+
+        let mut terminal =
+            Terminal::new(TestBackend::new(110, 28)).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render_settings_overlay(&app, frame, Rect::new(0, 0, 110, 28)))
+            .expect("settings overlay should render");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("↑↓ reorder"));
+        assert!(!rendered.contains("←→ line"));
+        assert!(!rendered.contains("space toggle"));
+        assert!(rendered.contains("c color"));
+        assert!(rendered.contains("enter done"));
+    }
+
+    #[test]
+    fn sidebar_config_rows_do_not_render_past_content_area() {
+        let mut app = AppState::test_new();
+        app.sidebar_space.lines = vec![Vec::new(); 24];
+        app.view.sidebar_rect = Rect::new(0, 0, 110, 28);
+        app.view.terminal_area = Rect::new(0, 0, 110, 28);
+        app.settings.section = SettingsSection::Sidebar;
+        app.settings.sidebar_config_group = crate::app::state::SidebarConfigGroup::Spaces;
+        app.mode = Mode::Settings;
+
+        let mut terminal =
+            Terminal::new(TestBackend::new(110, 28)).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render_settings_overlay(&app, frame, Rect::new(0, 0, 110, 28)))
+            .expect("settings overlay should render");
+        let buffer = terminal.backend().buffer();
+        let content = app.settings_content_rect();
+
+        for y in content.y + content.height..28 {
+            let row = (0..110)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>();
+            assert!(!row.contains("line"), "row {y} leaked config rows: {row:?}");
+            assert!(
+                !row.contains("space branch"),
+                "row {y} leaked config rows: {row:?}"
+            );
+        }
     }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -11,11 +11,11 @@ use ratatui::{
 use super::scrollbar::{render_scrollbar, should_show_scrollbar};
 use super::status::{agent_icon, state_dot, state_label, state_label_color};
 use crate::app::state::{
-    ordered_agent_view_items, ordered_space_view_items, AgentPanelScope, AgentViewItem, Palette,
-    SpaceViewItem, ViewLine,
+    ordered_sidebar_space_items, AgentPanelScope, Palette, SidebarAgentItem, SidebarLine,
+    SidebarSpaceItem,
 };
 use crate::app::{AppState, Mode};
-use crate::config::ViewColorPreset;
+use crate::config::{SidebarColorPreset, SidebarItem};
 use crate::detect::AgentState;
 use crate::terminal::{TerminalRuntimeRegistry, WorkingDuration};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -205,8 +205,7 @@ fn agent_panel_entries_with_runtimes(
 }
 
 fn truncate_text(text: &str, max_width: usize) -> String {
-    let len = text.chars().count();
-    if len <= max_width {
+    if UnicodeWidthStr::width(text) <= max_width {
         return text.to_string();
     }
     if max_width == 0 {
@@ -215,7 +214,17 @@ fn truncate_text(text: &str, max_width: usize) -> String {
     if max_width == 1 {
         return "…".to_string();
     }
-    let prefix: String = text.chars().take(max_width.saturating_sub(1)).collect();
+    let prefix_width = max_width.saturating_sub(1);
+    let mut width = 0;
+    let mut prefix = String::new();
+    for ch in text.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_width > prefix_width {
+            break;
+        }
+        prefix.push(ch);
+        width += ch_width;
+    }
     format!("{prefix}…")
 }
 
@@ -279,7 +288,7 @@ fn truncated_pane_side_segments(
     max_width: usize,
 ) -> Vec<AgentPanelPrimarySegment> {
     let separator = " · ";
-    let separator_width = separator.chars().count();
+    let separator_width = UnicodeWidthStr::width(separator);
     let Some(tab_label) = tab_label else {
         return vec![AgentPanelPrimarySegment::new(
             truncate_text(pane_label, max_width),
@@ -287,9 +296,9 @@ fn truncated_pane_side_segments(
         )];
     };
 
-    let tab_width = tab_label.chars().count();
+    let tab_width = UnicodeWidthStr::width(tab_label);
     let full_side = format!("{pane_label}{separator}{tab_label}");
-    if full_side.chars().count() <= max_width {
+    if UnicodeWidthStr::width(full_side.as_str()) <= max_width {
         return vec![
             AgentPanelPrimarySegment::new(pane_label, AgentPanelPrimarySegmentKind::Pane),
             AgentPanelPrimarySegment::new(separator, AgentPanelPrimarySegmentKind::Separator),
@@ -322,7 +331,7 @@ fn agent_panel_primary_label_segments_with_options(
     show_tab_name: bool,
 ) -> Vec<AgentPanelPrimarySegment> {
     let separator = " · ";
-    let separator_width = separator.chars().count();
+    let separator_width = UnicodeWidthStr::width(separator);
     let pane_label = show_pane_name
         .then_some(entry.pane_label.as_deref())
         .flatten();
@@ -338,7 +347,7 @@ fn agent_panel_primary_label_segments_with_options(
         };
 
         let full = format!("{tab_label}{separator}{}", entry.primary_label);
-        if full.chars().count() <= max_width {
+        if UnicodeWidthStr::width(full.as_str()) <= max_width {
             return vec![
                 AgentPanelPrimarySegment::new(tab_label, AgentPanelPrimarySegmentKind::Tab),
                 AgentPanelPrimarySegment::new(separator, AgentPanelPrimarySegmentKind::Separator),
@@ -349,7 +358,7 @@ fn agent_panel_primary_label_segments_with_options(
             ];
         }
 
-        let workspace_width = entry.primary_label.chars().count();
+        let workspace_width = UnicodeWidthStr::width(entry.primary_label.as_str());
         if max_width > workspace_width + separator_width {
             let tab_width = max_width - workspace_width - separator_width;
             return vec![
@@ -376,13 +385,13 @@ fn agent_panel_primary_label_segments_with_options(
         None => pane_label.to_string(),
     };
     let full = format!("{side}{separator}{}", entry.primary_label);
-    if full.chars().count() <= max_width {
+    if UnicodeWidthStr::width(full.as_str()) <= max_width {
         let mut segments = Vec::new();
         push_full_primary_segments(&mut segments, pane_label, tab_label, &entry.primary_label);
         return segments;
     }
 
-    let workspace_width = entry.primary_label.chars().count();
+    let workspace_width = UnicodeWidthStr::width(entry.primary_label.as_str());
     let min_named_side_width = 1;
     if max_width >= workspace_width + separator_width + min_named_side_width {
         let side_width = max_width - workspace_width - separator_width;
@@ -404,6 +413,7 @@ fn agent_panel_primary_label_segments_with_options(
     )]
 }
 
+#[cfg(test)]
 pub(super) fn format_agent_panel_primary_label(
     entry: &AgentPanelEntry,
     max_width: usize,
@@ -411,6 +421,7 @@ pub(super) fn format_agent_panel_primary_label(
     format_agent_panel_primary_label_with_options(entry, max_width, true, true)
 }
 
+#[cfg(test)]
 fn format_agent_panel_primary_label_with_options(
     entry: &AgentPanelEntry,
     max_width: usize,
@@ -486,7 +497,6 @@ fn duration_unit_style(unit: &str, duration: WorkingDuration, p: &Palette) -> St
     let color = match unit {
         "h" => p.subtext0,
         "m" => p.overlay1,
-        "s" => p.overlay0,
         _ => p.overlay0,
     };
     Style::default().fg(color)
@@ -501,25 +511,25 @@ fn duration_value_spans(duration: WorkingDuration, p: &Palette) -> Vec<Span<'sta
     spans
 }
 
-fn style_with_view_color(
+fn style_with_sidebar_color(
     style: Style,
-    preset: ViewColorPreset,
+    preset: SidebarColorPreset,
     default: Color,
     p: &Palette,
 ) -> Style {
-    if preset == ViewColorPreset::Default {
+    if preset == SidebarColorPreset::Default {
         style
     } else {
-        style.fg(p.view_color(preset, default))
+        style.fg(p.sidebar_color(preset, default))
     }
 }
 
-fn spans_with_view_color(
+fn spans_with_sidebar_color(
     spans: Vec<Span<'static>>,
-    preset: ViewColorPreset,
+    preset: SidebarColorPreset,
     p: &Palette,
 ) -> Vec<Span<'static>> {
-    if preset == ViewColorPreset::Default {
+    if preset == SidebarColorPreset::Default {
         return spans;
     }
 
@@ -528,7 +538,7 @@ fn spans_with_view_color(
         .map(|span| {
             let Span { content, style } = span;
             let default = style.fg.unwrap_or(p.text);
-            Span::styled(content, style_with_view_color(style, preset, default, p))
+            Span::styled(content, style_with_sidebar_color(style, preset, default, p))
         })
         .collect()
 }
@@ -566,41 +576,44 @@ fn branch_status_parts(
     (!parts.is_empty()).then_some(parts)
 }
 
-fn space_item_has_content(
+fn sidebar_space_item_has_content(
     app: &AppState,
     ws: &crate::workspace::Workspace,
-    item: SpaceViewItem,
+    item: SidebarSpaceItem,
 ) -> bool {
-    if !item.enabled(&app.space_view) {
+    if !item.enabled(&app.sidebar_space) {
         return false;
     }
     match item {
-        SpaceViewItem::Status | SpaceViewItem::Name => true,
-        SpaceViewItem::Branch => ws.branch().is_some(),
-        SpaceViewItem::BranchStatus => ws.branch().is_some() && ws.git_ahead_behind().is_some(),
+        SidebarSpaceItem::Status | SidebarSpaceItem::Name => true,
+        SidebarSpaceItem::Branch => ws.branch().is_some(),
+        SidebarSpaceItem::BranchStatus => ws.branch().is_some() && ws.git_ahead_behind().is_some(),
     }
 }
 
 fn workspace_line_has_content(
     app: &AppState,
     ws: &crate::workspace::Workspace,
-    line: ViewLine,
+    line: SidebarLine,
 ) -> bool {
-    ordered_space_view_items(&app.space_view)
+    ordered_sidebar_space_items(&app.sidebar_space)
         .into_iter()
-        .filter(|item| item.line(&app.space_view) == line)
-        .any(|item| space_item_has_content(app, ws, item))
+        .filter(|item| item.line(&app.sidebar_space) == line)
+        .any(|item| sidebar_space_item_has_content(app, ws, item))
 }
 
-fn workspace_render_lines(app: &AppState, ws: &crate::workspace::Workspace) -> Vec<ViewLine> {
+fn workspace_render_lines(app: &AppState, ws: &crate::workspace::Workspace) -> Vec<SidebarLine> {
     let mut lines = Vec::new();
-    for line in (0..app.space_view.lines.len().max(1)).map(ViewLine::from_index) {
+    for line in (0..app.sidebar_space.lines.len().max(1)).map(SidebarLine::from_index) {
         if workspace_line_has_content(app, ws, line) {
             lines.push(line);
         }
     }
+    if !lines.is_empty() && !lines.contains(&SidebarLine::First) {
+        lines.insert(0, SidebarLine::First);
+    }
     if lines.is_empty() {
-        lines.push(ViewLine::First);
+        lines.push(SidebarLine::First);
     }
     lines
 }
@@ -886,23 +899,23 @@ pub(crate) fn agent_panel_body_rect(area: Rect, has_scrollbar: bool) -> Rect {
     Rect::new(area.x, body_y, body_width, body_height)
 }
 
-fn agent_view_render_lines(app: &AppState) -> Vec<ViewLine> {
+fn sidebar_agent_render_lines(app: &AppState) -> Vec<SidebarLine> {
     let mut lines: Vec<_> = app
-        .agent_view
+        .sidebar_agent
         .lines
         .iter()
         .enumerate()
         .filter(|(_, line)| line.iter().any(|item| item.show))
-        .map(|(idx, _)| ViewLine::from_index(idx))
+        .map(|(idx, _)| SidebarLine::from_index(idx))
         .collect();
     if lines.is_empty() {
-        lines.push(ViewLine::First);
+        lines.push(SidebarLine::First);
     }
     lines
 }
 
-fn agent_panel_entry_row_count(app: &AppState) -> u16 {
-    agent_view_render_lines(app).len() as u16
+pub(crate) fn agent_panel_entry_row_count(app: &AppState) -> u16 {
+    sidebar_agent_render_lines(app).len() as u16
 }
 
 fn agent_panel_visible_count(app: &AppState, area: Rect) -> usize {
@@ -1296,7 +1309,7 @@ fn render_workspace_list(
         };
         let branch_style = Style::default().fg(branch_color);
         let separator_style = Style::default().fg(p.overlay0);
-        let ordered_items = ordered_space_view_items(&app.space_view);
+        let ordered_items = ordered_sidebar_space_items(&app.sidebar_space);
         let render_lines = workspace_render_lines(app, ws);
 
         for (render_idx, line) in render_lines.into_iter().enumerate() {
@@ -1328,22 +1341,22 @@ fn render_workspace_list(
             for item in ordered_items
                 .iter()
                 .copied()
-                .filter(|item| item.line(&app.space_view) == line)
-                .filter(|item| item.enabled(&app.space_view))
+                .filter(|item| item.line(&app.sidebar_space) == line)
+                .filter(|item| item.enabled(&app.sidebar_space))
             {
                 match item {
-                    SpaceViewItem::Status => {
+                    SidebarSpaceItem::Status => {
                         push_separator(&mut content, separator_style);
-                        let icon_style = style_with_view_color(
+                        let icon_style = style_with_sidebar_color(
                             status_dot.1,
-                            item.color(&app.space_view),
+                            item.color(&app.sidebar_space),
                             status_dot.1.fg.unwrap_or(p.accent),
                             p,
                         );
                         content.push(Span::styled(status_dot.0, icon_style));
                         previous_was_status = true;
                     }
-                    SpaceViewItem::Name => {
+                    SidebarSpaceItem::Name => {
                         push_space_separator(
                             &mut content,
                             &mut previous_was_status,
@@ -1358,31 +1371,31 @@ fn render_workspace_list(
                         } else {
                             label.clone()
                         };
-                        let item_style = style_with_view_color(
+                        let item_style = style_with_sidebar_color(
                             name_style,
-                            item.color(&app.space_view),
+                            item.color(&app.sidebar_space),
                             name_style.fg.unwrap_or(p.subtext0),
                             p,
                         );
                         content.push(Span::styled(display_label, item_style));
                     }
-                    SpaceViewItem::Branch => {
+                    SidebarSpaceItem::Branch => {
                         if let Some(branch) = ws.branch() {
                             push_space_separator(
                                 &mut content,
                                 &mut previous_was_status,
                                 separator_style,
                             );
-                            let item_style = style_with_view_color(
+                            let item_style = style_with_sidebar_color(
                                 branch_style,
-                                item.color(&app.space_view),
+                                item.color(&app.sidebar_space),
                                 branch_style.fg.unwrap_or(p.overlay0),
                                 p,
                             );
                             content.push(Span::styled(branch, item_style));
                         }
                     }
-                    SpaceViewItem::BranchStatus => {
+                    SidebarSpaceItem::BranchStatus => {
                         if ws.branch().is_some() {
                             if let Some(parts) = branch_status_parts(ws.git_ahead_behind(), p) {
                                 push_space_separator(
@@ -1396,8 +1409,9 @@ fn render_workspace_list(
                                     }
                                     content.push(Span::styled(
                                         label,
-                                        Style::default()
-                                            .fg(p.view_color(item.color(&app.space_view), color)),
+                                        Style::default().fg(
+                                            p.sidebar_color(item.color(&app.sidebar_space), color)
+                                        ),
                                     ));
                                 }
                             }
@@ -1455,68 +1469,72 @@ fn render_workspace_list(
     }
 }
 
-fn agent_item_spans(
+fn sidebar_agent_item_spans(
     entry: &AgentPanelEntry,
     app: &AppState,
-    item: AgentViewItem,
+    item: SidebarAgentItem,
     name_style: Style,
     status_style: Style,
     agent_style: Style,
     p: &Palette,
 ) -> Option<Vec<Span<'static>>> {
-    if !item.enabled(&app.agent_view) {
+    if !item.enabled(&app.sidebar_agent) {
         return None;
     }
     let spans = match item {
-        AgentViewItem::AgentStatus => {
+        SidebarAgentItem::AgentStatus => {
             let (icon, icon_style) = agent_icon(entry.state, entry.seen, app.spinner_tick, p);
             Some(vec![Span::styled(icon, icon_style)])
         }
-        AgentViewItem::PaneName => entry
+        SidebarAgentItem::PaneName => entry
             .pane_label
             .as_ref()
             .map(|label| vec![Span::styled(label.clone(), Style::default().fg(p.green))]),
-        AgentViewItem::TabName => entry
+        SidebarAgentItem::TabName => entry
             .primary_tab_label
             .as_ref()
             .map(|label| vec![Span::styled(label.clone(), Style::default().fg(p.mauve))]),
-        AgentViewItem::SpaceName => {
+        SidebarAgentItem::SpaceName => {
             Some(vec![Span::styled(entry.primary_label.clone(), name_style)])
         }
-        AgentViewItem::Status => Some(vec![Span::styled(
+        SidebarAgentItem::Status => Some(vec![Span::styled(
             state_label(entry.state, entry.seen),
             status_style,
         )]),
-        AgentViewItem::Time => entry
+        SidebarAgentItem::Time => entry
             .working_duration
             .map(|duration| duration_value_spans(duration, p)),
-        AgentViewItem::CustomStatus => entry
+        SidebarAgentItem::CustomStatus => entry
             .custom_status
             .as_ref()
             .map(|status| vec![Span::styled(status.clone(), agent_style)]),
-        AgentViewItem::AgentName => entry
+        SidebarAgentItem::AgentName => entry
             .agent_label
             .as_ref()
             .map(|label| vec![Span::styled(label.clone(), agent_style)]),
-        AgentViewItem::RightAlignment => None,
+        SidebarAgentItem::RightAlignment => None,
     }?;
-    Some(spans_with_view_color(spans, item.color(&app.agent_view), p))
+    Some(spans_with_sidebar_color(
+        spans,
+        item.color(&app.sidebar_agent),
+        p,
+    ))
 }
 
-fn is_agent_identity_item(item: AgentViewItem) -> bool {
+fn is_agent_identity_item(item: SidebarAgentItem) -> bool {
     matches!(
         item,
-        AgentViewItem::PaneName | AgentViewItem::TabName | AgentViewItem::SpaceName
+        SidebarAgentItem::PaneName | SidebarAgentItem::TabName | SidebarAgentItem::SpaceName
     )
 }
 
-fn identity_items_keep_default_order(items: &[AgentViewItem]) -> bool {
+fn identity_items_keep_default_order(items: &[SidebarAgentItem]) -> bool {
     let mut next_default_idx = 0;
     for item in items {
         let Some(default_idx) = [
-            AgentViewItem::PaneName,
-            AgentViewItem::TabName,
-            AgentViewItem::SpaceName,
+            SidebarAgentItem::PaneName,
+            SidebarAgentItem::TabName,
+            SidebarAgentItem::SpaceName,
         ]
         .iter()
         .position(|candidate| candidate == item) else {
@@ -1527,11 +1545,11 @@ fn identity_items_keep_default_order(items: &[AgentViewItem]) -> bool {
         }
         next_default_idx = default_idx + 1;
     }
-    items.contains(&AgentViewItem::SpaceName)
+    items.contains(&SidebarAgentItem::SpaceName)
 }
 
 #[derive(Default)]
-struct AgentLineContent {
+struct SidebarAgentLineContent {
     left: Vec<Span<'static>>,
     right: Vec<Span<'static>>,
 }
@@ -1540,39 +1558,39 @@ fn push_agent_line_spans(
     spans: &mut Vec<Span<'static>>,
     previous_was_agent_status: &mut bool,
     item_spans: Vec<Span<'static>>,
-    item: AgentViewItem,
+    item: SidebarAgentItem,
     separator_style: Style,
 ) {
     push_space_separator(spans, previous_was_agent_status, separator_style);
     spans.extend(item_spans);
-    *previous_was_agent_status = item == AgentViewItem::AgentStatus;
+    *previous_was_agent_status = item == SidebarAgentItem::AgentStatus;
 }
 
-fn agent_line_content(
+fn sidebar_agent_line_content(
     entry: &AgentPanelEntry,
     app: &AppState,
-    line: ViewLine,
-    ordered_items: &[AgentViewItem],
+    line: SidebarLine,
     max_width: usize,
     name_style: Style,
     status_style: Style,
     agent_style: Style,
     p: &Palette,
-) -> AgentLineContent {
-    let mut content = AgentLineContent::default();
-    let line_items: Vec<_> = ordered_items
-        .iter()
-        .copied()
-        .filter(|item| item.line(&app.agent_view) == Some(line))
-        .collect();
+) -> SidebarAgentLineContent {
+    let mut content = SidebarAgentLineContent::default();
+    let line_items: Vec<SidebarItem<SidebarAgentItem>> = app
+        .sidebar_agent
+        .lines
+        .get(line.index())
+        .cloned()
+        .unwrap_or_default();
     let mut idx = 0;
     let mut right_aligned = false;
     let mut previous_left_was_agent_status = false;
     let mut previous_right_was_agent_status = false;
     while idx < line_items.len() {
-        let item = line_items[idx];
-        if item == AgentViewItem::RightAlignment {
-            if item.enabled(&app.agent_view) {
+        let item = line_items[idx].field;
+        if item == SidebarAgentItem::RightAlignment {
+            if line_items[idx].show {
                 right_aligned = true;
             }
             idx += 1;
@@ -1581,31 +1599,34 @@ fn agent_line_content(
         if is_agent_identity_item(item) {
             let end = line_items[idx..]
                 .iter()
-                .position(|candidate| !is_agent_identity_item(*candidate))
+                .position(|candidate| !is_agent_identity_item(candidate.field))
                 .map_or(line_items.len(), |offset| idx + offset);
-            let sequence = &line_items[idx..end];
-            if AgentViewItem::SpaceName.enabled(&app.agent_view)
-                && identity_items_keep_default_order(sequence)
+            let sequence: Vec<_> = line_items[idx..end]
+                .iter()
+                .map(|entry| entry.field)
+                .collect();
+            if SidebarAgentItem::SpaceName.enabled(&app.sidebar_agent)
+                && identity_items_keep_default_order(&sequence)
             {
-                let show_pane_name = sequence.contains(&AgentViewItem::PaneName)
-                    && AgentViewItem::PaneName.enabled(&app.agent_view);
-                let show_tab_name = sequence.contains(&AgentViewItem::TabName)
-                    && AgentViewItem::TabName.enabled(&app.agent_view);
-                let pane_style = style_with_view_color(
+                let show_pane_name = sequence.contains(&SidebarAgentItem::PaneName)
+                    && SidebarAgentItem::PaneName.enabled(&app.sidebar_agent);
+                let show_tab_name = sequence.contains(&SidebarAgentItem::TabName)
+                    && SidebarAgentItem::TabName.enabled(&app.sidebar_agent);
+                let pane_style = style_with_sidebar_color(
                     Style::default().fg(p.green),
-                    AgentViewItem::PaneName.color(&app.agent_view),
+                    SidebarAgentItem::PaneName.color(&app.sidebar_agent),
                     p.green,
                     p,
                 );
-                let tab_style = style_with_view_color(
+                let tab_style = style_with_sidebar_color(
                     Style::default().fg(p.mauve),
-                    AgentViewItem::TabName.color(&app.agent_view),
+                    SidebarAgentItem::TabName.color(&app.sidebar_agent),
                     p.mauve,
                     p,
                 );
-                let workspace_style = style_with_view_color(
+                let workspace_style = style_with_sidebar_color(
                     name_style,
-                    AgentViewItem::SpaceName.color(&app.agent_view),
+                    SidebarAgentItem::SpaceName.color(&app.sidebar_agent),
                     name_style.fg.unwrap_or(p.subtext0),
                     p,
                 );
@@ -1633,7 +1654,7 @@ fn agent_line_content(
                         &mut content.right,
                         &mut previous_right_was_agent_status,
                         item_spans,
-                        AgentViewItem::SpaceName,
+                        SidebarAgentItem::SpaceName,
                         agent_style,
                     );
                 } else {
@@ -1660,7 +1681,7 @@ fn agent_line_content(
                         &mut content.left,
                         &mut previous_left_was_agent_status,
                         item_spans,
-                        AgentViewItem::SpaceName,
+                        SidebarAgentItem::SpaceName,
                         agent_style,
                     );
                 }
@@ -1669,7 +1690,7 @@ fn agent_line_content(
             }
         }
         if let Some(item_spans) =
-            agent_item_spans(entry, app, item, name_style, status_style, agent_style, p)
+            sidebar_agent_item_spans(entry, app, item, name_style, status_style, agent_style, p)
         {
             if right_aligned {
                 push_agent_line_spans(
@@ -1725,7 +1746,7 @@ fn truncate_spans_to_width(spans: &[Span<'static>], max_width: usize) -> Vec<Spa
 }
 
 fn fixed_width_agent_line_spans(
-    mut content: AgentLineContent,
+    mut content: SidebarAgentLineContent,
     width: u16,
     fill_style: Style,
 ) -> Vec<Span<'static>> {
@@ -1758,7 +1779,7 @@ fn fixed_width_agent_line_spans(
 fn render_agent_line(
     frame: &mut Frame,
     rect: Rect,
-    content: AgentLineContent,
+    content: SidebarAgentLineContent,
     row_style: Style,
     right_style: Style,
 ) {
@@ -1807,7 +1828,7 @@ fn render_agent_line(
     }
 }
 
-pub(crate) fn settings_space_view_demo_lines(app: &AppState) -> Vec<Line<'static>> {
+pub(crate) fn settings_sidebar_space_demo_lines(app: &AppState) -> Vec<Line<'static>> {
     let p = &app.palette;
     let (status, status_style) = state_dot(AgentState::Working, true, p);
     let branch = "feature/sidebar";
@@ -1817,47 +1838,47 @@ pub(crate) fn settings_space_view_demo_lines(app: &AppState) -> Vec<Line<'static
     let branch_style = Style::default().fg(p.mauve);
     let mut lines = Vec::new();
 
-    for line in (0..app.space_view.lines.len().max(1)).map(ViewLine::from_index) {
+    for line in (0..app.sidebar_space.lines.len().max(1)).map(SidebarLine::from_index) {
         let mut content = Vec::new();
         let mut previous_was_status = false;
-        for item in ordered_space_view_items(&app.space_view)
+        for item in ordered_sidebar_space_items(&app.sidebar_space)
             .into_iter()
-            .filter(|item| item.line(&app.space_view) == line)
-            .filter(|item| item.enabled(&app.space_view))
+            .filter(|item| item.line(&app.sidebar_space) == line)
+            .filter(|item| item.enabled(&app.sidebar_space))
         {
             match item {
-                SpaceViewItem::Status => {
+                SidebarSpaceItem::Status => {
                     push_separator(&mut content, separator_style);
-                    let item_style = style_with_view_color(
+                    let item_style = style_with_sidebar_color(
                         status_style,
-                        item.color(&app.space_view),
+                        item.color(&app.sidebar_space),
                         status_style.fg.unwrap_or(p.accent),
                         p,
                     );
                     content.push(Span::styled(status, item_style));
                     previous_was_status = true;
                 }
-                SpaceViewItem::Name => {
+                SidebarSpaceItem::Name => {
                     push_space_separator(&mut content, &mut previous_was_status, separator_style);
-                    let item_style = style_with_view_color(
+                    let item_style = style_with_sidebar_color(
                         name_style,
-                        item.color(&app.space_view),
+                        item.color(&app.sidebar_space),
                         name_style.fg.unwrap_or(p.subtext0),
                         p,
                     );
                     content.push(Span::styled("demo-space", item_style));
                 }
-                SpaceViewItem::Branch => {
+                SidebarSpaceItem::Branch => {
                     push_space_separator(&mut content, &mut previous_was_status, separator_style);
-                    let item_style = style_with_view_color(
+                    let item_style = style_with_sidebar_color(
                         branch_style,
-                        item.color(&app.space_view),
+                        item.color(&app.sidebar_space),
                         branch_style.fg.unwrap_or(p.mauve),
                         p,
                     );
                     content.push(Span::styled(branch, item_style));
                 }
-                SpaceViewItem::BranchStatus => {
+                SidebarSpaceItem::BranchStatus => {
                     if let Some(parts) = branch_status.clone() {
                         push_space_separator(
                             &mut content,
@@ -1871,7 +1892,7 @@ pub(crate) fn settings_space_view_demo_lines(app: &AppState) -> Vec<Line<'static
                             content.push(Span::styled(
                                 label,
                                 Style::default()
-                                    .fg(p.view_color(item.color(&app.space_view), color)),
+                                    .fg(p.sidebar_color(item.color(&app.sidebar_space), color)),
                             ));
                         }
                     }
@@ -1894,11 +1915,11 @@ pub(crate) fn settings_space_view_demo_lines(app: &AppState) -> Vec<Line<'static
     lines
 }
 
-pub(crate) fn settings_agent_view_demo_width(app: &AppState) -> u16 {
+pub(crate) fn settings_sidebar_agent_demo_width(app: &AppState) -> u16 {
     app.view.sidebar_rect.width.max(app.sidebar_width).max(1)
 }
 
-pub(crate) fn settings_agent_view_demo_lines(app: &AppState, width: u16) -> Vec<Line<'static>> {
+pub(crate) fn settings_sidebar_agent_demo_lines(app: &AppState, width: u16) -> Vec<Line<'static>> {
     let p = &app.palette;
     let demos = [
         AgentPanelEntry {
@@ -1934,8 +1955,7 @@ pub(crate) fn settings_agent_view_demo_lines(app: &AppState, width: u16) -> Vec<
             }),
         },
     ];
-    let ordered_items = ordered_agent_view_items(&app.agent_view);
-    let render_lines = agent_view_render_lines(app);
+    let render_lines = sidebar_agent_render_lines(app);
     let mut lines = Vec::new();
 
     for entry in demos {
@@ -1945,11 +1965,10 @@ pub(crate) fn settings_agent_view_demo_lines(app: &AppState, width: u16) -> Vec<
         let agent_style = Style::default().fg(p.overlay0).add_modifier(Modifier::DIM);
         for (render_idx, line) in render_lines.iter().copied().enumerate() {
             let prefix = if render_idx == 0 { " " } else { "   " };
-            let mut content = agent_line_content(
+            let mut content = sidebar_agent_line_content(
                 &entry,
                 app,
                 line,
-                &ordered_items,
                 width.saturating_sub(prefix.len() as u16) as usize,
                 name_style,
                 status_style,
@@ -2017,14 +2036,13 @@ fn render_agent_detail(
 
     let mut row_y = body.y;
     let body_bottom = body.y + body.height;
-    let render_lines = agent_view_render_lines(app);
+    let render_lines = sidebar_agent_render_lines(app);
     for detail in details.iter().skip(app.agent_panel_scroll) {
         let entry_rows = render_lines.len() as u16;
         if row_y.saturating_add(entry_rows) > body_bottom {
             break;
         }
 
-        // Check if this agent entry corresponds to the active session
         let is_active = app.is_active_pane(detail.ws_idx, detail.tab_idx, detail.pane_id);
 
         let label_color = state_label_color(detail.state, detail.seen, p);
@@ -2047,14 +2065,12 @@ fn render_agent_detail(
         };
         let agent_style = Style::default().fg(p.overlay0).add_modifier(Modifier::DIM);
 
-        let ordered_items = ordered_agent_view_items(&app.agent_view);
         for (render_idx, line) in render_lines.iter().copied().enumerate() {
             let prefix = if render_idx == 0 { " " } else { "   " };
-            let mut content = agent_line_content(
+            let mut content = sidebar_agent_line_content(
                 detail,
                 app,
                 line,
-                &ordered_items,
                 body.width.saturating_sub(prefix.len() as u16) as usize,
                 name_style,
                 status_style,
@@ -2146,6 +2162,81 @@ mod tests {
         row.find(needle)
             .map(|byte_idx| row[..byte_idx].chars().count() as u16)
             .expect("substring should render")
+    }
+
+    fn root_terminal_id(app: &AppState) -> crate::terminal::TerminalId {
+        let pane = app.workspaces[0].tabs[0].root_pane;
+        app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone()
+    }
+
+    fn working_agent_app() -> AppState {
+        working_agent_app_at(std::time::Instant::now() - Duration::from_secs(132))
+    }
+
+    fn working_agent_app_at(start: std::time::Instant) -> AppState {
+        let mut app = AppState::test_new();
+        app.workspaces = vec![Workspace::test_new("herdr")];
+        app.ensure_test_terminals();
+        let terminal_id = root_terminal_id(&app);
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+        app
+    }
+
+    fn render_agent_detail_row(app: &AppState, width: u16, height: u16, row: u16) -> String {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, width, height),
+                )
+            })
+            .unwrap();
+        agent_entry_row_text(terminal.backend().buffer(), row, width)
+    }
+
+    #[test]
+    fn truncate_text_respects_display_width() {
+        assert_eq!(truncate_text("workspace", 6), "works…");
+        assert_eq!(truncate_text("작업중", 5), "작업…");
+        assert!(UnicodeWidthStr::width(truncate_text("작업중", 4).as_str()) <= 4);
+    }
+
+    #[test]
+    fn primary_label_segments_measure_display_width() {
+        let entry = AgentPanelEntry {
+            ws_idx: 0,
+            tab_idx: 0,
+            pane_id: crate::layout::PaneId::from_raw(1),
+            pane_label: Some("작업중".into()),
+            primary_label: "공간".into(),
+            primary_tab_label: Some("검토".into()),
+            agent_label: Some("codex".into()),
+            state: AgentState::Idle,
+            seen: true,
+            custom_status: None,
+            working_duration: None,
+        };
+
+        let label = format_agent_panel_primary_label_with_options(&entry, 10, true, true);
+
+        assert!(UnicodeWidthStr::width(label.as_str()) <= 10);
+        assert!(label.contains("…"));
     }
 
     #[test]
@@ -2284,14 +2375,15 @@ mod tests {
     #[test]
     fn settings_agent_demo_does_not_render_custom_status_outside_configured_fields() {
         let mut app = crate::app::state::AppState::test_new();
-        for item in crate::app::state::AGENT_VIEW_PLACEMENT_ITEMS {
-            item.set_enabled(&mut app.agent_view, false);
+        for item in crate::app::state::SIDEBAR_AGENT_ITEMS {
+            item.set_enabled(&mut app.sidebar_agent, false);
         }
-        crate::app::state::AgentViewItem::Status.set_enabled(&mut app.agent_view, true);
-        crate::app::state::AgentViewItem::AgentName.set_enabled(&mut app.agent_view, true);
-        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, false);
+        crate::app::state::SidebarAgentItem::Status.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::AgentName.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, false);
 
-        let rendered = settings_agent_view_demo_lines(&app, 32)
+        let rendered = settings_sidebar_agent_demo_lines(&app, 32)
             .iter()
             .map(line_text)
             .collect::<Vec<_>>()
@@ -2304,7 +2396,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_view_custom_status_follows_right_alignment_marker() {
+    fn sidebar_agent_custom_status_follows_right_alignment_marker() {
         let mut app = crate::app::state::AppState::test_new();
         let config: crate::config::Config = toml::from_str(
             r#"
@@ -2325,7 +2417,7 @@ lines = [
 "#,
         )
         .unwrap();
-        app.agent_view = config.ui.sidebar.agents;
+        app.sidebar_agent = config.ui.sidebar.agents;
         let workspace = Workspace::test_new("herdr");
         let pane = workspace.tabs[0].root_pane;
 
@@ -2366,10 +2458,12 @@ lines = [
     }
 
     #[test]
-    fn agent_view_color_preset_overrides_configured_item_color() {
+    fn sidebar_agent_color_preset_overrides_configured_item_color() {
         let mut app = crate::app::state::AppState::test_new();
-        crate::app::state::AgentViewItem::AgentName
-            .set_color(&mut app.agent_view, crate::config::ViewColorPreset::Cool);
+        crate::app::state::SidebarAgentItem::AgentName.set_color(
+            &mut app.sidebar_agent,
+            crate::config::SidebarColorPreset::Cool,
+        );
         let workspace = Workspace::test_new("herdr");
         let pane = workspace.tabs[0].root_pane;
 
@@ -2710,87 +2804,23 @@ lines = [
 
     #[test]
     fn status_row_keeps_agent_label_right_aligned_with_working_duration() {
-        let mut app = crate::app::state::AppState::test_new();
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
-        let backend = ratatui::backend::TestBackend::new(40, 8);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                render_agent_detail(
-                    &app,
-                    &TerminalRuntimeRegistry::new(),
-                    frame,
-                    Rect::new(0, 0, 40, 8),
-                )
-            })
-            .unwrap();
-        let row = agent_entry_row_text(terminal.backend().buffer(), 4, 40);
+        let app = working_agent_app();
+        let row = render_agent_detail_row(&app, 40, 8, 4);
 
         assert!(row.contains("   working · 2m12s"), "status row: {row:?}");
         assert!(row.ends_with("codex"), "status row: {row:?}");
     }
 
     #[test]
-    fn agent_view_can_hide_time_without_disabling_right_alignment() {
-        let mut app = crate::app::state::AppState::test_new();
-        crate::app::state::AgentViewItem::Time.set_enabled(&mut app.agent_view, false);
-        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, true);
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
+    fn sidebar_agent_can_hide_time_without_disabling_right_alignment() {
+        let mut app = working_agent_app();
+        crate::app::state::SidebarAgentItem::Time.set_enabled(&mut app.sidebar_agent, false);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, true);
+        let terminal_id = root_terminal_id(&app);
         let terminal = app.terminals.get_mut(&terminal_id).unwrap();
         terminal.set_manual_label("Echo".into());
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
-        let backend = ratatui::backend::TestBackend::new(40, 8);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                render_agent_detail(
-                    &app,
-                    &TerminalRuntimeRegistry::new(),
-                    frame,
-                    Rect::new(0, 0, 40, 8),
-                )
-            })
-            .unwrap();
-        let buffer = terminal.backend().buffer();
-        let status_row = agent_entry_row_text(buffer, 4, 40);
+        let status_row = render_agent_detail_row(&app, 40, 8, 4);
 
         assert!(
             status_row.contains("   working"),
@@ -2801,45 +2831,12 @@ lines = [
     }
 
     #[test]
-    fn agent_view_can_disable_right_alignment_without_hiding_time() {
-        let mut app = crate::app::state::AppState::test_new();
-        crate::app::state::AgentViewItem::Time.set_enabled(&mut app.agent_view, true);
-        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, false);
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
-        let backend = ratatui::backend::TestBackend::new(40, 8);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                render_agent_detail(
-                    &app,
-                    &TerminalRuntimeRegistry::new(),
-                    frame,
-                    Rect::new(0, 0, 40, 8),
-                )
-            })
-            .unwrap();
-        let buffer = terminal.backend().buffer();
-        let status_row = agent_entry_row_text(buffer, 4, 40);
+    fn sidebar_agent_can_disable_right_alignment_without_hiding_time() {
+        let mut app = working_agent_app();
+        crate::app::state::SidebarAgentItem::Time.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, false);
+        let status_row = render_agent_detail_row(&app, 40, 8, 4);
 
         assert!(
             status_row.contains("   working · 2m12s · codex"),
@@ -2848,46 +2845,14 @@ lines = [
     }
 
     #[test]
-    fn agent_view_right_alignment_marker_aligns_items_after_it() {
-        let mut app = crate::app::state::AppState::test_new();
-        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, true);
-        crate::app::state::AgentViewItem::RightAlignment.set_order(&mut app.agent_view, 1);
-        crate::app::state::AgentViewItem::Time.set_order(&mut app.agent_view, 2);
-        crate::app::state::AgentViewItem::AgentName.set_order(&mut app.agent_view, 3);
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
-        let backend = ratatui::backend::TestBackend::new(40, 8);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                render_agent_detail(
-                    &app,
-                    &TerminalRuntimeRegistry::new(),
-                    frame,
-                    Rect::new(0, 0, 40, 8),
-                )
-            })
-            .unwrap();
-        let status_row = agent_entry_row_text(terminal.backend().buffer(), 4, 40);
+    fn sidebar_agent_right_alignment_marker_aligns_items_after_it() {
+        let mut app = working_agent_app();
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::RightAlignment.set_order(&mut app.sidebar_agent, 1);
+        crate::app::state::SidebarAgentItem::Time.set_order(&mut app.sidebar_agent, 2);
+        crate::app::state::SidebarAgentItem::AgentName.set_order(&mut app.sidebar_agent, 3);
+        let status_row = render_agent_detail_row(&app, 40, 8, 4);
 
         assert!(
             status_row.contains("   working"),
@@ -2900,64 +2865,33 @@ lines = [
     }
 
     #[test]
-    fn agent_view_line_order_can_move_time_to_first_row() {
-        let mut app = crate::app::state::AppState::test_new();
-        crate::app::state::AgentViewItem::AgentStatus.set_enabled(&mut app.agent_view, false);
-        crate::app::state::AgentViewItem::Time
-            .set_line(&mut app.agent_view, crate::app::state::ViewLine::First);
-        crate::app::state::AgentViewItem::Time.set_order(&mut app.agent_view, 0);
-        crate::app::state::AgentViewItem::PaneName.set_order(&mut app.agent_view, 1);
-        crate::app::state::AgentViewItem::TabName.set_order(&mut app.agent_view, 2);
-        crate::app::state::AgentViewItem::SpaceName.set_order(&mut app.agent_view, 3);
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
+    fn sidebar_agent_line_order_can_move_time_to_first_row() {
+        let mut app = working_agent_app();
+        crate::app::state::SidebarAgentItem::AgentStatus.set_enabled(&mut app.sidebar_agent, false);
+        crate::app::state::SidebarAgentItem::Time.set_line(
+            &mut app.sidebar_agent,
+            crate::app::state::SidebarLine::First,
         );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
-        let backend = ratatui::backend::TestBackend::new(40, 8);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                render_agent_detail(
-                    &app,
-                    &TerminalRuntimeRegistry::new(),
-                    frame,
-                    Rect::new(0, 0, 40, 8),
-                )
-            })
-            .unwrap();
-        let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
+        crate::app::state::SidebarAgentItem::Time.set_order(&mut app.sidebar_agent, 0);
+        crate::app::state::SidebarAgentItem::PaneName.set_order(&mut app.sidebar_agent, 1);
+        crate::app::state::SidebarAgentItem::TabName.set_order(&mut app.sidebar_agent, 2);
+        crate::app::state::SidebarAgentItem::SpaceName.set_order(&mut app.sidebar_agent, 3);
+        let first_row = render_agent_detail_row(&app, 40, 8, 3);
 
         assert!(first_row.contains("2m12s · herdr"), "row: {first_row:?}");
     }
 
     #[test]
-    fn agent_view_reorders_identity_items_in_agents_panel() {
+    fn sidebar_agent_reorders_identity_items_in_agents_panel() {
         let mut app = crate::app::state::AppState::test_new();
         let mut workspace = Workspace::test_new("herdr");
         workspace.tabs[0].custom_name = Some("main".into());
         let pane = workspace.tabs[0].root_pane;
         workspace.test_add_tab(Some("2"));
 
-        crate::app::state::AgentViewItem::TabName.set_order(&mut app.agent_view, 1);
-        crate::app::state::AgentViewItem::PaneName.set_order(&mut app.agent_view, 2);
-        crate::app::state::AgentViewItem::SpaceName.set_order(&mut app.agent_view, 3);
+        crate::app::state::SidebarAgentItem::TabName.set_order(&mut app.sidebar_agent, 1);
+        crate::app::state::SidebarAgentItem::PaneName.set_order(&mut app.sidebar_agent, 2);
+        crate::app::state::SidebarAgentItem::SpaceName.set_order(&mut app.sidebar_agent, 3);
         app.workspaces = vec![workspace];
         app.ensure_test_terminals();
         let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
@@ -2989,17 +2923,20 @@ lines = [
     }
 
     #[test]
-    fn agent_view_can_move_pane_name_to_second_row() {
+    fn sidebar_agent_can_move_pane_name_to_second_row() {
         let mut app = crate::app::state::AppState::test_new();
         let mut workspace = Workspace::test_new("herdr");
         workspace.tabs[0].custom_name = Some("main".into());
         let pane = workspace.tabs[0].root_pane;
         workspace.test_add_tab(Some("2"));
 
-        crate::app::state::AgentViewItem::PaneName
-            .set_line(&mut app.agent_view, crate::app::state::ViewLine::Second);
-        crate::app::state::AgentViewItem::PaneName.set_order(&mut app.agent_view, 3);
-        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, false);
+        crate::app::state::SidebarAgentItem::PaneName.set_line(
+            &mut app.sidebar_agent,
+            crate::app::state::SidebarLine::Second,
+        );
+        crate::app::state::SidebarAgentItem::PaneName.set_order(&mut app.sidebar_agent, 3);
+        crate::app::state::SidebarAgentItem::RightAlignment
+            .set_enabled(&mut app.sidebar_agent, false);
         app.workspaces = vec![workspace];
         app.ensure_test_terminals();
         let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
@@ -3031,7 +2968,7 @@ lines = [
     }
 
     #[test]
-    fn agent_view_can_hide_and_move_agent_status_indicator() {
+    fn sidebar_agent_can_hide_and_move_agent_status_indicator() {
         let mut app = crate::app::state::AppState::test_new();
         let workspace = Workspace::test_new("herdr");
         let pane = workspace.tabs[0].root_pane;
@@ -3062,7 +2999,7 @@ lines = [
         let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
         assert!(first_row.contains("✓ herdr"), "row: {first_row:?}");
 
-        crate::app::state::AgentViewItem::AgentStatus.set_enabled(&mut app.agent_view, false);
+        crate::app::state::SidebarAgentItem::AgentStatus.set_enabled(&mut app.sidebar_agent, false);
         terminal
             .draw(|frame| {
                 render_agent_detail(
@@ -3076,13 +3013,15 @@ lines = [
         let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
         assert!(!first_row.contains("✓"), "row: {first_row:?}");
 
-        crate::app::state::AgentViewItem::AgentStatus.set_enabled(&mut app.agent_view, true);
-        crate::app::state::AgentViewItem::AgentStatus
-            .set_line(&mut app.agent_view, crate::app::state::ViewLine::Second);
-        crate::app::state::AgentViewItem::AgentStatus.set_order(&mut app.agent_view, 0);
-        crate::app::state::AgentViewItem::Status.set_order(&mut app.agent_view, 1);
-        crate::app::state::AgentViewItem::Time.set_order(&mut app.agent_view, 2);
-        crate::app::state::AgentViewItem::AgentName.set_order(&mut app.agent_view, 3);
+        crate::app::state::SidebarAgentItem::AgentStatus.set_enabled(&mut app.sidebar_agent, true);
+        crate::app::state::SidebarAgentItem::AgentStatus.set_line(
+            &mut app.sidebar_agent,
+            crate::app::state::SidebarLine::Second,
+        );
+        crate::app::state::SidebarAgentItem::AgentStatus.set_order(&mut app.sidebar_agent, 0);
+        crate::app::state::SidebarAgentItem::Status.set_order(&mut app.sidebar_agent, 1);
+        crate::app::state::SidebarAgentItem::Time.set_order(&mut app.sidebar_agent, 2);
+        crate::app::state::SidebarAgentItem::AgentName.set_order(&mut app.sidebar_agent, 3);
         terminal
             .draw(|frame| {
                 render_agent_detail(
@@ -3102,37 +3041,18 @@ lines = [
     }
 
     #[test]
-    fn agent_view_renders_one_configured_line_from_config_model() {
-        let mut app = crate::app::state::AppState::test_new();
-        app.agent_view.lines = vec![vec![
-            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentStatus),
-            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::SpaceName),
-            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Status),
-            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Time),
-            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::RightAlignment),
-            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentName),
+    fn sidebar_agent_renders_one_configured_line_from_config_model() {
+        let mut app = working_agent_app();
+        app.sidebar_agent.lines = vec![vec![
+            crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::AgentStatus),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::SpaceName),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::Status),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::Time),
+            crate::config::SidebarItem::visible(
+                crate::app::state::SidebarAgentItem::RightAlignment,
+            ),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::AgentName),
         ]];
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
         let backend = ratatui::backend::TestBackend::new(40, 8);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
@@ -3158,43 +3078,26 @@ lines = [
     }
 
     #[test]
-    fn agent_view_renders_three_configured_lines_from_config_model() {
-        let mut app = crate::app::state::AppState::test_new();
-        app.agent_view.lines = vec![
+    fn sidebar_agent_renders_three_configured_lines_from_config_model() {
+        let mut app = working_agent_app();
+        app.sidebar_agent.lines = vec![
             vec![
-                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentStatus),
-                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::SpaceName),
+                crate::config::SidebarItem::visible(
+                    crate::app::state::SidebarAgentItem::AgentStatus,
+                ),
+                crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::SpaceName),
             ],
             vec![
-                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Status),
-                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Time),
+                crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::Status),
+                crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::Time),
             ],
             vec![
-                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::RightAlignment),
-                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentName),
+                crate::config::SidebarItem::visible(
+                    crate::app::state::SidebarAgentItem::RightAlignment,
+                ),
+                crate::config::SidebarItem::visible(crate::app::state::SidebarAgentItem::AgentName),
             ],
         ];
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
-        let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
-
         let backend = ratatui::backend::TestBackend::new(40, 9);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
@@ -3221,14 +3124,15 @@ lines = [
     }
 
     #[test]
-    fn spaces_view_can_hide_branch_status_without_hiding_branch() {
+    fn sidebar_space_can_hide_branch_status_without_hiding_branch() {
         let mut app = crate::app::state::AppState::test_new();
         let mut workspace = Workspace::test_new("herdr");
         workspace.cached_git_branch = Some("main".into());
         workspace.cached_git_ahead_behind = Some((2, 1));
         app.workspaces = vec![workspace];
-        crate::app::state::SpaceViewItem::Branch.set_enabled(&mut app.space_view, true);
-        crate::app::state::SpaceViewItem::BranchStatus.set_enabled(&mut app.space_view, false);
+        crate::app::state::SidebarSpaceItem::Branch.set_enabled(&mut app.sidebar_space, true);
+        crate::app::state::SidebarSpaceItem::BranchStatus
+            .set_enabled(&mut app.sidebar_space, false);
         app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
             ws_idx: 0,
             rect: Rect::new(0, 2, 40, 2),
@@ -3256,16 +3160,16 @@ lines = [
     }
 
     #[test]
-    fn spaces_view_renders_one_row_when_config_places_all_items_on_one_line() {
+    fn sidebar_space_renders_one_row_when_config_places_all_items_on_one_line() {
         let mut app = crate::app::state::AppState::test_new();
         let mut workspace = Workspace::test_new("herdr");
         workspace.cached_git_branch = Some("main".into());
         workspace.cached_git_ahead_behind = Some((2, 1));
-        app.space_view.lines = vec![vec![
-            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::Status),
-            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::Name),
-            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::Branch),
-            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::BranchStatus),
+        app.sidebar_space.lines = vec![vec![
+            crate::config::SidebarItem::visible(crate::app::state::SidebarSpaceItem::Status),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarSpaceItem::Name),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarSpaceItem::Branch),
+            crate::config::SidebarItem::visible(crate::app::state::SidebarSpaceItem::BranchStatus),
         ]];
         app.workspaces = vec![workspace];
         app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
@@ -3297,17 +3201,20 @@ lines = [
     }
 
     #[test]
-    fn spaces_view_line_order_can_move_branch_to_first_row() {
+    fn sidebar_space_line_order_can_move_branch_to_first_row() {
         let mut app = crate::app::state::AppState::test_new();
         let mut workspace = Workspace::test_new("herdr");
         workspace.cached_git_branch = Some("main".into());
         app.workspaces = vec![workspace];
-        crate::app::state::SpaceViewItem::Status.set_enabled(&mut app.space_view, false);
-        crate::app::state::SpaceViewItem::Branch
-            .set_line(&mut app.space_view, crate::app::state::ViewLine::First);
-        crate::app::state::SpaceViewItem::Branch.set_order(&mut app.space_view, 0);
-        crate::app::state::SpaceViewItem::Name.set_order(&mut app.space_view, 1);
-        crate::app::state::SpaceViewItem::BranchStatus.set_enabled(&mut app.space_view, false);
+        crate::app::state::SidebarSpaceItem::Status.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::Branch.set_line(
+            &mut app.sidebar_space,
+            crate::app::state::SidebarLine::First,
+        );
+        crate::app::state::SidebarSpaceItem::Branch.set_order(&mut app.sidebar_space, 0);
+        crate::app::state::SidebarSpaceItem::Name.set_order(&mut app.sidebar_space, 1);
+        crate::app::state::SidebarSpaceItem::BranchStatus
+            .set_enabled(&mut app.sidebar_space, false);
         app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
             ws_idx: 0,
             rect: Rect::new(0, 2, 40, 1),
@@ -3333,7 +3240,7 @@ lines = [
     }
 
     #[test]
-    fn spaces_view_can_hide_status_without_hiding_name() {
+    fn sidebar_space_can_hide_status_without_hiding_name() {
         let mut app = crate::app::state::AppState::test_new();
         let workspace = Workspace::test_new("herdr");
         let pane = workspace.tabs[0].root_pane;
@@ -3343,8 +3250,8 @@ lines = [
             .attached_terminal_id
             .clone();
         app.terminals.get_mut(&terminal_id).unwrap().detected_agent = Some(Agent::Codex);
-        crate::app::state::SpaceViewItem::Status.set_enabled(&mut app.space_view, false);
-        crate::app::state::SpaceViewItem::Name.set_enabled(&mut app.space_view, true);
+        crate::app::state::SidebarSpaceItem::Status.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::Name.set_enabled(&mut app.sidebar_space, true);
         app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
             ws_idx: 0,
             rect: Rect::new(0, 2, 40, 1),
@@ -3371,13 +3278,53 @@ lines = [
     }
 
     #[test]
-    fn spaces_view_can_hide_space_name_and_branch() {
+    fn sidebar_space_preserves_blank_first_row_when_first_line_items_hidden() {
         let mut app = crate::app::state::AppState::test_new();
         let mut workspace = Workspace::test_new("herdr");
         workspace.cached_git_branch = Some("main".into());
         app.workspaces = vec![workspace];
-        crate::app::state::SpaceViewItem::Name.set_enabled(&mut app.space_view, false);
-        crate::app::state::SpaceViewItem::Branch.set_enabled(&mut app.space_view, false);
+        crate::app::state::SidebarSpaceItem::Status.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::Name.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::Branch.set_enabled(&mut app.sidebar_space, true);
+        crate::app::state::SidebarSpaceItem::BranchStatus
+            .set_enabled(&mut app.sidebar_space, false);
+        app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
+            ws_idx: 0,
+            rect: Rect::new(0, 2, 40, 2),
+            indented: false,
+        }];
+
+        assert_eq!(workspace_row_height(&app, &app.workspaces[0]), 2);
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                    false,
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let first_row = agent_entry_row_text(buffer, 2, 40);
+        let second_row = agent_entry_row_text(buffer, 3, 40);
+
+        assert!(!first_row.contains("main"), "first row: {first_row:?}");
+        assert!(second_row.contains("main"), "second row: {second_row:?}");
+    }
+
+    #[test]
+    fn sidebar_space_can_hide_space_name_and_branch() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.cached_git_branch = Some("main".into());
+        app.workspaces = vec![workspace];
+        crate::app::state::SidebarSpaceItem::Name.set_enabled(&mut app.sidebar_space, false);
+        crate::app::state::SidebarSpaceItem::Branch.set_enabled(&mut app.sidebar_space, false);
         app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
             ws_idx: 0,
             rect: Rect::new(0, 2, 40, 1),
@@ -3407,26 +3354,10 @@ lines = [
 
     #[test]
     fn stale_status_duration_is_dimmed_after_working_finishes() {
-        let mut app = crate::app::state::AppState::test_new();
-        let workspace = Workspace::test_new("herdr");
-        let pane = workspace.tabs[0].root_pane;
-
-        app.workspaces = vec![workspace];
-        app.ensure_test_terminals();
-        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
-            .attached_terminal_id
-            .clone();
-        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
         let start = std::time::Instant::now() - Duration::from_secs(132);
-        terminal.set_detected_state_with_screen_signals_at(
-            Some(Agent::Codex),
-            AgentState::Working,
-            false,
-            false,
-            true,
-            false,
-            start,
-        );
+        let mut app = working_agent_app_at(start);
+        let terminal_id = root_terminal_id(&app);
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
         terminal.set_detected_state_with_screen_signals_at(
             Some(Agent::Codex),
             AgentState::Idle,
@@ -3436,7 +3367,6 @@ lines = [
             false,
             start + Duration::from_secs(132),
         );
-        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
 
         let backend = ratatui::backend::TestBackend::new(40, 8);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,6 +1,8 @@
+use std::time::Duration;
+
 use ratatui::{
     layout::{Alignment, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
@@ -8,10 +10,15 @@ use ratatui::{
 
 use super::scrollbar::{render_scrollbar, should_show_scrollbar};
 use super::status::{agent_icon, state_dot, state_label, state_label_color};
-use crate::app::state::{AgentPanelScope, Palette};
+use crate::app::state::{
+    ordered_agent_view_items, ordered_space_view_items, AgentPanelScope, AgentViewItem, Palette,
+    SpaceViewItem, ViewLine,
+};
 use crate::app::{AppState, Mode};
+use crate::config::ViewColorPreset;
 use crate::detect::AgentState;
-use crate::terminal::TerminalRuntimeRegistry;
+use crate::terminal::{TerminalRuntimeRegistry, WorkingDuration};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const WORKSPACE_SECTION_HEADER_ROWS: u16 = 2;
 const AGENT_PANEL_HEADER_ROWS: u16 = 3;
@@ -20,12 +27,14 @@ pub(crate) struct AgentPanelEntry {
     pub ws_idx: usize,
     pub tab_idx: usize,
     pub pane_id: crate::layout::PaneId,
+    pub pane_label: Option<String>,
     pub primary_label: String,
     pub primary_tab_label: Option<String>,
     pub agent_label: Option<String>,
     pub state: AgentState,
     pub seen: bool,
     pub custom_status: Option<String>,
+    pub working_duration: Option<WorkingDuration>,
 }
 
 fn sidebar_section_heights(total_h: u16, split_ratio: f32) -> (u16, u16) {
@@ -141,18 +150,30 @@ fn agent_panel_entries_with_runtimes(
             let Some(ws) = app.workspaces.get(ws_idx) else {
                 return Vec::new();
             };
+            let multi_tab = ws.tabs.len() > 1;
+            let workspace_label = ws.display_name_from(&app.terminals, terminal_runtimes);
             ws.pane_details(&app.terminals)
                 .into_iter()
-                .map(|detail| AgentPanelEntry {
-                    ws_idx,
-                    tab_idx: detail.tab_idx,
-                    pane_id: detail.pane_id,
-                    primary_label: detail.label,
-                    primary_tab_label: None,
-                    agent_label: None,
-                    state: detail.state,
-                    seen: detail.seen,
-                    custom_status: detail.custom_status,
+                .map(|detail| {
+                    let has_pane_label = detail.pane_label.is_some();
+                    AgentPanelEntry {
+                        ws_idx,
+                        tab_idx: detail.tab_idx,
+                        pane_id: detail.pane_id,
+                        pane_label: detail.pane_label,
+                        primary_label: if has_pane_label {
+                            workspace_label.clone()
+                        } else {
+                            detail.label
+                        },
+                        primary_tab_label: (has_pane_label && multi_tab)
+                            .then_some(detail.tab_label),
+                        agent_label: Some(detail.agent_label),
+                        state: detail.state,
+                        seen: detail.seen,
+                        custom_status: detail.custom_status,
+                        working_duration: detail.working_duration,
+                    }
                 })
                 .collect()
         }
@@ -169,12 +190,14 @@ fn agent_panel_entries_with_runtimes(
                         ws_idx,
                         tab_idx: detail.tab_idx,
                         pane_id: detail.pane_id,
+                        pane_label: detail.pane_label,
                         primary_label: workspace_label.clone(),
                         primary_tab_label: multi_tab.then_some(detail.tab_label),
                         agent_label: Some(detail.agent_label),
                         state: detail.state,
                         seen: detail.seen,
                         custom_status: detail.custom_status,
+                        working_duration: detail.working_duration,
                     })
             })
             .collect(),
@@ -196,56 +219,394 @@ fn truncate_text(text: &str, max_width: usize) -> String {
     format!("{prefix}…")
 }
 
-fn format_agent_panel_primary_label(entry: &AgentPanelEntry, max_width: usize) -> String {
-    let Some(tab_label) = entry.primary_tab_label.as_deref() else {
-        return truncate_text(&entry.primary_label, max_width);
-    };
-
-    let separator = " · ";
-    let separator_width = separator.chars().count();
-    if max_width <= separator_width + 2 {
-        return truncate_text(
-            &format!("{}{}{}", entry.primary_label, separator, tab_label),
-            max_width,
-        );
-    }
-
-    let available = max_width.saturating_sub(separator_width);
-    let min_tab = 4.min(available.saturating_sub(1)).max(1);
-    let preferred_workspace = ((available * 2) / 3).max(1);
-    let mut workspace_budget = preferred_workspace
-        .min(available.saturating_sub(min_tab))
-        .max(1);
-    let mut tab_budget = available.saturating_sub(workspace_budget);
-
-    let workspace_len = entry.primary_label.chars().count();
-    let tab_len = tab_label.chars().count();
-
-    if workspace_len < workspace_budget {
-        let spare = workspace_budget - workspace_len;
-        workspace_budget = workspace_len;
-        tab_budget = (tab_budget + spare).min(available.saturating_sub(workspace_budget));
-    }
-    if tab_len < tab_budget {
-        let spare = tab_budget - tab_len;
-        tab_budget = tab_len;
-        workspace_budget = (workspace_budget + spare).min(available.saturating_sub(tab_budget));
-    }
-
-    format!(
-        "{}{}{}",
-        truncate_text(&entry.primary_label, workspace_budget),
-        separator,
-        truncate_text(tab_label, tab_budget)
-    )
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentPanelPrimarySegmentKind {
+    Pane,
+    Tab,
+    Workspace,
+    Separator,
 }
 
-fn workspace_row_height(ws: &crate::workspace::Workspace) -> u16 {
-    if ws.branch().is_some() {
-        2
-    } else {
-        1
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentPanelPrimarySegment {
+    text: String,
+    kind: AgentPanelPrimarySegmentKind,
+}
+
+impl AgentPanelPrimarySegment {
+    fn new(text: impl Into<String>, kind: AgentPanelPrimarySegmentKind) -> Self {
+        Self {
+            text: text.into(),
+            kind,
+        }
     }
+}
+
+fn push_full_primary_segments(
+    segments: &mut Vec<AgentPanelPrimarySegment>,
+    pane_label: &str,
+    tab_label: Option<&str>,
+    workspace_label: &str,
+) {
+    let separator = " · ";
+    segments.push(AgentPanelPrimarySegment::new(
+        pane_label,
+        AgentPanelPrimarySegmentKind::Pane,
+    ));
+    if let Some(tab_label) = tab_label {
+        segments.push(AgentPanelPrimarySegment::new(
+            separator,
+            AgentPanelPrimarySegmentKind::Separator,
+        ));
+        segments.push(AgentPanelPrimarySegment::new(
+            tab_label,
+            AgentPanelPrimarySegmentKind::Tab,
+        ));
+    }
+    segments.push(AgentPanelPrimarySegment::new(
+        separator,
+        AgentPanelPrimarySegmentKind::Separator,
+    ));
+    segments.push(AgentPanelPrimarySegment::new(
+        workspace_label,
+        AgentPanelPrimarySegmentKind::Workspace,
+    ));
+}
+
+fn truncated_pane_side_segments(
+    pane_label: &str,
+    tab_label: Option<&str>,
+    max_width: usize,
+) -> Vec<AgentPanelPrimarySegment> {
+    let separator = " · ";
+    let separator_width = separator.chars().count();
+    let Some(tab_label) = tab_label else {
+        return vec![AgentPanelPrimarySegment::new(
+            truncate_text(pane_label, max_width),
+            AgentPanelPrimarySegmentKind::Pane,
+        )];
+    };
+
+    let tab_width = tab_label.chars().count();
+    let full_side = format!("{pane_label}{separator}{tab_label}");
+    if full_side.chars().count() <= max_width {
+        return vec![
+            AgentPanelPrimarySegment::new(pane_label, AgentPanelPrimarySegmentKind::Pane),
+            AgentPanelPrimarySegment::new(separator, AgentPanelPrimarySegmentKind::Separator),
+            AgentPanelPrimarySegment::new(tab_label, AgentPanelPrimarySegmentKind::Tab),
+        ];
+    }
+
+    if max_width > separator_width + tab_width {
+        let pane_width = max_width - separator_width - tab_width;
+        return vec![
+            AgentPanelPrimarySegment::new(
+                truncate_text(pane_label, pane_width),
+                AgentPanelPrimarySegmentKind::Pane,
+            ),
+            AgentPanelPrimarySegment::new(separator, AgentPanelPrimarySegmentKind::Separator),
+            AgentPanelPrimarySegment::new(tab_label, AgentPanelPrimarySegmentKind::Tab),
+        ];
+    }
+
+    vec![AgentPanelPrimarySegment::new(
+        truncate_text(&full_side, max_width),
+        AgentPanelPrimarySegmentKind::Pane,
+    )]
+}
+
+fn agent_panel_primary_label_segments_with_options(
+    entry: &AgentPanelEntry,
+    max_width: usize,
+    show_pane_name: bool,
+    show_tab_name: bool,
+) -> Vec<AgentPanelPrimarySegment> {
+    let separator = " · ";
+    let separator_width = separator.chars().count();
+    let pane_label = show_pane_name
+        .then_some(entry.pane_label.as_deref())
+        .flatten();
+    let tab_label = show_tab_name
+        .then_some(entry.primary_tab_label.as_deref())
+        .flatten();
+    let Some(pane_label) = pane_label else {
+        let Some(tab_label) = tab_label else {
+            return vec![AgentPanelPrimarySegment::new(
+                truncate_text(&entry.primary_label, max_width),
+                AgentPanelPrimarySegmentKind::Workspace,
+            )];
+        };
+
+        let full = format!("{tab_label}{separator}{}", entry.primary_label);
+        if full.chars().count() <= max_width {
+            return vec![
+                AgentPanelPrimarySegment::new(tab_label, AgentPanelPrimarySegmentKind::Tab),
+                AgentPanelPrimarySegment::new(separator, AgentPanelPrimarySegmentKind::Separator),
+                AgentPanelPrimarySegment::new(
+                    entry.primary_label.clone(),
+                    AgentPanelPrimarySegmentKind::Workspace,
+                ),
+            ];
+        }
+
+        let workspace_width = entry.primary_label.chars().count();
+        if max_width > workspace_width + separator_width {
+            let tab_width = max_width - workspace_width - separator_width;
+            return vec![
+                AgentPanelPrimarySegment::new(
+                    truncate_text(tab_label, tab_width),
+                    AgentPanelPrimarySegmentKind::Tab,
+                ),
+                AgentPanelPrimarySegment::new(separator, AgentPanelPrimarySegmentKind::Separator),
+                AgentPanelPrimarySegment::new(
+                    entry.primary_label.clone(),
+                    AgentPanelPrimarySegmentKind::Workspace,
+                ),
+            ];
+        }
+
+        return vec![AgentPanelPrimarySegment::new(
+            truncate_text(&full, max_width),
+            AgentPanelPrimarySegmentKind::Workspace,
+        )];
+    };
+
+    let side = match tab_label {
+        Some(tab_label) => format!("{pane_label}{separator}{tab_label}"),
+        None => pane_label.to_string(),
+    };
+    let full = format!("{side}{separator}{}", entry.primary_label);
+    if full.chars().count() <= max_width {
+        let mut segments = Vec::new();
+        push_full_primary_segments(&mut segments, pane_label, tab_label, &entry.primary_label);
+        return segments;
+    }
+
+    let workspace_width = entry.primary_label.chars().count();
+    let min_named_side_width = 1;
+    if max_width >= workspace_width + separator_width + min_named_side_width {
+        let side_width = max_width - workspace_width - separator_width;
+        let mut segments = truncated_pane_side_segments(pane_label, tab_label, side_width);
+        segments.push(AgentPanelPrimarySegment::new(
+            separator,
+            AgentPanelPrimarySegmentKind::Separator,
+        ));
+        segments.push(AgentPanelPrimarySegment::new(
+            entry.primary_label.clone(),
+            AgentPanelPrimarySegmentKind::Workspace,
+        ));
+        return segments;
+    }
+
+    vec![AgentPanelPrimarySegment::new(
+        truncate_text(&full, max_width),
+        AgentPanelPrimarySegmentKind::Workspace,
+    )]
+}
+
+pub(super) fn format_agent_panel_primary_label(
+    entry: &AgentPanelEntry,
+    max_width: usize,
+) -> String {
+    format_agent_panel_primary_label_with_options(entry, max_width, true, true)
+}
+
+fn format_agent_panel_primary_label_with_options(
+    entry: &AgentPanelEntry,
+    max_width: usize,
+    show_pane_name: bool,
+    show_tab_name: bool,
+) -> String {
+    agent_panel_primary_label_segments_with_options(entry, max_width, show_pane_name, show_tab_name)
+        .into_iter()
+        .map(|segment| segment.text)
+        .collect()
+}
+
+fn agent_panel_primary_label_spans(
+    entry: &AgentPanelEntry,
+    max_width: usize,
+    show_pane_name: bool,
+    show_tab_name: bool,
+    pane_style: Style,
+    tab_style: Style,
+    workspace_style: Style,
+    p: &Palette,
+) -> Vec<Span<'static>> {
+    agent_panel_primary_label_segments_with_options(entry, max_width, show_pane_name, show_tab_name)
+        .into_iter()
+        .map(|segment| {
+            let style = match segment.kind {
+                AgentPanelPrimarySegmentKind::Pane => pane_style,
+                AgentPanelPrimarySegmentKind::Tab => tab_style,
+                AgentPanelPrimarySegmentKind::Workspace => workspace_style,
+                AgentPanelPrimarySegmentKind::Separator => Style::default().fg(p.overlay0),
+            };
+            Span::styled(segment.text, style)
+        })
+        .collect()
+}
+
+fn compact_duration_parts(duration: Duration) -> Vec<(String, &'static str)> {
+    let total_seconds = duration.as_secs().max(1);
+    if total_seconds < 60 {
+        return vec![(total_seconds.to_string(), "s")];
+    }
+
+    let total_minutes = total_seconds / 60;
+    if total_minutes < 60 {
+        return vec![
+            (total_minutes.to_string(), "m"),
+            ((total_seconds % 60).to_string(), "s"),
+        ];
+    }
+
+    vec![
+        ((total_minutes / 60).to_string(), "h"),
+        ((total_minutes % 60).to_string(), "m"),
+    ]
+}
+
+fn duration_number_style(duration: WorkingDuration, p: &Palette) -> Style {
+    if duration.is_live {
+        Style::default().fg(p.subtext0)
+    } else {
+        Style::default().fg(p.overlay0).add_modifier(Modifier::DIM)
+    }
+}
+
+fn duration_unit_style(unit: &str, duration: WorkingDuration, p: &Palette) -> Style {
+    if !duration.is_live {
+        return duration_number_style(duration, p);
+    }
+    if unit == "s" {
+        return duration_number_style(duration, p);
+    }
+
+    let color = match unit {
+        "h" => p.subtext0,
+        "m" => p.overlay1,
+        "s" => p.overlay0,
+        _ => p.overlay0,
+    };
+    Style::default().fg(color)
+}
+
+fn duration_value_spans(duration: WorkingDuration, p: &Palette) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    for (value, unit) in compact_duration_parts(duration.elapsed) {
+        spans.push(Span::styled(value, duration_number_style(duration, p)));
+        spans.push(Span::styled(unit, duration_unit_style(unit, duration, p)));
+    }
+    spans
+}
+
+fn style_with_view_color(
+    style: Style,
+    preset: ViewColorPreset,
+    default: Color,
+    p: &Palette,
+) -> Style {
+    if preset == ViewColorPreset::Default {
+        style
+    } else {
+        style.fg(p.view_color(preset, default))
+    }
+}
+
+fn spans_with_view_color(
+    spans: Vec<Span<'static>>,
+    preset: ViewColorPreset,
+    p: &Palette,
+) -> Vec<Span<'static>> {
+    if preset == ViewColorPreset::Default {
+        return spans;
+    }
+
+    spans
+        .into_iter()
+        .map(|span| {
+            let Span { content, style } = span;
+            let default = style.fg.unwrap_or(p.text);
+            Span::styled(content, style_with_view_color(style, preset, default, p))
+        })
+        .collect()
+}
+
+fn push_separator(spans: &mut Vec<Span<'static>>, style: Style) {
+    if !spans.is_empty() {
+        spans.push(Span::styled(" · ", style));
+    }
+}
+
+fn push_space_separator(
+    spans: &mut Vec<Span<'static>>,
+    previous_was_status: &mut bool,
+    style: Style,
+) {
+    if !spans.is_empty() {
+        let separator = if *previous_was_status { " " } else { " · " };
+        spans.push(Span::styled(separator, style));
+    }
+    *previous_was_status = false;
+}
+
+fn branch_status_parts(
+    ahead_behind: Option<(usize, usize)>,
+    p: &Palette,
+) -> Option<Vec<(String, ratatui::style::Color)>> {
+    let (ahead, behind) = ahead_behind?;
+    let mut parts = Vec::new();
+    if ahead > 0 {
+        parts.push((format!("↑{}", ahead), p.green));
+    }
+    if behind > 0 {
+        parts.push((format!("↓{}", behind), p.red));
+    }
+    (!parts.is_empty()).then_some(parts)
+}
+
+fn space_item_has_content(
+    app: &AppState,
+    ws: &crate::workspace::Workspace,
+    item: SpaceViewItem,
+) -> bool {
+    if !item.enabled(&app.space_view) {
+        return false;
+    }
+    match item {
+        SpaceViewItem::Status | SpaceViewItem::Name => true,
+        SpaceViewItem::Branch => ws.branch().is_some(),
+        SpaceViewItem::BranchStatus => ws.branch().is_some() && ws.git_ahead_behind().is_some(),
+    }
+}
+
+fn workspace_line_has_content(
+    app: &AppState,
+    ws: &crate::workspace::Workspace,
+    line: ViewLine,
+) -> bool {
+    ordered_space_view_items(&app.space_view)
+        .into_iter()
+        .filter(|item| item.line(&app.space_view) == line)
+        .any(|item| space_item_has_content(app, ws, item))
+}
+
+fn workspace_render_lines(app: &AppState, ws: &crate::workspace::Workspace) -> Vec<ViewLine> {
+    let mut lines = Vec::new();
+    for line in (0..app.space_view.lines.len().max(1)).map(ViewLine::from_index) {
+        if workspace_line_has_content(app, ws, line) {
+            lines.push(line);
+        }
+    }
+    if lines.is_empty() {
+        lines.push(ViewLine::First);
+    }
+    lines
+}
+
+fn workspace_row_height(app: &AppState, ws: &crate::workspace::Workspace) -> u16 {
+    workspace_render_lines(app, ws).len() as u16
 }
 
 fn workspace_attention_priority(state: AgentState, seen: bool) -> u8 {
@@ -466,7 +827,7 @@ fn workspace_list_visible_count(app: &AppState, area: Rect, scroll: usize) -> us
                 let row_height = if *indented {
                     1
                 } else {
-                    workspace_row_height(ws)
+                    workspace_row_height(app, ws)
                 };
                 let gap = u16::from(
                     !(*indented && next_entry_is_indented_workspace(&entries, entry_idx)),
@@ -525,16 +886,36 @@ pub(crate) fn agent_panel_body_rect(area: Rect, has_scrollbar: bool) -> Rect {
     Rect::new(area.x, body_y, body_width, body_height)
 }
 
-fn agent_panel_visible_count(area: Rect) -> usize {
+fn agent_view_render_lines(app: &AppState) -> Vec<ViewLine> {
+    let mut lines: Vec<_> = app
+        .agent_view
+        .lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.iter().any(|item| item.show))
+        .map(|(idx, _)| ViewLine::from_index(idx))
+        .collect();
+    if lines.is_empty() {
+        lines.push(ViewLine::First);
+    }
+    lines
+}
+
+fn agent_panel_entry_row_count(app: &AppState) -> u16 {
+    agent_view_render_lines(app).len() as u16
+}
+
+fn agent_panel_visible_count(app: &AppState, area: Rect) -> usize {
     let body = agent_panel_body_rect(area, false);
-    if body.width == 0 || body.height < 2 {
+    let entry_rows = agent_panel_entry_row_count(app);
+    if body.width == 0 || entry_rows == 0 || body.height < entry_rows {
         return 0;
     }
 
     let mut used_rows = 0u16;
     let mut visible = 0usize;
-    while used_rows.saturating_add(2) <= body.height {
-        used_rows = used_rows.saturating_add(2);
+    while used_rows.saturating_add(entry_rows) <= body.height {
+        used_rows = used_rows.saturating_add(entry_rows);
         visible += 1;
         if used_rows < body.height {
             used_rows = used_rows.saturating_add(1);
@@ -544,7 +925,7 @@ fn agent_panel_visible_count(area: Rect) -> usize {
 }
 
 pub(crate) fn agent_panel_scroll_metrics(app: &AppState, area: Rect) -> crate::pane::ScrollMetrics {
-    let viewport_rows = agent_panel_visible_count(area);
+    let viewport_rows = agent_panel_visible_count(app, area);
     let total_rows = agent_panel_entries(app).len();
     let max_offset_from_bottom = total_rows.saturating_sub(viewport_rows);
     let offset_from_bottom = total_rows
@@ -600,7 +981,7 @@ pub(crate) fn compute_workspace_list_areas(
                 let row_height = if *indented {
                     1
                 } else {
-                    workspace_row_height(ws)
+                    workspace_row_height(app, ws)
                 };
                 let gap = u16::from(
                     !(*indented && next_entry_is_indented_workspace(&entries, entry_idx)),
@@ -899,96 +1280,137 @@ fn render_workspace_list(
 
         let (icon, icon_style) = state_dot(agg_state, agg_seen, p);
         let label = ws.display_name_from(&app.terminals, terminal_runtimes);
-        let mut line1 = Vec::new();
-        let mut show_workspace_icon = true;
-        if card.indented {
-            line1.push(Span::styled("   ", Style::default()));
-        } else if let Some((key, collapsed)) = workspace_parent_group_state(app, i) {
-            let icon = if collapsed { "▸" } else { "▾" };
-            let (state_icon, state_style) = if collapsed {
-                let (state, seen) = space_aggregate_state(app, &key);
-                state_dot(state, seen, p)
-            } else {
-                (icon, Style::default().fg(p.accent))
-            };
-            line1.push(Span::styled(icon, Style::default().fg(p.accent)));
-            if collapsed {
-                line1.push(Span::styled(" ", Style::default()));
-                line1.push(Span::styled(state_icon, state_style));
-                show_workspace_icon = false;
+        let parent_group = (!card.indented)
+            .then(|| workspace_parent_group_state(app, i))
+            .flatten();
+        let status_dot = if let Some((key, true)) = parent_group.as_ref() {
+            let (state, seen) = space_aggregate_state(app, key);
+            state_dot(state, seen, p)
+        } else {
+            (icon, icon_style)
+        };
+        let branch_color = if selected || is_active {
+            p.mauve
+        } else {
+            p.overlay0
+        };
+        let branch_style = Style::default().fg(branch_color);
+        let separator_style = Style::default().fg(p.overlay0);
+        let ordered_items = ordered_space_view_items(&app.space_view);
+        let render_lines = workspace_render_lines(app, ws);
+
+        for (render_idx, line) in render_lines.into_iter().enumerate() {
+            let y = row_y + render_idx as u16;
+            if y >= list_bottom || render_idx as u16 >= row_height {
+                continue;
             }
-            line1.push(Span::styled(" ", Style::default()));
-        } else {
-            line1.push(Span::styled(" ", Style::default()));
-        }
-        if show_workspace_icon {
-            line1.push(Span::styled(icon, icon_style));
-            line1.push(Span::styled(" ", Style::default()));
-        }
-        if card.indented {
-            let display_label = grouped_child_display_label(
-                &label,
-                ws.branch().as_deref(),
-                ws.custom_name.is_some(),
-            );
-            line1.push(Span::styled(display_label, name_style));
-        } else {
-            line1.push(Span::styled(label, name_style));
-        }
 
-        frame.render_widget(
-            Paragraph::new(Line::from(line1)),
-            Rect::new(card.rect.x, row_y, card.rect.width, 1),
-        );
+            let mut prefix = Vec::new();
+            if render_idx == 0 {
+                if card.indented {
+                    prefix.push(Span::styled("   ", Style::default()));
+                } else if let Some((_, collapsed)) = parent_group.as_ref() {
+                    let icon = if *collapsed { "▸" } else { "▾" };
+                    prefix.push(Span::styled(icon, Style::default().fg(p.accent)));
+                    prefix.push(Span::styled(" ", Style::default()));
+                } else {
+                    prefix.push(Span::styled(" ", Style::default()));
+                }
+            } else {
+                prefix.push(Span::styled(
+                    if card.indented { "     " } else { "   " },
+                    Style::default(),
+                ));
+            }
 
-        if row_height > 1 && row_y + 1 < list_bottom {
-            if let Some(branch) = ws.branch() {
-                let upstream_label = ws.git_ahead_behind().and_then(|(ahead, behind)| {
-                    let mut parts = Vec::new();
-                    if ahead > 0 {
-                        parts.push((format!("↑{}", ahead), p.green));
+            let mut content = Vec::new();
+            let mut previous_was_status = false;
+            for item in ordered_items
+                .iter()
+                .copied()
+                .filter(|item| item.line(&app.space_view) == line)
+                .filter(|item| item.enabled(&app.space_view))
+            {
+                match item {
+                    SpaceViewItem::Status => {
+                        push_separator(&mut content, separator_style);
+                        let icon_style = style_with_view_color(
+                            status_dot.1,
+                            item.color(&app.space_view),
+                            status_dot.1.fg.unwrap_or(p.accent),
+                            p,
+                        );
+                        content.push(Span::styled(status_dot.0, icon_style));
+                        previous_was_status = true;
                     }
-                    if behind > 0 {
-                        parts.push((format!("↓{}", behind), p.red));
+                    SpaceViewItem::Name => {
+                        push_space_separator(
+                            &mut content,
+                            &mut previous_was_status,
+                            separator_style,
+                        );
+                        let display_label = if card.indented {
+                            grouped_child_display_label(
+                                &label,
+                                ws.branch().as_deref(),
+                                ws.custom_name.is_some(),
+                            )
+                        } else {
+                            label.clone()
+                        };
+                        let item_style = style_with_view_color(
+                            name_style,
+                            item.color(&app.space_view),
+                            name_style.fg.unwrap_or(p.subtext0),
+                            p,
+                        );
+                        content.push(Span::styled(display_label, item_style));
                     }
-                    (!parts.is_empty()).then_some(parts)
-                });
-                let reserved = upstream_label
-                    .as_ref()
-                    .map(|parts| {
-                        parts.iter().map(|(label, _)| label.len()).sum::<usize>() + parts.len()
-                    })
-                    .unwrap_or(0);
-                let max_branch_len = (card.rect.width as usize).saturating_sub(5 + reserved);
-                let branch_display = if branch.len() > max_branch_len {
-                    format!("{}…", &branch[..max_branch_len.saturating_sub(1)])
-                } else {
-                    branch
-                };
-                let branch_color = if selected || is_active {
-                    p.mauve
-                } else {
-                    p.overlay0
-                };
-                let branch_indent = if card.indented { "     " } else { "   " };
-                let mut spans = vec![
-                    Span::styled(branch_indent, Style::default()),
-                    Span::styled(branch_display, Style::default().fg(branch_color)),
-                ];
-                if let Some(parts) = upstream_label {
-                    spans.push(Span::styled(" ", Style::default()));
-                    for (idx, (label, color)) in parts.into_iter().enumerate() {
-                        if idx > 0 {
-                            spans.push(Span::styled(" ", Style::default()));
+                    SpaceViewItem::Branch => {
+                        if let Some(branch) = ws.branch() {
+                            push_space_separator(
+                                &mut content,
+                                &mut previous_was_status,
+                                separator_style,
+                            );
+                            let item_style = style_with_view_color(
+                                branch_style,
+                                item.color(&app.space_view),
+                                branch_style.fg.unwrap_or(p.overlay0),
+                                p,
+                            );
+                            content.push(Span::styled(branch, item_style));
                         }
-                        spans.push(Span::styled(label, Style::default().fg(color)));
+                    }
+                    SpaceViewItem::BranchStatus => {
+                        if ws.branch().is_some() {
+                            if let Some(parts) = branch_status_parts(ws.git_ahead_behind(), p) {
+                                push_space_separator(
+                                    &mut content,
+                                    &mut previous_was_status,
+                                    separator_style,
+                                );
+                                for (idx, (label, color)) in parts.into_iter().enumerate() {
+                                    if idx > 0 {
+                                        content.push(Span::styled(" ", Style::default()));
+                                    }
+                                    content.push(Span::styled(
+                                        label,
+                                        Style::default()
+                                            .fg(p.view_color(item.color(&app.space_view), color)),
+                                    ));
+                                }
+                            }
+                        }
                     }
                 }
-                frame.render_widget(
-                    Paragraph::new(Line::from(spans)),
-                    Rect::new(card.rect.x, row_y + 1, card.rect.width, 1),
-                );
             }
+
+            prefix.extend(content);
+            frame.render_widget(
+                Paragraph::new(Line::from(prefix)),
+                Rect::new(card.rect.x, y, card.rect.width, 1),
+            );
         }
     }
 
@@ -1031,6 +1453,521 @@ fn render_workspace_list(
             menu_rect,
         );
     }
+}
+
+fn agent_item_spans(
+    entry: &AgentPanelEntry,
+    app: &AppState,
+    item: AgentViewItem,
+    name_style: Style,
+    status_style: Style,
+    agent_style: Style,
+    p: &Palette,
+) -> Option<Vec<Span<'static>>> {
+    if !item.enabled(&app.agent_view) {
+        return None;
+    }
+    let spans = match item {
+        AgentViewItem::AgentStatus => {
+            let (icon, icon_style) = agent_icon(entry.state, entry.seen, app.spinner_tick, p);
+            Some(vec![Span::styled(icon, icon_style)])
+        }
+        AgentViewItem::PaneName => entry
+            .pane_label
+            .as_ref()
+            .map(|label| vec![Span::styled(label.clone(), Style::default().fg(p.green))]),
+        AgentViewItem::TabName => entry
+            .primary_tab_label
+            .as_ref()
+            .map(|label| vec![Span::styled(label.clone(), Style::default().fg(p.mauve))]),
+        AgentViewItem::SpaceName => {
+            Some(vec![Span::styled(entry.primary_label.clone(), name_style)])
+        }
+        AgentViewItem::Status => Some(vec![Span::styled(
+            state_label(entry.state, entry.seen),
+            status_style,
+        )]),
+        AgentViewItem::Time => entry
+            .working_duration
+            .map(|duration| duration_value_spans(duration, p)),
+        AgentViewItem::CustomStatus => entry
+            .custom_status
+            .as_ref()
+            .map(|status| vec![Span::styled(status.clone(), agent_style)]),
+        AgentViewItem::AgentName => entry
+            .agent_label
+            .as_ref()
+            .map(|label| vec![Span::styled(label.clone(), agent_style)]),
+        AgentViewItem::RightAlignment => None,
+    }?;
+    Some(spans_with_view_color(spans, item.color(&app.agent_view), p))
+}
+
+fn is_agent_identity_item(item: AgentViewItem) -> bool {
+    matches!(
+        item,
+        AgentViewItem::PaneName | AgentViewItem::TabName | AgentViewItem::SpaceName
+    )
+}
+
+fn identity_items_keep_default_order(items: &[AgentViewItem]) -> bool {
+    let mut next_default_idx = 0;
+    for item in items {
+        let Some(default_idx) = [
+            AgentViewItem::PaneName,
+            AgentViewItem::TabName,
+            AgentViewItem::SpaceName,
+        ]
+        .iter()
+        .position(|candidate| candidate == item) else {
+            return false;
+        };
+        if default_idx < next_default_idx {
+            return false;
+        }
+        next_default_idx = default_idx + 1;
+    }
+    items.contains(&AgentViewItem::SpaceName)
+}
+
+#[derive(Default)]
+struct AgentLineContent {
+    left: Vec<Span<'static>>,
+    right: Vec<Span<'static>>,
+}
+
+fn push_agent_line_spans(
+    spans: &mut Vec<Span<'static>>,
+    previous_was_agent_status: &mut bool,
+    item_spans: Vec<Span<'static>>,
+    item: AgentViewItem,
+    separator_style: Style,
+) {
+    push_space_separator(spans, previous_was_agent_status, separator_style);
+    spans.extend(item_spans);
+    *previous_was_agent_status = item == AgentViewItem::AgentStatus;
+}
+
+fn agent_line_content(
+    entry: &AgentPanelEntry,
+    app: &AppState,
+    line: ViewLine,
+    ordered_items: &[AgentViewItem],
+    max_width: usize,
+    name_style: Style,
+    status_style: Style,
+    agent_style: Style,
+    p: &Palette,
+) -> AgentLineContent {
+    let mut content = AgentLineContent::default();
+    let line_items: Vec<_> = ordered_items
+        .iter()
+        .copied()
+        .filter(|item| item.line(&app.agent_view) == Some(line))
+        .collect();
+    let mut idx = 0;
+    let mut right_aligned = false;
+    let mut previous_left_was_agent_status = false;
+    let mut previous_right_was_agent_status = false;
+    while idx < line_items.len() {
+        let item = line_items[idx];
+        if item == AgentViewItem::RightAlignment {
+            if item.enabled(&app.agent_view) {
+                right_aligned = true;
+            }
+            idx += 1;
+            continue;
+        }
+        if is_agent_identity_item(item) {
+            let end = line_items[idx..]
+                .iter()
+                .position(|candidate| !is_agent_identity_item(*candidate))
+                .map_or(line_items.len(), |offset| idx + offset);
+            let sequence = &line_items[idx..end];
+            if AgentViewItem::SpaceName.enabled(&app.agent_view)
+                && identity_items_keep_default_order(sequence)
+            {
+                let show_pane_name = sequence.contains(&AgentViewItem::PaneName)
+                    && AgentViewItem::PaneName.enabled(&app.agent_view);
+                let show_tab_name = sequence.contains(&AgentViewItem::TabName)
+                    && AgentViewItem::TabName.enabled(&app.agent_view);
+                let pane_style = style_with_view_color(
+                    Style::default().fg(p.green),
+                    AgentViewItem::PaneName.color(&app.agent_view),
+                    p.green,
+                    p,
+                );
+                let tab_style = style_with_view_color(
+                    Style::default().fg(p.mauve),
+                    AgentViewItem::TabName.color(&app.agent_view),
+                    p.mauve,
+                    p,
+                );
+                let workspace_style = style_with_view_color(
+                    name_style,
+                    AgentViewItem::SpaceName.color(&app.agent_view),
+                    name_style.fg.unwrap_or(p.subtext0),
+                    p,
+                );
+                if right_aligned {
+                    let separator_width = if content.right.is_empty() {
+                        0
+                    } else if previous_right_was_agent_status {
+                        1
+                    } else {
+                        3
+                    };
+                    let available_width =
+                        max_width.saturating_sub(spans_width(&content.right) + separator_width);
+                    let item_spans = agent_panel_primary_label_spans(
+                        entry,
+                        available_width,
+                        show_pane_name,
+                        show_tab_name,
+                        pane_style,
+                        tab_style,
+                        workspace_style,
+                        p,
+                    );
+                    push_agent_line_spans(
+                        &mut content.right,
+                        &mut previous_right_was_agent_status,
+                        item_spans,
+                        AgentViewItem::SpaceName,
+                        agent_style,
+                    );
+                } else {
+                    let separator_width = if content.left.is_empty() {
+                        0
+                    } else if previous_left_was_agent_status {
+                        1
+                    } else {
+                        3
+                    };
+                    let available_width =
+                        max_width.saturating_sub(spans_width(&content.left) + separator_width);
+                    let item_spans = agent_panel_primary_label_spans(
+                        entry,
+                        available_width,
+                        show_pane_name,
+                        show_tab_name,
+                        pane_style,
+                        tab_style,
+                        workspace_style,
+                        p,
+                    );
+                    push_agent_line_spans(
+                        &mut content.left,
+                        &mut previous_left_was_agent_status,
+                        item_spans,
+                        AgentViewItem::SpaceName,
+                        agent_style,
+                    );
+                }
+                idx = end;
+                continue;
+            }
+        }
+        if let Some(item_spans) =
+            agent_item_spans(entry, app, item, name_style, status_style, agent_style, p)
+        {
+            if right_aligned {
+                push_agent_line_spans(
+                    &mut content.right,
+                    &mut previous_right_was_agent_status,
+                    item_spans,
+                    item,
+                    agent_style,
+                );
+            } else {
+                push_agent_line_spans(
+                    &mut content.left,
+                    &mut previous_left_was_agent_status,
+                    item_spans,
+                    item,
+                    agent_style,
+                );
+            }
+        }
+        idx += 1;
+    }
+    content
+}
+
+fn spans_width(spans: &[Span<'_>]) -> usize {
+    spans
+        .iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum()
+}
+
+fn truncate_spans_to_width(spans: &[Span<'static>], max_width: usize) -> Vec<Span<'static>> {
+    let mut width = 0;
+    let mut truncated = Vec::new();
+    for span in spans {
+        if width >= max_width {
+            break;
+        }
+        let mut content = String::new();
+        for ch in span.content.chars() {
+            let ch_width = ch.width().unwrap_or(0);
+            if width + ch_width > max_width {
+                break;
+            }
+            content.push(ch);
+            width += ch_width;
+        }
+        if !content.is_empty() {
+            truncated.push(Span::styled(content, span.style));
+        }
+    }
+    truncated
+}
+
+fn fixed_width_agent_line_spans(
+    mut content: AgentLineContent,
+    width: u16,
+    fill_style: Style,
+) -> Vec<Span<'static>> {
+    let width = width as usize;
+    if width == 0 {
+        return Vec::new();
+    }
+    if content.right.is_empty() {
+        return truncate_spans_to_width(&content.left, width);
+    }
+
+    let mut right = content.right;
+    let right_width = spans_width(&right).min(width);
+    if right_width < spans_width(&right) {
+        right = truncate_spans_to_width(&right, right_width);
+    }
+    let gap = usize::from(!content.left.is_empty() && right_width < width);
+    let left_width = width.saturating_sub(right_width + gap);
+    content.left = truncate_spans_to_width(&content.left, left_width);
+    let left_width = spans_width(&content.left);
+    let pad_width = width.saturating_sub(left_width + right_width);
+    let mut spans = content.left;
+    if pad_width > 0 {
+        spans.push(Span::styled(" ".repeat(pad_width), fill_style));
+    }
+    spans.extend(right);
+    spans
+}
+
+fn render_agent_line(
+    frame: &mut Frame,
+    rect: Rect,
+    content: AgentLineContent,
+    row_style: Style,
+    right_style: Style,
+) {
+    if rect.width == 0 {
+        return;
+    }
+    if content.right.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(content.left)).style(row_style),
+            rect,
+        );
+        return;
+    }
+
+    {
+        let buf = frame.buffer_mut();
+        for x in rect.x..rect.x + rect.width {
+            buf[(x, rect.y)].set_style(row_style);
+        }
+    }
+    let right_width = spans_width(&content.right).min(rect.width as usize) as u16;
+    let gap = u16::from(!content.left.is_empty() && right_width < rect.width);
+    let left_width = rect.width.saturating_sub(right_width.saturating_add(gap));
+    if left_width > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(content.left)).style(row_style),
+            Rect::new(rect.x, rect.y, left_width, 1),
+        );
+    }
+    if right_width > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(content.right))
+                .style(row_style)
+                .alignment(Alignment::Right),
+            Rect::new(
+                rect.x + rect.width.saturating_sub(right_width),
+                rect.y,
+                right_width,
+                1,
+            ),
+        );
+        if gap > 0 {
+            let gap_x = rect.x + rect.width.saturating_sub(right_width + gap);
+            frame.buffer_mut()[(gap_x, rect.y)].set_style(right_style);
+        }
+    }
+}
+
+pub(crate) fn settings_space_view_demo_lines(app: &AppState) -> Vec<Line<'static>> {
+    let p = &app.palette;
+    let (status, status_style) = state_dot(AgentState::Working, true, p);
+    let branch = "feature/sidebar";
+    let branch_status = branch_status_parts(Some((2, 1)), p);
+    let separator_style = Style::default().fg(p.overlay0);
+    let name_style = Style::default().fg(p.subtext0).add_modifier(Modifier::BOLD);
+    let branch_style = Style::default().fg(p.mauve);
+    let mut lines = Vec::new();
+
+    for line in (0..app.space_view.lines.len().max(1)).map(ViewLine::from_index) {
+        let mut content = Vec::new();
+        let mut previous_was_status = false;
+        for item in ordered_space_view_items(&app.space_view)
+            .into_iter()
+            .filter(|item| item.line(&app.space_view) == line)
+            .filter(|item| item.enabled(&app.space_view))
+        {
+            match item {
+                SpaceViewItem::Status => {
+                    push_separator(&mut content, separator_style);
+                    let item_style = style_with_view_color(
+                        status_style,
+                        item.color(&app.space_view),
+                        status_style.fg.unwrap_or(p.accent),
+                        p,
+                    );
+                    content.push(Span::styled(status, item_style));
+                    previous_was_status = true;
+                }
+                SpaceViewItem::Name => {
+                    push_space_separator(&mut content, &mut previous_was_status, separator_style);
+                    let item_style = style_with_view_color(
+                        name_style,
+                        item.color(&app.space_view),
+                        name_style.fg.unwrap_or(p.subtext0),
+                        p,
+                    );
+                    content.push(Span::styled("demo-space", item_style));
+                }
+                SpaceViewItem::Branch => {
+                    push_space_separator(&mut content, &mut previous_was_status, separator_style);
+                    let item_style = style_with_view_color(
+                        branch_style,
+                        item.color(&app.space_view),
+                        branch_style.fg.unwrap_or(p.mauve),
+                        p,
+                    );
+                    content.push(Span::styled(branch, item_style));
+                }
+                SpaceViewItem::BranchStatus => {
+                    if let Some(parts) = branch_status.clone() {
+                        push_space_separator(
+                            &mut content,
+                            &mut previous_was_status,
+                            separator_style,
+                        );
+                        for (idx, (label, color)) in parts.into_iter().enumerate() {
+                            if idx > 0 {
+                                content.push(Span::styled(" ", Style::default()));
+                            }
+                            content.push(Span::styled(
+                                label,
+                                Style::default()
+                                    .fg(p.view_color(item.color(&app.space_view), color)),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        if !content.is_empty() {
+            let mut spans = vec![Span::styled("  ", Style::default())];
+            spans.extend(content);
+            lines.push(Line::from(spans));
+        }
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  all demo space fields hidden",
+            Style::default().fg(p.overlay1),
+        )));
+    }
+    lines
+}
+
+pub(crate) fn settings_agent_view_demo_width(app: &AppState) -> u16 {
+    app.view.sidebar_rect.width.max(app.sidebar_width).max(1)
+}
+
+pub(crate) fn settings_agent_view_demo_lines(app: &AppState, width: u16) -> Vec<Line<'static>> {
+    let p = &app.palette;
+    let demos = [
+        AgentPanelEntry {
+            ws_idx: 0,
+            tab_idx: 0,
+            pane_id: crate::layout::PaneId::from_raw(1),
+            pane_label: Some("pane-alpha".into()),
+            primary_label: "workspace-app".into(),
+            primary_tab_label: Some("main".into()),
+            agent_label: Some("claude".into()),
+            state: AgentState::Working,
+            seen: true,
+            custom_status: Some("planning".into()),
+            working_duration: Some(WorkingDuration {
+                elapsed: Duration::from_secs(92),
+                is_live: true,
+            }),
+        },
+        AgentPanelEntry {
+            ws_idx: 0,
+            tab_idx: 1,
+            pane_id: crate::layout::PaneId::from_raw(2),
+            pane_label: Some("pane-beta".into()),
+            primary_label: "workspace-tests".into(),
+            primary_tab_label: Some("review".into()),
+            agent_label: Some("codex".into()),
+            state: AgentState::Idle,
+            seen: true,
+            custom_status: Some("ready".into()),
+            working_duration: Some(WorkingDuration {
+                elapsed: Duration::from_secs(8),
+                is_live: false,
+            }),
+        },
+    ];
+    let ordered_items = ordered_agent_view_items(&app.agent_view);
+    let render_lines = agent_view_render_lines(app);
+    let mut lines = Vec::new();
+
+    for entry in demos {
+        let label_color = state_label_color(entry.state, entry.seen, p);
+        let name_style = Style::default().fg(p.subtext0).add_modifier(Modifier::BOLD);
+        let status_style = Style::default().fg(label_color);
+        let agent_style = Style::default().fg(p.overlay0).add_modifier(Modifier::DIM);
+        for (render_idx, line) in render_lines.iter().copied().enumerate() {
+            let prefix = if render_idx == 0 { " " } else { "   " };
+            let mut content = agent_line_content(
+                &entry,
+                app,
+                line,
+                &ordered_items,
+                width.saturating_sub(prefix.len() as u16) as usize,
+                name_style,
+                status_style,
+                agent_style,
+                p,
+            );
+            content
+                .left
+                .insert(0, Span::styled(prefix, Style::default()));
+            lines.push(Line::from(fixed_width_agent_line_spans(
+                content,
+                width,
+                agent_style,
+            )));
+        }
+    }
+
+    lines
 }
 
 fn render_agent_detail(
@@ -1080,17 +2017,17 @@ fn render_agent_detail(
 
     let mut row_y = body.y;
     let body_bottom = body.y + body.height;
+    let render_lines = agent_view_render_lines(app);
     for detail in details.iter().skip(app.agent_panel_scroll) {
-        if row_y.saturating_add(1) >= body_bottom {
+        let entry_rows = render_lines.len() as u16;
+        if row_y.saturating_add(entry_rows) > body_bottom {
             break;
         }
 
         // Check if this agent entry corresponds to the active session
         let is_active = app.is_active_pane(detail.ws_idx, detail.tab_idx, detail.pane_id);
 
-        let (icon, icon_style) = agent_icon(detail.state, detail.seen, app.spinner_tick, p);
         let label_color = state_label_color(detail.state, detail.seen, p);
-        let label = state_label(detail.state, detail.seen);
 
         let row_style = if is_active {
             Style::default().bg(p.surface_dim)
@@ -1110,37 +2047,33 @@ fn render_agent_detail(
         };
         let agent_style = Style::default().fg(p.overlay0).add_modifier(Modifier::DIM);
 
-        let primary_label =
-            format_agent_panel_primary_label(detail, body.width.saturating_sub(3) as usize);
-        let name_line = Line::from(vec![
-            Span::styled(" ", Style::default()),
-            Span::styled(icon, icon_style),
-            Span::styled(" ", Style::default()),
-            Span::styled(primary_label, name_style),
-        ]);
-        frame.render_widget(
-            Paragraph::new(name_line).style(row_style),
-            Rect::new(body.x, row_y, body.width, 1),
-        );
-        row_y += 1;
+        let ordered_items = ordered_agent_view_items(&app.agent_view);
+        for (render_idx, line) in render_lines.iter().copied().enumerate() {
+            let prefix = if render_idx == 0 { " " } else { "   " };
+            let mut content = agent_line_content(
+                detail,
+                app,
+                line,
+                &ordered_items,
+                body.width.saturating_sub(prefix.len() as u16) as usize,
+                name_style,
+                status_style,
+                agent_style,
+                p,
+            );
+            content
+                .left
+                .insert(0, Span::styled(prefix, Style::default()));
 
-        let mut status_spans = vec![
-            Span::styled("   ", Style::default()),
-            Span::styled(label, status_style),
-        ];
-        if let Some(agent_label) = &detail.agent_label {
-            status_spans.push(Span::styled(" · ", agent_style));
-            status_spans.push(Span::styled(agent_label, agent_style));
+            render_agent_line(
+                frame,
+                Rect::new(body.x, row_y, body.width, 1),
+                content,
+                row_style,
+                agent_style,
+            );
+            row_y += 1;
         }
-        if let Some(custom_status) = &detail.custom_status {
-            status_spans.push(Span::styled(" · ", agent_style));
-            status_spans.push(Span::styled(custom_status.clone(), agent_style));
-        }
-        frame.render_widget(
-            Paragraph::new(Line::from(status_spans)).style(row_style),
-            Rect::new(body.x, row_y, body.width, 1),
-        );
-        row_y += 1;
 
         if row_y < body_bottom {
             row_y += 1;
@@ -1188,6 +2121,32 @@ fn render_sidebar_toggle(
 mod tests {
     use super::*;
     use crate::{detect::Agent, workspace::Workspace};
+
+    fn agent_entry_row_text(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {
+        (0..width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect::<String>()
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    fn compact_duration_text(duration: Duration) -> String {
+        compact_duration_parts(duration)
+            .into_iter()
+            .map(|(value, unit)| format!("{value}{unit}"))
+            .collect()
+    }
+
+    fn cell_col_for_substr(row: &str, needle: &str) -> u16 {
+        row.find(needle)
+            .map(|byte_idx| row[..byte_idx].chars().count() as u16)
+            .expect("substring should render")
+    }
 
     #[test]
     fn all_workspaces_agent_panel_entries_use_workspace_and_optional_tab_labels() {
@@ -1323,22 +2282,1182 @@ mod tests {
     }
 
     #[test]
-    fn all_workspaces_primary_label_truncates_workspace_and_tab() {
+    fn settings_agent_demo_does_not_render_custom_status_outside_configured_fields() {
+        let mut app = crate::app::state::AppState::test_new();
+        for item in crate::app::state::AGENT_VIEW_PLACEMENT_ITEMS {
+            item.set_enabled(&mut app.agent_view, false);
+        }
+        crate::app::state::AgentViewItem::Status.set_enabled(&mut app.agent_view, true);
+        crate::app::state::AgentViewItem::AgentName.set_enabled(&mut app.agent_view, true);
+        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, false);
+
+        let rendered = settings_agent_view_demo_lines(&app, 32)
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("working · claude"), "{rendered:?}");
+        assert!(rendered.contains("idle · codex"), "{rendered:?}");
+        assert!(!rendered.contains("planning"), "{rendered:?}");
+        assert!(!rendered.contains("ready"), "{rendered:?}");
+    }
+
+    #[test]
+    fn agent_view_custom_status_follows_right_alignment_marker() {
+        let mut app = crate::app::state::AppState::test_new();
+        let config: crate::config::Config = toml::from_str(
+            r#"
+[ui.sidebar.agents]
+lines = [
+  [
+    { field = "agent_status", show = false },
+    { field = "pane_name", show = false },
+    { field = "tab_name", show = false },
+    { field = "space_name", show = false },
+    { field = "status", show = true },
+    { field = "time", show = false },
+    { field = "right_alignment", show = true },
+    { field = "custom_status", show = true },
+    { field = "agent_name", show = true },
+  ],
+]
+"#,
+        )
+        .unwrap();
+        app.agent_view = config.ui.sidebar.agents;
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals
+            .get_mut(&terminal_id)
+            .unwrap()
+            .set_hook_authority_with_custom_status(
+                "test".into(),
+                "codex".into(),
+                AgentState::Working,
+                None,
+                Some("planning".into()),
+                None,
+            );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(42, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 42, 8),
+                )
+            })
+            .unwrap();
+        let row = agent_entry_row_text(terminal.backend().buffer(), 3, 42);
+
+        assert!(row.contains(" working"), "row: {row:?}");
+        assert!(row.ends_with("planning · codex"), "row: {row:?}");
+    }
+
+    #[test]
+    fn agent_view_color_preset_overrides_configured_item_color() {
+        let mut app = crate::app::state::AppState::test_new();
+        crate::app::state::AgentViewItem::AgentName
+            .set_color(&mut app.agent_view, crate::config::ViewColorPreset::Cool);
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals
+            .get_mut(&terminal_id)
+            .unwrap()
+            .set_hook_authority_with_custom_status(
+                "test".into(),
+                "codex".into(),
+                AgentState::Idle,
+                None,
+                None,
+                None,
+            );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(42, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 42, 8),
+                )
+            })
+            .unwrap();
+        let row = agent_entry_row_text(terminal.backend().buffer(), 4, 42);
+        let codex_col = row
+            .find("codex")
+            .unwrap_or_else(|| panic!("codex should render in row: {row:?}"))
+            as u16;
+
+        assert_eq!(
+            terminal.backend().buffer()[(codex_col, 4)].fg,
+            app.palette.teal
+        );
+    }
+
+    #[test]
+    fn all_workspaces_primary_label_without_pane_label_uses_tab_and_workspace_when_tab_exists() {
         let entry = AgentPanelEntry {
             ws_idx: 0,
             tab_idx: 0,
             pane_id: crate::layout::PaneId::from_raw(1),
+            pane_label: None,
             primary_label: "agent-browser".into(),
             primary_tab_label: Some("test-escalation".into()),
             agent_label: Some("claude".into()),
             state: AgentState::Idle,
             seen: true,
             custom_status: None,
+            working_duration: None,
         };
 
-        let label = format_agent_panel_primary_label(&entry, 18);
+        let label = format_agent_panel_primary_label(&entry, 23);
 
-        assert_eq!(label, "agent-bro… · test…");
+        assert_eq!(label, "test-e… · agent-browser");
+    }
+
+    #[test]
+    fn named_pane_primary_label_uses_pane_and_workspace_for_single_tab_workspace() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("Echo".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let entries = agent_panel_entries(&app);
+        let label = format_agent_panel_primary_label(&entries[0], 30);
+
+        assert_eq!(label, "Echo · herdr");
+    }
+
+    #[test]
+    fn named_pane_primary_label_includes_tab_context_for_multi_tab_workspace() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("Echo".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let entries = agent_panel_entries(&app);
+        let label = format_agent_panel_primary_label(&entries[0], 30);
+
+        assert_eq!(label, "Echo · main · herdr");
+    }
+
+    #[test]
+    fn agent_primary_label_can_hide_pane_and_tab_segments_independently() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("Echo".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let entries = agent_panel_entries(&app);
+
+        assert_eq!(
+            format_agent_panel_primary_label_with_options(&entries[0], 30, false, true),
+            "main · herdr"
+        );
+        assert_eq!(
+            format_agent_panel_primary_label_with_options(&entries[0], 30, true, false),
+            "Echo · herdr"
+        );
+        assert_eq!(
+            format_agent_panel_primary_label_with_options(&entries[0], 30, false, false),
+            "herdr"
+        );
+    }
+
+    #[test]
+    fn primary_label_truncates_pane_side_before_workspace_label() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("EchoLongName".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let entries = agent_panel_entries(&app);
+        let label = format_agent_panel_primary_label(&entries[0], 16);
+
+        assert_eq!(label, "EchoLon… · herdr");
+    }
+
+    #[test]
+    fn missing_pane_label_keeps_workspace_only_primary_label() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals.get_mut(&terminal_id).unwrap().detected_agent = Some(Agent::Codex);
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let entries = agent_panel_entries(&app);
+        let label = format_agent_panel_primary_label(&entries[0], 30);
+
+        assert_eq!(label, "herdr");
+    }
+
+    #[test]
+    fn missing_pane_label_in_multi_tab_workspace_uses_tab_and_workspace() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals.get_mut(&terminal_id).unwrap().detected_agent = Some(Agent::Codex);
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let entries = agent_panel_entries(&app);
+        let label = format_agent_panel_primary_label(&entries[0], 30);
+
+        assert_eq!(label, "main · herdr");
+    }
+
+    #[test]
+    fn named_pane_primary_label_segments_use_pane_tab_and_workspace_colors() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("Echo".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row = agent_entry_row_text(buffer, 3, 40);
+
+        assert!(row.contains("Echo · main · herdr"), "row: {row:?}");
+        assert_eq!(buffer[(3, 3)].fg, app.palette.green);
+        assert_eq!(buffer[(10, 3)].fg, app.palette.mauve);
+        assert_eq!(buffer[(17, 3)].fg, app.palette.subtext0);
+    }
+
+    #[test]
+    fn truncated_multi_tab_primary_label_keeps_tab_and_workspace_segment_colors() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("EchoLongName".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(24, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 24, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row = agent_entry_row_text(buffer, 3, 24);
+        let tab_col = cell_col_for_substr(&row, "main");
+        let workspace_col = cell_col_for_substr(&row, "herdr");
+
+        assert!(row.contains("EchoL… · main · herdr"), "row: {row:?}");
+        assert_eq!(buffer[(tab_col, 3)].fg, app.palette.mauve);
+        assert_eq!(buffer[(workspace_col, 3)].fg, app.palette.subtext0);
+    }
+
+    #[test]
+    fn status_duration_formats_compact_seconds_minutes_and_hours() {
+        assert_eq!(compact_duration_text(Duration::ZERO), "1s");
+        assert_eq!(compact_duration_text(Duration::from_secs(10)), "10s");
+        assert_eq!(compact_duration_text(Duration::from_secs(131)), "2m11s");
+        assert_eq!(compact_duration_text(Duration::from_secs(4_800)), "1h20m");
+    }
+
+    #[test]
+    fn duration_unit_styles_keep_seconds_unit_as_visible_as_number() {
+        let palette = Palette::catppuccin();
+        let live = WorkingDuration {
+            elapsed: Duration::from_secs(4_800),
+            is_live: true,
+        };
+        let stale = WorkingDuration {
+            elapsed: Duration::from_secs(4_800),
+            is_live: false,
+        };
+
+        assert_eq!(
+            duration_unit_style("h", live, &palette).fg,
+            Some(palette.subtext0)
+        );
+        assert_eq!(
+            duration_unit_style("m", live, &palette).fg,
+            Some(palette.overlay1)
+        );
+        assert_eq!(
+            duration_unit_style("s", live, &palette).fg,
+            duration_number_style(live, &palette).fg
+        );
+        assert_eq!(
+            duration_unit_style("h", stale, &palette),
+            duration_number_style(stale, &palette)
+        );
+        assert_eq!(
+            duration_unit_style("m", stale, &palette),
+            duration_number_style(stale, &palette)
+        );
+        assert_eq!(
+            duration_unit_style("s", stale, &palette),
+            duration_number_style(stale, &palette)
+        );
+        assert!(duration_unit_style("h", stale, &palette)
+            .add_modifier
+            .contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn status_row_keeps_agent_label_right_aligned_with_working_duration() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let row = agent_entry_row_text(terminal.backend().buffer(), 4, 40);
+
+        assert!(row.contains("   working · 2m12s"), "status row: {row:?}");
+        assert!(row.ends_with("codex"), "status row: {row:?}");
+    }
+
+    #[test]
+    fn agent_view_can_hide_time_without_disabling_right_alignment() {
+        let mut app = crate::app::state::AppState::test_new();
+        crate::app::state::AgentViewItem::Time.set_enabled(&mut app.agent_view, false);
+        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, true);
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_manual_label("Echo".into());
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let status_row = agent_entry_row_text(buffer, 4, 40);
+
+        assert!(
+            status_row.contains("   working"),
+            "status row: {status_row:?}"
+        );
+        assert!(!status_row.contains("2m12s"), "status row: {status_row:?}");
+        assert!(status_row.ends_with("codex"), "status row: {status_row:?}");
+    }
+
+    #[test]
+    fn agent_view_can_disable_right_alignment_without_hiding_time() {
+        let mut app = crate::app::state::AppState::test_new();
+        crate::app::state::AgentViewItem::Time.set_enabled(&mut app.agent_view, true);
+        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, false);
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let status_row = agent_entry_row_text(buffer, 4, 40);
+
+        assert!(
+            status_row.contains("   working · 2m12s · codex"),
+            "status row: {status_row:?}"
+        );
+    }
+
+    #[test]
+    fn agent_view_right_alignment_marker_aligns_items_after_it() {
+        let mut app = crate::app::state::AppState::test_new();
+        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, true);
+        crate::app::state::AgentViewItem::RightAlignment.set_order(&mut app.agent_view, 1);
+        crate::app::state::AgentViewItem::Time.set_order(&mut app.agent_view, 2);
+        crate::app::state::AgentViewItem::AgentName.set_order(&mut app.agent_view, 3);
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let status_row = agent_entry_row_text(terminal.backend().buffer(), 4, 40);
+
+        assert!(
+            status_row.contains("   working"),
+            "status row: {status_row:?}"
+        );
+        assert!(
+            status_row.ends_with("2m12s · codex"),
+            "status row: {status_row:?}"
+        );
+    }
+
+    #[test]
+    fn agent_view_line_order_can_move_time_to_first_row() {
+        let mut app = crate::app::state::AppState::test_new();
+        crate::app::state::AgentViewItem::AgentStatus.set_enabled(&mut app.agent_view, false);
+        crate::app::state::AgentViewItem::Time
+            .set_line(&mut app.agent_view, crate::app::state::ViewLine::First);
+        crate::app::state::AgentViewItem::Time.set_order(&mut app.agent_view, 0);
+        crate::app::state::AgentViewItem::PaneName.set_order(&mut app.agent_view, 1);
+        crate::app::state::AgentViewItem::TabName.set_order(&mut app.agent_view, 2);
+        crate::app::state::AgentViewItem::SpaceName.set_order(&mut app.agent_view, 3);
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
+
+        assert!(first_row.contains("2m12s · herdr"), "row: {first_row:?}");
+    }
+
+    #[test]
+    fn agent_view_reorders_identity_items_in_agents_panel() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        crate::app::state::AgentViewItem::TabName.set_order(&mut app.agent_view, 1);
+        crate::app::state::AgentViewItem::PaneName.set_order(&mut app.agent_view, 2);
+        crate::app::state::AgentViewItem::SpaceName.set_order(&mut app.agent_view, 3);
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("Echo".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
+
+        assert!(
+            first_row.contains("main · Echo · herdr"),
+            "row: {first_row:?}"
+        );
+    }
+
+    #[test]
+    fn agent_view_can_move_pane_name_to_second_row() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.tabs[0].custom_name = Some("main".into());
+        let pane = workspace.tabs[0].root_pane;
+        workspace.test_add_tab(Some("2"));
+
+        crate::app::state::AgentViewItem::PaneName
+            .set_line(&mut app.agent_view, crate::app::state::ViewLine::Second);
+        crate::app::state::AgentViewItem::PaneName.set_order(&mut app.agent_view, 3);
+        crate::app::state::AgentViewItem::RightAlignment.set_enabled(&mut app.agent_view, false);
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        terminal.detected_agent = Some(Agent::Codex);
+        terminal.set_manual_label("Echo".into());
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let first_row = agent_entry_row_text(buffer, 3, 40);
+        let second_row = agent_entry_row_text(buffer, 4, 40);
+
+        assert!(!first_row.contains("Echo"), "row: {first_row:?}");
+        assert!(second_row.contains("Echo"), "row: {second_row:?}");
+    }
+
+    #[test]
+    fn agent_view_can_hide_and_move_agent_status_indicator() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals
+            .get_mut(&terminal_id)
+            .unwrap()
+            .set_detected_state(Some(Agent::Codex), AgentState::Idle);
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
+        assert!(first_row.contains("✓ herdr"), "row: {first_row:?}");
+
+        crate::app::state::AgentViewItem::AgentStatus.set_enabled(&mut app.agent_view, false);
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let first_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
+        assert!(!first_row.contains("✓"), "row: {first_row:?}");
+
+        crate::app::state::AgentViewItem::AgentStatus.set_enabled(&mut app.agent_view, true);
+        crate::app::state::AgentViewItem::AgentStatus
+            .set_line(&mut app.agent_view, crate::app::state::ViewLine::Second);
+        crate::app::state::AgentViewItem::AgentStatus.set_order(&mut app.agent_view, 0);
+        crate::app::state::AgentViewItem::Status.set_order(&mut app.agent_view, 1);
+        crate::app::state::AgentViewItem::Time.set_order(&mut app.agent_view, 2);
+        crate::app::state::AgentViewItem::AgentName.set_order(&mut app.agent_view, 3);
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let first_row = agent_entry_row_text(buffer, 3, 40);
+        let second_row = agent_entry_row_text(buffer, 4, 40);
+
+        assert!(!first_row.contains("✓"), "row: {first_row:?}");
+        assert!(second_row.contains("✓ idle"), "row: {second_row:?}");
+    }
+
+    #[test]
+    fn agent_view_renders_one_configured_line_from_config_model() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.agent_view.lines = vec![vec![
+            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentStatus),
+            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::SpaceName),
+            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Status),
+            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Time),
+            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::RightAlignment),
+            crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentName),
+        ]];
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let first_row = agent_entry_row_text(buffer, 3, 40);
+        let second_row = agent_entry_row_text(buffer, 4, 40);
+
+        assert!(first_row.contains("herdr"), "row: {first_row:?}");
+        assert!(first_row.contains("working"), "row: {first_row:?}");
+        assert!(first_row.ends_with("codex"), "row: {first_row:?}");
+        assert!(!second_row.contains("herdr"), "row: {second_row:?}");
+        assert!(!second_row.contains("working"), "row: {second_row:?}");
+        assert!(!second_row.contains("codex"), "row: {second_row:?}");
+    }
+
+    #[test]
+    fn agent_view_renders_three_configured_lines_from_config_model() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.agent_view.lines = vec![
+            vec![
+                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentStatus),
+                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::SpaceName),
+            ],
+            vec![
+                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Status),
+                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::Time),
+            ],
+            vec![
+                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::RightAlignment),
+                crate::config::ViewItem::visible(crate::app::state::AgentViewItem::AgentName),
+            ],
+        ];
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 9);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 9),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let first_row = agent_entry_row_text(buffer, 3, 40);
+        let second_row = agent_entry_row_text(buffer, 4, 40);
+        let third_row = agent_entry_row_text(buffer, 5, 40);
+
+        assert!(first_row.contains("herdr"), "row: {first_row:?}");
+        assert!(
+            second_row.contains("working · 2m12s"),
+            "row: {second_row:?}"
+        );
+        assert!(third_row.ends_with("codex"), "row: {third_row:?}");
+    }
+
+    #[test]
+    fn spaces_view_can_hide_branch_status_without_hiding_branch() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.cached_git_branch = Some("main".into());
+        workspace.cached_git_ahead_behind = Some((2, 1));
+        app.workspaces = vec![workspace];
+        crate::app::state::SpaceViewItem::Branch.set_enabled(&mut app.space_view, true);
+        crate::app::state::SpaceViewItem::BranchStatus.set_enabled(&mut app.space_view, false);
+        app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
+            ws_idx: 0,
+            rect: Rect::new(0, 2, 40, 2),
+            indented: false,
+        }];
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                    false,
+                )
+            })
+            .unwrap();
+        let branch_row = agent_entry_row_text(terminal.backend().buffer(), 3, 40);
+
+        assert!(branch_row.contains("main"), "branch row: {branch_row:?}");
+        assert!(!branch_row.contains("↑2"), "branch row: {branch_row:?}");
+        assert!(!branch_row.contains("↓1"), "branch row: {branch_row:?}");
+    }
+
+    #[test]
+    fn spaces_view_renders_one_row_when_config_places_all_items_on_one_line() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.cached_git_branch = Some("main".into());
+        workspace.cached_git_ahead_behind = Some((2, 1));
+        app.space_view.lines = vec![vec![
+            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::Status),
+            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::Name),
+            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::Branch),
+            crate::config::ViewItem::visible(crate::app::state::SpaceViewItem::BranchStatus),
+        ]];
+        app.workspaces = vec![workspace];
+        app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
+            ws_idx: 0,
+            rect: Rect::new(0, 2, 40, 1),
+            indented: false,
+        }];
+
+        assert_eq!(workspace_row_height(&app, &app.workspaces[0]), 1);
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                    false,
+                )
+            })
+            .unwrap();
+        let row = agent_entry_row_text(terminal.backend().buffer(), 2, 40);
+
+        assert!(row.contains("herdr"), "row: {row:?}");
+        assert!(row.contains("main"), "row: {row:?}");
+        assert!(row.contains("↑2"), "row: {row:?}");
+    }
+
+    #[test]
+    fn spaces_view_line_order_can_move_branch_to_first_row() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.cached_git_branch = Some("main".into());
+        app.workspaces = vec![workspace];
+        crate::app::state::SpaceViewItem::Status.set_enabled(&mut app.space_view, false);
+        crate::app::state::SpaceViewItem::Branch
+            .set_line(&mut app.space_view, crate::app::state::ViewLine::First);
+        crate::app::state::SpaceViewItem::Branch.set_order(&mut app.space_view, 0);
+        crate::app::state::SpaceViewItem::Name.set_order(&mut app.space_view, 1);
+        crate::app::state::SpaceViewItem::BranchStatus.set_enabled(&mut app.space_view, false);
+        app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
+            ws_idx: 0,
+            rect: Rect::new(0, 2, 40, 1),
+            indented: false,
+        }];
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                    false,
+                )
+            })
+            .unwrap();
+        let row = agent_entry_row_text(terminal.backend().buffer(), 2, 40);
+
+        assert!(row.contains("main · herdr"), "row: {row:?}");
+    }
+
+    #[test]
+    fn spaces_view_can_hide_status_without_hiding_name() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals.get_mut(&terminal_id).unwrap().detected_agent = Some(Agent::Codex);
+        crate::app::state::SpaceViewItem::Status.set_enabled(&mut app.space_view, false);
+        crate::app::state::SpaceViewItem::Name.set_enabled(&mut app.space_view, true);
+        app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
+            ws_idx: 0,
+            rect: Rect::new(0, 2, 40, 1),
+            indented: false,
+        }];
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                    false,
+                )
+            })
+            .unwrap();
+        let name_row = agent_entry_row_text(terminal.backend().buffer(), 2, 40);
+
+        assert!(name_row.contains("herdr"), "name row: {name_row:?}");
+        assert!(!name_row.contains("○"), "name row: {name_row:?}");
+    }
+
+    #[test]
+    fn spaces_view_can_hide_space_name_and_branch() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut workspace = Workspace::test_new("herdr");
+        workspace.cached_git_branch = Some("main".into());
+        app.workspaces = vec![workspace];
+        crate::app::state::SpaceViewItem::Name.set_enabled(&mut app.space_view, false);
+        crate::app::state::SpaceViewItem::Branch.set_enabled(&mut app.space_view, false);
+        app.view.workspace_card_areas = vec![crate::app::state::WorkspaceCardArea {
+            ws_idx: 0,
+            rect: Rect::new(0, 2, 40, 1),
+            indented: false,
+        }];
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                    false,
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let name_row = agent_entry_row_text(buffer, 2, 40);
+        let branch_row = agent_entry_row_text(buffer, 3, 40);
+
+        assert!(!name_row.contains("herdr"), "name row: {name_row:?}");
+        assert!(!branch_row.contains("main"), "branch row: {branch_row:?}");
+    }
+
+    #[test]
+    fn stale_status_duration_is_dimmed_after_working_finishes() {
+        let mut app = crate::app::state::AppState::test_new();
+        let workspace = Workspace::test_new("herdr");
+        let pane = workspace.tabs[0].root_pane;
+
+        app.workspaces = vec![workspace];
+        app.ensure_test_terminals();
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.terminals.get_mut(&terminal_id).unwrap();
+        let start = std::time::Instant::now() - Duration::from_secs(132);
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Working,
+            false,
+            false,
+            true,
+            false,
+            start,
+        );
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Codex),
+            AgentState::Idle,
+            false,
+            true,
+            false,
+            false,
+            start + Duration::from_secs(132),
+        );
+        app.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        let backend = ratatui::backend::TestBackend::new(40, 8);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_agent_detail(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 8),
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row = agent_entry_row_text(buffer, 4, 40);
+        let duration_col = row.find("2m12s").expect("duration should render") as u16;
+
+        assert!(
+            buffer[(duration_col, 4)].modifier.contains(Modifier::DIM),
+            "duration cell should be dimmed in row: {row:?}"
+        );
     }
 
     #[test]

--- a/src/workspace/aggregate.rs
+++ b/src/workspace/aggregate.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use std::time::Instant;
 
 use crate::detect::{Agent, AgentState};
 use crate::layout::PaneId;
-use crate::terminal::{TerminalId, TerminalState};
+use crate::terminal::{TerminalId, TerminalState, WorkingDuration};
 
 use super::{Tab, Workspace};
 
@@ -11,6 +12,7 @@ pub struct PaneDetail {
     pub pane_id: PaneId,
     pub tab_idx: usize,
     pub tab_label: String,
+    pub pane_label: Option<String>,
     pub label: String,
     pub agent_label: String,
     #[allow(dead_code)]
@@ -18,6 +20,7 @@ pub struct PaneDetail {
     pub state: AgentState,
     pub seen: bool,
     pub custom_status: Option<String>,
+    pub working_duration: Option<WorkingDuration>,
 }
 
 impl Tab {
@@ -29,7 +32,11 @@ impl Tab {
         })
     }
 
-    pub fn pane_details(&self, terminals: &HashMap<TerminalId, TerminalState>) -> Vec<PaneDetail> {
+    pub(crate) fn pane_details_at(
+        &self,
+        terminals: &HashMap<TerminalId, TerminalState>,
+        now: Instant,
+    ) -> Vec<PaneDetail> {
         self.layout
             .pane_ids()
             .iter()
@@ -45,12 +52,14 @@ impl Tab {
                     pane_id: *id,
                     tab_idx: self.number.saturating_sub(1),
                     tab_label: self.display_name(),
+                    pane_label: terminal.manual_label.clone(),
                     label: agent_label.clone(),
                     agent_label,
                     agent: terminal.effective_known_agent(),
                     state: terminal.state,
                     seen: pane.seen,
                     custom_status: terminal.effective_custom_status().map(str::to_string),
+                    working_duration: terminal.working_duration_at(now),
                 })
             })
             .collect()
@@ -89,10 +98,18 @@ impl Workspace {
     }
 
     pub fn pane_details(&self, terminals: &HashMap<TerminalId, TerminalState>) -> Vec<PaneDetail> {
+        self.pane_details_at(terminals, Instant::now())
+    }
+
+    pub(crate) fn pane_details_at(
+        &self,
+        terminals: &HashMap<TerminalId, TerminalState>,
+        now: Instant,
+    ) -> Vec<PaneDetail> {
         let multi_tab = self.tabs.len() > 1;
         self.tabs
             .iter()
-            .flat_map(|tab| tab.pane_details(terminals))
+            .flat_map(|tab| tab.pane_details_at(terminals, now))
             .map(|mut detail| {
                 if multi_tab {
                     detail.label = format!("{}·{}", detail.tab_label, detail.agent_label);

--- a/tests/client_mode.rs
+++ b/tests/client_mode.rs
@@ -15,8 +15,7 @@ use serde::Deserialize;
 use support::{
     cleanup_test_base, client_handshake, encode_varint_u16, encode_varint_u32, frame_message,
     read_server_message, register_runtime_dir, register_spawned_herdr_pid,
-    unregister_spawned_herdr_pid, wait_for_file, wait_for_message_variant, wait_for_socket,
-    wait_until,
+    unregister_spawned_herdr_pid, wait_for_message_variant, wait_for_socket, wait_until,
 };
 
 fn unique_test_dir() -> PathBuf {
@@ -269,7 +268,7 @@ fn client_connects_and_receives_frame() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -338,7 +337,7 @@ fn client_sees_headless_startup_config_diagnostic() {
         child,
     };
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
     let (version, error) =
@@ -386,7 +385,7 @@ fn client_input_forwarded_to_pane() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -440,7 +439,7 @@ fn client_resize_sends_message() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -499,7 +498,7 @@ fn server_shutdown_sends_message_to_client() {
 
     let mut spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -615,7 +614,7 @@ fn server_crash_after_attach_causes_lost_connection_error() {
 
     let mut spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Attach a real thin client (client subcommand) through PTY so handshake and
     // terminal setup paths are exercised.
@@ -731,7 +730,7 @@ fn client_receives_frame_after_pane_output() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -778,7 +777,7 @@ fn navigate_mode_keybind_dispatch_in_server() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -855,7 +854,7 @@ fn pane_spawn_cwd_fallback_in_server() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // The server should have started successfully even though there are
     // no existing sessions (fresh state). The test verifies that the
@@ -896,7 +895,7 @@ fn graceful_shutdown_sends_server_shutdown_to_client() {
 
     let mut spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -995,7 +994,7 @@ fn client_receives_notify_on_agent_state_change() {
         child,
     };
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect as a client and perform handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");

--- a/tests/detach_reattach.rs
+++ b/tests/detach_reattach.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use support::{
     cleanup_test_base, client_handshake, drain_messages, read_server_message, register_runtime_dir,
     register_spawned_herdr_pid, send_detach, send_input, unregister_spawned_herdr_pid,
-    wait_for_disconnect, wait_for_file, wait_for_message_variant, wait_for_socket, wait_until,
+    wait_for_disconnect, wait_for_message_variant, wait_for_socket, wait_until,
 };
 
 fn unique_test_dir() -> PathBuf {
@@ -271,7 +271,7 @@ fn navigate_q_detaches_client_and_server_persists() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
@@ -333,7 +333,7 @@ fn explicit_detach_message_causes_clean_disconnect() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");
@@ -392,7 +392,7 @@ fn reattach_after_detach_shows_current_state() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // --- Client A ---
     let mut stream_a = UnixStream::connect(&client_socket).expect("client A should connect");
@@ -504,7 +504,7 @@ fn processes_survive_during_and_after_detach() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Verify server starts with a workspace (session restore or fresh state).
     let response = ping_socket(&api_socket);
@@ -599,7 +599,7 @@ fn server_persists_after_client_connection_drop() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");
@@ -649,7 +649,7 @@ fn detached_output_preserves_last_attached_pty_size() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     let mut stream = UnixStream::connect(&client_socket).expect("client should connect");
     let (version, error) =
@@ -717,7 +717,7 @@ fn output_accumulated_while_detached_visible_on_reattach() {
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket, &client_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));
-    wait_for_file(&client_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
 
     // Connect and handshake client A.
     let mut stream_a = UnixStream::connect(&client_socket).expect("client A should connect");


### PR DESCRIPTION
Refs #304

Issue: https://github.com/ogulcancelik/herdr/issues/304

## Summary

This PR turns the sidebar from a fixed, hardcoded display into a configurable layout surface for spaces and agents.

The default layout stays the same, but users can now decide which sidebar metadata is visible, how it is split across rows, where right-aligned content begins, and which color preset each item uses. The same model is exposed both in `config.toml` and in the in-app Settings UI.

## Why

This started from a concrete agents-sidebar problem: when multiple agents are running, they are hard to tell apart because the sidebar did not show the pane name. The first goal was to add pane names so agents could be distinguished more easily.

While working on that, it also became useful to show how long each agent had been working. Once the agents sidebar had pane names, working durations, and more display choices, continuing to hardcode each layout decision made less sense.

So the scope grew: instead of only adding a couple of fixed labels, this PR makes the sidebar configurable from the TUI.

## High-Level Changes

- Adds `[ui.sidebar.spaces]` and `[ui.sidebar.agents]` config sections based on `lines = [...]`.
- Treats each sidebar segment as a configurable item with visibility, order, row placement, and color preset.
- Makes `right_alignment` and `custom_status` first-class sidebar items instead of special appended behavior.
- Adds a Settings > Sidebar screen with live previews for spaces and agents.
- Lets agent sidebar layouts render one, two, three, or more rows based on config.
- Moves agent working-duration ownership into terminal state so `working -> blocked -> working` keeps one continuous timer, `working -> idle -> blocked -> working` starts a fresh span, and `working -> blocked -> idle` clears the frozen duration.
- Hardens sidebar config parsing, explicit item omission, config-save failure handling, hook report sequencing, and display-width truncation based on PR review findings.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo nextest run --locked --status-level fail --final-status-level fail --failure-output final --success-output never`
- `python3 -m unittest scripts.test_changelog scripts.test_vendor_libghostty_vt`
- `just check` passes 1582/1582 plus maintenance unittest 30/30.
