### PR TITLE
fix: conditional clipboard feedback and wayland background write

### DIFF
--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -22,10 +22,12 @@ impl App {
     pub(crate) fn handle_internal_event(&mut self, ev: AppEvent) {
         if let AppEvent::ClipboardWrite { content } = ev {
             #[cfg(not(test))]
-            crate::selection::write_osc52_bytes(&content);
+            let ok = crate::selection::write_osc52_bytes(&content);
             #[cfg(test)]
-            let _ = content;
-            self.show_clipboard_feedback();
+            let ok = { let _ = content; true };
+            if ok {
+                self.show_clipboard_feedback();
+            }
             return;
         }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1086,7 +1086,7 @@ fn forward_clipboard(data: &str) {
         return;
     };
 
-    crate::selection::write_osc52_bytes(&bytes);
+    let _ = crate::selection::write_osc52_bytes(&bytes);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -319,7 +319,9 @@ fn clipboard_commands() -> Vec<ClipboardCommand> {
     if std::env::var_os("WAYLAND_DISPLAY").is_some() {
         commands.push(ClipboardCommand {
             program: "wl-copy",
-            args: &["--type", "text/plain;charset=utf-8"],
+            // --background keeps the child alive serving clipboard data;
+            // without it the data is cleared when wl-copy exits.
+            args: &["--type", "text/plain;charset=utf-8", "--background"],
         });
     }
 
@@ -361,6 +363,15 @@ fn run_clipboard_command(command: &ClipboardCommand, bytes: &[u8]) -> bool {
         return false;
     }
     drop(stdin);
+
+    // wl-copy --background stays alive to serve clipboard requests.
+    // Detach the wait to avoid blocking the caller.
+    if command.program == "wl-copy" {
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+        return true;
+    }
 
     child.wait().map(|status| status.success()).unwrap_or(false)
 }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -319,18 +319,25 @@ fn should_prefer_osc52() -> bool {
 
 /// Write clipboard bytes to the system clipboard via OSC 52.
 ///
+/// Returns `true` if the clipboard was successfully written via the platform
+/// clipboard provider (e.g. `xclip`, `wl-copy`, `pbcopy`). Returns `false`
+/// if the platform provider was unavailable or failed — in that case the OSC
+/// 52 fallback sequence is emitted to stdout, but herdr cannot verify whether
+/// the host terminal or widget actually processed it.
+///
 /// OSC 52 format: `ESC ] 52 ; c ; <base64> BEL`
 ///
 /// Some terminals still only honor BEL-terminated OSC 52 writes, so herdr
 /// emits BEL here even though ST works in newer emulators.
-pub fn write_osc52_bytes(bytes: &[u8]) {
+pub fn write_osc52_bytes(bytes: &[u8]) -> bool {
     if !should_prefer_osc52() && crate::platform::write_clipboard(bytes) {
-        return;
+        return true;
     }
 
     let sequence = osc52_sequence(bytes);
     let _ = std::io::stdout().write_all(sequence.as_bytes());
     let _ = std::io::stdout().flush();
+    false
 }
 
 #[cfg(test)]

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -1308,8 +1308,8 @@ impl HeadlessServer {
                 if let Some(client_id) = self.foreground_client_id {
                     let data = base64::engine::general_purpose::STANDARD.encode(content.as_slice());
                     self.send_to_client(client_id, ServerMessage::Clipboard { data });
+                    self.app.show_clipboard_feedback();
                 }
-                self.app.show_clipboard_feedback();
                 true
             }
             AppEvent::StateChanged { pane_id, agent, .. } => {


### PR DESCRIPTION
### Changes

- `write_osc52_bytes()` now returns `bool` instead of `()` so callers know whether the platform clipboard write succeeded
- Clipboard feedback toast is only shown when `write_osc52_bytes()` returns `true` (platform write succeeded)
- Same conditional toast logic applied to headless server mode (moved `show_clipboard_feedback()` inside the foreground-client check)
- `wl-copy` on Wayland now runs with `--background` so clipboard data persists after the child process exits
- `wl-copy` child wait is detached via `thread::spawn` since `--background` keeps the process alive
- `forward_clipboard` in client mode explicitly discards the unused return value

### Why

Issue #443: toast showed "copied to clipboard" even when the actual clipboard write failed, misleading users into thinking the copy succeeded.

On Linux X11 without `xclip` installed, herdr silently fell back to OSC 52 on stdout which the terminal widget may not handle, yet the toast still appeared. On Wayland, `wl-copy` without `--background` could lose clipboard data on exit.

### Test plan

- **X11 (w/ xclip)**: drag-select text, verify toast appears and clipboard content is actually set
- **X11 (w/o xclip)**: drag-select text, verify no toast appears (OSC 52 fallback, cannot verify)
- **Wayland**: drag-select text, verify clipboard persists after `wl-copy` exits
- **macOS**: drag-select text, verify normal `pbcopy` behavior unchanged
- **Headless client**: server forwards clipboard write, client receives and writes to clipboard

refs #443