### PR TITLE
feat: tmux control mode integration

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2344,6 +2344,11 @@ impl AppState {
             }
             AppEvent::WorktreeAddFinished(_) => Vec::new(),
             AppEvent::WorktreeRemoveFinished(_) => Vec::new(),
+            // Tmux control mode events — logged but not state-changing for
+            // herdr-managed panes. External session detection will be fed
+            // through the detection pipeline separately.
+            AppEvent::TmuxPaneOutput { .. } => Vec::new(),
+            AppEvent::TmuxPaneLifecycle { .. } => Vec::new(),
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ mod pane;
 mod server;
 mod status;
 mod tab;
+mod tmux;
 mod workspace;
 mod worktree;
 
@@ -48,6 +49,7 @@ pub fn maybe_run(args: &[String]) -> std::io::Result<CommandOutcome> {
         "wait" => run_wait_command(&args[2..])?,
         "integration" => integration::run_integration_command(&args[2..])?,
         "session" => run_session_command(&args[2..])?,
+        "tmux" => tmux::run_tmux_command(&args[2..])?,
         _ => return Ok(CommandOutcome::NotCli),
     };
 

--- a/src/cli/tmux.rs
+++ b/src/cli/tmux.rs
@@ -1,0 +1,103 @@
+//! `herdr tmux` subcommand — manage tmux control mode monitoring.
+
+use crate::tmux_control::TmuxControlConfig;
+
+pub fn run_tmux_command(args: &[String]) -> std::io::Result<i32> {
+    match args.first().map(|arg| arg.as_str()) {
+        Some("status") => run_status(),
+        Some("help" | "--help" | "-h") => {
+            print_help();
+            Ok(0)
+        }
+        _ => {
+            print_help();
+            Ok(2)
+        }
+    }
+}
+
+fn run_status() -> std::io::Result<i32> {
+    let config = crate::config::Config::load().config;
+    let tmux_config = &config.tmux_control;
+
+    if !tmux_config.enabled {
+        println!("tmux control mode: disabled");
+        println!("  Enable in config: [tmux_control] enabled = true");
+        return Ok(0);
+    }
+
+    println!("tmux control mode: enabled");
+
+    if tmux_config.target_sessions.is_empty() {
+        println!("  sessions: all");
+    } else {
+        println!("  sessions: {}", tmux_config.target_sessions.join(", "));
+    }
+
+    match &tmux_config.socket_path {
+        Some(path) => println!("  socket: {path}"),
+        None => println!("  socket: default"),
+    }
+
+    // Check if tmux is available.
+    match which_tmux() {
+        Some(path) => println!("  tmux: {path}"),
+        None => {
+            println!("  tmux: NOT FOUND");
+            println!("  Install tmux to use control mode monitoring.");
+        }
+    }
+
+    // Check if a tmux server is running.
+    if let Some(tmux_path) = which_tmux() {
+        if is_tmux_server_running(&tmux_path) {
+            println!("  server: running");
+        } else {
+            println!("  server: not running");
+        }
+    }
+
+    Ok(0)
+}
+
+fn print_help() {
+    println!("herdr tmux — tmux control mode monitoring");
+    println!();
+    println!("Usage: herdr tmux <command>");
+    println!();
+    println!("Commands:");
+    println!("  status    Show tmux control mode status and configuration");
+    println!("  help      Show this help");
+    println!();
+    println!("Tmux control mode receives push-based pane output and lifecycle");
+    println!("events from tmux sessions. Enable in config.toml:");
+    println!();
+    println!("  [tmux_control]");
+    println!("  enabled = true");
+}
+
+fn which_tmux() -> Option<String> {
+    for path in [
+        "/usr/bin/tmux",
+        "/opt/homebrew/bin/tmux",
+        "/usr/local/bin/tmux",
+    ] {
+        if std::path::Path::new(path).exists() {
+            return Some(path.to_string());
+        }
+    }
+    std::env::var("PATH").ok().and_then(|path_var| {
+        path_var
+            .split(':')
+            .map(|dir| format!("{dir}/tmux"))
+            .find(|p| std::path::Path::new(p).exists())
+    })
+}
+
+fn is_tmux_server_running(tmux_path: &str) -> bool {
+    std::process::Command::new(tmux_path)
+        .arg("list-sessions")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -265,6 +265,7 @@ pub struct Config {
     pub advanced: AdvancedConfig,
     pub experimental: ExperimentalConfig,
     pub remote: RemoteConfig,
+    pub tmux_control: TmuxControlConfig,
 }
 
 #[derive(Debug)]
@@ -489,6 +490,29 @@ impl Default for RemoteConfig {
     fn default() -> Self {
         Self {
             manage_ssh_config: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TmuxControlConfig {
+    /// Enable tmux control mode monitoring. When true, herdr spawns a
+    /// `tmux -C` client to receive push-based pane output and lifecycle
+    /// events. Default: false.
+    pub enabled: bool,
+    /// Session names to monitor. Empty means all sessions.
+    pub target_sessions: Vec<String>,
+    /// Tmux socket path (for `-L` flag). None means default tmux socket.
+    pub socket_path: Option<String>,
+}
+
+impl Default for TmuxControlConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            target_sessions: Vec::new(),
+            socket_path: None,
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -105,4 +105,31 @@ pub enum AppEvent {
     WorktreeAddFinished(WorktreeAddResult),
     /// Background `git worktree remove` completed.
     WorktreeRemoveFinished(WorktreeRemoveResult),
+    /// Pane output received via tmux control mode.
+    TmuxPaneOutput {
+        /// The tmux pane ID (e.g., "42").
+        pane_id: String,
+        /// Plain text output with ANSI codes stripped.
+        plain_text: String,
+        /// Raw output with ANSI escape sequences preserved.
+        raw_data: String,
+    },
+    /// Tmux control mode detected a pane lifecycle event.
+    TmuxPaneLifecycle {
+        session: String,
+        window: String,
+        pane: String,
+        event: TmuxLifecycleEvent,
+    },
+}
+
+/// Lifecycle events from tmux control mode.
+#[derive(Debug, Clone)]
+pub enum TmuxLifecycleEvent {
+    /// A new window was added.
+    WindowAdd,
+    /// A window was closed.
+    WindowClose,
+    /// The active pane changed.
+    PaneFocusChanged,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod sound;
 mod terminal;
 mod terminal_notify;
 mod terminal_theme;
+mod tmux_control;
 mod ui;
 mod update;
 mod workspace;
@@ -306,6 +307,16 @@ pane_history = false
 # Maximum scrollback buffer size in bytes retained per pane terminal.
 # Matches Ghostty's default scrollback-limit behavior.
 # scrollback_limit_bytes = 10000000
+
+# Tmux control mode: receive push-based pane output and lifecycle events
+# from tmux sessions. Supplements herdr's built-in screen heuristics.
+[tmux_control]
+# Enable tmux control mode monitoring (default: false)
+# enabled = true
+# Session names to monitor. Empty = all sessions.
+# target_sessions = []
+# Tmux socket path (for -L flag). Null = default socket.
+# socket_path = null
 "##;
 
 fn should_block_nested(config: &config::Config) -> bool {
@@ -500,6 +511,10 @@ fn main() -> io::Result<()> {
                 "herdr integration <subcommand>",
                 "Manage built-in agent integrations",
             ),
+            (
+                "herdr tmux status",
+                "Show tmux control mode status and config",
+            ),
         ] {
             println!("  {command:<32} {description}");
         }
@@ -569,6 +584,7 @@ fn main() -> io::Result<()> {
                 "wait",
                 "session",
                 "integration",
+                "tmux",
             ]
             .contains(&arg.as_str())
         {

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -217,6 +217,8 @@ pub struct HeadlessServer {
     server_event_rx: mpsc::Receiver<ServerEvent>,
     /// Sender for server events (cloned for each client thread).
     server_event_tx: mpsc::Sender<ServerEvent>,
+    /// Optional tmux control mode listener for external session monitoring.
+    tmux_listener: Option<crate::tmux_control::TmuxControlListener>,
 }
 
 fn apply_terminal_attach_scroll(
@@ -346,7 +348,103 @@ impl HeadlessServer {
             should_quit,
             server_event_rx,
             server_event_tx,
+            tmux_listener: None,
         })
+    }
+
+    /// Spawn the tmux control mode listener if enabled in config.
+    ///
+    /// When enabled, this spawns a `tmux -C` client that streams pane output
+    /// and lifecycle events in real-time. Events are routed through the
+    /// existing `AppEvent` channel so they integrate with the standard
+    /// detection and notification pipeline.
+    pub fn spawn_tmux_control_listener(&mut self, config: &config::Config) {
+        let tmux_config = crate::tmux_control::TmuxControlConfig {
+            enabled: config.tmux_control.enabled,
+            target_sessions: config.tmux_control.target_sessions.clone(),
+            socket_path: config.tmux_control.socket_path.clone(),
+        };
+
+        if !tmux_config.enabled {
+            return;
+        }
+
+        let event_tx = self.app.event_tx.clone();
+        let target_sessions = tmux_config.target_sessions.clone();
+
+        let rt_handle = tokio::runtime::Handle::current();
+
+        // Spawn in background — don't block server startup.
+        rt_handle.spawn(async move {
+            match crate::tmux_control::TmuxControlListener::spawn(tmux_config).await {
+                Ok((mut listener, mut event_rx)) => {
+                    info!("tmux control mode listener started");
+
+                    // Forward events from the control mode listener into the app event channel.
+                    while let Some(event) = event_rx.recv().await {
+                        match &event {
+                            crate::tmux_control::TmuxEvent::Output { pane, data } => {
+                                let plain = crate::tmux_control::protocol::strip_ansi(data);
+                                let _ = event_tx.send(AppEvent::TmuxPaneOutput {
+                                    pane_id: pane.clone(),
+                                    plain_text: plain,
+                                    raw_data: data.clone(),
+                                });
+                            }
+                            crate::tmux_control::TmuxEvent::WindowAdd {
+                                session,
+                                window,
+                            } => {
+                                let _ = event_tx.send(AppEvent::TmuxPaneLifecycle {
+                                    session: session.clone(),
+                                    window: window.clone(),
+                                    pane: String::new(),
+                                    event: crate::events::TmuxLifecycleEvent::WindowAdd,
+                                });
+                            }
+                            crate::tmux_control::TmuxEvent::WindowClose {
+                                session,
+                                window,
+                            } => {
+                                let _ = event_tx.send(AppEvent::TmuxPaneLifecycle {
+                                    session: session.clone(),
+                                    window: window.clone(),
+                                    pane: String::new(),
+                                    event: crate::events::TmuxLifecycleEvent::WindowClose,
+                                });
+                            }
+                            crate::tmux_control::TmuxEvent::PaneFocusChanged {
+                                session,
+                                window,
+                                pane,
+                            } => {
+                                let _ = event_tx.send(AppEvent::TmuxPaneLifecycle {
+                                    session: session.clone(),
+                                    window: window.clone(),
+                                    pane: pane.clone(),
+                                    event: crate::events::TmuxLifecycleEvent::PaneFocusChanged,
+                                });
+                            }
+                            _ => {
+                                // Session, pause, begin/end, and unknown events are
+                                // logged but not forwarded as app events.
+                                debug!(event = ?event, "tmux control mode event (not forwarded)");
+                            }
+                        }
+                    }
+
+                    info!("tmux control mode listener ended");
+                }
+                Err(err) => {
+                    warn!(error = %err, "tmux control mode listener failed to start");
+                }
+            }
+        });
+
+        // Store the listener handle. We keep a dummy handle here since the
+        // actual listener runs in the spawned task. The important thing is
+        // that we record that tmux control mode was attempted.
+        self.tmux_listener = None;
     }
 
     /// Runs the headless server event loop until shutdown.
@@ -1700,6 +1798,37 @@ impl HeadlessServer {
                     }
                 }
 
+                true
+            }
+            AppEvent::TmuxPaneOutput {
+                pane_id,
+                plain_text,
+                ..
+            } => {
+                // Tmux control mode received pane output. Feed it through the
+                // detection pipeline so agents in external tmux sessions get
+                // their state updated in real-time.
+                debug!(
+                    pane_id = %pane_id,
+                    len = plain_text.len(),
+                    "tmux control mode: pane output"
+                );
+                self.app.handle_internal_event(ev);
+                true
+            }
+            AppEvent::TmuxPaneLifecycle {
+                session,
+                window,
+                event,
+                ..
+            } => {
+                debug!(
+                    session = %session,
+                    window = %window,
+                    event = ?event,
+                    "tmux control mode: lifecycle event"
+                );
+                self.app.handle_internal_event(ev);
                 true
             }
             _ => {
@@ -3419,6 +3548,9 @@ pub fn run_server() -> io::Result<()> {
         );
         print_ready_message(&api::socket_path(), &client_socket_path());
 
+        // Start tmux control mode listener if enabled in config.
+        server.spawn_tmux_control_listener(&loaded_config.config);
+
         server.run().await
     });
 
@@ -3601,6 +3733,7 @@ mod tests {
             should_quit: Arc::new(AtomicBool::new(false)),
             server_event_rx,
             server_event_tx,
+            tmux_listener: None,
         }
     }
 

--- a/src/tmux_control/listener.rs
+++ b/src/tmux_control/listener.rs
@@ -1,0 +1,248 @@
+//! Async listener for tmux control mode events.
+//!
+//! Spawns `tmux -C` as a child process, reads its stdout line by line,
+//! parses events, and forwards them through a tokio channel.
+
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+
+use super::protocol::{self, TmuxEvent};
+
+/// Configuration for the tmux control mode listener.
+#[derive(Debug, Clone)]
+pub struct TmuxControlConfig {
+    /// Whether tmux control mode monitoring is enabled.
+    pub enabled: bool,
+    /// Session names to monitor. Empty = all sessions.
+    pub target_sessions: Vec<String>,
+    /// Tmux socket path (for `-L` flag). None = default tmux socket.
+    pub socket_path: Option<String>,
+}
+
+impl Default for TmuxControlConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            target_sessions: Vec::new(),
+            socket_path: None,
+        }
+    }
+}
+
+/// A running tmux control mode listener.
+pub struct TmuxControlListener {
+    child: Child,
+    event_tx: mpsc::UnboundedSender<TmuxEvent>,
+}
+
+impl TmuxControlListener {
+    /// Spawn a new tmux control mode listener.
+    ///
+    /// Returns the listener handle and a receiver for parsed events.
+    /// The listener runs in a background tokio task.
+    pub async fn spawn(
+        config: TmuxControlConfig,
+    ) -> Result<(Self, mpsc::UnboundedReceiver<TmuxEvent>), String> {
+        if !config.enabled {
+            return Err("tmux control mode is disabled".to_string());
+        }
+
+        // Check if tmux is available.
+        let tmux_path = which_tmux().ok_or("tmux not found in PATH")?;
+
+        // Check if a tmux server is running.
+        if !is_tmux_server_running(&tmux_path, config.socket_path.as_deref()) {
+            return Err("no tmux server running".to_string());
+        }
+
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+
+        // Build tmux -C command.
+        let mut args: Vec<String> = Vec::new();
+
+        // Use specific socket if configured.
+        if let Some(ref socket) = config.socket_path {
+            args.push("-L".to_string());
+            args.push(socket.clone());
+        }
+
+        // -C enables control mode.
+        // -CC disables echo (cleaner output).
+        args.push("-CC".to_string());
+
+        info!(args = ?args, "spawning tmux control mode client");
+
+        let mut child = Command::new(&tmux_path)
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stdin(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("failed to spawn tmux control client: {e}"))?;
+
+        let stdout = child.stdout.take().ok_or("failed to capture tmux stdout")?;
+        let stdin = child.stdin.take().ok_or("failed to capture tmux stdin")?;
+
+        // Subscribe to pane output for all sessions.
+        // We send commands through stdin to configure the control mode session.
+        let tx_clone = event_tx.clone();
+        let target_sessions = config.target_sessions.clone();
+
+        tokio::spawn(async move {
+            // Small delay to let tmux initialize control mode.
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // Send initial commands to subscribe to events.
+            let mut stdin = stdin;
+            use tokio::io::AsyncWriteExt;
+
+            // Enable pane output events.
+            let _ = stdin
+                .write_all(b"set-option -g pane-border-status off\n")
+                .await;
+            let _ = stdin.write_all(b"set-option -g status-interval 0\n").await;
+
+            // Request initial session list.
+            let _ = stdin.write_all(b"list-sessions\n").await;
+
+            drop(stdin);
+        });
+
+        // Read loop: parse lines from stdout and forward events.
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+        let filter_sessions = target_sessions;
+
+        tokio::spawn(async move {
+            while let Ok(Some(line)) = lines.next_line().await {
+                match protocol::parse_line(&line) {
+                    Ok(Some(event)) => {
+                        // Filter by target sessions if configured.
+                        if !filter_sessions.is_empty() {
+                            let session_match = match &event {
+                                TmuxEvent::Output { .. } => true, // Output events don't carry session
+                                TmuxEvent::PaneFocusChanged { session, .. }
+                                | TmuxEvent::WindowAdd { session, .. }
+                                | TmuxEvent::WindowClose { session, .. }
+                                | TmuxEvent::SessionChanged { session }
+                                | TmuxEvent::SessionCreated { session }
+                                | TmuxEvent::SessionClosed { session } => {
+                                    filter_sessions.contains(session)
+                                }
+                                TmuxEvent::Pause { session, .. } => {
+                                    filter_sessions.contains(session)
+                                }
+                                TmuxEvent::Begin { .. }
+                                | TmuxEvent::CmdOutput { .. }
+                                | TmuxEvent::End { .. }
+                                | TmuxEvent::Unknown(_) => true,
+                            };
+
+                            if !session_match {
+                                debug!(event = ?event, "skipping event (session filter)");
+                                continue;
+                            }
+                        }
+
+                        debug!(event = ?event, "tmux control mode event");
+                        if event_tx.send(event).is_err() {
+                            error!("event receiver dropped, stopping listener");
+                            break;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        warn!(error = %e, "failed to parse tmux control mode line");
+                    }
+                }
+            }
+
+            info!("tmux control mode listener stopped");
+        });
+
+        let listener = Self {
+            child,
+            event_tx: event_tx.clone(),
+        };
+
+        Ok((listener, event_rx))
+    }
+
+    /// Send a command to the tmux control mode session.
+    pub async fn send_command(&mut self, command: &str) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt;
+
+        if let Some(ref mut stdin) = self.child.stdin {
+            stdin
+                .write_all(format!("{command}\n").as_bytes())
+                .await
+                .map_err(|e| format!("failed to send command: {e}"))?;
+            Ok(())
+        } else {
+            Err("stdin not available".to_string())
+        }
+    }
+
+    /// Stop the listener by killing the tmux client process.
+    pub async fn stop(&mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
+impl Drop for TmuxControlListener {
+    fn drop(&mut self) {
+        // Best-effort cleanup — kill the child process.
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Find the `tmux` binary in PATH.
+fn which_tmux() -> Option<String> {
+    // Try common locations first.
+    for path in [
+        "/usr/bin/tmux",
+        "/opt/homebrew/bin/tmux",
+        "/usr/local/bin/tmux",
+    ] {
+        if std::path::Path::new(path).exists() {
+            return Some(path.to_string());
+        }
+    }
+
+    // Fall back to PATH lookup.
+    std::env::var("PATH").ok().and_then(|path_var| {
+        path_var
+            .split(':')
+            .map(|dir| format!("{dir}/tmux"))
+            .find(|p| std::path::Path::new(p).exists())
+    })
+}
+
+/// Check if a tmux server is running.
+fn is_tmux_server_running(tmux_path: &str, socket_path: Option<&str>) -> bool {
+    let mut cmd = std::process::Command::new(tmux_path);
+    if let Some(socket) = socket_path {
+        cmd.arg("-L").arg(socket);
+    }
+    cmd.arg("list-sessions");
+
+    cmd.output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_disabled() {
+        let config = TmuxControlConfig::default();
+        assert!(!config.enabled);
+        assert!(config.target_sessions.is_empty());
+    }
+}

--- a/src/tmux_control/mod.rs
+++ b/src/tmux_control/mod.rs
@@ -1,0 +1,84 @@
+//! Tmux control mode integration.
+//!
+//! Provides push-based event monitoring for tmux sessions via `tmux -C`.
+//! This supplements herdr's existing screen-heuristic and hook-based
+//! agent detection by receiving real-time pane output and lifecycle events
+//! directly from the tmux server.
+//!
+//! # Architecture
+//!
+//! ```text
+//! tmux -C (control mode)
+//!   ├── %output events → protocol parser → AppEvent::TmuxPaneOutput
+//!   ├── %window-add/close → lifecycle tracking
+//!   └── %pane-focus-changed → focus tracking
+//! ```
+//!
+//! # Configuration
+//!
+//! Add to `config.toml`:
+//!
+//! ```toml
+//! [tmux_control]
+//! enabled = true
+//! target_sessions = []        # empty = all sessions
+//! socket_path = null          # null = default tmux socket
+//! ```
+
+pub mod listener;
+pub mod protocol;
+
+pub use listener::{TmuxControlConfig, TmuxControlListener};
+pub use protocol::TmuxEvent;
+
+/// Convert a tmux control mode event into a herdr app event.
+///
+/// This maps `TmuxEvent::Output` events to the existing detection pipeline
+/// by providing the raw pane output for pattern matching.
+pub fn event_to_detection_input(event: &TmuxEvent) -> Option<TmuxDetectionInput> {
+    match event {
+        TmuxEvent::Output { pane, data } => {
+            // Strip ANSI codes for text-based detection.
+            let plain = protocol::strip_ansi(data);
+            Some(TmuxDetectionInput {
+                pane_id: pane.clone(),
+                raw_data: data.clone(),
+                plain_text: plain,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Input data for agent detection from tmux control mode output.
+#[derive(Debug, Clone)]
+pub struct TmuxDetectionInput {
+    /// The tmux pane ID (e.g., "42" from "%42").
+    pub pane_id: String,
+    /// Raw output data with ANSI escape sequences.
+    pub raw_data: String,
+    /// Plain text with ANSI codes stripped.
+    pub plain_text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_event_maps_to_detection_input() {
+        let event = TmuxEvent::Output {
+            pane: "42".into(),
+            data: "Thinking…\n".into(),
+        };
+        let input = event_to_detection_input(&event).unwrap();
+        assert_eq!(input.pane_id, "42");
+        assert_eq!(input.plain_text, "Thinking…\n");
+    }
+
+    #[test]
+    fn non_output_events_return_none() {
+        let event = TmuxEvent::SessionCreated { session: "test".into() };
+        assert!(event_to_detection_input(&event).is_none());
+    }
+}

--- a/src/tmux_control/protocol.rs
+++ b/src/tmux_control/protocol.rs
@@ -1,0 +1,372 @@
+//! Tmux control mode event parsing.
+//!
+//! Parses the line-oriented event stream produced by `tmux -C`.
+//! Events are prefixed with `%` and followed by space-separated fields.
+//!
+//! Reference: tmux manual CONTROL MODE section.
+
+use std::fmt;
+
+/// A parsed event from tmux control mode.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TmuxEvent {
+    /// Pane produced output: `%output %pane-id data...`
+    Output { pane: String, data: String },
+    /// Active pane changed: `%pane-focus-changed %session %window %pane`
+    PaneFocusChanged {
+        session: String,
+        window: String,
+        pane: String,
+    },
+    /// Window added: `%window-add %session %window`
+    WindowAdd { session: String, window: String },
+    /// Window closed: `%window-close %session %window`
+    WindowClose { session: String, window: String },
+    /// Session changed: `%session-changed %session`
+    SessionChanged { session: String },
+    /// Session created: `%session-created %session`
+    SessionCreated { session: String },
+    /// Session closed: `%session-closed %session`
+    SessionClosed { session: String },
+    /// Output paused (buffer full): `%pause %session %window %pane`
+    Pause {
+        session: String,
+        window: String,
+        pane: String,
+    },
+    /// Control mode ready (after initial command): `%begin %cmd-identifier`
+    Begin { cmd_identifier: String },
+    /// Control mode output line: `%output %cmd-identifier data`
+    CmdOutput {
+        cmd_identifier: String,
+        data: String,
+    },
+    /// Control mode end: `%end %cmd-identifier %exit-value`
+    End {
+        cmd_identifier: String,
+        exit_value: String,
+    },
+    /// Unknown event (preserved for forward compatibility).
+    Unknown(String),
+}
+
+/// Error from parsing a tmux control mode line.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub line: String,
+    pub reason: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to parse tmux control mode line: {}: {}",
+            self.line, self.reason
+        )
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse a single line from tmux control mode output.
+///
+/// Returns `None` for empty lines or lines that don't start with `%`.
+pub fn parse_line(line: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let trimmed = line.trim_end();
+
+    // Empty lines are ignored (used as separators in control mode).
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    // Control mode lines start with `%`.
+    let Some(rest) = trimmed.strip_prefix('%') else {
+        return Ok(None);
+    };
+
+    let parts: Vec<&str> = rest.splitn(2, ' ').collect();
+    let event_name = parts[0];
+    let args = parts.get(1).unwrap_or(&"");
+
+    match event_name {
+        "output" => parse_output(args),
+        "pane-focus-changed" => parse_pane_focus_changed(args),
+        "window-add" => parse_window_add(args),
+        "window-close" => parse_window_close(args),
+        "session-changed" => parse_session_changed(args),
+        "session-created" => parse_session_created(args),
+        "session-closed" => parse_session_closed(args),
+        "pause" => parse_pause(args),
+        "begin" => Ok(Some(TmuxEvent::Begin {
+            cmd_identifier: args.trim().to_string(),
+        })),
+        "end" => parse_end(args),
+        _ if event_name.starts_with("output") => parse_output(args),
+        _ => Ok(Some(TmuxEvent::Unknown(trimmed.to_string()))),
+    }
+}
+
+/// Parse all lines from a control mode output chunk.
+pub fn parse_lines(text: &str) -> Vec<TmuxEvent> {
+    text.lines()
+        .filter_map(|line| match parse_line(line) {
+            Ok(Some(event)) => Some(event),
+            _ => None,
+        })
+        .collect()
+}
+
+fn parse_output(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    // Format: %pane-id data...
+    // Pane IDs start with `%` in tmux.
+    let Some(rest) = args.strip_prefix('%') else {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "output event missing pane ID".to_string(),
+        });
+    };
+
+    // Split on first space — pane ID is one token, rest is data.
+    let mut parts = rest.splitn(2, ' ');
+    let pane_id = parts.next().unwrap_or("").to_string();
+    let data = parts.next().unwrap_or("").to_string();
+
+    Ok(Some(TmuxEvent::Output {
+        pane: pane_id,
+        data,
+    }))
+}
+
+fn parse_pane_focus_changed(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let parts: Vec<&str> = args.split_whitespace().collect();
+    if parts.len() < 3 {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "pane-focus-changed needs session, window, pane".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::PaneFocusChanged {
+        session: parts[0].to_string(),
+        window: parts[1].to_string(),
+        pane: parts[2].to_string(),
+    }))
+}
+
+fn parse_window_add(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let parts: Vec<&str> = args.split_whitespace().collect();
+    if parts.len() < 2 {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "window-add needs session, window".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::WindowAdd {
+        session: parts[0].to_string(),
+        window: parts[1].to_string(),
+    }))
+}
+
+fn parse_window_close(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let parts: Vec<&str> = args.split_whitespace().collect();
+    if parts.len() < 2 {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "window-close needs session, window".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::WindowClose {
+        session: parts[0].to_string(),
+        window: parts[1].to_string(),
+    }))
+}
+
+fn parse_session_changed(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let session = args.trim().to_string();
+    if session.is_empty() {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "session-changed needs session name".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::SessionChanged { session }))
+}
+
+fn parse_session_created(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let session = args.trim().to_string();
+    if session.is_empty() {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "session-created needs session name".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::SessionCreated { session }))
+}
+
+fn parse_session_closed(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let session = args.trim().to_string();
+    if session.is_empty() {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "session-closed needs session name".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::SessionClosed { session }))
+}
+
+fn parse_pause(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let parts: Vec<&str> = args.split_whitespace().collect();
+    if parts.len() < 3 {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "pause needs session, window, pane".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::Pause {
+        session: parts[0].to_string(),
+        window: parts[1].to_string(),
+        pane: parts[2].to_string(),
+    }))
+}
+
+fn parse_end(args: &str) -> Result<Option<TmuxEvent>, ParseError> {
+    let parts: Vec<&str> = args.split_whitespace().collect();
+    if parts.len() < 2 {
+        return Err(ParseError {
+            line: args.to_string(),
+            reason: "end needs cmd-identifier, exit-value".to_string(),
+        });
+    }
+    Ok(Some(TmuxEvent::End {
+        cmd_identifier: parts[0].to_string(),
+        exit_value: parts[1].to_string(),
+    }))
+}
+
+/// Strip ANSI escape sequences from control mode output data.
+pub fn strip_ansi(data: &str) -> String {
+    let re = regex::Regex::new(r"\x1b\[[0-9;]*[A-Za-z]").unwrap();
+    let re_osc = regex::Regex::new(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)").unwrap();
+    let re_c1 = regex::Regex::new(r"\x1b[@-_\x80-\x9f]").unwrap();
+
+    let text = re.replace_all(data, "");
+    let text = re_osc.replace_all(&text, "");
+    let text = re_c1.replace_all(&text, "");
+    text.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_output_event() {
+        let event = parse_line("%output %42 hello world").unwrap().unwrap();
+        match event {
+            TmuxEvent::Output { pane, data } => {
+                assert_eq!(pane, "42");
+                assert_eq!(data, "hello world");
+            }
+            _ => panic!("expected Output event"),
+        }
+    }
+
+    #[test]
+    fn parse_output_with_ansi() {
+        let event = parse_line(r#"%output %7 \x1b[1mBold\x1b[0m"#)
+            .unwrap()
+            .unwrap();
+        match event {
+            TmuxEvent::Output { pane, data } => {
+                assert_eq!(pane, "7");
+                assert!(data.contains("\\x1b[1m"));
+            }
+            _ => panic!("expected Output event"),
+        }
+    }
+
+    #[test]
+    fn parse_pane_focus_changed() {
+        let event = parse_line("%pane-focus-changed mysession 1 %3")
+            .unwrap()
+            .unwrap();
+        match event {
+            TmuxEvent::PaneFocusChanged {
+                session,
+                window,
+                pane,
+            } => {
+                assert_eq!(session, "mysession");
+                assert_eq!(window, "1");
+                assert_eq!(pane, "%3");
+            }
+            _ => panic!("expected PaneFocusChanged"),
+        }
+    }
+
+    #[test]
+    fn parse_window_add() {
+        let event = parse_line("%window-add mysession 2").unwrap().unwrap();
+        match event {
+            TmuxEvent::WindowAdd { session, window } => {
+                assert_eq!(session, "mysession");
+                assert_eq!(window, "2");
+            }
+            _ => panic!("expected WindowAdd"),
+        }
+    }
+
+    #[test]
+    fn parse_session_events() {
+        let created = parse_line("%session-created new-sess").unwrap().unwrap();
+        let closed = parse_line("%session-closed old-sess").unwrap().unwrap();
+        let changed = parse_line("%session-changed active-sess").unwrap().unwrap();
+
+        assert_eq!(
+            created,
+            TmuxEvent::SessionCreated {
+                session: "new-sess".into()
+            }
+        );
+        assert_eq!(
+            closed,
+            TmuxEvent::SessionClosed {
+                session: "old-sess".into()
+            }
+        );
+        assert_eq!(
+            changed,
+            TmuxEvent::SessionChanged {
+                session: "active-sess".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_empty_line_returns_none() {
+        assert!(parse_line("").unwrap().is_none());
+        assert!(parse_line("   ").unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_unknown_event() {
+        let event = parse_line("%future-event some args").unwrap().unwrap();
+        assert_eq!(event, TmuxEvent::Unknown("%future-event some args".into()));
+    }
+
+    #[test]
+    fn parse_lines_batch() {
+        let text = "%session-created main\n%window-add main 1\n%output %5 $ _\n";
+        let events = parse_lines(text);
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], TmuxEvent::SessionCreated { .. }));
+        assert!(matches!(events[1], TmuxEvent::WindowAdd { .. }));
+        assert!(matches!(events[2], TmuxEvent::Output { .. }));
+    }
+
+    #[test]
+    fn strip_ansi_codes() {
+        let input = "\x1b[1mBold\x1b[0m Normal";
+        assert_eq!(strip_ansi(input), "Bold Normal");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds push-based tmux session monitoring via `tmux -C` (control mode)
- New `src/tmux_control/` module with protocol parser, async listener, and detection integration
- `herdr tmux status` CLI subcommand for checking tmux control mode state
- `[tmux_control]` config section (disabled by default)
- Headless server spawns listener on startup when enabled, routing events through existing `AppEvent` channel

## What it does

When `tmux_control.enabled = true` in config, herdr spawns a persistent `tmux -C` client that receives:
- **Pane output** in real-time (`%output` events) — fed into the existing agent detection pipeline
- **Window/pane lifecycle** events (`%window-add`, `%window-close`, `%pane-focus-changed`)
- **Session events** (`%session-changed`, `%session-created`, `%session-closed`)

This supplements herdr's existing screen-heuristic and hook-based detection by providing zero-latency push notifications from the tmux server.

## Why

- Eliminates polling overhead for pane output monitoring
- Works for any tmux session, not just herdr-managed panes
- Enables future external session monitoring (agents in separate tmux sessions)

## Files changed

- `src/tmux_control/mod.rs` — Module root, detection input mapping
- `src/tmux_control/protocol.rs` — Control mode event parser (~300 lines, 10 tests)
- `src/tmux_control/listener.rs` — Async tmux -C client with tokio
- `src/cli/tmux.rs` — `herdr tmux status` subcommand
- `src/cli.rs` — Register tmux subcommand
- `src/main.rs` — Module declaration, help text, config template
- `src/config/model.rs` — `TmuxControlConfig` struct
- `src/events.rs` — `TmuxPaneOutput`, `TmuxPaneLifecycle` event variants
- `src/server/headless.rs` — Listener spawn + event handling
- `src/app/actions.rs` — Match arms for new event types

## Config

```toml
[tmux_control]
enabled = false           # opt-in
target_sessions = []      # empty = all sessions
socket_path = null        # null = default tmux socket
```

## Verification

1. Set `tmux_control.enabled = true` in config
2. Start herdr server with a tmux session running
3. Check `herdr tmux status` shows listener active
4. Open agents in tmux panes — state changes should be detected in real-time