### PR TITLE
feat: display agent session names in the agent panel sidebar

### DIFF
--- a/src/integration/assets/claude/herdr-agent-state.sh
+++ b/src/integration/assets/claude/herdr-agent-state.sh
@@ -55,6 +55,48 @@ if hook_event_name == "SubagentStop":
     # to durable working, but Claude recap/away-summary can emit it after the
     # main turn has already stopped. Never let it revive an idle pane.
     raise SystemExit(0)
+
+def send_rpc(request):
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(0.5)
+        client.connect(socket_path)
+        client.sendall((json.dumps(request) + "\n").encode())
+        try:
+            client.recv(4096)
+        except Exception:
+            pass
+        client.close()
+    except Exception:
+        pass
+
+def resolve_session_title():
+    # Priority 1: session_title provided directly in hook input (available
+    # from the second turn onward once Claude has named the session).
+    title = hook_input.get("session_title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+
+    # Priority 2: read summary from sessions-index.json in the transcript dir.
+    try:
+        transcript_path = hook_input.get("transcript_path")
+        session_id_val = hook_input.get("session_id")
+        if not isinstance(transcript_path, str) or not isinstance(session_id_val, str):
+            return None
+        import pathlib
+        index_path = pathlib.Path(transcript_path).parent / "sessions-index.json"
+        with open(index_path, encoding="utf-8") as fh:
+            index = json.loads(fh.read())
+        sessions = index if isinstance(index, list) else index.get("sessions", [])
+        for entry in sessions:
+            if entry.get("id") == session_id_val or entry.get("session_id") == session_id_val:
+                summary = entry.get("summary") or entry.get("title") or entry.get("name")
+                if isinstance(summary, str) and summary.strip():
+                    return summary.strip()
+    except Exception:
+        pass
+    return None
+
 request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
 report_seq = time.time_ns()
 session_id = hook_input.get("session_id")
@@ -74,16 +116,21 @@ if agent_session_id:
 else:
     raise SystemExit(0)
 
-try:
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    client.settimeout(0.5)
-    client.connect(socket_path)
-    client.sendall((json.dumps(request) + "\n").encode())
-    try:
-        client.recv(4096)
-    except Exception:
-        pass
-    client.close()
-except Exception:
-    pass
+send_rpc(request)
+
+session_title = resolve_session_title()
+if session_title:
+    meta_request = {
+        "id": f"{source}:meta:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}",
+        "method": "pane.report_metadata",
+        "params": {
+            "pane_id": pane_id,
+            "source": source,
+            "agent": "claude",
+            "applies_to_source": source,
+            "custom_status": session_title,
+            "seq": report_seq + 1,
+        },
+    }
+    send_rpc(meta_request)
 PY

--- a/src/integration/assets/codex/herdr-agent-state.sh
+++ b/src/integration/assets/codex/herdr-agent-state.sh
@@ -48,6 +48,46 @@ if hook_input_file:
     except Exception:
         hook_input = {}
 
+def send_rpc(request):
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(0.5)
+        client.connect(socket_path)
+        client.sendall((json.dumps(request) + "\n").encode())
+        try:
+            client.recv(4096)
+        except Exception:
+            pass
+        client.close()
+    except Exception:
+        pass
+
+def resolve_session_title():
+    # Priority 1: session_title provided directly in hook input.
+    title = hook_input.get("session_title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+
+    # Priority 2: read summary from sessions-index.json in the transcript dir.
+    try:
+        transcript_path = hook_input.get("transcript_path")
+        session_id_val = hook_input.get("session_id")
+        if not isinstance(transcript_path, str) or not isinstance(session_id_val, str):
+            return None
+        import pathlib
+        index_path = pathlib.Path(transcript_path).parent / "sessions-index.json"
+        with open(index_path, encoding="utf-8") as fh:
+            index = json.loads(fh.read())
+        sessions = index if isinstance(index, list) else index.get("sessions", [])
+        for entry in sessions:
+            if entry.get("id") == session_id_val or entry.get("session_id") == session_id_val:
+                summary = entry.get("summary") or entry.get("title") or entry.get("name")
+                if isinstance(summary, str) and summary.strip():
+                    return summary.strip()
+    except Exception:
+        pass
+    return None
+
 request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
 report_seq = time.time_ns()
 session_id = hook_input.get("session_id")
@@ -67,16 +107,21 @@ if agent_session_id:
 else:
     raise SystemExit(0)
 
-try:
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    client.settimeout(0.5)
-    client.connect(socket_path)
-    client.sendall((json.dumps(request) + "\n").encode())
-    try:
-        client.recv(4096)
-    except Exception:
-        pass
-    client.close()
-except Exception:
-    pass
+send_rpc(request)
+
+session_title = resolve_session_title()
+if session_title:
+    meta_request = {
+        "id": f"{source}:meta:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}",
+        "method": "pane.report_metadata",
+        "params": {
+            "pane_id": pane_id,
+            "source": source,
+            "agent": "codex",
+            "applies_to_source": source,
+            "custom_status": session_title,
+            "seq": report_seq + 1,
+        },
+    }
+    send_rpc(meta_request)
 PY

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=2
+// HERDR_INTEGRATION_VERSION=3
 // @ts-nocheck
 
 import { createConnection } from "node:net";
@@ -53,6 +53,7 @@ const retryGraceMs = parseDurationEnv("HERDR_OMP_RETRY_GRACE_MS", 2500);
 const retryableErrorPattern =
   /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
 let reportSeq = Date.now() * 1000;
+let currentSessionTitle: string | undefined;
 
 function nextReportSeq(): number {
   reportSeq += 1;
@@ -82,6 +83,7 @@ function sendState(state: AgentState, message?: string, seq = nextReportSeq()): 
       state,
       message,
       seq,
+      ...(currentSessionTitle ? { custom_status: currentSessionTitle } : {}),
     },
   });
 }
@@ -253,14 +255,25 @@ export default function (pi) {
     publishState();
   });
 
-  pi.on("session_start", () => {
+  function updateSessionTitle(ctx: any): void {
+    try {
+      const name = ctx?.sessionManager?.getSessionName?.();
+      currentSessionTitle = typeof name === "string" && name.trim() ? name.trim() : undefined;
+    } catch {
+      currentSessionTitle = undefined;
+    }
+  }
+
+  pi.on("session_start", (_event, ctx) => {
+    updateSessionTitle(ctx);
     publishState();
   });
 
-  pi.on("agent_start", () => {
+  pi.on("agent_start", (_event, ctx) => {
     clearPendingTimers();
     clearFailureState();
     agentActive = true;
+    updateSessionTitle(ctx);
     publishState();
   });
 

--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -8,6 +8,7 @@ import net from "node:net";
 
 const SOURCE = "herdr:opencode";
 let reportSeq = Date.now() * 1000;
+let currentSessionTitle;
 
 function nextReportSeq() {
   reportSeq += 1;
@@ -18,6 +19,32 @@ function sessionIDFromProperties(properties) {
   return typeof properties?.sessionID === "string" && properties.sessionID
     ? properties.sessionID
     : undefined;
+}
+
+function sendRequest(request) {
+  const paneId = process.env.HERDR_PANE_ID;
+  const socketPath = process.env.HERDR_SOCKET_PATH;
+
+  if (!paneId || !socketPath) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const client = net.createConnection(socketPath, () => {
+      client.write(`${JSON.stringify(request)}\n`);
+    });
+
+    const finish = () => {
+      client.destroy();
+      resolve();
+    };
+
+    client.setTimeout(500, finish);
+    client.on("data", finish);
+    client.on("error", finish);
+    client.on("end", finish);
+    client.on("close", resolve);
+  });
 }
 
 function reportSession(sessionID) {
@@ -46,22 +73,34 @@ function reportSession(sessionID) {
     },
   };
 
-  return new Promise((resolve) => {
-    const client = net.createConnection(socketPath, () => {
-      client.write(`${JSON.stringify(request)}\n`);
-    });
+  return sendRequest(request);
+}
 
-    const finish = () => {
-      client.destroy();
-      resolve();
-    };
+function reportSessionTitle(title) {
+  const paneId = process.env.HERDR_PANE_ID;
+  const socketPath = process.env.HERDR_SOCKET_PATH;
 
-    client.setTimeout(500, finish);
-    client.on("data", finish);
-    client.on("error", finish);
-    client.on("end", finish);
-    client.on("close", resolve);
-  });
+  if (!paneId || !socketPath || !title) {
+    return Promise.resolve();
+  }
+
+  const requestId = `${SOURCE}:meta:${Date.now()}:${Math.floor(Math.random() * 1_000_000)
+    .toString()
+    .padStart(6, "0")}`;
+  const request = {
+    id: requestId,
+    method: "pane.report_metadata",
+    params: {
+      pane_id: paneId,
+      source: SOURCE,
+      agent: "opencode",
+      applies_to_source: SOURCE,
+      custom_status: title,
+      seq: nextReportSeq(),
+    },
+  };
+
+  return sendRequest(request);
 }
 
 export const HerdrAgentStatePlugin = async () => {
@@ -81,7 +120,16 @@ export const HerdrAgentStatePlugin = async () => {
 
       switch (type) {
         case "session.created":
-        case "session.updated":
+        case "session.updated": {
+          // Extract the session title from the event info for display.
+          const infoTitle = properties?.info?.title;
+          if (typeof infoTitle === "string" && infoTitle.trim()) {
+            currentSessionTitle = infoTitle.trim();
+            await reportSessionTitle(currentSessionTitle);
+          }
+          await reportSession(sessionID);
+          break;
+        }
         case "session.status":
           await reportSession(sessionID);
           break;

--- a/src/integration/assets/pi/herdr-agent-state.ts
+++ b/src/integration/assets/pi/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=pi
-// HERDR_INTEGRATION_VERSION=2
+// HERDR_INTEGRATION_VERSION=3
 // @ts-nocheck
 
 import { createConnection } from "node:net";
@@ -55,6 +55,7 @@ const retryableErrorPattern =
 let reportSeq = Date.now() * 1000;
 let currentAgentSessionId: string | undefined;
 let currentAgentSessionPath: string | undefined;
+let currentSessionTitle: string | undefined;
 
 function nextReportSeq(): number {
   reportSeq += 1;
@@ -92,10 +93,12 @@ function updateSessionRef(ctx: any): void {
 
 function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
   if (currentAgentSessionPath) {
-    return { ...params, agent_session_path: currentAgentSessionPath };
+    params = { ...params, agent_session_path: currentAgentSessionPath };
+  } else if (currentAgentSessionId) {
+    params = { ...params, agent_session_id: currentAgentSessionId };
   }
-  if (currentAgentSessionId) {
-    return { ...params, agent_session_id: currentAgentSessionId };
+  if (currentSessionTitle) {
+    params = { ...params, custom_status: currentSessionTitle };
   }
   return params;
 }
@@ -250,8 +253,18 @@ export default function (pi) {
     idleTimer.unref?.();
   }
 
+  function updateSessionTitle(): void {
+    try {
+      const name = pi.getSessionName?.();
+      currentSessionTitle = typeof name === "string" && name.trim() ? name.trim() : undefined;
+    } catch {
+      currentSessionTitle = undefined;
+    }
+  }
+
   pi.on("session_start", (_event, ctx) => {
     updateSessionRef(ctx);
+    updateSessionTitle();
     publishState(true);
   });
 
@@ -291,6 +304,7 @@ export default function (pi) {
     clearPendingTimers();
     clearFailureState();
     agentActive = true;
+    updateSessionTitle();
     publishState();
   });
 

--- a/src/integration/assets/qodercli/herdr-agent-state.sh
+++ b/src/integration/assets/qodercli/herdr-agent-state.sh
@@ -3,7 +3,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=qodercli
-# HERDR_INTEGRATION_VERSION=1
+# HERDR_INTEGRATION_VERSION=2
 #
 # Reports qodercli agent state changes to herdr. Registered as a Command hook
 # in ~/.qoder/settings.json by `herdr integration install qodercli` and
@@ -69,6 +69,46 @@ if is_subagent and action in ("idle", "release"):
     # Subagent completion must not make the parent pane look done early.
     raise SystemExit(0)
 
+def send_rpc(request):
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(0.5)
+        client.connect(socket_path)
+        client.sendall((json.dumps(request) + "\n").encode())
+        try:
+            client.recv(4096)
+        except Exception:
+            pass
+        client.close()
+    except Exception:
+        pass
+
+def resolve_session_title():
+    # Priority 1: session_title provided directly in hook input.
+    title = hook_input.get("session_title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+
+    # Priority 2: read summary from sessions-index.json in the transcript dir.
+    try:
+        transcript_path = hook_input.get("transcript_path")
+        session_id_val = hook_input.get("session_id")
+        if not isinstance(transcript_path, str) or not isinstance(session_id_val, str):
+            return None
+        import pathlib
+        index_path = pathlib.Path(transcript_path).parent / "sessions-index.json"
+        with open(index_path, encoding="utf-8") as fh:
+            index = json.loads(fh.read())
+        sessions = index if isinstance(index, list) else index.get("sessions", [])
+        for entry in sessions:
+            if entry.get("id") == session_id_val or entry.get("session_id") == session_id_val:
+                summary = entry.get("summary") or entry.get("title") or entry.get("name")
+                if isinstance(summary, str) and summary.strip():
+                    return summary.strip()
+    except Exception:
+        pass
+    return None
+
 request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
 report_seq = time.time_ns()
 session_id = hook_input.get("session_id")
@@ -85,30 +125,23 @@ if action == "release":
         },
     }
 else:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": "qodercli",
+        "state": action,
+        "seq": report_seq,
+    }
+    if agent_session_id:
+        params["agent_session_id"] = agent_session_id
+    session_title = resolve_session_title()
+    if session_title:
+        params["custom_status"] = session_title
     request = {
         "id": request_id,
         "method": "pane.report_agent",
-        "params": {
-            "pane_id": pane_id,
-            "source": source,
-            "agent": "qodercli",
-            "state": action,
-            "seq": report_seq,
-        },
+        "params": params,
     }
-    if agent_session_id:
-        request["params"]["agent_session_id"] = agent_session_id
 
-try:
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    client.settimeout(0.5)
-    client.connect(socket_path)
-    client.sendall((json.dumps(request) + "\n").encode())
-    try:
-        client.recv(4096)
-    except Exception:
-        pass
-    client.close()
-except Exception:
-    pass
+send_rpc(request)
 PY

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -12,10 +12,10 @@ use crate::layout::PaneId;
 pub(crate) const HERDR_PANE_ID_ENV_VAR: &str = "HERDR_PANE_ID";
 const PI_EXTENSION_INSTALL_NAME: &str = "herdr-agent-state.ts";
 const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
-const PI_INTEGRATION_VERSION: u32 = 2;
+const PI_INTEGRATION_VERSION: u32 = 3;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 2;
+const OMP_INTEGRATION_VERSION: u32 = 3;
 const PI_CODING_AGENT_DIR_ENV_VAR: &str = "PI_CODING_AGENT_DIR";
 const CLAUDE_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const CLAUDE_HOOK_ASSET: &str = include_str!("assets/claude/herdr-agent-state.sh");
@@ -40,7 +40,7 @@ const HERMES_PLUGIN_INIT_ASSET: &str = include_str!("assets/hermes/__init__.py")
 const HERMES_INTEGRATION_VERSION: u32 = 2;
 const QODERCLI_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const QODERCLI_HOOK_ASSET: &str = include_str!("assets/qodercli/herdr-agent-state.sh");
-const QODERCLI_INTEGRATION_VERSION: u32 = 1;
+const QODERCLI_INTEGRATION_VERSION: u32 = 2;
 const QODERCLI_CONFIG_DIR_ENV_VAR: &str = "QODER_CONFIG_DIR";
 const INTEGRATION_VERSION_MARKER: &str = "HERDR_INTEGRATION_VERSION=";
 


### PR DESCRIPTION
Report each agent's auto-generated session name as custom_status in pane.report_agent so the sidebar shows e.g. "working · claude · fixing auth bug" instead of just "working · claude".

- Claude/Codex/QoderCLI: extract session_title from hook input JSON, falling back to the summary field in sessions-index.json matched by session_id. Also refactors the inline socket send into a reusable send_rpc() helper.

- OpenCode: track session title from session.created/session.updated events via event.properties.info.title.

- Pi: read session name via pi.getSessionName() on session_start and agent_start.

- OMP: read session name via ctx.sessionManager.getSessionName() on session_start and agent_start.

All title resolution is fully defensive — any failure silently skips
the custom_status, leaving the existing display unchanged.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
