### PR TITLE
feat: add tab.move api method and cli command

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,6 +33,7 @@ pub(crate) fn request_changes_ui(request: &Request) -> bool {
             | Method::TabFocus(_)
             | Method::TabRename(_)
             | Method::TabClose(_)
+            | Method::TabMove(_)
             | Method::AgentRename(_)
             | Method::AgentFocus(_)
             | Method::AgentStart(_)

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -52,6 +52,8 @@ pub enum Method {
     TabRename(TabRenameParams),
     #[serde(rename = "tab.close")]
     TabClose(TabTarget),
+    #[serde(rename = "tab.move")]
+    TabMove(TabMoveParams),
     #[serde(rename = "agent.list")]
     AgentList(EmptyParams),
     #[serde(rename = "agent.get")]
@@ -214,6 +216,13 @@ pub struct TabListParams {
 pub struct TabRenameParams {
     pub tab_id: String,
     pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TabMoveParams {
+    pub tab_id: String,
+    /// 1-based target position for the tab.
+    pub position: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -458,6 +467,8 @@ pub enum Subscription {
     TabFocused {},
     #[serde(rename = "tab.renamed")]
     TabRenamed {},
+    #[serde(rename = "tab.moved")]
+    TabMoved {},
     #[serde(rename = "pane.created")]
     PaneCreated {},
     #[serde(rename = "pane.closed")]
@@ -574,6 +585,9 @@ pub enum EventMatch {
     TabFocused {
         tab_id: String,
     },
+    TabMoved {
+        tab_id: String,
+    },
     PaneCreated {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pane_id: Option<String>,
@@ -617,6 +631,7 @@ pub enum EventKind {
     TabClosed,
     TabRenamed,
     TabFocused,
+    TabMoved,
     PaneCreated,
     PaneClosed,
     PaneFocused,
@@ -976,6 +991,11 @@ pub enum EventData {
     TabFocused {
         tab_id: String,
         workspace_id: String,
+    },
+    TabMoved {
+        tab_id: String,
+        workspace_id: String,
+        position: usize,
     },
     PaneCreated {
         pane: PaneInfo,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -287,6 +287,7 @@ fn api_method_name(method: &Method) -> &'static str {
         Method::TabFocus(_) => "tab.focus",
         Method::TabRename(_) => "tab.rename",
         Method::TabClose(_) => "tab.close",
+        Method::TabMove(_) => "tab.move",
         Method::AgentList(_) => "agent.list",
         Method::AgentGet(_) => "agent.get",
         Method::AgentRead(_) => "agent.read",

--- a/src/api/subscriptions.rs
+++ b/src/api/subscriptions.rs
@@ -144,6 +144,10 @@ impl ActiveSubscription {
                 event_kind: crate::api::schema::EventKind::TabRenamed,
                 last_sequence: 0,
             })),
+            Subscription::TabMoved {} => Ok(Self::Event(ActiveEventSubscription {
+                event_kind: crate::api::schema::EventKind::TabMoved,
+                last_sequence: 0,
+            })),
             Subscription::PaneCreated {} => Ok(Self::Event(ActiveEventSubscription {
                 event_kind: crate::api::schema::EventKind::PaneCreated,
                 last_sequence: 0,

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -547,6 +547,7 @@ impl App {
             Method::TabFocus(target) => return self.handle_tab_focus(request.id, target),
             Method::TabRename(params) => return self.handle_tab_rename(request.id, params),
             Method::TabClose(target) => return self.handle_tab_close(request.id, target),
+            Method::TabMove(params) => return self.handle_tab_move(request.id, params),
             Method::AgentList(_) => return self.handle_agent_list(request.id),
             Method::AgentGet(target) => return self.handle_agent_get(request.id, target),
             Method::AgentFocus(target) => return self.handle_agent_focus(request.id, target),

--- a/src/app/api/tabs.rs
+++ b/src/app/api/tabs.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::api::schema::{
     EventData, EventEnvelope, EventKind, ResponseResult, TabCreateParams, TabListParams,
-    TabRenameParams, TabTarget,
+    TabMoveParams, TabRenameParams, TabTarget,
 };
 use crate::app::{App, Mode};
 
@@ -216,6 +216,76 @@ impl App {
         });
 
         encode_success(id, ResponseResult::Ok {})
+    }
+
+    pub(super) fn handle_tab_move(&mut self, id: String, params: TabMoveParams) -> String {
+        let Some((ws_idx, source_tab_idx)) = self.parse_tab_id(&params.tab_id) else {
+            return tab_not_found(id, &params.tab_id);
+        };
+        let Some(ws) = self.state.workspaces.get_mut(ws_idx) else {
+            return tab_not_found(id, &params.tab_id);
+        };
+        let tab_count = ws.tabs.len();
+        if params.position == 0 || params.position > tab_count {
+            return encode_error(
+                id,
+                "invalid_position",
+                format!(
+                    "position must be between 1 and {} (got {})",
+                    tab_count, params.position
+                ),
+            );
+        }
+        // Convert 1-based position to 0-based insert_idx.
+        let insert_idx = params.position - 1;
+        // move_tab uses insertion semantics: to place the tab *at* index N,
+        // we pass insert_idx = N when source is after N, or insert_idx = N + 1
+        // when source is before N. The simplest correct mapping: pass the raw
+        // target index when source >= target (moving left), or target + 1 when
+        // source < target (moving right), because remove-then-insert shifts
+        // indices. But Workspace::move_tab already handles this internally —
+        // it normalises `insert_idx` by subtracting 1 when source < insert_idx.
+        // So we can pass `params.position` directly (which equals target + 1 in
+        // 0-based remove-then-insert terms when moving right, and target when
+        // moving left... actually let's just map cleanly).
+        //
+        // Workspace::move_tab(source, insert) does:
+        //   target = if source < insert { insert - 1 } else { insert }
+        //   remove(source); insert(target)
+        //
+        // We want the tab to end up at 0-based index `desired = position - 1`.
+        // If source < desired: target = insert - 1 = desired => insert = desired + 1
+        //                                                      = position
+        // If source > desired: target = insert = desired => insert = desired
+        //                                                  = position - 1
+        // If source == desired: no-op (move_tab returns false)
+        let insert_idx = if source_tab_idx < insert_idx {
+            insert_idx + 1
+        } else {
+            insert_idx
+        };
+        let workspace_id = self.state.workspaces[ws_idx].id.clone();
+        let ws = self.state.workspaces.get_mut(ws_idx).unwrap();
+        ws.move_tab(source_tab_idx, insert_idx);
+        let new_tab_idx = params.position - 1;
+        let tab_id = self
+            .public_tab_id(ws_idx, new_tab_idx)
+            .unwrap_or_else(|| format!("{}:{}", workspace_id, params.position));
+        crate::logging::tab_moved(&workspace_id, &tab_id);
+        self.schedule_session_save();
+        self.emit_event(EventEnvelope {
+            event: EventKind::TabMoved,
+            data: EventData::TabMoved {
+                tab_id: self
+                    .public_tab_id(ws_idx, new_tab_idx)
+                    .unwrap_or_else(|| format!("{}:{}", workspace_id, params.position)),
+                workspace_id: self.public_workspace_id(ws_idx),
+                position: params.position,
+            },
+        });
+        let tab = self.tab_info(ws_idx, new_tab_idx).unwrap();
+
+        encode_success(id, ResponseResult::TabInfo { tab })
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3518,4 +3518,112 @@ last_pane = "prefix+tab"
             b"a"
         );
     }
+
+    #[test]
+    fn tab_move_changes_order_and_returns_updated_info() {
+        let mut app = test_app();
+        let mut workspace = Workspace::test_new("api-tab-move");
+        workspace.test_add_tab(Some("alpha"));
+        workspace.test_add_tab(Some("beta"));
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+
+        // Tab order before: [1: api-tab-move, 2: alpha, 3: beta]
+        // Move tab 3 (beta) to position 1.
+        let third_tab_id = app.public_tab_id(0, 2).unwrap();
+
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "req_tab_move".into(),
+            method: crate::api::schema::Method::TabMove(crate::api::schema::TabMoveParams {
+                tab_id: third_tab_id,
+                position: 1,
+            }),
+        });
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert_eq!(response["result"]["type"], "tab_info");
+        assert_eq!(response["result"]["tab"]["number"], 1);
+        assert_eq!(response["result"]["tab"]["label"], "beta");
+
+        // Verify the full order is now [beta, <auto:2>, alpha].
+        // The first tab is auto-named (no custom_name), so display_name returns
+        // its renumbered position "2".
+        let labels: Vec<_> = app.state.workspaces[0]
+            .tabs
+            .iter()
+            .map(|t| t.display_name())
+            .collect();
+        assert_eq!(labels, vec!["beta", "2", "alpha"]);
+    }
+
+    #[test]
+    fn tab_move_rejects_invalid_position() {
+        let mut app = test_app();
+        let mut workspace = Workspace::test_new("api-tab-move-err");
+        workspace.test_add_tab(None);
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+
+        let tab_id = app.public_tab_id(0, 0).unwrap();
+
+        // Position 0 is invalid (1-based).
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "req_tab_move_zero".into(),
+            method: crate::api::schema::Method::TabMove(crate::api::schema::TabMoveParams {
+                tab_id: tab_id.clone(),
+                position: 0,
+            }),
+        });
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(response["error"]["code"].as_str().unwrap() == "invalid_position");
+
+        // Position 3 is beyond tab count of 2.
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "req_tab_move_oob".into(),
+            method: crate::api::schema::Method::TabMove(crate::api::schema::TabMoveParams {
+                tab_id,
+                position: 3,
+            }),
+        });
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(response["error"]["code"].as_str().unwrap() == "invalid_position");
+    }
+
+    #[test]
+    fn tab_move_to_same_position_is_noop() {
+        let mut app = test_app();
+        let mut workspace = Workspace::test_new("api-tab-move-noop");
+        workspace.test_add_tab(Some("second"));
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+
+        let tab_id = app.public_tab_id(0, 0).unwrap();
+
+        // Move tab 1 to position 1 — should be a no-op but still succeed.
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "req_tab_move_noop".into(),
+            method: crate::api::schema::Method::TabMove(crate::api::schema::TabMoveParams {
+                tab_id,
+                position: 1,
+            }),
+        });
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(response["result"]["type"], "tab_info");
+        assert_eq!(response["result"]["tab"]["number"], 1);
+
+        // Order unchanged. The first tab is auto-named, so display_name
+        // returns its number "1".
+        let labels: Vec<_> = app.state.workspaces[0]
+            .tabs
+            .iter()
+            .map(|t| t.display_name())
+            .collect();
+        assert_eq!(labels, vec!["1", "second"]);
+    }
 }

--- a/src/cli/tab.rs
+++ b/src/cli/tab.rs
@@ -1,5 +1,5 @@
 use crate::api::schema::{
-    Method, Request, TabCreateParams, TabListParams, TabRenameParams, TabTarget,
+    Method, Request, TabCreateParams, TabListParams, TabMoveParams, TabRenameParams, TabTarget,
 };
 
 pub(super) fn run_tab_command(args: &[String]) -> std::io::Result<i32> {
@@ -14,6 +14,7 @@ pub(super) fn run_tab_command(args: &[String]) -> std::io::Result<i32> {
         "get" => tab_get(&args[1..]),
         "focus" => tab_focus(&args[1..]),
         "rename" => tab_rename(&args[1..]),
+        "move" => tab_move(&args[1..]),
         "close" => tab_close(&args[1..]),
         "help" | "--help" | "-h" => {
             print_tab_help();
@@ -163,6 +164,29 @@ fn tab_rename(args: &[String]) -> std::io::Result<i32> {
     })?)
 }
 
+fn tab_move(args: &[String]) -> std::io::Result<i32> {
+    if args.len() != 2 {
+        eprintln!("usage: herdr tab move <tab_id> <position>");
+        return Ok(2);
+    }
+
+    let position: usize = match args[1].parse() {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("position must be a positive integer");
+            return Ok(2);
+        }
+    };
+
+    super::print_response(&super::send_request(&Request {
+        id: "cli:tab:move".into(),
+        method: Method::TabMove(TabMoveParams {
+            tab_id: super::normalize_tab_id(&args[0]),
+            position,
+        }),
+    })?)
+}
+
 fn tab_close(args: &[String]) -> std::io::Result<i32> {
     let Some(raw_tab_id) = args.first() else {
         eprintln!("usage: herdr tab close <tab_id>");
@@ -190,5 +214,6 @@ fn print_tab_help() {
     eprintln!("  herdr tab get <tab_id>");
     eprintln!("  herdr tab focus <tab_id>");
     eprintln!("  herdr tab rename <tab_id> <label>");
+    eprintln!("  herdr tab move <tab_id> <position>");
     eprintln!("  herdr tab close <tab_id>");
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -299,6 +299,17 @@ pub(crate) fn tab_renamed(workspace_id: &str, tab_id: &str) {
     );
 }
 
+pub(crate) fn tab_moved(workspace_id: &str, tab_id: &str) {
+    tracing::info!(
+        event = "tab.move",
+        subsystem = "tab",
+        outcome = "ok",
+        workspace_id,
+        tab_id,
+        "tab moved"
+    );
+}
+
 pub(crate) fn session_saved(path: &Path, workspaces: usize) {
     tracing::info!(
         event = "persist.save",

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -595,6 +595,95 @@ fn tab_methods_round_trip_over_socket() {
     cleanup_spawned_herdr(child, base);
 }
 
+#[test]
+fn tab_move_round_trip_over_socket() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let socket_path = runtime_dir.join("herdr.sock");
+
+    let child = spawn_herdr(&config_home, &runtime_dir, &socket_path);
+    wait_for_socket(&socket_path, Duration::from_secs(5));
+
+    // Create a workspace.
+    let created = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_m1","method":"workspace.create","params":{{"cwd":"{}","focus":true}}}}"#,
+            base.display()
+        ),
+    );
+    let workspace_id = created["result"]["workspace"]["workspace_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create two more tabs (3 total).
+    let tab2 = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_m2","method":"tab.create","params":{{"workspace_id":"{}","label":"alpha","focus":true}}}}"#,
+            workspace_id
+        ),
+    );
+    let tab2_id = tab2["result"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let tab3 = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_m3","method":"tab.create","params":{{"workspace_id":"{}","label":"beta","focus":true}}}}"#,
+            workspace_id
+        ),
+    );
+    let tab3_id = tab3["result"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Move tab 3 (beta) to position 1.
+    let moved = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_m4","method":"tab.move","params":{{"tab_id":"{}","position":1}}}}"#,
+            tab3_id
+        ),
+    );
+    assert_eq!(moved["result"]["type"], "tab_info");
+    assert_eq!(moved["result"]["tab"]["label"], "beta");
+    assert_eq!(moved["result"]["tab"]["number"], 1);
+
+    // Verify the full order via tab.list.
+    let tab_list = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_m5","method":"tab.list","params":{{"workspace_id":"{}"}}}}"#,
+            workspace_id
+        ),
+    );
+    let tabs = tab_list["result"]["tabs"].as_array().unwrap();
+    assert_eq!(tabs.len(), 3);
+    assert_eq!(tabs[0]["label"], "beta");
+    assert_eq!(tabs[0]["number"], 1);
+    assert_eq!(tabs[2]["label"], "alpha");
+    assert_eq!(tabs[2]["number"], 3);
+
+    // Invalid position returns an error.
+    let bad_pos = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_m6","method":"tab.move","params":{{"tab_id":"{}","position":0}}}}"#,
+            tab2_id
+        ),
+    );
+    assert!(bad_pos["error"]["code"].as_str().unwrap() == "invalid_position");
+
+    cleanup_spawned_herdr(child, base);
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn pane_info_reports_foreground_cwd_without_changing_pane_cwd() {

--- a/tests/cli_wrapper.rs
+++ b/tests/cli_wrapper.rs
@@ -2096,6 +2096,77 @@ fn tab_management_commands_work() {
 }
 
 #[test]
+fn tab_move_command_works() {
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let socket_path = runtime_dir.join("herdr.sock");
+
+    let herdr = spawn_herdr(&config_home, &runtime_dir, &socket_path);
+    wait_for_socket(&socket_path, Duration::from_secs(5));
+
+    let created = run_cli(
+        &socket_path,
+        &["workspace", "create", "--cwd", base.to_str().unwrap()],
+    );
+    assert!(created.status.success());
+    let created_json: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+    let workspace_id = created_json["result"]["workspace"]["workspace_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create two more tabs (3 total).
+    let tab2 = run_cli(
+        &socket_path,
+        &[
+            "tab",
+            "create",
+            "--workspace",
+            &workspace_id,
+            "--label",
+            "alpha",
+        ],
+    );
+    assert!(tab2.status.success());
+
+    let tab3 = run_cli(
+        &socket_path,
+        &[
+            "tab",
+            "create",
+            "--workspace",
+            &workspace_id,
+            "--label",
+            "beta",
+        ],
+    );
+    assert!(tab3.status.success());
+    let tab3_json: serde_json::Value = serde_json::from_slice(&tab3.stdout).unwrap();
+    let tab3_id = tab3_json["result"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Move tab 3 (beta) to position 1.
+    let moved = run_cli(&socket_path, &["tab", "move", &tab3_id, "1"]);
+    assert!(moved.status.success());
+    let moved_json: serde_json::Value = serde_json::from_slice(&moved.stdout).unwrap();
+    assert_eq!(moved_json["result"]["tab"]["label"], "beta");
+    assert_eq!(moved_json["result"]["tab"]["number"], 1);
+
+    // Verify via tab list.
+    let listed = run_cli(&socket_path, &["tab", "list", "--workspace", &workspace_id]);
+    assert!(listed.status.success());
+    let listed_json: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    let tabs = listed_json["result"]["tabs"].as_array().unwrap();
+    assert_eq!(tabs[0]["label"], "beta");
+    assert_eq!(tabs[0]["number"], 1);
+
+    cleanup_spawned_herdr(herdr, base);
+}
+
+#[test]
 fn agent_start_command_works() {
     let base = unique_test_dir();
     let config_home = base.join("config");


### PR DESCRIPTION
expose the existing Workspace::move_tab through a new tab.move api endpoint and herdr tab move <tab_id> <position> cli command. position is 1-based to match displayed tab numbers.

includes TabMoved event kind, subscription support, and logging.