### PR TITLE
docs: align qodercli naming and surface Qoder CLI brand on homepage

### DIFF
--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -195,7 +195,7 @@ automatic detection works out of the box. process name matching plus terminal ou
 | antigravity cli | ✓ | ✓ | ✓ |
 | kimi code cli | ✓ | ✓ | ✓ |
 | [github copilot cli](https://github.com/features/copilot) | ✓ | ✓ | ✓ |
-| qoder cli | ✓ | ✓ | ✓ |
+| [qodercli](https://qoder.com/cli) | ✓ | ✓ | ✓ |
 | [kiro cli](https://kiro.dev/docs/cli/) | ✓ | ✓ | — |
 
 detected but not fully tested: gemini cli, cline.
@@ -204,7 +204,7 @@ for agents outside the built-in list, herdr still works as a terminal multiplexe
 
 ### direct integrations
 
-the built-in pi, omp, claude code, codex, opencode, hermes, and qoder cli integrations forward semantic state to herdr over the socket api. install with:
+the built-in pi, omp, claude code, codex, opencode, hermes, and qodercli integrations forward semantic state to herdr over the socket api. install with:
 
 ```bash
 herdr integration install pi
@@ -297,7 +297,7 @@ full logging and environment variable details: [configuration docs](https://herd
 ## docs
 
 - [configuration](https://herdr.dev/docs/configuration/) — keybindings, themes, notifications, environment variables
-- [integrations](https://herdr.dev/docs/integrations/) — pi, omp, claude code, codex, opencode, hermes, qoder cli integrations
+- [integrations](https://herdr.dev/docs/integrations/) — pi, omp, claude code, codex, opencode, hermes, qodercli integrations
 - [`SKILL.md`](./SKILL.md) — reusable agent skill
 - [socket api](https://herdr.dev/docs/socket-api/) — socket protocol and cli reference
 

--- a/website/index.html
+++ b/website/index.html
@@ -714,7 +714,7 @@ $ herdr</code></pre>
                     <div class="agent-card"><span class="agent-icon" style="--agent-icon: url('/assets/agent-icons/kimi.svg')"></span><span>Kimi</span></div>
                     <div class="agent-card"><span class="agent-icon" style="--agent-icon: url('/assets/agent-icons/kiro-mask.svg')"></span><span>Kiro</span></div>
                     <div class="agent-card"><span class="agent-icon" style="--agent-icon: url('/assets/agent-icons/github-copilot.svg')"></span><span>Copilot</span></div>
-                    <div class="agent-card"><span class="agent-icon" style="--agent-icon: url('/assets/agent-icons/qoder-mask.svg')"></span><span>Qoder</span></div>
+                    <div class="agent-card"><span class="agent-icon" style="--agent-icon: url('/assets/agent-icons/qoder-mask.svg')"></span><span>Qoder CLI</span></div>
                 </div>
                 <p class="integration-note">
                     Any terminal agent works in Herdr. Use the Herdr API to add


### PR DESCRIPTION
Follow-up to #309 — small naming tweak.

Convention: `Qoder CLI` is the product name, `qodercli` is the command (as in `herdr integration install qodercli`).

Two changes:

- `docs/next/README.md`: `qoder cli` → `qodercli` in three spots, with the supported-agents row linking to https://qoder.com/cli (matching how peers like `[claude code]` and `[github copilot cli]` already link out).
- `website/index.html`: homepage agent card `Qoder` → `Qoder CLI`. Same idea as `Grok CLI` keeping its suffix to stay distinct from the parent brand — Qoder is a parent brand and `Qoder CLI` is the specific product Herdr integrates with.

Root `README.md` and `website/src/content/docs/` left alone per `CONTRIBUTING.md`; the `docs/next/` change will sync at the next release.

refs #309