### PR TITLE
docs: add keybindings reference page

### DIFF
--- a/docs/next/website/src/content/docs/concepts.mdx
+++ b/docs/next/website/src/content/docs/concepts.mdx
@@ -71,7 +71,7 @@ Herdr has terminal mode, prefix mode, and navigate mode.
 
 Terminal mode sends keys to the focused pane. Prefix mode waits for one Herdr action after the prefix key. Navigate mode is the persistent workspace navigation surface.
 
-Press the prefix key, default `ctrl+b`, then an action key such as `c` for a new tab or `w` for workspace navigation.
+Press the prefix key, default `ctrl+b`, then an action key such as `c` for a new tab or `w` for workspace navigation. See [Keybindings](/docs/keybindings/) for the full default hotkey reference.
 
 ## Mouse UI
 

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -115,6 +115,8 @@ When enabled, `herdr --remote` writes a private temporary SSH config that includ
 
 ## Keybindings
 
+For a cheat sheet of the built-in defaults, see [Keybindings](/docs/keybindings/).
+
 Herdr has a prefix mode similar to tmux. The default prefix is `ctrl+b`. Keybinding strings are explicit: `prefix+n` means press the configured prefix and then `n`; `ctrl+alt+n` is a direct terminal-mode shortcut.
 
 A small keybinding override looks like this:
@@ -181,13 +183,13 @@ Optional actions are unset by default. Bind them with `prefix+` for prefix-mode 
 [keys]
 previous_workspace = "prefix+shift+left"
 next_workspace = "prefix+shift+right"
-last_pane = "prefix+tab"
+last_pane = "prefix+semicolon"
 open_worktree = "prefix+shift+o"
 remove_worktree = "prefix+alt+d"
 next_tab = ["prefix+n", "ctrl+alt+]"]
 ```
 
-`last_pane` switches back to the last focused pane across workspaces and tabs. It is unset by default because the tmux-style pane binding `prefix+l` is already used for pane-right focus.
+`last_pane` switches back to the last focused pane across workspaces and tabs. It is unset by default. `prefix+l` is already bound to focus pane right, and `prefix+tab` is bound to cycle pane next, so use a free chord such as `prefix+semicolon`.
 
 Key strings accept plain keys, modifier combinations such as `ctrl+a`, `shift+n`, `alt+1`, `cmd+k`, and special keys such as `enter`, `tab`, `esc`, `left`, `right`, `up`, and `down`. Named punctuation such as `minus`, `comma`, `ampersand`, `plus`, and `backtick` is also accepted. Plain direct printable keys such as `n` are unsafe because they intercept typing; use `prefix+n` unless you intentionally want a direct binding. The `navigate_workspace_*` and `navigate_pane_*` fields are navigate-mode-only and may use plain keys such as `j` or `k`; they must not use `prefix+`, `esc`, `enter`, `tab`, `shift+tab`, `left`, `right`, or unmodified `1` through `9`. Left and right arrows are permanent aliases for pane-left and pane-right navigation. These navigate-mode shortcuts are independent from general action bindings such as `focus_pane_down = "prefix+j"`; when both use the same key, the navigate-mode shortcut wins while navigate mode is open. Alt, Cmd/Super, and punctuation with modifiers depend on your terminal and tmux settings.
 

--- a/docs/next/website/src/content/docs/keybindings.mdx
+++ b/docs/next/website/src/content/docs/keybindings.mdx
@@ -1,0 +1,136 @@
+---
+title: Keybindings
+description: Default Herdr hotkeys for prefix mode, navigation, panes, copy mode, and resize mode.
+---
+
+Herdr uses a tmux-style prefix key. The default prefix is `ctrl+b`. Press the prefix, then press an action key.
+
+Press `prefix+?` at any time to open the in-app keybind help. It shows your configured shortcuts, including any custom command bindings.
+
+To change bindings, see [Configuration](/docs/configuration/#keybindings).
+
+## Global
+
+| Key | Action |
+| --- | --- |
+| `ctrl+b` | Enter prefix mode |
+| `prefix+?` | Open keybind help |
+| `prefix+s` | Open settings |
+| `prefix+q` | Detach client |
+| `prefix+shift+r` | Reload `config.toml` |
+| `prefix+o` | Open notification target |
+
+## Workspaces and tabs
+
+| Key | Action |
+| --- | --- |
+| `prefix+w` | Open workspace navigation |
+| `prefix+g` | Open session navigator |
+| `prefix+shift+n` | New workspace |
+| `prefix+shift+g` | New worktree |
+| `prefix+shift+w` | Rename workspace |
+| `prefix+shift+d` | Close workspace |
+| `prefix+c` | New tab |
+| `prefix+shift+t` | Rename tab |
+| `prefix+p` | Previous tab |
+| `prefix+n` | Next tab |
+| `prefix+1` … `prefix+9` | Switch to tab 1–9 |
+| `prefix+shift+x` | Close tab |
+
+## Panes
+
+| Key | Action |
+| --- | --- |
+| `prefix+v` | Split right |
+| `prefix+minus` | Split down |
+| `prefix+x` | Close pane |
+| `prefix+shift+p` | Rename pane |
+| `prefix+e` | Edit scrollback in `$EDITOR` |
+| `prefix+[` | Enter copy mode |
+| `prefix+z` | Zoom focused pane |
+| `prefix+r` | Enter resize mode |
+| `prefix+b` | Toggle sidebar |
+| `prefix+h` | Focus pane left |
+| `prefix+j` | Focus pane down |
+| `prefix+k` | Focus pane up |
+| `prefix+l` | Focus pane right |
+| `prefix+shift+h` | Swap pane left |
+| `prefix+shift+j` | Swap pane down |
+| `prefix+shift+k` | Swap pane up |
+| `prefix+shift+l` | Swap pane right |
+| `prefix+tab` | Cycle pane next |
+| `prefix+shift+tab` | Cycle pane previous |
+
+## Workspace navigation mode
+
+Open this with `prefix+w`. Keys apply only while navigate mode is active.
+
+| Key | Action |
+| --- | --- |
+| `esc` | Back |
+| `up` / `down` | Move workspace selection |
+| `h` / `j` / `k` / `l` | Move pane focus |
+| `left` / `right` | Move pane focus left / right |
+| `tab` / `shift+tab` | Cycle pane |
+| `enter` | Open selected workspace |
+| `1` … `9` | Switch to workspace 1–9 |
+
+## Session navigator
+
+Open this with `prefix+g`.
+
+| Key | Action |
+| --- | --- |
+| `esc` | Close |
+| `/` | Focus search |
+| `j` / `k` / `up` / `down` | Move selection |
+| `enter` | Jump to selection |
+| `b` / `w` / `i` / `d` / `a` | Filter by agent state |
+| `space` | Expand or collapse workspace |
+
+While search is focused, type to filter. Use `ctrl+n` / `ctrl+p` to move the selection, `ctrl+u` to clear the query, and `enter` to jump.
+
+## Copy mode
+
+Enter with `prefix+[`.
+
+| Key | Action |
+| --- | --- |
+| `h` / `j` / `k` / `l` | Move cursor |
+| `left` / `right` / `up` / `down` | Move cursor |
+| `w` / `b` / `e` | Word motion |
+| `{` / `}` | Paragraph motion |
+| `v` / `space` | Start selection |
+| `V` | Select line |
+| `y` / `enter` | Copy selection and exit |
+| `q` / `esc` | Exit without copying |
+| `pageup` / `pagedown` | Scroll viewport |
+| `ctrl+u` / `ctrl+d` | Scroll half page |
+
+## Resize mode
+
+Enter with `prefix+r`.
+
+| Key | Action |
+| --- | --- |
+| `h` / `j` / `k` / `l` | Resize toward left / down / up / right |
+| `left` / `right` / `up` / `down` | Resize |
+| `esc` / `enter` / `prefix+r` | Exit resize mode |
+
+## Optional bindings
+
+These actions are unset by default. Bind them in `config.toml` when you want them.
+
+| Config field | Example binding |
+| --- | --- |
+| `previous_workspace` | `prefix+shift+left` |
+| `next_workspace` | `prefix+shift+right` |
+| `switch_workspace` | `prefix+shift+1..9` |
+| `previous_agent` | `prefix+shift+a` |
+| `next_agent` | `prefix+a` |
+| `focus_agent` | `prefix+alt+1..9` |
+| `last_pane` | `prefix+semicolon` |
+| `open_worktree` | `prefix+shift+o` |
+| `remove_worktree` | `prefix+alt+d` |
+
+`last_pane` jumps back to the last focused pane across workspaces and tabs. It is unset by default. `prefix+l` is already bound to focus pane right, and `prefix+tab` is bound to cycle pane next, so use a free chord such as `prefix+semicolon`.

--- a/docs/next/website/src/content/docs/quick-start.mdx
+++ b/docs/next/website/src/content/docs/quick-start.mdx
@@ -31,7 +31,7 @@ Herdr detects supported agents automatically. The sidebar shows whether each age
 
 ## Keyboard control
 
-Press `ctrl+b` to enter prefix mode, then press an action key.
+Press `ctrl+b` to enter prefix mode, then press an action key. Press `prefix+?` to open the in-app keybind help.
 
 Common actions:
 
@@ -44,6 +44,8 @@ Common actions:
 | Workspace navigation | `prefix+w` |
 | New workspace | `prefix+shift+n` |
 | Detach client | `prefix+q` |
+
+See [Keybindings](/docs/keybindings/) for the full default hotkey reference.
 
 After detaching, run `herdr` again to reattach to the same session.
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -107,6 +107,7 @@ export default defineConfig({
             { label: 'Quick start', slug: 'docs/quick-start' },
             { label: 'How to work with Herdr', slug: 'docs/how-to-work' },
             { label: 'Concepts', slug: 'docs/concepts' },
+            { label: 'Keybindings', slug: 'docs/keybindings' },
           ],
         },
         {

--- a/website/src/content/docs/concepts.mdx
+++ b/website/src/content/docs/concepts.mdx
@@ -71,7 +71,7 @@ Herdr has terminal mode, prefix mode, and navigate mode.
 
 Terminal mode sends keys to the focused pane. Prefix mode waits for one Herdr action after the prefix key. Navigate mode is the persistent workspace navigation surface.
 
-Press the prefix key, default `ctrl+b`, then an action key such as `c` for a new tab or `w` for workspace navigation.
+Press the prefix key, default `ctrl+b`, then an action key such as `c` for a new tab or `w` for workspace navigation. See [Keybindings](/docs/keybindings/) for the full default hotkey reference.
 
 ## Mouse UI
 

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -115,6 +115,8 @@ When enabled, `herdr --remote` writes a private temporary SSH config that includ
 
 ## Keybindings
 
+For a cheat sheet of the built-in defaults, see [Keybindings](/docs/keybindings/).
+
 Herdr has a prefix mode similar to tmux. The default prefix is `ctrl+b`. Keybinding strings are explicit: `prefix+n` means press the configured prefix and then `n`; `ctrl+alt+n` is a direct terminal-mode shortcut.
 
 A small keybinding override looks like this:
@@ -177,13 +179,13 @@ Optional actions are unset by default. Bind them with `prefix+` for prefix-mode 
 [keys]
 previous_workspace = "prefix+shift+left"
 next_workspace = "prefix+shift+right"
-last_pane = "prefix+tab"
+last_pane = "prefix+semicolon"
 open_worktree = "prefix+shift+o"
 remove_worktree = "prefix+alt+d"
 next_tab = ["prefix+n", "ctrl+alt+]"]
 ```
 
-`last_pane` switches back to the last focused pane across workspaces and tabs. It is unset by default because the tmux-style pane binding `prefix+l` is already used for pane-right focus.
+`last_pane` switches back to the last focused pane across workspaces and tabs. It is unset by default. `prefix+l` is already bound to focus pane right, and `prefix+tab` is bound to cycle pane next, so use a free chord such as `prefix+semicolon`.
 
 Key strings accept plain keys, modifier combinations such as `ctrl+a`, `shift+n`, `alt+1`, `cmd+k`, and special keys such as `enter`, `tab`, `esc`, `left`, `right`, `up`, and `down`. Named punctuation such as `minus`, `comma`, `ampersand`, `plus`, and `backtick` is also accepted. Plain direct printable keys such as `n` are unsafe because they intercept typing; use `prefix+n` unless you intentionally want a direct binding. The `navigate_workspace_*` and `navigate_pane_*` fields are navigate-mode-only and may use plain keys such as `j` or `k`; they must not use `prefix+`, `esc`, `enter`, `tab`, `shift+tab`, `left`, `right`, or unmodified `1` through `9`. Left and right arrows are permanent aliases for pane-left and pane-right navigation. These navigate-mode shortcuts are independent from general action bindings such as `focus_pane_down = "prefix+j"`; when both use the same key, the navigate-mode shortcut wins while navigate mode is open. Alt, Cmd/Super, and punctuation with modifiers depend on your terminal and tmux settings.
 

--- a/website/src/content/docs/keybindings.mdx
+++ b/website/src/content/docs/keybindings.mdx
@@ -1,0 +1,136 @@
+---
+title: Keybindings
+description: Default Herdr hotkeys for prefix mode, navigation, panes, copy mode, and resize mode.
+---
+
+Herdr uses a tmux-style prefix key. The default prefix is `ctrl+b`. Press the prefix, then press an action key.
+
+Press `prefix+?` at any time to open the in-app keybind help. It shows your configured shortcuts, including any custom command bindings.
+
+To change bindings, see [Configuration](/docs/configuration/#keybindings).
+
+## Global
+
+| Key | Action |
+| --- | --- |
+| `ctrl+b` | Enter prefix mode |
+| `prefix+?` | Open keybind help |
+| `prefix+s` | Open settings |
+| `prefix+q` | Detach client |
+| `prefix+shift+r` | Reload `config.toml` |
+| `prefix+o` | Open notification target |
+
+## Workspaces and tabs
+
+| Key | Action |
+| --- | --- |
+| `prefix+w` | Open workspace navigation |
+| `prefix+g` | Open session navigator |
+| `prefix+shift+n` | New workspace |
+| `prefix+shift+g` | New worktree |
+| `prefix+shift+w` | Rename workspace |
+| `prefix+shift+d` | Close workspace |
+| `prefix+c` | New tab |
+| `prefix+shift+t` | Rename tab |
+| `prefix+p` | Previous tab |
+| `prefix+n` | Next tab |
+| `prefix+1` … `prefix+9` | Switch to tab 1–9 |
+| `prefix+shift+x` | Close tab |
+
+## Panes
+
+| Key | Action |
+| --- | --- |
+| `prefix+v` | Split right |
+| `prefix+minus` | Split down |
+| `prefix+x` | Close pane |
+| `prefix+shift+p` | Rename pane |
+| `prefix+e` | Edit scrollback in `$EDITOR` |
+| `prefix+[` | Enter copy mode |
+| `prefix+z` | Zoom focused pane |
+| `prefix+r` | Enter resize mode |
+| `prefix+b` | Toggle sidebar |
+| `prefix+h` | Focus pane left |
+| `prefix+j` | Focus pane down |
+| `prefix+k` | Focus pane up |
+| `prefix+l` | Focus pane right |
+| `prefix+shift+h` | Swap pane left |
+| `prefix+shift+j` | Swap pane down |
+| `prefix+shift+k` | Swap pane up |
+| `prefix+shift+l` | Swap pane right |
+| `prefix+tab` | Cycle pane next |
+| `prefix+shift+tab` | Cycle pane previous |
+
+## Workspace navigation mode
+
+Open this with `prefix+w`. Keys apply only while navigate mode is active.
+
+| Key | Action |
+| --- | --- |
+| `esc` | Back |
+| `up` / `down` | Move workspace selection |
+| `h` / `j` / `k` / `l` | Move pane focus |
+| `left` / `right` | Move pane focus left / right |
+| `tab` / `shift+tab` | Cycle pane |
+| `enter` | Open selected workspace |
+| `1` … `9` | Switch to workspace 1–9 |
+
+## Session navigator
+
+Open this with `prefix+g`.
+
+| Key | Action |
+| --- | --- |
+| `esc` | Close |
+| `/` | Focus search |
+| `j` / `k` / `up` / `down` | Move selection |
+| `enter` | Jump to selection |
+| `b` / `w` / `i` / `d` / `a` | Filter by agent state |
+| `space` | Expand or collapse workspace |
+
+While search is focused, type to filter. Use `ctrl+n` / `ctrl+p` to move the selection, `ctrl+u` to clear the query, and `enter` to jump.
+
+## Copy mode
+
+Enter with `prefix+[`.
+
+| Key | Action |
+| --- | --- |
+| `h` / `j` / `k` / `l` | Move cursor |
+| `left` / `right` / `up` / `down` | Move cursor |
+| `w` / `b` / `e` | Word motion |
+| `{` / `}` | Paragraph motion |
+| `v` / `space` | Start selection |
+| `V` | Select line |
+| `y` / `enter` | Copy selection and exit |
+| `q` / `esc` | Exit without copying |
+| `pageup` / `pagedown` | Scroll viewport |
+| `ctrl+u` / `ctrl+d` | Scroll half page |
+
+## Resize mode
+
+Enter with `prefix+r`.
+
+| Key | Action |
+| --- | --- |
+| `h` / `j` / `k` / `l` | Resize toward left / down / up / right |
+| `left` / `right` / `up` / `down` | Resize |
+| `esc` / `enter` / `prefix+r` | Exit resize mode |
+
+## Optional bindings
+
+These actions are unset by default. Bind them in `config.toml` when you want them.
+
+| Config field | Example binding |
+| --- | --- |
+| `previous_workspace` | `prefix+shift+left` |
+| `next_workspace` | `prefix+shift+right` |
+| `switch_workspace` | `prefix+shift+1..9` |
+| `previous_agent` | `prefix+shift+a` |
+| `next_agent` | `prefix+a` |
+| `focus_agent` | `prefix+alt+1..9` |
+| `last_pane` | `prefix+semicolon` |
+| `open_worktree` | `prefix+shift+o` |
+| `remove_worktree` | `prefix+alt+d` |
+
+`last_pane` jumps back to the last focused pane across workspaces and tabs. It is unset by default. `prefix+l` is already bound to focus pane right, and `prefix+tab` is bound to cycle pane next, so use a free chord such as `prefix+semicolon`.

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -31,7 +31,7 @@ Herdr detects supported agents automatically. The sidebar shows whether each age
 
 ## Keyboard control
 
-Press `ctrl+b` to enter prefix mode, then press an action key.
+Press `ctrl+b` to enter prefix mode, then press an action key. Press `prefix+?` to open the in-app keybind help.
 
 Common actions:
 
@@ -44,6 +44,8 @@ Common actions:
 | Workspace navigation | `prefix+w` |
 | New workspace | `prefix+shift+n` |
 | Detach client | `prefix+q` |
+
+See [Keybindings](/docs/keybindings/) for the full default hotkey reference.
 
 After detaching, run `herdr` again to reattach to the same session.
 


### PR DESCRIPTION
Add a default hotkey cheat sheet to the website docs, link it from quick-start, concepts, and configuration, and fix the last_pane example to use prefix+semicolon instead of a colliding prefix+tab binding.