### PR TITLE
feat: tmux-compatible status bar (opt-in)

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added an opt-in tmux-compatible status bar via `[ui.status_bar]`, off by default. It renders a one-row bar in `terminal attach` / `agent attach` and in the full-TUI view, using tmux's format mini-language (`#{...}`, `#[...]`, `#(...)`) so an existing tmux status config can be reused. Native variables include `session_name`, `pane_title`, `agent_state`, and `agent_done`; user options (`@name`) are supported via `[ui.status_bar.user_options]` or a `.tmux.conf`-subset file referenced by `status_bar.tmux_conf`. The literal-parity data sources — inner-app OSC 0/2 title capture for `#{pane_title}`, the `#{window_activity}` timestamp, and `#(shell)` expansion — are gated behind `status_bar.tmux_compat` so the default never touches per-pane hot paths or spawns subprocesses.
+
 ## [0.6.4] - 2026-05-27
 
 ### Fixed

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -254,6 +254,67 @@ Set `mouse_scroll_lines` to change how many pane scrollback lines each mouse whe
 
 Set `show_agent_labels_on_pane_borders = true` if you want detected agent labels in split pane borders when no manual pane label is set.
 
+## Status bar
+
+Herdr has an opt-in, tmux-compatible status bar. It is **off by default**. When enabled it draws a one-row bar in `terminal attach` / `agent attach` (at the configured edge) and in the full-TUI view (always at the bottom, since the tab bar owns the top row).
+
+```toml
+[ui.status_bar]
+enabled = true
+# Layer B: enable literal-parity data sources (OSC title, window_activity, #(shell)).
+# Off by default; touches per-pane hot paths only when on.
+tmux_compat = false
+position = "bottom"            # or "top" (attach mode)
+style = "bg=colour238,fg=colour231"
+left = ""
+window_current_format = " #{pane_title} #{?agent_done,✓,[#{agent_state}]} "
+right = " #{session_name} "
+left_length = 0               # 0 = unlimited
+right_length = 40
+
+[ui.status_bar.user_options]
+# tmux @-options, referenced as #{@sc} / #{E:@sc} (store the key without the @).
+sc = "colour167"
+```
+
+Format strings use tmux's mini-language: `#{var}`, conditionals `#{?cond,a,b}`, comparisons `#{==:a,b}`, substitution `#{s/re/rep/flags:var}`, the expand modifier `#{E:@opt}`, truncation `#{=N:var}`, style directives `#[fg=…,bg=…,bold]`, single-char aliases (`#S`, `#T`, …), and `##` for a literal `#`.
+
+### Variables
+
+| Variable | Meaning |
+|----------|---------|
+| `session_name`, `#S` | The pane's workspace display name |
+| `pane_title`, `#T` | Agent/effective pane title (the inner app's OSC 0/2 title under `tmux_compat`) |
+| `agent_state` | `working` \| `idle` \| `blocked` \| `unknown` |
+| `agent_done` | `1` when an agent finished while unseen, else `0` |
+| `window_activity` | Epoch seconds of last output — **requires `tmux_compat`** |
+| `@name` | User option from `[ui.status_bar.user_options]` |
+
+The recommended activity signal is `agent_state`/`agent_done`, which Herdr tracks first-class — more accurate than a `now − window_activity` idle counter.
+
+### `tmux_compat` layer
+
+Setting `tmux_compat = true` enables three literal-parity data sources, each of which would otherwise add cost to code every pane runs:
+
+- `#{pane_title}` prefers the inner app's OSC 0/2 title (falling back to the agent/effective title).
+- `#{window_activity}` is populated from a per-pane last-output timestamp.
+- `#(command)` expansion runs `sh -c command`, cached for ~1 second. Keep commands fast; they run on the render path only while `tmux_compat` is on.
+
+With it off, the status bar never spawns subprocesses, captures titles, or stamps timestamps.
+
+### Reusing an existing `.tmux.conf`
+
+Point `status_bar.tmux_conf` at a file and Herdr applies its `set [-g] [-a]` status options on top of the fields above:
+
+```toml
+[ui.status_bar]
+enabled = true
+tmux_compat = true
+tmux_conf = "~/.tmux.conf"
+```
+
+Recognized directives are `status-style`, `status-left`, `status-right`, `window-status-current-format`, `window-status-format`, `status-left-length`, `status-right-length`, `status-position`, `status`, and `@user-options`. Other directives (bindings, hooks, non-status options) are ignored with a warning. Multi-line `status` (2–5 rows) and clickable status ranges are not supported.
+
 ## Notifications
 
 Herdr can show popup notifications when agents finish or need input.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -452,6 +452,7 @@ impl App {
                 tab_scroll_right_hit_area: Rect::default(),
                 new_tab_hit_area: Rect::default(),
                 terminal_area: Rect::default(),
+                status_bar_rect: Rect::default(),
                 mobile_header_rect: Rect::default(),
                 mobile_menu_hit_area: Rect::default(),
                 toast_hit_area: Rect::default(),
@@ -503,6 +504,19 @@ impl App {
             sound: config.ui.sound.clone(),
             local_sound_playback: true,
             toast_config: config.ui.toast.clone(),
+            status_bar: {
+                let mut sb = config.ui.status_bar.clone();
+                if let Some(path) = sb.tmux_conf.clone() {
+                    let resolved = crate::worktree::expand_tilde_path(&path);
+                    match std::fs::read_to_string(&resolved) {
+                        Ok(contents) => sb.apply_tmux_conf(&contents),
+                        Err(err) => {
+                            tracing::warn!(path, %err, "failed to read status_bar.tmux_conf")
+                        }
+                    }
+                }
+                sb
+            },
             keybinds: config.keybinds(),
             spinner_tick: 0,
             palette: resolve_palette(config),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -624,6 +624,8 @@ pub struct ViewState {
     pub tab_scroll_right_hit_area: Rect,
     pub new_tab_hit_area: Rect,
     pub terminal_area: Rect,
+    /// Status-bar row (full-TUI). `Rect::default()` (zero height) when disabled.
+    pub status_bar_rect: Rect,
     pub mobile_header_rect: Rect,
     pub mobile_menu_hit_area: Rect,
     pub toast_hit_area: Rect,
@@ -1153,6 +1155,8 @@ pub struct AppState {
     pub sound: SoundConfig,
     pub local_sound_playback: bool,
     pub toast_config: ToastConfig,
+    /// tmux-style status bar configuration (opt-in; inert when disabled).
+    pub status_bar: crate::config::StatusBarConfig,
     pub keybinds: Keybinds,
     /// Frame counter for spinner animations (wraps around).
     pub spinner_tick: u32,
@@ -1304,6 +1308,72 @@ impl AppState {
         self.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, pane_id)
     }
 
+    /// Build the status-bar variable context for an attached terminal.
+    pub(crate) fn status_bar_context(
+        &self,
+        terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+        tid: &crate::terminal::TerminalId,
+    ) -> crate::status::StatusContext {
+        let mut session_name = String::new();
+        let mut seen = true;
+        'find: for ws in &self.workspaces {
+            for tab in &ws.tabs {
+                for pane in tab.panes.values() {
+                    if &pane.attached_terminal_id == tid {
+                        session_name = ws.display_name_from(&self.terminals, terminal_runtimes);
+                        seen = pane.seen;
+                        break 'find;
+                    }
+                }
+            }
+        }
+        let term = self.terminals.get(tid);
+        let pane_title = term
+            .and_then(|t| t.border_label(true))
+            .unwrap_or_default();
+        let state = term
+            .map(|t| t.state)
+            .unwrap_or(crate::detect::AgentState::Unknown);
+        let agent_state = match state {
+            crate::detect::AgentState::Working => "working",
+            crate::detect::AgentState::Idle => "idle",
+            crate::detect::AgentState::Blocked => "blocked",
+            crate::detect::AgentState::Unknown => "unknown",
+        }
+        .to_string();
+        let agent_done = !seen && matches!(state, crate::detect::AgentState::Idle);
+        crate::status::StatusContext {
+            session_name,
+            pane_title,
+            agent_state,
+            agent_done,
+            // Layer B (`tmux_compat`) populates these; unset under the clean default.
+            window_activity: None,
+            user_options: self.status_bar.user_options.clone(),
+            allow_shell: false,
+        }
+    }
+
+    /// Compose the status-bar line for an attached terminal, `width` columns wide.
+    pub(crate) fn compose_status_line(
+        &self,
+        terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+        tid: &crate::terminal::TerminalId,
+        width: u16,
+    ) -> ratatui::text::Line<'static> {
+        let ctx = self.status_bar_context(terminal_runtimes, tid);
+        let cfg = &self.status_bar;
+        let spec = crate::status::StatusSpec {
+            style: &cfg.style,
+            left: &cfg.left,
+            right: &cfg.right,
+            window: &cfg.window_current_format,
+            left_length: cfg.left_length,
+            right_length: cfg.right_length,
+        };
+        crate::status::compose(&spec, width, &ctx)
+    }
+
     pub fn is_active_pane(
         &self,
         ws_idx: usize,
@@ -1399,6 +1469,7 @@ impl AppState {
                 tab_scroll_right_hit_area: Rect::default(),
                 new_tab_hit_area: Rect::default(),
                 terminal_area: Rect::default(),
+                status_bar_rect: Rect::default(),
                 mobile_header_rect: Rect::default(),
                 mobile_menu_hit_area: Rect::default(),
                 toast_hit_area: Rect::default(),
@@ -1453,6 +1524,7 @@ impl AppState {
             },
             local_sound_playback: false,
             toast_config: ToastConfig::default(),
+            status_bar: crate::config::StatusBarConfig::default(),
             keybinds: Keybinds::default(),
             spinner_tick: 0,
             palette: Palette::catppuccin(),
@@ -1510,6 +1582,61 @@ impl AppState {
 mod tests {
     use super::*;
     use crossterm::event::KeyEvent;
+
+    #[test]
+    fn status_bar_context_binds_workspace_terminal_state() {
+        let mut app = AppState::test_new();
+        let ws = Workspace::test_new("ws3");
+        let tid = ws.tabs[0]
+            .panes
+            .values()
+            .next()
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+        let mut term =
+            crate::terminal::TerminalState::new(tid.clone(), std::path::PathBuf::from("/tmp"));
+        term.state = crate::detect::AgentState::Working;
+        term.set_manual_label("claude".to_string());
+        app.terminals.insert(tid.clone(), term);
+        app.workspaces.push(ws);
+
+        let registry = crate::terminal::TerminalRuntimeRegistry::new();
+        let ctx = app.status_bar_context(&registry, &tid);
+        assert_eq!(ctx.session_name, "ws3");
+        assert_eq!(ctx.pane_title, "claude");
+        assert_eq!(ctx.agent_state, "working");
+        assert!(!ctx.agent_done);
+    }
+
+    #[test]
+    fn compose_status_line_renders_title_and_session() {
+        let mut app = AppState::test_new();
+        let ws = Workspace::test_new("1");
+        let tid = ws.tabs[0]
+            .panes
+            .values()
+            .next()
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+        let mut term =
+            crate::terminal::TerminalState::new(tid.clone(), std::path::PathBuf::from("/tmp"));
+        term.state = crate::detect::AgentState::Working;
+        term.set_manual_label("agent".to_string());
+        app.terminals.insert(tid.clone(), term);
+        app.workspaces.push(ws);
+        app.status_bar.enabled = true;
+        app.status_bar.window_current_format = " #{pane_title} [#{agent_state}] ".into();
+        app.status_bar.right = " #{session_name} ".into();
+
+        let registry = crate::terminal::TerminalRuntimeRegistry::new();
+        let line = app.compose_status_line(&registry, &tid, 40);
+        assert_eq!(line.width(), 40);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("agent [working]"), "got: {text:?}");
+        assert!(text.trim_end().ends_with(" 1"), "session right: {text:?}");
+    }
 
     #[test]
     fn built_in_theme_names_resolve() {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1328,8 +1328,19 @@ impl AppState {
             }
         }
         let term = self.terminals.get(tid);
-        let pane_title = term
-            .and_then(|t| t.border_label(true))
+        let tmux_compat = self.status_bar.tmux_compat;
+        // Layer B: prefer the inner app's OSC 0/2 title; fall back to herdr's
+        // agent/effective title (the clean-default source).
+        let osc_title = if tmux_compat {
+            terminal_runtimes
+                .get(tid)
+                .map(|rt| rt.osc_title())
+                .filter(|t| !t.is_empty())
+        } else {
+            None
+        };
+        let pane_title = osc_title
+            .or_else(|| term.and_then(|t| t.border_label(true)))
             .unwrap_or_default();
         let state = term
             .map(|t| t.state)
@@ -1347,10 +1358,15 @@ impl AppState {
             pane_title,
             agent_state,
             agent_done,
-            // Layer B (`tmux_compat`) populates these; unset under the clean default.
-            window_activity: None,
+            // Layer B (`tmux_compat`) exposes `window_activity` from the per-pane
+            // output timestamp; unset under the clean default.
+            window_activity: if tmux_compat {
+                term.and_then(|t| t.window_activity_epoch())
+            } else {
+                None
+            },
             user_options: self.status_bar.user_options.clone(),
-            allow_shell: false,
+            allow_shell: tmux_compat,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,8 @@ pub use self::{
     },
     model::{
         validated_sidebar_bounds, AgentPanelScopeConfig, Config, ConfigReloadReport,
-        ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, ToastConfig, ToastDelivery,
+        ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, StatusBarConfig, StatusBarPosition,
+        ToastConfig, ToastDelivery,
     },
     sound::SoundConfig,
     theme::{parse_color, CustomThemeColors, ThemeConfig},

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 use serde::{Deserialize, Deserializer, Serialize};
@@ -282,6 +283,201 @@ pub struct UiConfig {
     pub toast: ToastConfig,
     /// Play sounds when agents change state in background workspaces.
     pub sound: SoundConfig,
+    /// tmux-style status bar (opt-in). See [`StatusBarConfig`].
+    pub status_bar: StatusBarConfig,
+}
+
+/// Where the status bar is drawn relative to the terminal/pane area.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusBarPosition {
+    Top,
+    #[default]
+    Bottom,
+}
+
+/// tmux-compatible status bar configuration.
+///
+/// Layer A (default) binds to herdr state that already exists (`agent_state`,
+/// `session_name`, `pane_title`). Layer B (`tmux_compat`) additionally enables
+/// OSC-title capture and the `window_activity` timestamp, which touch shared
+/// hot paths; it is off by default. Format strings use the tmux mini-language
+/// (`#{...}`, `#[...]`, `#(...)`). See `docs/plans/tmux-status-bar.md`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct StatusBarConfig {
+    /// Master switch. Default: false (fully inert when off).
+    pub enabled: bool,
+    /// Enable literal-parity data sources (OSC title capture + `window_activity`
+    /// timestamp). Touches per-pane hot paths. Default: false.
+    pub tmux_compat: bool,
+    /// Bar position. Default: bottom.
+    pub position: StatusBarPosition,
+    /// `status-style`: base style for the whole bar.
+    pub style: String,
+    /// `status-left`.
+    pub left: String,
+    /// `status-right`.
+    pub right: String,
+    /// `window-status-current-format`: the focused/attached pane's segment.
+    pub window_current_format: String,
+    /// `window-status-format`: non-focused panes (full-TUI multi-pane only).
+    pub window_format: String,
+    /// `status-left-length` (0 = unlimited).
+    pub left_length: usize,
+    /// `status-right-length` (0 = unlimited).
+    pub right_length: usize,
+    /// User options (`@name`), referenced via `#{@name}` / `#{E:@name}`. Keys
+    /// are stored without the leading `@`.
+    pub user_options: HashMap<String, String>,
+    /// Optional path to a `.tmux.conf`-style file. Its `set [-g]` status options
+    /// are parsed and applied on top of the fields above, so an existing tmux
+    /// status config can be reused nearly verbatim.
+    pub tmux_conf: Option<String>,
+}
+
+impl Default for StatusBarConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            tmux_compat: false,
+            position: StatusBarPosition::Bottom,
+            style: "bg=colour238,fg=colour231".into(),
+            left: String::new(),
+            window_current_format: " #{pane_title} #{?agent_done,✓,[#{agent_state}]} ".into(),
+            window_format: " #{pane_title} ".into(),
+            right: " #{session_name} ".into(),
+            left_length: 0,
+            right_length: 40,
+            user_options: HashMap::new(),
+            tmux_conf: None,
+        }
+    }
+}
+
+impl StatusBarConfig {
+    /// Apply `set [-g] [-a] <option> <value>` lines from a `.tmux.conf`-style
+    /// string on top of the current config. Unsupported directives are ignored
+    /// with a warning. Only status-related options are recognized.
+    pub fn apply_tmux_conf(&mut self, contents: &str) {
+        for raw in contents.lines() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let tokens = tokenize_conf_line(line);
+            self.apply_tmux_tokens(&tokens);
+        }
+    }
+
+    fn apply_tmux_tokens(&mut self, tokens: &[String]) {
+        let mut i = 0;
+        match tokens.first().map(String::as_str) {
+            Some("set" | "set-option" | "setw" | "set-window-option") => i += 1,
+            _ => return,
+        }
+        let mut append = false;
+        while let Some(tok) = tokens.get(i) {
+            if let Some(flags) = tok.strip_prefix('-') {
+                if flags.contains('a') {
+                    append = true;
+                }
+                i += 1;
+            } else {
+                break;
+            }
+        }
+        let Some(name) = tokens.get(i) else {
+            return;
+        };
+        let value = tokens.get(i + 1).cloned().unwrap_or_default();
+        self.set_tmux_option(name, &value, append);
+    }
+
+    fn set_tmux_option(&mut self, name: &str, value: &str, append: bool) {
+        fn assign(field: &mut String, value: &str, append: bool) {
+            if append {
+                field.push_str(value);
+            } else {
+                *field = value.to_string();
+            }
+        }
+        if let Some(user) = name.strip_prefix('@') {
+            let entry = self.user_options.entry(user.to_string()).or_default();
+            assign(entry, value, append);
+            return;
+        }
+        match name {
+            "status-style" => assign(&mut self.style, value, append),
+            "status-left" => assign(&mut self.left, value, append),
+            "status-right" => assign(&mut self.right, value, append),
+            "window-status-current-format" => {
+                assign(&mut self.window_current_format, value, append)
+            }
+            "window-status-format" => assign(&mut self.window_format, value, append),
+            "status-left-length" => {
+                if let Ok(n) = value.parse() {
+                    self.left_length = n;
+                }
+            }
+            "status-right-length" => {
+                if let Ok(n) = value.parse() {
+                    self.right_length = n;
+                }
+            }
+            "status-position" => {
+                self.position = if value == "top" {
+                    StatusBarPosition::Top
+                } else {
+                    StatusBarPosition::Bottom
+                };
+            }
+            // `status` is on/off/0-5 in tmux; treat anything but off/0 as enabled.
+            "status" => self.enabled = !matches!(value, "off" | "0"),
+            other => {
+                tracing::warn!(option = other, "unsupported tmux status option ignored");
+            }
+        }
+    }
+}
+
+/// Split a config line on whitespace, honoring single and double quotes.
+fn tokenize_conf_line(line: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut quote: Option<char> = None;
+    let mut has_token = false;
+    for ch in line.chars() {
+        match quote {
+            Some(q) => {
+                if ch == q {
+                    quote = None;
+                } else {
+                    cur.push(ch);
+                }
+            }
+            None => match ch {
+                '\'' | '"' => {
+                    quote = Some(ch);
+                    has_token = true;
+                }
+                c if c.is_whitespace() => {
+                    if has_token {
+                        tokens.push(std::mem::take(&mut cur));
+                        has_token = false;
+                    }
+                }
+                c => {
+                    cur.push(c);
+                    has_token = true;
+                }
+            },
+        }
+    }
+    if has_token {
+        tokens.push(cur);
+    }
+    tokens
 }
 
 /// Cursor shape (DECSCUSR) used for the forced IME anchor.
@@ -433,6 +629,7 @@ impl Default for UiConfig {
             accent: "cyan".into(),
             toast: ToastConfig::default(),
             sound: SoundConfig::default(),
+            status_bar: StatusBarConfig::default(),
         }
     }
 }
@@ -486,6 +683,57 @@ impl Default for AdvancedConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tmux_conf_subset_applies_status_options() {
+        let mut sb = StatusBarConfig::default();
+        let conf = r#"
+# the user's bar
+set -g status-style 'bg=#{E:@sc},fg=colour16'
+set -g @sc 'colour167'
+set-option -g status-right '#[fg=colour16,bold] #{session_name} '
+set -g status-right-length 12
+set -g status-position top
+set -g window-status-current-format ' #{pane_title}  #(idle.sh) '
+bind a attach-session -d
+"#;
+        sb.apply_tmux_conf(conf);
+        assert_eq!(sb.style, "bg=#{E:@sc},fg=colour16");
+        assert_eq!(sb.user_options.get("sc").map(String::as_str), Some("colour167"));
+        assert_eq!(sb.right, "#[fg=colour16,bold] #{session_name} ");
+        assert_eq!(sb.right_length, 12);
+        assert_eq!(sb.position, StatusBarPosition::Top);
+        assert_eq!(sb.window_current_format, " #{pane_title}  #(idle.sh) ");
+    }
+
+    #[test]
+    fn tmux_conf_append_concatenates() {
+        let mut sb = StatusBarConfig::default();
+        sb.apply_tmux_conf("set -g status-right 'a'\nset -ga status-right 'b'");
+        assert_eq!(sb.right, "ab");
+    }
+
+    #[test]
+    fn status_bar_config_parses_from_toml() {
+        let toml = r#"
+[ui.status_bar]
+enabled = true
+tmux_compat = true
+position = "top"
+right = " #{session_name} "
+
+[ui.status_bar.user_options]
+sc = "colour208"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.ui.status_bar.enabled);
+        assert!(config.ui.status_bar.tmux_compat);
+        assert_eq!(config.ui.status_bar.position, StatusBarPosition::Top);
+        assert_eq!(
+            config.ui.status_bar.user_options.get("sc").map(String::as_str),
+            Some("colour208")
+        );
+    }
 
     #[test]
     fn terminal_default_shell_defaults_empty_and_parses() {

--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -703,6 +703,30 @@ impl Terminal {
         self.get_usize(ffi::GhosttyTerminalData_GHOSTTY_TERMINAL_DATA_SCROLLBACK_ROWS)
     }
 
+    /// The terminal title set via OSC 0/2, or an empty string if none.
+    ///
+    /// The returned bytes are borrowed by ghostty until the next `vt_write`, so
+    /// we copy them out immediately into an owned `String`.
+    pub fn title(&self) -> Result<String, Error> {
+        let mut out = ffi::GhosttyString {
+            ptr: ptr::null(),
+            len: 0,
+        };
+        unsafe {
+            ffi::ghostty_terminal_get(
+                self.raw,
+                ffi::GhosttyTerminalData_GHOSTTY_TERMINAL_DATA_TITLE,
+                (&mut out as *mut ffi::GhosttyString).cast(),
+            )
+            .into_result()?;
+        }
+        if out.ptr.is_null() || out.len == 0 {
+            return Ok(String::new());
+        }
+        let bytes = unsafe { slice::from_raw_parts(out.ptr, out.len) };
+        Ok(String::from_utf8_lossy(bytes).into_owned())
+    }
+
     pub fn scrollbar(&self) -> Result<TerminalScrollbar, Error> {
         let mut out = ffi::GhosttyTerminalScrollbar::default();
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod selection;
 mod server;
 mod session;
 mod sound;
+mod status;
 mod terminal;
 mod terminal_notify;
 mod terminal_theme;

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1884,6 +1884,10 @@ impl PaneRuntime {
         })
     }
 
+    pub fn osc_title(&self) -> String {
+        self.terminal.osc_title()
+    }
+
     pub fn visible_text(&self) -> String {
         self.terminal.visible_text()
     }

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -153,6 +153,10 @@ impl PaneTerminal {
         self.ghostty.cursor_state()
     }
 
+    pub fn osc_title(&self) -> String {
+        self.ghostty.osc_title()
+    }
+
     pub fn visible_text(&self) -> String {
         self.ghostty.visible_text()
     }
@@ -625,6 +629,14 @@ impl GhosttyPaneTerminal {
         encoder.encode(&event).ok()
     }
 
+    pub fn osc_title(&self) -> String {
+        self.core
+            .lock()
+            .ok()
+            .and_then(|core| ghostty_title(&core).ok())
+            .unwrap_or_default()
+    }
+
     pub fn visible_text(&self) -> String {
         self.core
             .lock()
@@ -847,6 +859,10 @@ fn ghostty_visible_hyperlinks(
         y += 1;
     }
     Ok(links)
+}
+
+fn ghostty_title(core: &GhosttyPaneCore) -> Result<String, crate::ghostty::Error> {
+    core.terminal.title()
 }
 
 fn ghostty_visible_text(core: &mut GhosttyPaneCore) -> Result<String, crate::ghostty::Error> {

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -1558,6 +1558,16 @@ impl HeadlessServer {
         self.resize_shared_runtime_to_effective_size();
     }
 
+    /// Rows reserved for the status bar in attach mode (0 when disabled, so the
+    /// resize/render paths are byte-identical to today when off).
+    fn status_bar_rows(&self) -> u16 {
+        if self.app.state.status_bar.enabled {
+            1
+        } else {
+            0
+        }
+    }
+
     fn attach_terminal_client(
         &mut self,
         client_id: u64,
@@ -1624,8 +1634,14 @@ impl HeadlessServer {
             .state
             .direct_attach_resize_locks
             .insert(real_terminal_id.clone());
+        let bar_rows = self.status_bar_rows();
         if let Some(runtime) = self.app.terminal_runtimes.get(&real_terminal_id) {
-            runtime.resize(rows, cols, cell_size.width_px, cell_size.height_px);
+            runtime.resize(
+                rows.saturating_sub(bar_rows),
+                cols,
+                cell_size.width_px,
+                cell_size.height_px,
+            );
         }
         true
     }
@@ -1853,8 +1869,14 @@ impl HeadlessServer {
                     None
                 };
                 if let Some(terminal_id) = direct_terminal_id {
+                    let bar_rows = self.status_bar_rows();
                     if let Some(runtime) = self.runtime_for_terminal_id_string(&terminal_id) {
-                        runtime.resize(rows, cols, cell_width_px, cell_height_px);
+                        runtime.resize(
+                            rows.saturating_sub(bar_rows),
+                            cols,
+                            cell_width_px,
+                            cell_height_px,
+                        );
                     }
                     return true;
                 }
@@ -2246,6 +2268,26 @@ impl HeadlessServer {
                     FrameData::from_ratatui_buffer_with_hyperlinks(&buffer, cursor, &hyperlinks)
                 }
                 ClientConnectionMode::TerminalAttach { terminal_id } => {
+                    let position = self.app.state.status_bar.position;
+                    let status = if self.status_bar_rows() > 0 {
+                        self.terminal_id_by_string(&terminal_id).map(|tid| {
+                            (
+                                self.app.state.compose_status_line(
+                                    &self.app.terminal_runtimes,
+                                    &tid,
+                                    area.width,
+                                ),
+                                position,
+                            )
+                        })
+                    } else {
+                        None
+                    };
+                    let inner_area = crate::server::render_stream::attach_inner_area(
+                        area,
+                        status.is_some(),
+                        position,
+                    );
                     let Some(runtime) = self.runtime_for_terminal_id_string(&terminal_id) else {
                         self.send_to_client(
                             client_id,
@@ -2258,9 +2300,10 @@ impl HeadlessServer {
                         broken_clients.push(client_id);
                         continue;
                     };
-                    let (buffer, cursor) =
-                        crate::server::render_stream::render_terminal_virtual(runtime, area);
-                    let hyperlinks = runtime.visible_hyperlinks(area);
+                    let (buffer, cursor) = crate::server::render_stream::render_terminal_virtual(
+                        runtime, area, status,
+                    );
+                    let hyperlinks = runtime.visible_hyperlinks(inner_area);
                     FrameData::from_ratatui_buffer_with_hyperlinks(&buffer, cursor, &hyperlinks)
                 }
             };

--- a/src/server/render_stream.rs
+++ b/src/server/render_stream.rs
@@ -261,23 +261,66 @@ pub(crate) fn render_virtual_with_runtime_registry(
     (buffer, cursor)
 }
 
+/// The sub-rect the attached terminal renders into, given whether a status bar
+/// is present and where. Single source of truth shared by the renderer and the
+/// hyperlink mapping so they always agree.
+pub(crate) fn attach_inner_area(
+    area: Rect,
+    status_present: bool,
+    position: crate::config::StatusBarPosition,
+) -> Rect {
+    let bar_rows: u16 = if status_present { 1 } else { 0 };
+    let body_height = area.height.saturating_sub(bar_rows);
+    match position {
+        crate::config::StatusBarPosition::Top if status_present => Rect {
+            y: area.y + bar_rows,
+            height: body_height,
+            ..area
+        },
+        _ => Rect {
+            height: body_height,
+            ..area
+        },
+    }
+}
+
 /// Renders one server-owned terminal directly for `terminal attach` clients.
+///
+/// When `status` is `Some`, a one-row status bar is composited at the configured
+/// edge and the terminal is rendered into the remaining area. The inner runtime
+/// must already be sized to that reduced height (see `attach_terminal_client` /
+/// the `ClientResize` handler), so its content lines up with the inner area.
 pub(crate) fn render_terminal_virtual(
     runtime: &crate::terminal::TerminalRuntime,
     area: Rect,
+    status: Option<(ratatui::text::Line<'static>, crate::config::StatusBarPosition)>,
 ) -> (ratatui::buffer::Buffer, Option<CursorState>) {
+    let position = status
+        .as_ref()
+        .map(|(_, pos)| *pos)
+        .unwrap_or(crate::config::StatusBarPosition::Bottom);
+    let inner_area = attach_inner_area(area, status.is_some(), position);
+    let bar_y = match position {
+        crate::config::StatusBarPosition::Top => area.y,
+        crate::config::StatusBarPosition::Bottom => area.y + inner_area.height,
+    };
+
     let backend = CursorTrackingBackend::new(area.width, area.height);
     let mut terminal = ratatui::Terminal::new(backend).expect("TestBackend::new should never fail");
 
     terminal
         .draw(|frame| {
-            runtime.render(frame, area, true);
+            runtime.render(frame, inner_area, true);
         })
         .expect("render to TestBackend should never fail");
 
-    let buffer = terminal.backend().buffer().clone();
+    let mut buffer = terminal.backend().buffer().clone();
+    if let Some((line, _)) = status {
+        buffer.set_line(area.x, bar_y, &line, area.width);
+    }
+
     let cursor = runtime
-        .cursor_state(area, true)
+        .cursor_state(inner_area, true)
         .map(|cursor| CursorState {
             x: cursor.x,
             y: cursor.y,
@@ -380,5 +423,38 @@ fn focused_terminal_cursor(
         })
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod status_bar_tests {
+    use super::attach_inner_area;
+    use crate::config::StatusBarPosition;
+    use ratatui::layout::Rect;
+
+    #[test]
+    fn no_status_bar_is_inert() {
+        // When no bar is present the inner area is the full area (byte-identical
+        // to pre-feature behavior).
+        let area = Rect::new(0, 0, 80, 24);
+        assert_eq!(
+            attach_inner_area(area, false, StatusBarPosition::Bottom),
+            area
+        );
+        assert_eq!(attach_inner_area(area, false, StatusBarPosition::Top), area);
+    }
+
+    #[test]
+    fn bottom_bar_reserves_last_row() {
+        let area = Rect::new(0, 0, 80, 24);
+        let inner = attach_inner_area(area, true, StatusBarPosition::Bottom);
+        assert_eq!(inner, Rect::new(0, 0, 80, 23));
+    }
+
+    #[test]
+    fn top_bar_reserves_first_row() {
+        let area = Rect::new(0, 0, 80, 24);
+        let inner = attach_inner_area(area, true, StatusBarPosition::Top);
+        assert_eq!(inner, Rect::new(0, 1, 80, 23));
     }
 }

--- a/src/status/bar.rs
+++ b/src/status/bar.rs
@@ -1,0 +1,89 @@
+//! Status-line composition: assemble `status-left`, the (single) window-status
+//! segment, and `status-right` into a width-filled ratatui [`Line`], mirroring
+//! tmux's left/right justification.
+
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use unicode_width::UnicodeWidthStr;
+
+use super::expand::{expand_str, render_segments, FormatResolver};
+use super::style::apply_style_spec;
+
+/// Format strings + length limits for one status line. Field names mirror tmux
+/// options. Lengths of `0` mean "unlimited" (as in tmux).
+pub struct StatusSpec<'a> {
+    pub style: &'a str,
+    pub left: &'a str,
+    pub right: &'a str,
+    pub window: &'a str,
+    pub left_length: usize,
+    pub right_length: usize,
+}
+
+/// Compose a status line of exactly `width` columns.
+pub fn compose(spec: &StatusSpec, width: u16, r: &dyn FormatResolver) -> Line<'static> {
+    let width = width as usize;
+    let base = apply_style_spec(&expand_str(spec.style, r), Style::default(), Style::default());
+
+    let mut left = render_segments(spec.left, base, r);
+    if spec.left_length > 0 {
+        truncate_segments(&mut left, spec.left_length);
+    }
+    let window = render_segments(spec.window, base, r);
+    let mut right = render_segments(spec.right, base, r);
+    if spec.right_length > 0 {
+        truncate_segments(&mut right, spec.right_length);
+    }
+
+    let right_width = segments_width(&right);
+    let mut left_part = left;
+    left_part.extend(window);
+
+    // Reserve space for the right segment; truncate the left part if needed.
+    let left_budget = width.saturating_sub(right_width);
+    truncate_segments(&mut left_part, left_budget);
+    let left_width = segments_width(&left_part);
+
+    let pad = width.saturating_sub(left_width + right_width);
+
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(left_part.len() + right.len() + 1);
+    for (text, style) in left_part {
+        spans.push(Span::styled(text, style));
+    }
+    if pad > 0 {
+        spans.push(Span::styled(" ".repeat(pad), base));
+    }
+    for (text, style) in right {
+        spans.push(Span::styled(text, style));
+    }
+    Line::from(spans)
+}
+
+fn segments_width(segs: &[(String, Style)]) -> usize {
+    segs.iter().map(|(t, _)| UnicodeWidthStr::width(t.as_str())).sum()
+}
+
+/// Truncate styled segments to at most `max` display columns (column-accurate).
+fn truncate_segments(segs: &mut Vec<(String, Style)>, max: usize) {
+    use unicode_width::UnicodeWidthChar;
+    let mut width = 0usize;
+    let mut keep = Vec::new();
+    'outer: for (text, style) in segs.drain(..) {
+        let mut piece = String::new();
+        for ch in text.chars() {
+            let w = ch.width().unwrap_or(0);
+            if width + w > max {
+                if !piece.is_empty() {
+                    keep.push((piece, style));
+                }
+                break 'outer;
+            }
+            width += w;
+            piece.push(ch);
+        }
+        if !piece.is_empty() {
+            keep.push((piece, style));
+        }
+    }
+    *segs = keep;
+}

--- a/src/status/expand.rs
+++ b/src/status/expand.rs
@@ -1,0 +1,510 @@
+//! tmux format-string expansion: `#{...}` expressions, `#(...)` shell commands,
+//! `#[...]` style directives, single-char aliases (`#S`, `#T`, ...), and `##`.
+//!
+//! This is a clean-room Rust reimplementation of the subset of tmux's `format.c`
+//! that the status bar needs (see `docs/plans/tmux-status-bar.md`). It is a pure
+//! function of the input string and a [`FormatResolver`]; it has no herdr
+//! coupling, so it is unit- and parity-testable in isolation.
+//!
+//! Known divergences from tmux (documented, acceptable for the status bar):
+//! - `#{...}` brace matching is structural; a `}` *inside* a substitution pattern
+//!   (e.g. `s/a}b/x/`) closes the expression early. Patterns needing literal `}`
+//!   are unsupported.
+//! - Numeric comparison falls back to byte-string ordering when operands aren't
+//!   both parseable as `f64`.
+
+use std::borrow::Cow;
+
+use ratatui::style::Style;
+
+use super::style::apply_style_spec;
+
+/// Source of variable and user-option values, plus optional `#(shell)` output.
+///
+/// `var("session_name")` returns built-in/native variables; `var("@foo")` returns
+/// the *raw* (unexpanded) user-option value — `#{E:@foo}` re-expands it.
+pub trait FormatResolver {
+    fn var(&self, name: &str) -> Option<Cow<'_, str>>;
+    /// Expand a `#(command)` to its (already-cached) stdout. Default: unsupported.
+    fn shell(&self, command: &str) -> Option<String> {
+        let _ = command;
+        None
+    }
+}
+
+/// Render a format string into styled `(text, Style)` segments, starting from
+/// `base`. `#[...]` directives switch the active style for following text.
+pub fn render_segments(input: &str, base: Style, r: &dyn FormatResolver) -> Vec<(String, Style)> {
+    let mut segs: Vec<(String, Style)> = Vec::new();
+    let mut cur = base;
+    let mut buf = String::new();
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    macro_rules! flush {
+        () => {
+            if !buf.is_empty() {
+                segs.push((std::mem::take(&mut buf), cur));
+            }
+        };
+    }
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'#' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'#' => {
+                    buf.push('#');
+                    i += 2;
+                    continue;
+                }
+                b'{' => {
+                    if let Some(close) = matching_close(input, i) {
+                        buf.push_str(&eval_inner(&input[i + 2..close], r));
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                b'(' => {
+                    if let Some(close) = matching_close(input, i) {
+                        let cmd = expand_str(&input[i + 2..close], r);
+                        if let Some(out) = r.shell(&cmd) {
+                            buf.push_str(out.trim_end_matches('\n'));
+                        }
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                b'[' => {
+                    if let Some(close) = matching_close(input, i) {
+                        let spec = expand_str(&input[i + 2..close], r);
+                        flush!();
+                        cur = apply_style_spec(&spec, base, cur);
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                other => {
+                    if let Some(name) = alias(other) {
+                        buf.push_str(&var_lookup(name, r));
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+        }
+        let ch = input[i..].chars().next().unwrap();
+        buf.push(ch);
+        i += ch.len_utf8();
+    }
+    flush!();
+    segs
+}
+
+/// Expand a format string to a plain `String` (style directives consumed but not
+/// applied). Used for nested contexts: conditions, comparison operands, the
+/// values fed to modifiers, and `#(shell)` command text.
+pub fn expand_str(input: &str, r: &dyn FormatResolver) -> String {
+    let mut out = String::new();
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'#' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'#' => {
+                    out.push('#');
+                    i += 2;
+                    continue;
+                }
+                b'{' => {
+                    if let Some(close) = matching_close(input, i) {
+                        out.push_str(&eval_inner(&input[i + 2..close], r));
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                b'(' => {
+                    if let Some(close) = matching_close(input, i) {
+                        let cmd = expand_str(&input[i + 2..close], r);
+                        if let Some(o) = r.shell(&cmd) {
+                            out.push_str(o.trim_end_matches('\n'));
+                        }
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                b'[' => {
+                    if let Some(close) = matching_close(input, i) {
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                other => {
+                    if let Some(name) = alias(other) {
+                        out.push_str(&var_lookup(name, r));
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+        }
+        let ch = input[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// Evaluate the contents of a single `#{...}` (without the braces).
+fn eval_inner(content: &str, r: &dyn FormatResolver) -> String {
+    // Conditional: #{?condition,true,false}
+    if let Some(body) = content.strip_prefix('?') {
+        let (cond, rest) = split_first(body, b',');
+        let (t, f) = match rest {
+            Some(rest) => split_first(rest, b','),
+            None => ("", None),
+        };
+        // tmux treats a bare condition name as a variable reference
+        // (e.g. `#{?client_prefix,...}`), while `#{...}` conditions expand.
+        let cond_val = eval_or_var(cond, r);
+        return if is_true(&cond_val) {
+            expand_str(t, r)
+        } else {
+            expand_str(f.unwrap_or(""), r)
+        };
+    }
+
+    // Comparison / logical operators: #{OP:a,b}
+    for op in ["||", "&&", "==", "!=", "<=", ">=", "<", ">"] {
+        if let Some(arg) = content
+            .strip_prefix(op)
+            .and_then(|rest| rest.strip_prefix(':'))
+        {
+            let (a, b) = split_first(arg, b',');
+            let av = expand_str(a, r);
+            let bv = expand_str(b.unwrap_or(""), r);
+            return bool_str(compare(op, &av, &bv));
+        }
+    }
+
+    // Substitution: #{s/pattern/replacement/flags:arg}
+    if content.starts_with('s') {
+        if let Some(&d) = content.as_bytes().get(1) {
+            if !d.is_ascii_alphanumeric() && d != b':' {
+                if let Some(res) = eval_substitution(content, r) {
+                    return res;
+                }
+            }
+        }
+    }
+
+    // Expand modifier: #{E:expr} — expand the value of expr a second time.
+    if let Some(inner) = content.strip_prefix("E:") {
+        let once = eval_inner(inner, r);
+        return expand_str(&once, r);
+    }
+
+    // Truncation: #{=N:arg} (truncate to N columns).
+    if let Some(rest) = content.strip_prefix('=') {
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if !digits.is_empty() {
+            if let Some(arg) = rest[digits.len()..].strip_prefix(':') {
+                let n: usize = digits.parse().unwrap_or(0);
+                return truncate_cols(&eval_or_var(arg, r), n);
+            }
+        }
+    }
+
+    // Simple string modifiers.
+    if let Some(arg) = content.strip_prefix("b:") {
+        return basename(&eval_or_var(arg, r));
+    }
+    if let Some(arg) = content.strip_prefix("d:") {
+        return dirname(&eval_or_var(arg, r));
+    }
+    if let Some(arg) = content.strip_prefix("q:") {
+        return eval_or_var(arg, r);
+    }
+
+    // Bare variable / user option.
+    var_lookup(content, r)
+}
+
+/// A modifier argument may be a nested format or a bare variable name.
+fn eval_or_var(arg: &str, r: &dyn FormatResolver) -> String {
+    if arg.contains("#{") || arg.contains("#(") || arg.starts_with('#') {
+        expand_str(arg, r)
+    } else {
+        var_lookup(arg, r)
+    }
+}
+
+fn var_lookup(name: &str, r: &dyn FormatResolver) -> String {
+    r.var(name).map(|c| c.into_owned()).unwrap_or_default()
+}
+
+fn eval_substitution(content: &str, r: &dyn FormatResolver) -> Option<String> {
+    let b = content.as_bytes();
+    let delim = b[1];
+    let mut parts: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut i = 2;
+    while i < b.len() && parts.len() < 2 {
+        let c = b[i];
+        if c == b'\\' && i + 1 < b.len() {
+            // Preserve escapes for the regex (e.g. `\/` -> escaped delimiter).
+            cur.push('\\');
+            let ch = content[i + 1..].chars().next().unwrap();
+            cur.push(ch);
+            i += 1 + ch.len_utf8();
+            continue;
+        }
+        if c == delim {
+            parts.push(std::mem::take(&mut cur));
+            i += 1;
+            continue;
+        }
+        let ch = content[i..].chars().next().unwrap();
+        cur.push(ch);
+        i += ch.len_utf8();
+    }
+    if parts.len() < 2 {
+        return None;
+    }
+    let pattern = parts[0].clone();
+    let replacement = parts[1].clone();
+    let rest = &content[i..];
+    let (flags, arg) = match rest.find(':') {
+        Some(p) => (&rest[..p], &rest[p + 1..]),
+        None => return None,
+    };
+    let mut global = false;
+    let mut icase = false;
+    for f in flags.chars() {
+        match f {
+            'g' => global = true,
+            'i' => icase = true,
+            _ => {}
+        }
+    }
+    let target = eval_or_var(arg, r);
+    let pat = if icase {
+        format!("(?i){pattern}")
+    } else {
+        pattern
+    };
+    let re = regex::Regex::new(&pat).ok()?;
+    let rep = translate_replacement(&replacement);
+    let out = if global {
+        re.replace_all(&target, rep.as_str()).into_owned()
+    } else {
+        re.replace(&target, rep.as_str()).into_owned()
+    };
+    Some(out)
+}
+
+/// Translate tmux `\N` backreferences to Rust-regex `${N}` and escape literal `$`.
+fn translate_replacement(s: &str) -> String {
+    let mut out = String::new();
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        let c = b[i];
+        if c == b'\\' && i + 1 < b.len() && b[i + 1].is_ascii_digit() {
+            out.push_str("${");
+            out.push(b[i + 1] as char);
+            out.push('}');
+            i += 2;
+            continue;
+        }
+        if c == b'$' {
+            out.push_str("$$");
+            i += 1;
+            continue;
+        }
+        let ch = s[i..].chars().next().unwrap();
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// tmux truthiness: non-empty and not `"0"`.
+fn is_true(s: &str) -> bool {
+    !s.is_empty() && s != "0"
+}
+
+fn bool_str(b: bool) -> String {
+    if b { "1" } else { "0" }.to_string()
+}
+
+fn compare(op: &str, a: &str, b: &str) -> bool {
+    match op {
+        "==" => a == b,
+        "!=" => a != b,
+        "&&" => is_true(a) && is_true(b),
+        "||" => is_true(a) || is_true(b),
+        _ => {
+            if let (Ok(x), Ok(y)) = (a.trim().parse::<f64>(), b.trim().parse::<f64>()) {
+                match op {
+                    "<" => x < y,
+                    ">" => x > y,
+                    "<=" => x <= y,
+                    ">=" => x >= y,
+                    _ => false,
+                }
+            } else {
+                match op {
+                    "<" => a < b,
+                    ">" => a > b,
+                    "<=" => a <= b,
+                    ">=" => a >= b,
+                    _ => false,
+                }
+            }
+        }
+    }
+}
+
+fn alias(b: u8) -> Option<&'static str> {
+    Some(match b {
+        b'S' => "session_name",
+        b'T' => "pane_title",
+        b'W' => "window_name",
+        b'H' => "host",
+        b'h' => "host_short",
+        b'I' => "window_index",
+        b'P' => "pane_index",
+        b'D' => "pane_id",
+        b'F' => "window_flags",
+        _ => return None,
+    })
+}
+
+fn truncate_cols(s: &str, max: usize) -> String {
+    use unicode_width::UnicodeWidthChar;
+    let mut width = 0usize;
+    let mut out = String::new();
+    for ch in s.chars() {
+        let w = ch.width().unwrap_or(0);
+        if width + w > max {
+            break;
+        }
+        width += w;
+        out.push(ch);
+    }
+    out
+}
+
+fn basename(s: &str) -> String {
+    s.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or(s)
+        .to_string()
+}
+
+fn dirname(s: &str) -> String {
+    let trimmed = s.trim_end_matches('/');
+    match trimmed.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(p) => trimmed[..p].to_string(),
+        None => ".".to_string(),
+    }
+}
+
+/// Find the byte index of the closer matching the `#{`/`#(`/`#[` whose `#` is at
+/// `open_at`. Brace tracking keys off `#`-prefixed openers, so bare `[`/`]`/`(`
+/// inside regex patterns are not counted.
+fn matching_close(s: &str, open_at: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let first = match bytes.get(open_at + 1)? {
+        b'{' => b'}',
+        b'(' => b')',
+        b'[' => b']',
+        _ => return None,
+    };
+    let mut stack = vec![first];
+    let mut i = open_at + 2;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'#' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'#' => {
+                    i += 2;
+                    continue;
+                }
+                b'{' => {
+                    stack.push(b'}');
+                    i += 2;
+                    continue;
+                }
+                b'(' => {
+                    stack.push(b')');
+                    i += 2;
+                    continue;
+                }
+                b'[' => {
+                    stack.push(b']');
+                    i += 2;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        if c == *stack.last().unwrap() {
+            stack.pop();
+            if stack.is_empty() {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split `s` at the first top-level (depth-0) occurrence of `delim`.
+fn split_first(s: &str, delim: u8) -> (&str, Option<&str>) {
+    let bytes = s.as_bytes();
+    let mut stack: Vec<u8> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'#' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'#' => {
+                    i += 2;
+                    continue;
+                }
+                b'{' => {
+                    stack.push(b'}');
+                    i += 2;
+                    continue;
+                }
+                b'(' => {
+                    stack.push(b')');
+                    i += 2;
+                    continue;
+                }
+                b'[' => {
+                    stack.push(b']');
+                    i += 2;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        if let Some(&top) = stack.last() {
+            if c == top {
+                stack.pop();
+                i += 1;
+                continue;
+            }
+        } else if c == delim {
+            return (&s[..i], Some(&s[i + 1..]));
+        }
+        i += 1;
+    }
+    (s, None)
+}

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -1,0 +1,201 @@
+//! tmux-compatible status bar: a clean-room subset of tmux's format-expansion
+//! engine plus status-line composition, rendered into ratatui.
+//!
+//! Layered design (see `docs/plans/tmux-status-bar.md`):
+//! - **Layer A (this module + bindings + render):** the engine and renderer, bound
+//!   to herdr state that already exists. Self-contained and unit-testable.
+//! - **Layer B (gated `tmux_compat`):** OSC-title capture and a `window_activity`
+//!   timestamp that touch shared hot paths; provided elsewhere, opt-in.
+
+pub mod bar;
+pub mod expand;
+pub mod resolver;
+pub mod style;
+
+pub use bar::{compose, StatusSpec};
+pub use resolver::StatusContext;
+
+#[cfg(test)]
+mod tests {
+    use super::expand::{expand_str, render_segments, FormatResolver};
+    use super::*;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+
+    /// Fixed-map resolver for engine tests (no herdr coupling).
+    struct StubResolver {
+        vars: HashMap<String, String>,
+        shells: HashMap<String, String>,
+    }
+
+    impl StubResolver {
+        fn new() -> Self {
+            Self {
+                vars: HashMap::new(),
+                shells: HashMap::new(),
+            }
+        }
+        fn with(mut self, k: &str, v: &str) -> Self {
+            self.vars.insert(k.to_string(), v.to_string());
+            self
+        }
+    }
+
+    impl FormatResolver for StubResolver {
+        fn var(&self, name: &str) -> Option<Cow<'_, str>> {
+            self.vars.get(name).map(|s| Cow::Borrowed(s.as_str()))
+        }
+        fn shell(&self, command: &str) -> Option<String> {
+            self.shells.get(command).cloned()
+        }
+    }
+
+    fn expand(input: &str, r: &dyn FormatResolver) -> String {
+        expand_str(input, r)
+    }
+
+    #[test]
+    fn plain_variable() {
+        let r = StubResolver::new().with("session_name", "work");
+        assert_eq!(expand("#{session_name}", &r), "work");
+        assert_eq!(expand("#S", &r), "work");
+    }
+
+    #[test]
+    fn literal_hash_escape() {
+        let r = StubResolver::new();
+        assert_eq!(expand("a##b", &r), "a#b");
+    }
+
+    #[test]
+    fn conditional_truthy() {
+        let r = StubResolver::new().with("x", "1");
+        assert_eq!(expand("#{?x,yes,no}", &r), "yes");
+        let r0 = StubResolver::new().with("x", "0");
+        assert_eq!(expand("#{?x,yes,no}", &r0), "no");
+        let re = StubResolver::new().with("x", "");
+        assert_eq!(expand("#{?x,yes,no}", &re), "no");
+    }
+
+    #[test]
+    fn comparison_eq() {
+        let r = StubResolver::new().with("a", "3");
+        assert_eq!(expand("#{==:#{a},3}", &r), "1");
+        assert_eq!(expand("#{==:#{a},4}", &r), "0");
+        assert_eq!(expand("#{?#{==:#{a},3},match,nope}", &r), "match");
+    }
+
+    #[test]
+    fn substitution_strip_nondigits() {
+        let r = StubResolver::new().with("session_name", "herdr7srv");
+        assert_eq!(expand("#{s/[^0-9]//g:session_name}", &r), "7");
+    }
+
+    #[test]
+    fn substitution_no_digits_empty() {
+        let r = StubResolver::new().with("session_name", "herdrsrv");
+        assert_eq!(expand("#{s/[^0-9]//g:session_name}", &r), "");
+    }
+
+    #[test]
+    fn expand_modifier_reexpands_user_option() {
+        // @sc holds a format string; #{E:@sc} expands it against the same vars.
+        let sc = "#{?#{==:#{s/[^0-9]//g:session_name},1},colour167,#{?#{==:#{s/[^0-9]//g:session_name},3},colour226,colour244}}";
+        let r = StubResolver::new()
+            .with("@sc", sc)
+            .with("session_name", "3");
+        assert_eq!(expand("#{E:@sc}", &r), "colour226");
+
+        let r1 = StubResolver::new().with("@sc", sc).with("session_name", "1");
+        assert_eq!(expand("#{E:@sc}", &r1), "colour167");
+
+        let rg = StubResolver::new()
+            .with("@sc", sc)
+            .with("session_name", "herdrsrv");
+        assert_eq!(expand("#{E:@sc}", &rg), "colour244");
+    }
+
+    /// Parity cases verified byte-for-byte against `tmux 3.5a` via
+    /// `tmux display-message -p` on 2026-05-28 (see docs/plans/tmux-status-bar.md,
+    /// finding 0.4). `@name` stands in for tmux's built-in `session_name` so the
+    /// inputs are controllable user options on both sides.
+    #[test]
+    fn parity_with_tmux_3_5a() {
+        let sc = "#{?#{==:#{s/[^0-9]//g:@name},1},colour167,#{?#{==:#{s/[^0-9]//g:@name},2},colour208,#{?#{==:#{s/[^0-9]//g:@name},3},colour226,colour244}}}";
+        let cases: &[(&str, &[(&str, &str)], &str)] = &[
+            ("#{s/[^0-9]//g:@name}", &[("@name", "herdr7srv")], "7"),
+            ("#{s/[^0-9]//g:@name}", &[("@name", "herdrsrv")], ""),
+            (
+                "#{?#{==:#{s/[^0-9]//g:@name},1},RED,OTHER}",
+                &[("@name", "ws1")],
+                "RED",
+            ),
+            ("#{E:@sc}", &[("@sc", sc), ("@name", "1")], "colour167"),
+            ("#{E:@sc}", &[("@sc", sc), ("@name", "2")], "colour208"),
+            ("#{E:@sc}", &[("@sc", sc), ("@name", "3")], "colour226"),
+            ("#{E:@sc}", &[("@sc", sc), ("@name", "herdrsrv")], "colour244"),
+            ("#{=5:@title}", &[("@title", "hello world")], "hello"),
+            ("#{?@flag,yes,no}", &[("@flag", "0")], "no"),
+            ("#{?@flag,yes,no}", &[("@flag", "1")], "yes"),
+            ("a##b", &[], "a#b"),
+        ];
+        for (fmt, vars, expected) in cases {
+            let mut r = StubResolver::new();
+            for (k, v) in *vars {
+                r = r.with(k, v);
+            }
+            assert_eq!(&expand(fmt, &r), expected, "tmux parity: {fmt:?} {vars:?}");
+        }
+    }
+
+    #[test]
+    fn truncate_modifier() {
+        let r = StubResolver::new().with("t", "hello world");
+        assert_eq!(expand("#{=5:#{t}}", &r), "hello");
+    }
+
+    #[test]
+    fn shell_expansion() {
+        let mut r = StubResolver::new().with("window_activity", "1000");
+        r.shells.insert("idle.sh 1000".to_string(), "3m\n".to_string());
+        assert_eq!(expand("#(idle.sh #{window_activity})", &r), "3m");
+    }
+
+    #[test]
+    fn style_segments_switch_style() {
+        use ratatui::style::{Color, Modifier};
+        let r = StubResolver::new()
+            .with("@sc", "colour208")
+            .with("session_name", "work");
+        let segs = render_segments(
+            "#[fg=colour16,bg=#{E:@sc},bold] #{session_name} ",
+            ratatui::style::Style::default(),
+            &r,
+        );
+        // First non-empty styled segment carries the directive's style.
+        let styled = segs.iter().find(|(t, _)| t.contains("work")).unwrap();
+        assert_eq!(styled.1.fg, Some(Color::Indexed(16)));
+        assert_eq!(styled.1.bg, Some(Color::Indexed(208)));
+        assert!(styled.1.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn compose_fills_width_and_flushes_right() {
+        let r = StubResolver::new()
+            .with("pane_title", "claude")
+            .with("session_name", "1");
+        let spec = StatusSpec {
+            style: "bg=colour244,fg=colour16",
+            left: "",
+            right: "#[fg=colour16,bold] #{session_name} ",
+            window: "#[fg=colour16,bold] #{pane_title} ",
+            left_length: 0,
+            right_length: 12,
+        };
+        let line = compose(&spec, 40, &r);
+        assert_eq!(line.width(), 40, "status line must fill the width");
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.starts_with(" claude "), "title flush-left: {text:?}");
+        assert!(text.trim_end().ends_with(" 1"), "session flush-right: {text:?}");
+    }
+}

--- a/src/status/resolver.rs
+++ b/src/status/resolver.rs
@@ -1,0 +1,125 @@
+//! [`FormatResolver`] implementations that bind the format engine to concrete
+//! data. [`StatusContext`] is the herdr binding; it carries pre-resolved values
+//! so the engine stays decoupled from herdr types.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use super::expand::FormatResolver;
+
+/// `#(command)` results are cached for this long so the status bar (re-rendered
+/// at ~12fps) spawns each unique command at most ~once per second.
+const SHELL_TTL: Duration = Duration::from_millis(1000);
+
+fn shell_cache() -> &'static Mutex<HashMap<String, (Instant, String)>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, (Instant, String)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Run `command` via `sh -c`, caching stdout for [`SHELL_TTL`]. Best-effort:
+/// failures yield an empty string. Only reached when `tmux_compat` is on, and
+/// the user owns the commands, so a brief synchronous run is acceptable.
+fn run_shell_cached(command: &str) -> String {
+    if let Ok(cache) = shell_cache().lock() {
+        if let Some((at, val)) = cache.get(command) {
+            if at.elapsed() < SHELL_TTL {
+                return val.clone();
+            }
+        }
+    }
+    let val = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+        .unwrap_or_default();
+    if let Ok(mut cache) = shell_cache().lock() {
+        cache.insert(command.to_string(), (Instant::now(), val.clone()));
+    }
+    val
+}
+
+/// Pre-resolved variable values for one rendered status line.
+///
+/// Built by the render layer from herdr state. Native variables:
+/// - `session_name` — the owning workspace's display name
+/// - `pane_title` — agent/effective title (OSC title under `tmux_compat`)
+/// - `agent_state` — `working` | `idle` | `blocked` | `unknown`
+/// - `agent_done` — `1` when the agent finished while unseen, else `0`
+/// - `window_activity` — epoch seconds of last output (Layer B; `None` otherwise)
+///
+/// User options (`@name`) fall through to `user_options`.
+#[derive(Debug, Default, Clone)]
+pub struct StatusContext {
+    pub session_name: String,
+    pub pane_title: String,
+    pub agent_state: String,
+    pub agent_done: bool,
+    pub window_activity: Option<String>,
+    pub user_options: HashMap<String, String>,
+    /// When true, `#(shell)` expansion runs commands (Layer B). Off by default
+    /// so the clean default never spawns subprocesses.
+    pub allow_shell: bool,
+}
+
+impl FormatResolver for StatusContext {
+    fn var(&self, name: &str) -> Option<Cow<'_, str>> {
+        let v = match name {
+            "session_name" => return Some(Cow::Borrowed(self.session_name.as_str())),
+            "pane_title" => return Some(Cow::Borrowed(self.pane_title.as_str())),
+            "agent_state" => return Some(Cow::Borrowed(self.agent_state.as_str())),
+            "agent_done" => return Some(Cow::Borrowed(if self.agent_done { "1" } else { "0" })),
+            "window_activity" => return self.window_activity.as_deref().map(Cow::Borrowed),
+            other => other,
+        };
+        // User options are stored without the leading `@`.
+        let key = v.strip_prefix('@').unwrap_or(v);
+        self.user_options.get(key).map(|s| Cow::Borrowed(s.as_str()))
+    }
+
+    fn shell(&self, command: &str) -> Option<String> {
+        self.allow_shell.then(|| run_shell_cached(command))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::status::expand::expand_str;
+
+    #[test]
+    fn shell_disabled_by_default() {
+        let ctx = StatusContext {
+            allow_shell: false,
+            ..Default::default()
+        };
+        // No subprocess runs; the `#(...)` yields nothing.
+        assert_eq!(expand_str("[#(echo hi)]", &ctx), "[]");
+    }
+
+    #[test]
+    fn shell_runs_when_allowed() {
+        let ctx = StatusContext {
+            allow_shell: true,
+            ..Default::default()
+        };
+        assert_eq!(expand_str("[#(echo hi)]", &ctx), "[hi]");
+    }
+
+    #[test]
+    fn native_vars_resolve() {
+        let ctx = StatusContext {
+            session_name: "ws".into(),
+            agent_state: "working".into(),
+            agent_done: true,
+            window_activity: Some("1000".into()),
+            ..Default::default()
+        };
+        assert_eq!(expand_str("#{session_name}", &ctx), "ws");
+        assert_eq!(expand_str("#{agent_state}", &ctx), "working");
+        assert_eq!(expand_str("#{agent_done}", &ctx), "1");
+        assert_eq!(expand_str("#{window_activity}", &ctx), "1000");
+    }
+}

--- a/src/status/style.rs
+++ b/src/status/style.rs
@@ -1,0 +1,109 @@
+//! tmux `#[...]` style-directive parsing into ratatui [`Style`].
+//!
+//! Supports the attribute set the status bar uses: `fg=`, `bg=`, `bold`/`nobold`,
+//! `dim`, `italics`, `underscore`/`underline`, `reverse`, `blink`, `hidden`,
+//! `strikethrough`, and `default`/`none` (reset to the base style). Unknown tokens
+//! (e.g. `align=...`) are ignored rather than erroring, matching tmux's leniency.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// Parse a tmux color token into a ratatui [`Color`].
+///
+/// Extends [`crate::config::theme::parse_color`] with tmux's `colourN`/`colorN`
+/// and bare-integer 256-color indices. Returns `None` only for an empty token.
+pub fn parse_status_color(token: &str) -> Option<Color> {
+    let s = token.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if s.eq_ignore_ascii_case("default") || s.eq_ignore_ascii_case("none") {
+        return Some(Color::Reset);
+    }
+    let lower = s.to_ascii_lowercase();
+    let idx = lower
+        .strip_prefix("colour")
+        .or_else(|| lower.strip_prefix("color"));
+    if let Some(n) = idx {
+        if let Ok(i) = n.parse::<u8>() {
+            return Some(Color::Indexed(i));
+        }
+    }
+    if let Ok(i) = s.parse::<u8>() {
+        return Some(Color::Indexed(i));
+    }
+    // hex (#rrggbb / #rgb), named, rgb(r,g,b), reset aliases.
+    Some(crate::config::parse_color(s))
+}
+
+/// Apply a (comma-separated) style spec on top of `current`, with `base` used as
+/// the reset target for `default`/`none`. The spec must already have had its
+/// `#{...}` expansions resolved.
+pub fn apply_style_spec(spec: &str, base: Style, current: Style) -> Style {
+    let mut style = current;
+    for raw in spec.split(',') {
+        let tok = raw.trim();
+        if tok.is_empty() {
+            continue;
+        }
+        let lower = tok.to_ascii_lowercase();
+        match lower.as_str() {
+            "default" | "none" => style = base,
+            "bold" | "bright" => style = style.add_modifier(Modifier::BOLD),
+            "nobold" | "norm" => style = style.remove_modifier(Modifier::BOLD),
+            "dim" => style = style.add_modifier(Modifier::DIM),
+            "italics" | "italic" => style = style.add_modifier(Modifier::ITALIC),
+            "underscore" | "underline" => style = style.add_modifier(Modifier::UNDERLINED),
+            "reverse" => style = style.add_modifier(Modifier::REVERSED),
+            "blink" => style = style.add_modifier(Modifier::SLOW_BLINK),
+            "hidden" => style = style.add_modifier(Modifier::HIDDEN),
+            "strikethrough" => style = style.add_modifier(Modifier::CROSSED_OUT),
+            _ => {
+                if let Some(v) = lower.strip_prefix("fg=") {
+                    if let Some(c) = parse_status_color(v) {
+                        style = style.fg(c);
+                    }
+                } else if let Some(v) = lower.strip_prefix("bg=") {
+                    if let Some(c) = parse_status_color(v) {
+                        style = style.bg(c);
+                    }
+                }
+                // Unknown tokens (align=, list=, range=, push/pop) are ignored.
+            }
+        }
+    }
+    style
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colour_index_parses() {
+        assert_eq!(parse_status_color("colour167"), Some(Color::Indexed(167)));
+        assert_eq!(parse_status_color("color16"), Some(Color::Indexed(16)));
+        assert_eq!(parse_status_color("244"), Some(Color::Indexed(244)));
+    }
+
+    #[test]
+    fn default_resets() {
+        assert_eq!(parse_status_color("default"), Some(Color::Reset));
+    }
+
+    #[test]
+    fn style_spec_applies_fg_bg_bold() {
+        let s = apply_style_spec("fg=colour16,bg=colour167,bold", Style::default(), Style::default());
+        assert_eq!(s.fg, Some(Color::Indexed(16)));
+        assert_eq!(s.bg, Some(Color::Indexed(167)));
+        assert!(s.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn default_token_resets_to_base() {
+        let base = Style::default().fg(Color::Red);
+        let cur = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+        let s = apply_style_spec("default", base, cur);
+        assert_eq!(s.fg, Some(Color::Red));
+        assert!(!s.add_modifier.contains(Modifier::BOLD));
+    }
+}

--- a/src/terminal/runtime.rs
+++ b/src/terminal/runtime.rs
@@ -261,6 +261,11 @@ impl TerminalRuntime {
         self.0.cursor_state(area, show_cursor)
     }
 
+    /// The pane's OSC 0/2 title (Layer B / `tmux_compat`), empty if unset.
+    pub fn osc_title(&self) -> String {
+        self.0.osc_title()
+    }
+
     pub fn visible_text(&self) -> String {
         self.0.visible_text()
     }

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -61,6 +61,10 @@ pub struct TerminalState {
     fallback_visible_idle: bool,
     fallback_visible_working: bool,
     fallback_observed_at: Option<Instant>,
+    /// Wall-clock time of last observed output, for `#{window_activity}`
+    /// (Layer B / `tmux_compat`). Updated cheaply on every observe; only read
+    /// when the status bar's literal-parity layer is enabled.
+    last_activity: Option<std::time::SystemTime>,
     stale_hook_idle_since: Option<Instant>,
     pub hook_authority: Option<HookAuthority>,
     pub agent_metadata: HashMap<String, AgentMetadata>,
@@ -85,6 +89,7 @@ impl TerminalState {
             fallback_visible_idle: false,
             fallback_visible_working: false,
             fallback_observed_at: None,
+            last_activity: None,
             stale_hook_idle_since: None,
             hook_authority: None,
             agent_metadata: HashMap::new(),
@@ -173,6 +178,7 @@ impl TerminalState {
         self.fallback_visible_idle = visible_idle && fallback_state == AgentState::Idle;
         self.fallback_visible_working = visible_working && fallback_state == AgentState::Working;
         self.fallback_observed_at = Some(now);
+        self.last_activity = Some(std::time::SystemTime::now());
         if process_exited
             && self.hook_authority_not_newer_than(now)
             && self.hook_authority.as_ref().is_some_and(|authority| {
@@ -638,6 +644,14 @@ impl TerminalState {
         self.agent_name.is_some()
             || self.effective_agent_label().is_some()
             || self.launch_argv.is_some()
+    }
+
+    /// Epoch-seconds of last observed output, formatted for `#{window_activity}`
+    /// (Layer B). `None` until any output has been observed.
+    pub fn window_activity_epoch(&self) -> Option<String> {
+        self.last_activity
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs().to_string())
     }
 
     pub fn border_label(&self, show_agent_labels: bool) -> Option<String> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -194,6 +194,17 @@ fn compute_view_internal(
         (Rect::default(), main_area)
     };
 
+    // Reserve a bottom status-bar row when enabled. The tab bar owns the top
+    // row in full-TUI, so the bar always sits at the bottom here regardless of
+    // `position`. Disabled => zero-height rect and `terminal_area` is unchanged.
+    let (terminal_area, status_bar_rect) = if app.status_bar.enabled && terminal_area.height > 1 {
+        let [body, bar] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(terminal_area);
+        (body, bar)
+    } else {
+        (terminal_area, Rect::default())
+    };
+
     if !app.sidebar_collapsed {
         app.workspace_scroll = normalized_workspace_scroll(app, sidebar_area, app.workspace_scroll);
         let (_, detail_area) = expanded_sidebar_sections(sidebar_area, app.sidebar_section_split);
@@ -265,6 +276,7 @@ fn compute_view_internal(
         tab_scroll_right_hit_area: tab_bar_view.scroll_right_hit_area,
         new_tab_hit_area: tab_bar_view.new_tab_hit_area,
         terminal_area,
+        status_bar_rect,
         mobile_header_rect: Rect::default(),
         mobile_menu_hit_area: Rect::default(),
         toast_hit_area,
@@ -334,6 +346,7 @@ fn compute_mobile_view(
         tab_scroll_right_hit_area: Rect::default(),
         new_tab_hit_area: Rect::default(),
         terminal_area,
+        status_bar_rect: Rect::default(),
         mobile_header_rect: header_rect,
         mobile_menu_hit_area: header_hits.menu,
         toast_hit_area,
@@ -370,6 +383,10 @@ pub fn render_with_runtime_registry(
     }
     render_panes(app, terminal_runtimes, frame, terminal_area);
 
+    if app.view.status_bar_rect.height > 0 {
+        render_status_bar(app, terminal_runtimes, frame, app.view.status_bar_rect);
+    }
+
     // Ambient notifications sit above panes, but below interactive overlays.
     render_notifications(app, frame, terminal_area);
 
@@ -401,6 +418,24 @@ pub fn render_with_runtime_registry(
         Mode::Navigator => render_navigator_overlay(app, frame),
         Mode::Terminal => {}
     }
+}
+
+/// Render the full-TUI status bar for the focused pane's terminal.
+fn render_status_bar(
+    app: &AppState,
+    terminal_runtimes: &TerminalRuntimeRegistry,
+    frame: &mut Frame,
+    area: Rect,
+) {
+    let Some(tid) = app
+        .active
+        .and_then(|i| app.workspaces.get(i))
+        .and_then(|ws| ws.focused_pane_id().and_then(|pane| ws.terminal_id(pane).cloned()))
+    else {
+        return;
+    };
+    let line = app.compose_status_line(terminal_runtimes, &tid, area.width);
+    frame.render_widget(ratatui::widgets::Paragraph::new(line), area);
 }
 
 fn render_notifications(app: &AppState, frame: &mut Frame, terminal_area: Rect) {


### PR DESCRIPTION
Closes #341.

Adds an opt-in, tmux-compatible status bar (`[ui.status_bar]`, off by default), rendered in `terminal attach` / `agent attach` and in the full-TUI view.

## Two layers

- **Default (Layer A):** a self-contained tmux format engine (`src/status/`) + renderer, bound to existing herdr state (`session_name`, `pane_title`, `agent_state`, `agent_done`). No shared-hot-path cost; a complete no-op when disabled.
- **`tmux_compat` (Layer B), opt-in:** OSC 0/2 title capture for `#{pane_title}`, a `#{window_activity}` timestamp, and `#(shell)` expansion — each gated so the default never captures titles, stamps timestamps, or spawns subprocesses.

Existing tmux status configs can be reused via `[ui.status_bar.user_options]` or `status_bar.tmux_conf = "~/.tmux.conf"`. The format mini-language supports `#{...}` (conditionals, `==`/comparisons, `s///`, `E:`, `=N`), `#[fg/bg/attrs]`, `#(...)`, single-char aliases, and `##`.

## Commits

1. `feat(status)`: format-expansion engine (`src/status/`)
2. `feat(status)`: status bar config + `.tmux.conf`-subset loader
3. `feat(status)`: render in attach and full-TUI modes (clean default)
4. `feat(status)`: gated `tmux_compat` layer (OSC title, window_activity, shell)
5. `docs(status)`: documentation

## Testing

- 54 unit tests (engine, style, bar, resolver, config, attach area-math, end-to-end bindings); the engine is parity-verified byte-for-byte against `tmux 3.5a`.
- All 36 integration tests (`server_headless`, `multi_client`, `live_handoff`) pass — no attach-protocol regression.
- `cargo clippy` clean; `enabled = false` is byte-identical to current behavior (proven by test).
- Manually smoke-tested in a real `agent attach`: the bar renders and the inner app correctly sees `rows − 1`.

## Notes

- Off by default and behind `enabled` / `tmux_compat` flags, so it's purely additive for existing users.
- Multi-line status (2–5 rows) and clickable status ranges are not supported; in full-TUI the bar sits at the bottom (the tab bar owns the top row).
