### PR TITLE
feat: add Smulx XTGETCAP and underline style rendering

### DIFF
--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -337,6 +337,30 @@ pub enum CellColor {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UnderlineStyle {
+    #[default]
+    None,
+    Single,
+    Double,
+    Curly,
+    Dotted,
+    Dashed,
+}
+
+impl From<u32> for UnderlineStyle {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Self::Single,
+            2 => Self::Double,
+            3 => Self::Curly,
+            4 => Self::Dotted,
+            5 => Self::Dashed,
+            _ => Self::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CellStyle {
     pub fg_color: Option<CellColor>,
     pub bg_color: Option<CellColor>,
@@ -350,6 +374,7 @@ pub struct CellStyle {
     pub strikethrough: bool,
     pub overline: bool,
     pub underlined: bool,
+    pub underline_style: UnderlineStyle,
 }
 
 impl From<ffi::GhosttyStyle> for CellStyle {
@@ -367,6 +392,7 @@ impl From<ffi::GhosttyStyle> for CellStyle {
             strikethrough: value.strikethrough,
             overline: value.overline,
             underlined: value.underline != 0,
+            underline_style: UnderlineStyle::from(value.underline as u32),
         }
     }
 }

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -1229,9 +1229,10 @@ impl GhosttyPaneTerminal {
                             symbol_scratch.as_str()
                         }
                     };
+                    let symbol = wrap_symbol_with_underline_style(symbol, basic.style.underline_style);
                     let cell = &mut buf[(area.x + x, area.y + y)];
                     cell.reset();
-                    cell.set_symbol(symbol);
+                    cell.set_symbol(&symbol);
                     cell.set_style(style);
                     x += 1;
                 }
@@ -1817,13 +1818,40 @@ fn ghostty_cell_style(
     if basic.style.blink {
         modifiers |= Modifier::SLOW_BLINK;
     }
-    if basic.style.underlined {
+    // Only set the generic UNDERLINED modifier for plain single underline.
+    // Non-standard underline styles (curly, dotted, dashed, double) are
+    // rendered by embedding escape sequences in the cell symbol, because
+    // ratatui's Modifier enum only knows about a single underline bit.
+    if basic.style.underlined && basic.style.underline_style == crate::ghostty::UnderlineStyle::Single {
         modifiers |= Modifier::UNDERLINED;
     }
     if basic.style.strikethrough {
         modifiers |= Modifier::CROSSED_OUT;
     }
     style.add_modifier(modifiers)
+}
+
+/// Wrap a cell symbol with SGR escape sequences for non-standard underline
+/// styles (curly, dotted, dashed, double).  Ratatui's `Modifier::UNDERLINED`
+/// only maps to a single plain underline, so we bypass it by embedding the
+/// exact escape sequence in the symbol string.  A trailing `\x1b[24m` resets
+/// the underline style so that it does not leak into neighbouring cells.
+fn wrap_symbol_with_underline_style(
+    symbol: &str,
+    style: crate::ghostty::UnderlineStyle,
+) -> String {
+    let (prefix, suffix): (&str, &str) = match style {
+        crate::ghostty::UnderlineStyle::Curly => ("\x1b[4:3m", "\x1b[24m"),
+        crate::ghostty::UnderlineStyle::Double => ("\x1b[4:2m", "\x1b[24m"),
+        crate::ghostty::UnderlineStyle::Dotted => ("\x1b[4:4m", "\x1b[24m"),
+        crate::ghostty::UnderlineStyle::Dashed => ("\x1b[4:5m", "\x1b[24m"),
+        _ => return symbol.to_owned(),
+    };
+    let mut out = String::with_capacity(prefix.len() + symbol.len() + suffix.len());
+    out.push_str(prefix);
+    out.push_str(symbol);
+    out.push_str(suffix);
+    out
 }
 
 #[derive(Debug)]
@@ -3234,7 +3262,7 @@ mod tests {
         let pane_id = PaneId::from_raw(1);
 
         let result =
-            pane.process_pty_bytes(pane_id, 0, b"\x1bP+q6E6F7065;536D756C78;4D7\x1b\\", &tx);
+            pane.process_pty_bytes(pane_id, 0, b"\x1bP+q6E6F7065;4D7\x1b\\", &tx);
 
         assert!(result.terminal_responses.is_empty());
         assert!(rx.try_recv().is_err());

--- a/src/pane/xtgettcap.rs
+++ b/src/pane/xtgettcap.rs
@@ -174,8 +174,7 @@ fn xtgettcap_response(cap_hex: &[u8]) -> Option<Bytes> {
 }
 
 fn xtgettcap_value(cap_hex: &[u8]) -> Option<Option<&'static [u8]>> {
-    // Mirror only the Ghostty terminfo capabilities that this pane path can
-    // stand behind. Smulx is intentionally absent until underline shapes render.
+    // Mirror Ghostty terminfo capabilities that this pane path can stand behind.
     match cap_hex {
         b"5463" => Some(None),
         b"524742" => Some(Some(b"8")),
@@ -186,6 +185,8 @@ fn xtgettcap_value(cap_hex: &[u8]) -> Option<Option<&'static [u8]>> {
         b"536574756C63" => Some(Some(
             b"\\E[58:2::%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m",
         )),
+        // Smulx — set underline style (curly, dotted, dashed, etc.)
+        b"536D756C78" => Some(Some(b"\\E[4:%p1%dm")),
         _ => None,
     }
 }
@@ -252,10 +253,24 @@ mod tests {
     }
 
     #[test]
+    fn tracker_returns_smulx_capability() {
+        let mut tracker = XtgettcapQueryTracker::default();
+
+        tracker.observe(b"\x1bP+q536D756C78\x1b\\");
+
+        assert_eq!(
+            response_bytes(tracker.drain_pending()),
+            vec![Bytes::from_static(
+                b"\x1bP1+r536D756C78=5C455B343A25703125646D\x1b\\"
+            )]
+        );
+    }
+
+    #[test]
     fn tracker_ignores_unsupported_capabilities() {
         let mut tracker = XtgettcapQueryTracker::default();
 
-        tracker.observe(b"\x1bP+q536D756C78;6E6F7065\x1b\\");
+        tracker.observe(b"\x1bP+q6E6F7065\x1b\\");
 
         assert!(response_bytes(tracker.drain_pending()).is_empty());
     }


### PR DESCRIPTION
This PR adds undercurl support by:

- Adding Smulx capability to XTGETTCAP responses
- Adding UnderlineStyle enum and passthrough rendering
- Embedding SGR escape sequences for non-standard underline styles

Note: This PR is opened to test the CI build on macOS. Please see the related issue before merging.