### PR TITLE
fix: report release when opencode process exits

### DIFF
--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=opencode
-// HERDR_INTEGRATION_VERSION=3
+// HERDR_INTEGRATION_VERSION=4
 
 import net from "node:net";
 
@@ -71,6 +71,34 @@ function reportState(action, sessionID) {
   });
 }
 
+function releaseSync() {
+  const paneId = process.env.HERDR_PANE_ID;
+  const socketPath = process.env.HERDR_SOCKET_PATH;
+  if (!paneId || !socketPath) return;
+
+  const request = {
+    id: `${SOURCE}:${Date.now()}:${Math.floor(Math.random() * 1_000_000).toString().padStart(6, "0")}`,
+    method: "pane.release_agent",
+    params: {
+      pane_id: paneId,
+      source: SOURCE,
+      agent: "opencode",
+      seq: nextReportSeq(),
+    },
+  };
+
+  try {
+    const client = net.createConnection(socketPath, () => {
+      client.write(`${JSON.stringify(request)}\n`);
+      client.end();
+    });
+    client.unref();
+    client.on("error", () => {});
+  } catch {
+    // process is shutting down — best effort only
+  }
+}
+
 export const HerdrAgentStatePlugin = async () => {
   if (
     process.env.HERDR_ENV !== "1" ||
@@ -79,6 +107,12 @@ export const HerdrAgentStatePlugin = async () => {
   ) {
     return {};
   }
+
+  process.on("beforeExit", releaseSync);
+  process.on("SIGINT", () => { releaseSync(); process.exit(128 + 2); });
+  process.on("SIGTERM", () => { releaseSync(); process.exit(128 + 15); });
+  process.on("SIGHUP", () => { releaseSync(); process.exit(128 + 1); });
+  process.on("SIGQUIT", () => { releaseSync(); process.exit(128 + 3); });
 
   return {
     event: async ({ event }) => {


### PR DESCRIPTION
## Problem
When opencode exits, its herdr plugin doesn't notify herdr — the pane stays stuck in whatever state was last reported (typically working or idle).

## Solution
Add a releaseSync() function that sends pane.release_agent via the Unix socket synchronously (best-effort) from process exit handlers:

- beforeExit — graceful shutdown
- SIGINT (Ctrl+C)
- SIGTERM (kill)
- SIGHUP (terminal close)
- SIGQUIT (core dump)

The socket connection is unrefed so it won't prevent the process from exiting.

## Testing
Tested locally with opencode inside a herdr pane. Verified:
- release is sent on Ctrl+C, closing the terminal tab, and normal exit
- After release, herdr correctly clears the agent from the pane sidebar
- No impact on existing working/blocked/idle state reporting during normal operation

refs #82