### PR TITLE
feat: emit terminal bell on agent notifications

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -34,6 +34,7 @@ pub fn play(sound: Sound, config: &crate::config::SoundConfig) {
     }
 
     let custom_path = config.path_for(sound);
+    let _ = crate::terminal_notify::emit_bell();
     std::thread::spawn(move || {
         if let Some(path) = custom_path {
             match play_file(&path) {

--- a/src/terminal_notify.rs
+++ b/src/terminal_notify.rs
@@ -92,6 +92,15 @@ fn sanitize_text(text: impl AsRef<str>) -> String {
         .collect()
 }
 
+/// Write a BEL character (0x07) to stdout so the host terminal triggers its
+/// bell indicator (dock bounce, taskbar flash, etc.).
+pub fn emit_bell() -> io::Result<()> {
+    let mut stdout = io::stdout();
+    stdout.write_all(b"\x07")?;
+    stdout.flush()?;
+    Ok(())
+}
+
 fn wrap_tmux_passthrough(sequence: &[u8]) -> Vec<u8> {
     let mut wrapped = Vec::with_capacity(sequence.len() + 16);
     wrapped.extend_from_slice(b"\x1bPtmux;");


### PR DESCRIPTION
## Summary

When Herdr plays a notification sound (agent done / agent requests input), it now also emits a BEL character (`0x07`) to the host terminal. This ensures that users receive a visual or audible indicator from the terminal itself — such as a dock bounce on macOS, a taskbar flash on Windows, or a window highlight in tmux — even when system audio playback is unavailable or muted.

## Motivation

Herdr's existing notification system relies on playing mp3 files through system audio tools (`afplay`, PowerShell MediaPlayer, `paplay`/`mpv`/`mpg123` etc.). This has several gaps:

- **No audio player available**: On minimal Linux installs or SSH sessions without PulseAudio/PipeWire, no mp3-capable player may exist. The sound is silently dropped.
- **Audio output muted or routed elsewhere**: Even when a player exists, the user may have system audio muted, or the output device may be a HDMI monitor with no speakers.
- **Headless / remote sessions**: Over SSH, audio playback often has no path to the user's local speakers.

The terminal BEL is a standard control character defined by ECMA-48 and supported by virtually every terminal emulator. It is the lowest-common-denominator notification mechanism — the terminal emulator decides how to present it (audible beep, visual bell, taskbar flash, dock icon bounce, etc.). Emitting BEL alongside sound playback bridges the gap for all of the above scenarios.

## Changes

### `src/terminal_notify.rs`

Add `emit_bell()` — a public function that writes `\x07` (BEL) to stdout and flushes:

```rust
pub fn emit_bell() -> io::Result<()> {
    let mut stdout = io::stdout();
    stdout.write_all(b"\x07")?;
    stdout.flush()?;
    Ok(())
}
```

This is placed in the existing `terminal_notify` module alongside `notify()` (which sends desktop toast notifications), since both are terminal/host-level notification primitives.

### `src/sound.rs`

Call `emit_bell()` synchronously in `play()` before spawning the audio playback thread:

```rust
let custom_path = config.path_for(sound);
let _ = crate::terminal_notify::emit_bell();
std::thread::spawn(move || { ... });
```

Key design decisions in this placement:

- **Synchronous call**: BEL is emitted on the calling thread, not inside `std::thread::spawn`. This guarantees the BEL is written immediately regardless of whether the audio thread starts successfully, and avoids any timing dependency on thread scheduling.
- **`let _ =` error suppression**: If stdout write fails (e.g., no TTY attached in a fully headless context), the error is silently ignored. The BEL is best-effort — failure should not prevent the audio playback path from continuing.
- **After `sound_playback_disabled_by_env()` check**: If the user has set `HERDR_DISABLE_SOUND=1` or the test harness (`NEXTEST`) is active, both sound and bell are suppressed. This is intentional: when sound is disabled for any reason, the bell should also be disabled to avoid unexpected notifications in test or CI environments.

## Why no `bell` config option?

A `bell = true/false` toggle in `[ui.sound]` was considered but intentionally **not** added. Rationale:

- **The host terminal already provides bell controls.** Every major terminal emulator has built-in settings for how to handle BEL:
  - **iTerm2**: Profiles → Terminal → "Enable bell" / "Silent bell"
  - **Windows Terminal**: `bellStyle` setting (`none`, `window`, `taskbar`, `audible`, `all`)
  - **kitty**: `enable_audio_bell`, `visual_bell_duration`
  - **Alacritty**: `bell` / `visual_bell` configuration
  - **tmux**: `monitor-bell`, `visual-bell`
  - **GNOME Terminal / Console**: profile bell preferences
- Adding a Herdr-level toggle would duplicate functionality that the terminal already owns, and would require the user to manage two separate bell settings (Herdr's and the terminal's) that could contradict each other.
- BEL is a terminal protocol primitive, like a newline or a cursor move. Herdr should not gate protocol-level signals behind its own configuration when the terminal already controls them.
- Herdr's config should remain focused on notification channels that **only** Herdr controls: custom mp3 sound files and desktop toast notifications.

## Testing

- Manual verification: run Herdr in a terminal with bell enabled, trigger an agent notification, observe the terminal's bell indicator (dock bounce, flash, etc.).
- Verified that `HERDR_DISABLE_SOUND=1` suppresses both sound and bell.
- Existing `just check` passes (no new dependencies, no new config surface, no new test-only behavior needed).

## Impact

- **No breaking changes**: The BEL is additive. Terminals that ignore BEL by default are unaffected.
- **No new configuration surface**: No config file changes, no new settings keys.
- **No new dependencies**: Uses only `std::io`.