### PR TITLE
feat: per-entity new_cwd overrides for workspaces, tabs, and panes

### DIFF
--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -85,6 +85,8 @@ new_cwd = "follow"
 
 `new_cwd = "follow"` keeps the default behavior and inherits the source pane or workspace. When there is no source workspace, Herdr starts in `$HOME`. Use `"home"` to always start in `$HOME`, `"current"` to use Herdr's process directory, or a fixed path such as `"~/Projects"`. Explicit `--cwd` values from the CLI or socket API still take precedence.
 
+`new_cwd_workspaces`, `new_cwd_tabs`, and `new_cwd_panes` override `new_cwd` for the corresponding entity type. The default `"inherit"` uses the global `new_cwd` value. Set any of them to `"follow"`, `"home"`, `"current"`, or a fixed path to override per entity.
+
 ## Worktrees
 
 Set the root directory Herdr uses for Git worktree checkouts created from the sidebar:

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -50,7 +50,7 @@ impl App {
                     &self.terminal_runtimes,
                 )
             });
-            Some(self.resolve_new_terminal_cwd(follow_cwd))
+            Some(self.resolve_domain_cwd(&self.state.new_terminal_cwd_panes, follow_cwd))
         });
         let default_shell = self.state.default_shell.clone();
         let scrollback_limit_bytes = self.state.pane_scrollback_limit_bytes;

--- a/src/app/api/tabs.rs
+++ b/src/app/api/tabs.rs
@@ -68,7 +68,7 @@ impl App {
                 .state
                 .focused_runtime_in_workspace(&self.terminal_runtimes, ws_idx)
                 .and_then(|rt| rt.cwd());
-            self.resolve_new_terminal_cwd(follow_cwd)
+            self.resolve_domain_cwd(&self.state.new_terminal_cwd_tabs, follow_cwd)
         });
         let (rows, cols) = self.state.estimate_pane_size();
         let default_shell = self.state.default_shell.clone();

--- a/src/app/api/workspaces.rs
+++ b/src/app/api/workspaces.rs
@@ -49,7 +49,7 @@ impl App {
             let follow_cwd = self
                 .workspace_creation_source()
                 .and_then(|ws_idx| self.seed_cwd_from_workspace(ws_idx));
-            self.resolve_new_terminal_cwd(follow_cwd)
+            self.resolve_domain_cwd(&self.state.new_terminal_cwd_workspaces, follow_cwd)
         });
         match self.create_workspace_with_options(cwd, params.focus) {
             Ok(index) => {

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -28,6 +28,16 @@ pub(crate) fn resolve_new_terminal_cwd(
     }
 }
 
+/// Resolve CWD for a specific entity type, falling back to the global policy.
+pub(crate) fn resolve_domain_cwd(
+    domain: &Option<NewTerminalCwdConfig>,
+    global: &NewTerminalCwdConfig,
+    follow_cwd: Option<PathBuf>,
+) -> PathBuf {
+    let policy = domain.as_ref().unwrap_or(global);
+    resolve_new_terminal_cwd(policy, follow_cwd)
+}
+
 impl App {
     pub(super) fn seed_cwd_from_workspace(&self, ws_idx: usize) -> Option<PathBuf> {
         self.state
@@ -36,8 +46,12 @@ impl App {
             .resolved_identity_cwd_from(&self.state.terminals, &self.terminal_runtimes)
     }
 
-    pub(super) fn resolve_new_terminal_cwd(&self, follow_cwd: Option<PathBuf>) -> PathBuf {
-        resolve_new_terminal_cwd(&self.state.new_terminal_cwd, follow_cwd)
+    pub(super) fn resolve_domain_cwd(
+        &self,
+        domain: &Option<NewTerminalCwdConfig>,
+        follow_cwd: Option<PathBuf>,
+    ) -> PathBuf {
+        resolve_domain_cwd(domain, &self.state.new_terminal_cwd, follow_cwd)
     }
 
     pub(super) fn workspace_creation_source(&self) -> Option<usize> {
@@ -60,7 +74,8 @@ impl App {
         let follow_cwd = self
             .workspace_creation_source()
             .and_then(|ws_idx| self.seed_cwd_from_workspace(ws_idx));
-        let initial_cwd = self.resolve_new_terminal_cwd(follow_cwd);
+        let initial_cwd =
+            self.resolve_domain_cwd(&self.state.new_terminal_cwd_workspaces, follow_cwd);
         if let Err(e) = self.create_workspace_with_options(initial_cwd, true) {
             error!(err = %e, "failed to create workspace");
             self.state.mode = Mode::Navigate;
@@ -73,7 +88,7 @@ impl App {
             .state
             .active
             .and_then(|ws_idx| self.seed_cwd_from_workspace(ws_idx));
-        let initial_cwd = self.resolve_new_terminal_cwd(follow_cwd);
+        let initial_cwd = self.resolve_domain_cwd(&self.state.new_terminal_cwd_tabs, follow_cwd);
         match self.create_tab_with_options(initial_cwd, true) {
             Ok(tab_idx) => {
                 if let Some(name) = custom_name {

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -496,7 +496,8 @@ impl AppState {
                 let tab = ws.active_tab()?;
                 tab.cwd_for_pane(tab.layout.focused(), &self.terminals, terminal_runtimes)
             });
-        let cwd = Some(super::creation::resolve_new_terminal_cwd(
+        let cwd = Some(super::creation::resolve_domain_cwd(
+            &self.new_terminal_cwd_panes,
             &self.new_terminal_cwd,
             follow_cwd,
         ));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -519,6 +519,9 @@ impl App {
             default_shell: config.terminal.default_shell.clone(),
             shell_mode: config.terminal.shell_mode,
             new_terminal_cwd: config.terminal.new_cwd.clone(),
+            new_terminal_cwd_workspaces: config.terminal.new_cwd_workspaces.0.clone(),
+            new_terminal_cwd_tabs: config.terminal.new_cwd_tabs.0.clone(),
+            new_terminal_cwd_panes: config.terminal.new_cwd_panes.0.clone(),
             pane_scrollback_limit_bytes: config.advanced.scrollback_limit_bytes,
             accent: crate::config::parse_color(&config.ui.accent),
             sound: config.ui.sound.clone(),
@@ -972,7 +975,7 @@ impl App {
             previous_mode,
             Mode::ReleaseNotes | Mode::ProductAnnouncement | Mode::Settings
         );
-        let cwd = self.resolve_new_terminal_cwd(None);
+        let cwd = self.resolve_domain_cwd(&self.state.new_terminal_cwd_workspaces, None);
 
         match self.create_workspace_with_options(cwd, true) {
             Ok(_) => {
@@ -1263,6 +1266,9 @@ impl App {
             self.state.default_shell = config.terminal.default_shell.clone();
             self.state.shell_mode = config.terminal.shell_mode;
             self.state.new_terminal_cwd = config.terminal.new_cwd.clone();
+            self.state.new_terminal_cwd_workspaces = config.terminal.new_cwd_workspaces.0.clone();
+            self.state.new_terminal_cwd_tabs = config.terminal.new_cwd_tabs.0.clone();
+            self.state.new_terminal_cwd_panes = config.terminal.new_cwd_panes.0.clone();
         }
 
         if !invalid_section("worktrees") {
@@ -2212,6 +2218,9 @@ mod tests {
             app.state.new_terminal_cwd,
             crate::config::NewTerminalCwdConfig::Home
         );
+        assert_eq!(app.state.new_terminal_cwd_workspaces, None);
+        assert_eq!(app.state.new_terminal_cwd_tabs, None);
+        assert_eq!(app.state.new_terminal_cwd_panes, None);
         assert!(app.state.switch_ascii_input_source_in_prefix);
         assert!(app.state.config_diagnostic.is_none());
         let toast = app.state.toast.as_ref().unwrap();
@@ -2486,12 +2495,21 @@ mod tests {
         let original_default_shell = app.state.default_shell.clone();
         let original_shell_mode = app.state.shell_mode;
         let original_new_cwd = app.state.new_terminal_cwd.clone();
+        let original_new_cwd_workspaces = app.state.new_terminal_cwd_workspaces.clone();
+        let original_new_cwd_tabs = app.state.new_terminal_cwd_tabs.clone();
+        let original_new_cwd_panes = app.state.new_terminal_cwd_panes.clone();
         let report = app.reload_config();
 
         assert_eq!(report.status, crate::config::ConfigReloadStatus::Partial);
         assert_eq!(app.state.default_shell, original_default_shell);
         assert_eq!(app.state.shell_mode, original_shell_mode);
         assert_eq!(app.state.new_terminal_cwd, original_new_cwd);
+        assert_eq!(
+            app.state.new_terminal_cwd_workspaces,
+            original_new_cwd_workspaces
+        );
+        assert_eq!(app.state.new_terminal_cwd_tabs, original_new_cwd_tabs);
+        assert_eq!(app.state.new_terminal_cwd_panes, original_new_cwd_panes);
         assert_eq!(
             app.state.toast_config.delivery,
             crate::config::ToastDelivery::Terminal
@@ -2955,6 +2973,31 @@ mod tests {
         );
 
         assert_eq!(cwd, std::path::PathBuf::from("/tmp/herdr-fixed"));
+    }
+
+    #[test]
+    fn new_terminal_cwd_domain_inherit_falls_through_to_global() {
+        let cwd = creation::resolve_domain_cwd(
+            &None,
+            &crate::config::NewTerminalCwdConfig::Home,
+            Some(std::path::PathBuf::from("/tmp/source")),
+        );
+        assert_eq!(
+            cwd,
+            std::env::var_os("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn new_terminal_cwd_domain_override_takes_precedence() {
+        let cwd = creation::resolve_domain_cwd(
+            &Some(crate::config::NewTerminalCwdConfig::Follow),
+            &crate::config::NewTerminalCwdConfig::Home,
+            Some(std::path::PathBuf::from("/tmp/source")),
+        );
+        assert_eq!(cwd, std::path::PathBuf::from("/tmp/source"));
     }
 
     #[test]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1361,6 +1361,9 @@ pub struct AppState {
     pub default_shell: String,
     pub shell_mode: crate::config::ShellModeConfig,
     pub new_terminal_cwd: NewTerminalCwdConfig,
+    pub new_terminal_cwd_workspaces: Option<NewTerminalCwdConfig>,
+    pub new_terminal_cwd_tabs: Option<NewTerminalCwdConfig>,
+    pub new_terminal_cwd_panes: Option<NewTerminalCwdConfig>,
     pub pane_scrollback_limit_bytes: usize,
     #[allow(dead_code)] // kept for backward compat; palette.accent is the source of truth
     pub accent: Color,
@@ -1691,6 +1694,9 @@ impl AppState {
             default_shell: String::new(),
             shell_mode: crate::config::ShellModeConfig::Auto,
             new_terminal_cwd: NewTerminalCwdConfig::Follow,
+            new_terminal_cwd_workspaces: None,
+            new_terminal_cwd_tabs: None,
+            new_terminal_cwd_panes: None,
             pane_scrollback_limit_bytes: crate::config::DEFAULT_SCROLLBACK_LIMIT_BYTES,
             accent: Color::Cyan,
             sound: SoundConfig {

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -197,6 +197,28 @@ impl<'de> Deserialize<'de> for NewTerminalCwdConfig {
     }
 }
 
+/// CWD policy for a specific entity (workspace/tab/pane).
+///
+/// Deserializes `"inherit"` to `None` (use global `new_cwd`), any other value to `Some(...)`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NewCwdDomainConfig(pub Option<NewTerminalCwdConfig>);
+
+impl<'de> Deserialize<'de> for NewCwdDomainConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.trim() {
+            "" | "inherit" => Ok(Self(None)),
+            "follow" => Ok(Self(Some(NewTerminalCwdConfig::Follow))),
+            "home" => Ok(Self(Some(NewTerminalCwdConfig::Home))),
+            "current" => Ok(Self(Some(NewTerminalCwdConfig::Current))),
+            _ => Ok(Self(Some(NewTerminalCwdConfig::Path(value)))),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ShellModeConfig {
@@ -215,6 +237,12 @@ pub struct TerminalConfig {
     pub shell_mode: ShellModeConfig,
     /// CWD policy for new interactive panes, tabs, and workspaces.
     pub new_cwd: NewTerminalCwdConfig,
+    /// CWD policy for new workspaces. None = inherit from `new_cwd`.
+    pub new_cwd_workspaces: NewCwdDomainConfig,
+    /// CWD policy for new tabs. None = inherit from `new_cwd`.
+    pub new_cwd_tabs: NewCwdDomainConfig,
+    /// CWD policy for new panes. None = inherit from `new_cwd`.
+    pub new_cwd_panes: NewCwdDomainConfig,
 }
 
 #[derive(Debug, Deserialize)]
@@ -779,6 +807,36 @@ new_cwd = "~/Projects"
         assert_eq!(
             config.terminal.new_cwd,
             NewTerminalCwdConfig::Path("~/Projects".into())
+        );
+    }
+
+    #[test]
+    fn new_cwd_domain_defaults_to_inherit() {
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(config.terminal.new_cwd_workspaces, NewCwdDomainConfig(None));
+        assert_eq!(config.terminal.new_cwd_tabs, NewCwdDomainConfig(None));
+        assert_eq!(config.terminal.new_cwd_panes, NewCwdDomainConfig(None));
+    }
+
+    #[test]
+    fn new_cwd_domain_inherits_and_overrides() {
+        let config: Config = toml::from_str(
+            r#"
+[terminal]
+new_cwd = "home"
+new_cwd_workspaces = "follow"
+new_cwd_panes = "~/Projects"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.terminal.new_cwd_workspaces,
+            NewCwdDomainConfig(Some(NewTerminalCwdConfig::Follow))
+        );
+        assert_eq!(config.terminal.new_cwd_tabs, NewCwdDomainConfig(None));
+        assert_eq!(
+            config.terminal.new_cwd_panes,
+            NewCwdDomainConfig(Some(NewTerminalCwdConfig::Path("~/Projects".into())))
         );
     }
 

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -85,6 +85,8 @@ new_cwd = "follow"
 
 `new_cwd = "follow"` keeps the default behavior and inherits the source pane or workspace. When there is no source workspace, Herdr starts in `$HOME`. Use `"home"` to always start in `$HOME`, `"current"` to use Herdr's process directory, or a fixed path such as `"~/Projects"`. Explicit `--cwd` values from the CLI or socket API still take precedence.
 
+`new_cwd_workspaces`, `new_cwd_tabs`, and `new_cwd_panes` override `new_cwd` for the corresponding entity type. The default `"inherit"` uses the global `new_cwd` value. Set any of them to `"follow"`, `"home"`, `"current"`, or a fixed path to override per entity.
+
 ## Worktrees
 
 Set the root directory Herdr uses for Git worktree checkouts created from the sidebar:


### PR DESCRIPTION
Closes #603

Add `new_cwd_workspaces`, `new_cwd_tabs`, and `new_cwd_panes` config keys under `[terminal]`. Each defaults to `"inherit"` which falls through to the global `new_cwd` value. Can be set to `"follow"`, `"home"`, `"current"`, or a fixed path to override per entity type.

```toml
[terminal]
new_cwd = follow
new_cwd_workspaces = inherit
new_cwd_tabs = inherit
new_cwd_panes = inherit
```

**Files changed:**
- `src/config/model.rs` — `NewCwdDomainConfig` wrapper type + 3 fields on `TerminalConfig` + tests
- `src/config.rs` — re-export
- `src/app/state.rs` — 3 fields on `AppState`
- `src/app/mod.rs` — wire config → state (init + reload), tests
- `src/app/creation.rs` — `resolve_domain_cwd` helper
- `src/app/api/workspaces.rs`, `tabs.rs`, `panes.rs` — use domain config
- `src/app/input/mod.rs` — use domain config
- `website/` + `docs/next/` — documented new keys

**Note:** Zig 0.15.2 build fails locally on macOS 26 (Tahoe). CI should validate on `macos-latest`.