### PR TITLE
Add option to hide tab and bar

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -493,6 +493,8 @@ impl App {
             sidebar_width_source,
             sidebar_width_auto: false,
             sidebar_collapsed: false,
+            sidebar_hidden_width: config.ui.sidebar_hidden_width,
+            hide_tab_bar_when_single_tab: config.ui.hide_tab_bar_when_single_tab,
             sidebar_section_split,
             agent_panel_scope,
             mouse_capture: config.ui.mouse_capture,
@@ -1202,6 +1204,8 @@ impl App {
                 }
                 self.state.sound = config.ui.sound.clone();
                 self.state.toast_config = config.ui.toast.clone();
+                self.state.sidebar_hidden_width = config.ui.sidebar_hidden_width;
+                self.state.hide_tab_bar_when_single_tab = config.ui.hide_tab_bar_when_single_tab;
             }
         }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1328,6 +1328,10 @@ pub struct AppState {
     pub sidebar_width_source: SidebarWidthSource,
     pub sidebar_width_auto: bool,
     pub sidebar_collapsed: bool,
+    /// Sidebar width in columns when collapsed. 0 = fully hidden.
+    pub sidebar_hidden_width: u16,
+    /// Hide the tab bar when the active workspace has 0 or 1 tabs.
+    pub hide_tab_bar_when_single_tab: bool,
     /// Ratio of sidebar height allocated to the workspaces section.
     pub sidebar_section_split: f32,
     pub agent_panel_scope: AgentPanelScope,
@@ -1661,6 +1665,8 @@ impl AppState {
             sidebar_width_source: SidebarWidthSource::ConfigDefault,
             sidebar_width_auto: false,
             sidebar_collapsed: false,
+            sidebar_hidden_width: 4,
+            hide_tab_bar_when_single_tab: false,
             sidebar_section_split: 0.5,
             agent_panel_scope: AgentPanelScope::AllWorkspaces,
             mouse_capture: true,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -449,6 +449,11 @@ pub struct UiConfig {
     pub toast: ToastConfig,
     /// Play sounds when agents change state in background workspaces.
     pub sound: SoundConfig,
+    /// Sidebar width in columns when collapsed (default: 4).
+    /// Set to 0 to make the sidebar fully disappear when toggled.
+    pub sidebar_hidden_width: u16,
+    /// Hide the tab bar when the active workspace has 0 or 1 tabs.
+    pub hide_tab_bar_when_single_tab: bool,
 }
 
 /// Cursor shape (DECSCUSR) used for the forced IME anchor.
@@ -629,6 +634,8 @@ impl Default for UiConfig {
             accent: "cyan".into(),
             toast: ToastConfig::default(),
             sound: SoundConfig::default(),
+            sidebar_hidden_width: 4,
+            hide_tab_bar_when_single_tab: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,14 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Accepts: hex (#89b4fa), named colors (cyan, blue, magenta), or rgb(r,g,b)
 # accent = "cyan"
 
+# Sidebar width in columns when collapsed (toggled with prefix+b).
+# Set to 0 to make the sidebar fully disappear when toggled.
+# sidebar_hidden_width = 4
+
+# Hide the tab bar when the workspace has a single tab.
+# Tab bar reappears automatically when a second tab is created.
+# hide_tab_bar_when_single_tab = false
+
 # Background notification popup delivery
 [ui.toast]
 # off = disable pop-up notifications

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -88,8 +88,6 @@ use crate::app::state::ViewLayout;
 use crate::app::{AppState, Mode};
 use crate::terminal::TerminalRuntimeRegistry;
 
-const COLLAPSED_WIDTH: u16 = 4; // num + space + dot + separator
-
 // Braille spinner frames — smooth rotation
 const SPINNERS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -178,7 +176,7 @@ fn compute_view_internal(
     }
 
     let sidebar_w = if app.sidebar_collapsed {
-        COLLAPSED_WIDTH
+        app.sidebar_hidden_width
     } else {
         app.sidebar_width
             .clamp(app.sidebar_min_width, app.sidebar_max_width)
@@ -187,8 +185,12 @@ fn compute_view_internal(
     let [sidebar_area, main_area] =
         Layout::horizontal([Constraint::Length(sidebar_w), Constraint::Min(1)]).areas(area);
 
-    let has_tabs = app.active.and_then(|i| app.workspaces.get(i)).is_some();
-    let (tab_bar_rect, terminal_area) = if has_tabs && main_area.height > 1 {
+    let active_ws = app.active.and_then(|i| app.workspaces.get(i));
+    let show_tab_bar = active_ws.is_some()
+        && main_area.height > 1
+        && !(app.hide_tab_bar_when_single_tab
+            && active_ws.map_or(false, |ws| ws.tabs.len() <= 1));
+    let (tab_bar_rect, terminal_area) = if show_tab_bar {
         let [tab_bar_rect, terminal_area] =
             Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(main_area);
         (tab_bar_rect, terminal_area)


### PR DESCRIPTION
     sidebar_hidden_width (default: 4) replaces the hardcoded COLLAPSED_WIDTH
     so the collapsed sidebar can be fully hidden (0) or set to any width.

     hide_tab_bar_when_single_tab (default: false) hides the tab bar when
     the active workspace has ≤1 tab. The tab bar reappears automatically
     on the next render cycle when a second tab is created."