### PR TITLE
feat(toast): add configurable corner position for in-app toasts

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1998,7 +1998,7 @@ impl AppState {
                 self.update_dismissed = true;
                 if matches!(
                     self.toast_config.delivery,
-                    crate::config::ToastDelivery::Herdr
+                    crate::config::ToastDelivery::Herdr { .. }
                 ) {
                     self.toast = Some(ToastNotification {
                         kind: ToastKind::UpdateInstalled,
@@ -2226,7 +2226,7 @@ impl AppState {
 
         if matches!(
             self.toast_config.delivery,
-            crate::config::ToastDelivery::Herdr
+            crate::config::ToastDelivery::Herdr { .. }
         ) {
             if let (Some(agent_label), Some(kind)) = (
                 change.agent_label.as_deref(),
@@ -2890,7 +2890,7 @@ mod tests {
     #[test]
     fn update_ready_sets_explicit_upgrade_toast() {
         let mut state = AppState::test_new();
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
 
         let updates = state.handle_app_event(crate::events::AppEvent::UpdateReady {
             version: "0.5.0".into(),
@@ -3533,7 +3533,7 @@ mod tests {
     fn background_waiting_sets_attention_toast() {
         let mut state = app_with_workspaces(&["active", "background"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let bg_pane_id = *state.workspaces[1].panes.keys().next().unwrap();
 
         state.handle_app_event(AppEvent::StateChanged {
@@ -3557,7 +3557,7 @@ mod tests {
     fn hook_reported_unknown_agent_sets_toast_title_from_label() {
         let mut state = app_with_workspaces(&["active", "background"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let bg_pane_id = *state.workspaces[1].panes.keys().next().unwrap();
 
         state.handle_app_event(AppEvent::HookStateReported {
@@ -3581,7 +3581,7 @@ mod tests {
     fn visible_blocker_overrides_hook_working_and_notifies() {
         let mut state = app_with_workspaces(&["active", "background"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let bg_pane_id = *state.workspaces[1].panes.keys().next().unwrap();
         let bg_terminal_id = state.workspaces[1]
             .panes
@@ -3632,7 +3632,7 @@ mod tests {
     fn reserved_native_state_report_does_not_override_screen_state() {
         let mut state = app_with_workspaces(&["active"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
         let terminal_id = state.workspaces[0]
             .panes
@@ -3753,7 +3753,7 @@ mod tests {
     fn background_idle_sets_finished_toast() {
         let mut state = app_with_workspaces(&["active", "background"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let bg_pane_id = *state.workspaces[1].panes.keys().next().unwrap();
         let bg_terminal_id = state.workspaces[1]
             .panes
@@ -3787,7 +3787,7 @@ mod tests {
     fn background_toast_includes_tab_name_when_workspace_has_multiple_tabs() {
         let mut state = app_with_workspaces(&["active", "background"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         state.workspaces[1].tabs[0].set_custom_name("main".into());
         let second_tab = state.workspaces[1].test_add_tab(Some("logs"));
         state.ensure_test_terminals();
@@ -3814,7 +3814,7 @@ mod tests {
     fn background_tab_in_active_workspace_still_sets_toast() {
         let mut state = app_with_workspaces(&["active"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         state.workspaces[0].tabs[0].set_custom_name("main".into());
         let second_tab = state.workspaces[0].test_add_tab(Some("logs"));
         state.ensure_test_terminals();
@@ -3841,7 +3841,7 @@ mod tests {
     fn active_workspace_active_tab_does_not_set_toast() {
         let mut state = app_with_workspaces(&["active"]);
         state.active = Some(0);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
 
         state.handle_app_event(AppEvent::StateChanged {
@@ -3863,7 +3863,7 @@ mod tests {
         let mut state = app_with_workspaces(&["active"]);
         state.active = Some(0);
         state.outer_terminal_focus = Some(false);
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
         let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
 
         state.handle_app_event(AppEvent::StateChanged {
@@ -3891,7 +3891,7 @@ mod tests {
     #[test]
     fn update_ready_sets_manual_update_toast() {
         let mut state = AppState::test_new();
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
 
         let updates = state.handle_app_event(AppEvent::UpdateReady {
             version: "0.5.0".into(),
@@ -3914,7 +3914,7 @@ mod tests {
     #[test]
     fn update_ready_uses_event_install_command_in_toast() {
         let mut state = AppState::test_new();
-        state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        state.enable_herdr_toasts();
 
         state.handle_app_event(AppEvent::UpdateReady {
             version: "0.5.0".into(),

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -220,7 +220,7 @@ impl App {
     ) {
         if !matches!(
             self.state.toast_config.delivery,
-            crate::config::ToastDelivery::Herdr
+            crate::config::ToastDelivery::Herdr { .. }
         ) || self.state.toast == *previous_toast
         {
             return;
@@ -650,7 +650,7 @@ mod tests {
         app.state.active = None;
         app.state.selected = 0;
         app.state.mode = Mode::Terminal;
-        app.state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        app.state.enable_herdr_toasts();
 
         let (events, _) = tokio::sync::mpsc::channel(4);
         let runtime = crate::terminal::TerminalRuntime::spawn(

--- a/src/app/config_io.rs
+++ b/src/app/config_io.rs
@@ -60,7 +60,7 @@ impl App {
     pub(super) fn save_toast_delivery(&mut self, delivery: crate::config::ToastDelivery) {
         let value = match delivery {
             crate::config::ToastDelivery::Off => "\"off\"",
-            crate::config::ToastDelivery::Herdr => "\"herdr\"",
+            crate::config::ToastDelivery::Herdr { .. } => "\"herdr\"",
             crate::config::ToastDelivery::Terminal => "\"terminal\"",
             crate::config::ToastDelivery::System => "\"system\"",
         };

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -2147,7 +2147,7 @@ mod tests {
         app.state.ensure_test_terminals();
         app.state.active = Some(0);
         app.state.selected = 0;
-        app.state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        app.state.enable_herdr_toasts();
         let target_terminal_id = app.state.workspaces[1]
             .panes
             .get(&target_pane)

--- a/src/app/input/settings.rs
+++ b/src/app/input/settings.rs
@@ -6,7 +6,7 @@ use crate::{
         state::{AppState, ExperimentSetting, SettingsSection, THEME_NAMES},
         App, Mode,
     },
-    config::ToastDelivery,
+    config::{ToastDelivery, ToastPosition},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,7 +81,7 @@ fn current_theme_index(theme_name: &str) -> usize {
 fn toast_delivery_index(delivery: ToastDelivery) -> usize {
     match delivery {
         ToastDelivery::Off => 0,
-        ToastDelivery::Herdr => 1,
+        ToastDelivery::Herdr { .. } => 1,
         ToastDelivery::Terminal => 2,
         ToastDelivery::System => 3,
     }
@@ -90,7 +90,7 @@ fn toast_delivery_index(delivery: ToastDelivery) -> usize {
 fn toast_delivery_for_index(idx: usize) -> ToastDelivery {
     match idx {
         0 => ToastDelivery::Off,
-        1 => ToastDelivery::Herdr,
+        1 => ToastDelivery::herdr(ToastPosition::default()),
         2 => ToastDelivery::Terminal,
         _ => ToastDelivery::System,
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1927,7 +1927,7 @@ mod tests {
             .matches_prefix(&KeyEvent::new(KeyCode::Char('m'), KeyModifiers::empty())));
         assert_eq!(
             app.state.toast_config.delivery,
-            crate::config::ToastDelivery::Herdr
+            crate::config::ToastDelivery::herdr(crate::config::ToastPosition::default())
         );
         assert_eq!(
             app.state.agent_panel_scope,
@@ -2183,7 +2183,7 @@ mod tests {
         std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
 
         let mut app = test_app();
-        app.state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        app.state.enable_herdr_toasts();
         let report = app.reload_config();
 
         assert_eq!(report.status, crate::config::ConfigReloadStatus::Partial);
@@ -2194,7 +2194,7 @@ mod tests {
             .matches_prefix(&KeyEvent::new(KeyCode::Char('m'), KeyModifiers::empty())));
         assert_eq!(
             app.state.toast_config.delivery,
-            crate::config::ToastDelivery::Herdr
+            crate::config::ToastDelivery::herdr(crate::config::ToastPosition::default())
         );
         assert!(app
             .state

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,4 +1,6 @@
-use crate::config::{Keybinds, NewTerminalCwdConfig, SoundConfig, ToastConfig, ToastDelivery};
+use crate::config::{
+    Keybinds, NewTerminalCwdConfig, SoundConfig, ToastConfig, ToastDelivery, ToastPosition,
+};
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::{Direction, Rect};
 use ratatui::style::Color;
@@ -1352,6 +1354,13 @@ impl AppState {
         self.toast_config.delivery
     }
 
+    pub fn toast_position(&self) -> ToastPosition {
+        match self.toast_config.delivery {
+            ToastDelivery::Herdr { position } => position,
+            _ => ToastPosition::default(),
+        }
+    }
+
     pub fn agent_border_labels_enabled(&self) -> bool {
         self.show_agent_labels_on_pane_borders
     }
@@ -1510,6 +1519,11 @@ pub fn key_matches(
 
 #[cfg(test)]
 impl AppState {
+    /// Enable in-Herdr toast delivery with the default position.
+    pub fn enable_herdr_toasts(&mut self) {
+        self.toast_config.delivery = ToastDelivery::herdr(ToastPosition::default());
+    }
+
     /// Create an AppState for testing — no channels, no PTYs.
     pub fn test_new() -> Self {
         Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub use self::{
     model::{
         validated_sidebar_bounds, AgentPanelScopeConfig, Config, ConfigReloadReport,
         ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, ShellModeConfig, ToastConfig,
-        ToastDelivery, UpdateChannelConfig,
+        ToastDelivery, ToastPosition, UpdateChannelConfig,
     },
     sound::SoundConfig,
     theme::{parse_color, CustomThemeColors, ThemeConfig},

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -39,14 +39,32 @@ impl Default for UpdateConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToastDelivery {
     #[default]
     Off,
-    Herdr,
+    Herdr {
+        position: ToastPosition,
+    },
     Terminal,
     System,
+}
+
+impl ToastDelivery {
+    /// In-Herdr delivery showing the toast in the given corner.
+    pub fn herdr(position: ToastPosition) -> Self {
+        Self::Herdr { position }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToastPosition {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    #[default]
+    BottomRight,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -597,19 +615,41 @@ impl<'de> Deserialize<'de> for ToastConfig {
     where
         D: Deserializer<'de>,
     {
+        #[derive(Deserialize, Clone, Copy, Default)]
+        #[serde(rename_all = "lowercase")]
+        enum RawToastDelivery {
+            #[default]
+            Off,
+            Herdr,
+            Terminal,
+            System,
+        }
+
+        #[derive(Deserialize, Default)]
+        #[serde(default)]
+        struct RawHerdrToastConfig {
+            position: Option<ToastPosition>,
+        }
+
         #[derive(Deserialize, Default)]
         #[serde(default)]
         struct RawToastConfig {
-            delivery: Option<ToastDelivery>,
+            delivery: Option<RawToastDelivery>,
             enabled: Option<bool>,
+            herdr: RawHerdrToastConfig,
         }
 
         let raw = RawToastConfig::deserialize(deserializer)?;
         let legacy_delivery = match raw.enabled {
-            Some(true) => ToastDelivery::Herdr,
-            Some(false) | None => ToastDelivery::Off,
+            Some(true) => RawToastDelivery::Herdr,
+            Some(false) | None => RawToastDelivery::Off,
         };
-        let delivery = raw.delivery.unwrap_or(legacy_delivery);
+        let delivery = match raw.delivery.unwrap_or(legacy_delivery) {
+            RawToastDelivery::Off => ToastDelivery::Off,
+            RawToastDelivery::Herdr => ToastDelivery::herdr(raw.herdr.position.unwrap_or_default()),
+            RawToastDelivery::Terminal => ToastDelivery::Terminal,
+            RawToastDelivery::System => ToastDelivery::System,
+        };
         Ok(Self { delivery })
     }
 }
@@ -994,7 +1034,10 @@ delivery = "system"
 enabled = true
 "#;
         let config: Config = toml::from_str(toml).unwrap();
-        assert_eq!(config.ui.toast.delivery, ToastDelivery::Herdr);
+        assert_eq!(
+            config.ui.toast.delivery,
+            ToastDelivery::herdr(ToastPosition::BottomRight)
+        );
     }
 
     #[test]
@@ -1016,6 +1059,69 @@ delivery = "terminal"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.ui.toast.delivery, ToastDelivery::Terminal);
+    }
+
+    #[test]
+    fn toast_config_parses_position() {
+        let toml = r#"
+[ui.toast]
+delivery = "herdr"
+herdr.position = "top-left"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.ui.toast.delivery,
+            ToastDelivery::herdr(ToastPosition::TopLeft)
+        );
+    }
+
+    #[test]
+    fn toast_config_parses_position_from_subsection() {
+        let toml = r#"
+[ui.toast]
+delivery = "herdr"
+
+[ui.toast.herdr]
+position = "top-left"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.ui.toast.delivery,
+            ToastDelivery::herdr(ToastPosition::TopLeft)
+        );
+    }
+
+    #[test]
+    fn toast_config_position_defaults_to_bottom_right() {
+        let toml = r#"
+[ui.toast]
+delivery = "herdr"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.ui.toast.delivery,
+            ToastDelivery::herdr(ToastPosition::BottomRight)
+        );
+    }
+
+    #[test]
+    fn toast_config_position_is_ignored_for_non_herdr_delivery() {
+        let toml = r#"
+[ui.toast]
+delivery = "terminal"
+herdr.position = "top-left"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.ui.toast.delivery, ToastDelivery::Terminal);
+    }
+
+    #[test]
+    fn toast_config_rejects_unknown_position() {
+        let toml = r#"
+[ui.toast]
+herdr.position = "center"
+"#;
+        assert!(toml::from_str::<Config>(toml).is_err());
     }
 
     #[test]

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -6070,7 +6070,7 @@ next_tab = ""
             ),
         );
         server.foreground_client_id = Some(1);
-        server.app.state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
+        server.app.state.enable_herdr_toasts();
 
         let changed = server.handle_internal_event_with_forwarding(AppEvent::UpdateReady {
             version: "9.9.9".to_string(),

--- a/src/server/notifications.rs
+++ b/src/server/notifications.rs
@@ -14,7 +14,7 @@ pub(crate) fn toast_notify_kind(delivery: config::ToastDelivery) -> Option<proto
     match delivery {
         config::ToastDelivery::Terminal => Some(protocol::NotifyKind::Toast),
         config::ToastDelivery::System => Some(protocol::NotifyKind::SystemToast),
-        config::ToastDelivery::Off | config::ToastDelivery::Herdr => None,
+        config::ToastDelivery::Off | config::ToastDelivery::Herdr { .. } => None,
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,6 +86,7 @@ pub(crate) use self::{
 };
 use crate::app::state::ViewLayout;
 use crate::app::{AppState, Mode};
+use crate::config::ToastPosition;
 use crate::terminal::TerminalRuntimeRegistry;
 
 const COLLAPSED_WIDTH: u16 = 4; // num + space + dot + separator
@@ -254,7 +255,14 @@ fn compute_view_internal(
     let toast_hit_area = app
         .toast
         .as_ref()
-        .map(|toast| toast_notification_rect(terminal_area, toast, app.config_diagnostic.is_some()))
+        .map(|toast| {
+            toast_notification_rect(
+                terminal_area,
+                toast,
+                app.toast_position(),
+                app.config_diagnostic.is_some(),
+            )
+        })
         .unwrap_or_default();
 
     app.view = crate::app::ViewState {
@@ -426,6 +434,7 @@ fn render_notifications(app: &AppState, frame: &mut Frame, terminal_area: Rect) 
                 frame,
                 terminal_area,
                 toast,
+                app.toast_position(),
                 has_config_diagnostic,
                 &app.palette,
             );
@@ -433,8 +442,19 @@ fn render_notifications(app: &AppState, frame: &mut Frame, terminal_area: Rect) 
         copy_feedback_offset =
             copy_feedback_offset.saturating_add(if app.view.layout == ViewLayout::Mobile {
                 1
+            } else if matches!(
+                app.toast_position(),
+                ToastPosition::BottomLeft | ToastPosition::BottomRight
+            ) {
+                toast_notification_rect(
+                    terminal_area,
+                    toast,
+                    app.toast_position(),
+                    has_config_diagnostic,
+                )
+                .height
             } else {
-                toast_notification_rect(terminal_area, toast, has_config_diagnostic).height
+                0
             });
     }
     if let Some(feedback) = &app.copy_feedback {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -113,7 +113,7 @@ pub(super) fn render_settings_overlay(app: &AppState, frame: &mut Frame, area: R
                 "choose where background popup notifications should appear",
                 &[
                     ("off", ToastDelivery::Off),
-                    ("inside herdr", ToastDelivery::Herdr),
+                    ("inside herdr", ToastDelivery::herdr(app.toast_position())),
                     ("via terminal", ToastDelivery::Terminal),
                     ("via system", ToastDelivery::System),
                 ],

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -9,6 +9,7 @@ use ratatui::{
 use super::widgets::panel_contrast_fg;
 use crate::{
     app::state::{CopyFeedback, Palette, ToastKind, ToastNotification},
+    config::ToastPosition,
     detect::AgentState,
 };
 
@@ -28,17 +29,28 @@ pub(crate) fn copy_feedback_rect(area: Rect, feedback: &CopyFeedback, offset_row
 pub(crate) fn toast_notification_rect(
     area: Rect,
     toast: &ToastNotification,
+    position: ToastPosition,
     offset_for_warning: bool,
 ) -> Rect {
     let content_width = (toast.title.len().max(toast.context.len()) as u16) + 4;
     let width = content_width.saturating_add(2).min(area.width);
     let content_height = if toast.context.is_empty() { 1 } else { 2 };
     let height = (content_height + 2).min(area.height);
-    let x = area.x + area.width.saturating_sub(width);
-    let y = area.y
-        + area
-            .height
-            .saturating_sub(height + if offset_for_warning { 1 } else { 0 });
+    let warning_rows = if offset_for_warning { 1 } else { 0 };
+    let x = match position {
+        ToastPosition::TopLeft | ToastPosition::BottomLeft => area.x,
+        ToastPosition::TopRight | ToastPosition::BottomRight => {
+            area.x + area.width.saturating_sub(width)
+        }
+    };
+    let y = match position {
+        ToastPosition::TopLeft | ToastPosition::TopRight => {
+            area.y + warning_rows.min(area.height.saturating_sub(height))
+        }
+        ToastPosition::BottomLeft | ToastPosition::BottomRight => {
+            area.y + area.height.saturating_sub(height + warning_rows)
+        }
+    };
     Rect::new(x, y, width, height)
 }
 
@@ -46,6 +58,7 @@ pub(super) fn render_toast_notification(
     frame: &mut Frame,
     area: Rect,
     toast: &ToastNotification,
+    position: ToastPosition,
     offset_for_warning: bool,
     p: &Palette,
 ) {
@@ -54,7 +67,7 @@ pub(super) fn render_toast_notification(
         ToastKind::Finished => p.blue,
         ToastKind::UpdateInstalled => p.accent,
     };
-    let toast_area = toast_notification_rect(area, toast, offset_for_warning);
+    let toast_area = toast_notification_rect(area, toast, position, offset_for_warning);
 
     frame.render_widget(Clear, toast_area);
     let block = Block::default()

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -299,11 +299,14 @@ Herdr can show popup notifications when agents finish or need input.
 ```toml
 [ui.toast]
 delivery = "off"
+herdr.position = "bottom-right"
 ```
 
 `delivery = "off"` disables popup notifications. This is the default.
 
-`delivery = "herdr"` shows a top-right toast inside the Herdr UI. Click the toast, or bind `keys.open_notification_target`, to focus the target workspace, tab, and pane.
+`delivery = "herdr"` shows a toast inside the Herdr UI. Click the toast, or bind `keys.open_notification_target`, to focus the target workspace, tab, and pane.
+
+`herdr.position` places the in-Herdr toast in one of the four corners: `top-left`, `top-right`, `bottom-left`, or `bottom-right`. The default is `bottom-right`. Options under `herdr` only affect `delivery = "herdr"` — they can stay set while using another delivery and take effect again when you switch back.
 
 `delivery = "terminal"` asks the outer terminal to show a desktop notification. Herdr sends terminal notification escape sequences for Ghostty, iTerm2, Kitty, and WezTerm. This is useful over SSH because the local terminal owns the notification.
 


### PR DESCRIPTION
Add a `herdr.position` option to `[ui.toast]` that places the in-Herdr toast in any of the four corners: `top-left`, `top-right`, `bottom-left`, or `bottom-right`. The default is `bottom-right`, matching the previous hardcoded placement, so existing configs render identically.

Since position only applies to in-app delivery, it's carried in the delivery variant itself — `ToastDelivery::Herdr { position }` — and the TOML nests it under a `herdr` table that mirrors the variant and namespaces any future herdr-only options. Both the inline dotted-key form and a `[ui.toast.herdr]` sub-section parse identically. A configured position survives switching delivery away and back: it stays in the TOML (only the `delivery` key is rewritten on save) and takes effect again on return to herdr delivery.

Top positions respect the config-diagnostic warning bar the same way bottom positions do: where a bottom toast shifts up one row to clear the bar, a top toast shifts down one row. The copy-feedback offset (which lifts the bottom-centered copy toast above the notification toast) now applies only for bottom positions, since a top toast cannot collide with it.

Also fix the configuration docs, which claimed `delivery = "herdr"` shows a top-right toast — it has always been bottom-right.