### PR TITLE
fix: add omp to is_official_agent_source to fix permanent lifecycle hook suppression

### DIFF
--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -198,6 +198,7 @@ fn is_official_agent_source(source: &str, agent: &str) -> bool {
             | ("herdr:devin", "devin")
             | ("herdr:droid", "droid")
             | ("herdr:kimi", "kimi")
+            | ("herdr:omp", "omp")
             | ("herdr:pi", "pi")
             | ("herdr:hermes", "hermes")
             | ("herdr:opencode", "opencode")

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -11,6 +11,9 @@ const HERDR_ENV = process.env.HERDR_ENV;
 const socketPath = process.env.HERDR_SOCKET_PATH;
 const paneId = process.env.HERDR_PANE_ID;
 const source = "herdr:omp";
+// Persistent session ID — lets Herdr clear lifecycle-hook suppression
+// when OMP re-registers after process restart.
+const agentSessionId: string = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}-${Math.random().toString(36).slice(2, 10)}`;
 
 function enabled() {
   return HERDR_ENV === "1" && !!socketPath && !!paneId;
@@ -79,6 +82,7 @@ function sendState(state: AgentState, message?: string, seq = nextReportSeq()): 
       pane_id: paneId,
       source,
       agent: "omp",
+      agent_session_id: agentSessionId,
       state,
       message,
       seq,


### PR DESCRIPTION
## Problem

OMP lifecycle hook reports (`source=herdr:omp`, `agent=omp`) are permanently suppressed after a process exit or release, preventing OMP from re-registering in the Agents panel after restart.

**Root cause:** `is_official_agent_source()` in `src/agent_resume.rs` does not include `("herdr:omp", "omp")`. This causes `session_ref_from_report()` to always return `None` for OMP reports, even when `agent_session_id` is provided.

Without a `Some(session_ref)`:
1. Suppression check at `terminal/state.rs:522` matches `(None, None) => true` → report silently dropped
2. Line 370 only clears suppression when `session_ref.is_some()` → suppression stuck forever

This affects two paths:
- **Explicit release:** `pane.release_agent` → `release_agent_with_mutation` → `suppress_full_lifecycle_hook_report` → adds suppression
- **Process exit:** `PaneDied` → `publish_pane_process_exit_if_agent` → `set_detected_state` with `process_exited=true` → `suppress_current_full_lifecycle_hook_authority` → adds suppression

Fixes #614.

## Changes

**`src/agent_resume.rs`** — add `("herdr:omp", "omp")` to `is_official_agent_source()`. This lets `session_ref_from_report()` accept `agent_session_id`, producing `Some(session_ref)`.

**`src/integration/assets/omp/herdr-agent-state.ts`** — add a persistent `agent_session_id` (generated once per extension load) to every `report_agent` call. Required for the session_ref machinery to produce a value.

With `Some(session_ref)`:
- Suppression check hits `(None, Some(_)) => false` → report allowed
- `suppressed_full_lifecycle_hook_reports.remove(&source)` clears the suppression

## Testing

1. `herdr integration install omp`
2. Run `omp` in a pane → verify it appears in Agents panel
3. Exit OMP → run `omp` again → verify it reappears

Closes #614