### PR TITLE
feat: add herdr GSD integration

### DIFF
--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -26,6 +26,7 @@ pub enum IntegrationTarget {
     Hermes,
     Qodercli,
     Cursor,
+    Gsd,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -103,13 +103,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|gsd>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|gsd>"
         );
         return Ok(None);
     }
@@ -156,6 +156,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install hermes");
     eprintln!("  herdr integration install qodercli");
     eprintln!("  herdr integration install cursor");
+    eprintln!("  herdr integration install gsd");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -169,5 +170,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall hermes");
     eprintln!("  herdr integration uninstall qodercli");
     eprintln!("  herdr integration uninstall cursor");
+    eprintln!("  herdr integration uninstall gsd");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -128,10 +128,11 @@ fn parse_integration_target(
         "hermes" => IntegrationTarget::Hermes,
         "qodercli" => IntegrationTarget::Qodercli,
         "cursor" => IntegrationTarget::Cursor,
+        "gsd" => IntegrationTarget::Gsd,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, gsd"
             );
             return Ok(None);
         }

--- a/src/integration/assets/gsd/herdr-agent-state.ts
+++ b/src/integration/assets/gsd/herdr-agent-state.ts
@@ -1,0 +1,346 @@
+// installed by herdr
+// managed by herdr; reinstalling or updating the integration overwrites this file.
+// add custom hooks/plugins beside this file instead of editing it.
+// HERDR_INTEGRATION_ID=gsd
+// HERDR_INTEGRATION_VERSION=1
+// @ts-nocheck
+
+import { createConnection } from "node:net";
+
+const HERDR_ENV = process.env.HERDR_ENV;
+const socketPath = process.env.HERDR_SOCKET_PATH;
+const paneId = process.env.HERDR_PANE_ID;
+const source = "herdr:gsd";
+
+function enabled() {
+  return HERDR_ENV === "1" && !!socketPath && !!paneId;
+}
+
+function sendRequest(request: unknown): Promise<void> {
+  if (!enabled()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      resolve();
+    };
+
+    const socket = createConnection(socketPath!);
+    socket.on("error", finish);
+    socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+    socket.on("data", finish);
+    socket.on("end", finish);
+    const timeout = setTimeout(finish, 500);
+    timeout.unref?.();
+  });
+}
+
+type AgentState = "working" | "blocked" | "idle";
+
+type QueuedState = {
+  state: AgentState;
+  message?: string;
+  seq: number;
+};
+
+const idleDebounceMs = parseDurationEnv("HERDR_GSD_IDLE_DEBOUNCE_MS", 250);
+const retryGraceMs = parseDurationEnv("HERDR_GSD_RETRY_GRACE_MS", 2500);
+const retryableErrorPattern =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+let reportSeq = Date.now() * 1000;
+let currentAgentSessionId: string | undefined;
+let currentAgentSessionPath: string | undefined;
+
+function nextReportSeq(): number {
+  reportSeq += 1;
+  return reportSeq;
+}
+
+function parseDurationEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function updateSessionRef(ctx: any): void {
+  try {
+    const file = ctx?.sessionManager?.getSessionFile?.();
+    currentAgentSessionPath =
+      typeof file === "string" && file.startsWith("/") ? file : undefined;
+  } catch {
+    currentAgentSessionPath = undefined;
+  }
+
+  try {
+    const id = ctx?.sessionManager?.getSessionId?.();
+    currentAgentSessionId = typeof id === "string" && id.length > 0 ? id : undefined;
+  } catch {
+    currentAgentSessionId = undefined;
+  }
+}
+
+function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
+  if (currentAgentSessionPath) {
+    return { ...params, agent_session_path: currentAgentSessionPath };
+  }
+  if (currentAgentSessionId) {
+    return { ...params, agent_session_id: currentAgentSessionId };
+  }
+  return params;
+}
+
+function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<void> {
+  return sendRequest({
+    id: `${source}:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.report_agent",
+    params: withSessionRef({
+      pane_id: paneId,
+      source,
+      agent: "gsd",
+      state,
+      message,
+      seq,
+    }),
+  });
+}
+
+let sendInFlight = false;
+let queuedState: QueuedState | undefined;
+
+function queueState(state: AgentState, message?: string): void {
+  queuedState = { state, message, seq: nextReportSeq() };
+  if (!sendInFlight) {
+    void drainStateQueue();
+  }
+}
+
+async function drainStateQueue(): Promise<void> {
+  if (sendInFlight) {
+    return;
+  }
+
+  sendInFlight = true;
+  try {
+    while (queuedState) {
+      const next = queuedState;
+      queuedState = undefined;
+      await sendState(next.state, next.message, next.seq);
+    }
+  } finally {
+    sendInFlight = false;
+    if (queuedState) {
+      void drainStateQueue();
+    }
+  }
+}
+
+function lastAssistantMessage(messages: unknown[]): any | undefined {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i] as any;
+    if (message?.role === "assistant") {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function retryableErrorMessage(event: any): string | undefined {
+  const messages = Array.isArray(event?.messages) ? event.messages : [];
+  const assistant = lastAssistantMessage(messages);
+  if (assistant?.stopReason !== "error") {
+    return undefined;
+  }
+
+  const errorMessage = String(assistant.errorMessage ?? "");
+  if (!retryableErrorPattern.test(errorMessage)) {
+    return undefined;
+  }
+  return errorMessage || "retryable provider error";
+}
+
+function releaseAgent(): Promise<void> {
+  return sendRequest({
+    id: `${source}:release:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.release_agent",
+    params: {
+      pane_id: paneId,
+      source,
+      agent: "gsd",
+      seq: nextReportSeq(),
+    },
+  });
+}
+
+export default function (gsd) {
+  if (!enabled()) {
+    return;
+  }
+
+  let agentActive = false;
+  let retryHoldActive = false;
+  let failureBlocked = false;
+  let failureMessage: string | undefined;
+  let blockedCount = 0;
+  let blockedMessage: string | undefined;
+  let lastState: AgentState | undefined;
+  let lastMessage: string | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function clearTimer(timer: ReturnType<typeof setTimeout> | undefined) {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  function clearPendingTimers() {
+    clearTimer(idleTimer);
+    clearTimer(retryTimer);
+    idleTimer = undefined;
+    retryTimer = undefined;
+  }
+
+  function clearFailureState() {
+    retryHoldActive = false;
+    failureBlocked = false;
+    failureMessage = undefined;
+  }
+
+  function desiredState() {
+    if (blockedCount > 0) {
+      return { state: "blocked" as const, message: blockedMessage };
+    }
+    if (failureBlocked) {
+      return { state: "blocked" as const, message: failureMessage };
+    }
+    if (agentActive || retryHoldActive) {
+      return { state: "working" as const, message: undefined };
+    }
+    return { state: "idle" as const, message: undefined };
+  }
+
+  function publishState(force = false) {
+    const next = desiredState();
+    if (!force && next.state === lastState && next.message === lastMessage) {
+      return;
+    }
+    lastState = next.state;
+    lastMessage = next.message;
+    queueState(next.state, next.message);
+  }
+
+  function scheduleIdle() {
+    clearPendingTimers();
+    clearFailureState();
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined;
+      publishState();
+    }, idleDebounceMs);
+    idleTimer.unref?.();
+  }
+
+  gsd.on("session_start", (_event, ctx) => {
+    updateSessionRef(ctx);
+    publishState(true);
+  });
+
+  function holdForRetry(message: string) {
+    clearPendingTimers();
+    retryHoldActive = true;
+    failureBlocked = false;
+    failureMessage = message;
+    publishState();
+
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined;
+      retryHoldActive = false;
+      failureBlocked = true;
+      publishState();
+    }, retryGraceMs);
+    retryTimer.unref?.();
+  }
+
+  gsd.events.on("herdr:blocked", (data) => {
+    if (!data?.active) {
+      blockedCount = Math.max(0, blockedCount - 1);
+      if (blockedCount === 0) {
+        blockedMessage = undefined;
+      }
+      publishState();
+      return;
+    }
+
+    clearPendingTimers();
+    blockedCount += 1;
+    blockedMessage = data.label;
+    publishState();
+  });
+
+  gsd.on("agent_start", () => {
+    clearPendingTimers();
+    clearFailureState();
+    agentActive = true;
+    publishState();
+  });
+
+  gsd.on("agent_end", (event) => {
+    if (!agentActive) {
+      // GSD can emit duplicate/late end events while auto-retry is already
+      // holding the pane in Working. Do not let an unqualified duplicate end
+      // cancel the retry hold and publish a false Idle.
+      return;
+    }
+
+    agentActive = false;
+
+    const retryableMessage = retryableErrorMessage(event);
+    if (retryableMessage) {
+      holdForRetry(retryableMessage);
+      return;
+    }
+
+    scheduleIdle();
+  });
+
+  gsd.on("session_shutdown", async () => {
+    clearPendingTimers();
+    await releaseAgent();
+  });
+
+  // GSD auto-mode events: enrich working state with milestone/slice context
+  gsd.on("auto:slice_start", (_event, ctx) => {
+    const slice = ctx?.sliceId ?? ctx?.current_slice?.id;
+    const milestone = ctx?.milestoneId ?? ctx?.current_milestone?.id;
+    if (slice || milestone) {
+      const label = [milestone, slice].filter(Boolean).join("/");
+      if (label) {
+        queueState("working", label);
+      }
+    }
+  });
+
+  gsd.on("auto:task_start", (_event, ctx) => {
+    const task = ctx?.taskId ?? ctx?.current_task?.id;
+    if (task) {
+      queueState("working", `task: ${task}`);
+    }
+  });
+
+  gsd.on("auto:milestone_start", (_event, ctx) => {
+    const milestone = ctx?.milestoneId ?? ctx?.current_milestone?.id;
+    if (milestone) {
+      queueState("working", `milestone: ${milestone}`);
+    }
+  });
+}

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -12,6 +12,10 @@ pub(crate) const HERDR_TAB_ID_ENV_VAR: &str = "HERDR_TAB_ID";
 pub(crate) const HERDR_WORKSPACE_ID_ENV_VAR: &str = "HERDR_WORKSPACE_ID";
 const PI_EXTENSION_INSTALL_NAME: &str = "herdr-agent-state.ts";
 const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
+const GSD_EXTENSION_INSTALL_NAME: &str = "herdr-agent-state.ts";
+const GSD_EXTENSION_ASSET: &str = include_str!("assets/gsd/herdr-agent-state.ts");
+const GSD_INTEGRATION_VERSION: u32 = 1;
+const GSD_AGENT_DIR_ENV_VAR: &str = "GSD_AGENT_DIR";
 const PI_INTEGRATION_VERSION: u32 = 2;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
@@ -258,6 +262,12 @@ pub(crate) struct CursorUninstallResult {
     pub hooks_path: PathBuf,
     pub removed_hook_file: bool,
     pub updated_hooks: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct GsdUninstallResult {
+    pub extension_path: PathBuf,
+    pub removed_extension: bool,
 }
 
 #[derive(Debug)]
@@ -659,6 +669,10 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                 format!("updated cursor hooks at {}", installed.hooks_path.display()),
             ]
         }
+        crate::api::schema::IntegrationTarget::Gsd => {
+            let path = install_gsd()?;
+            vec![format!("installed gsd integration to {}", path.display())]
+        }
     };
 
     if let Some(warning) = version_warning {
@@ -986,6 +1000,20 @@ pub(crate) fn uninstall_target(
             }
             messages
         }
+        crate::api::schema::IntegrationTarget::Gsd => {
+            let result = uninstall_gsd()?;
+            if result.removed_extension {
+                vec![format!(
+                    "removed gsd integration extension at {}",
+                    result.extension_path.display()
+                )]
+            } else {
+                vec![format!(
+                    "no gsd integration extension found at {}",
+                    result.extension_path.display()
+                )]
+            }
+        }
     };
 
     crate::logging::integration_action("uninstall", integration_target_label(target), "ok");
@@ -1009,6 +1037,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Hermes => "hermes",
         crate::api::schema::IntegrationTarget::Qodercli => "qodercli",
         crate::api::schema::IntegrationTarget::Cursor => "cursor",
+        crate::api::schema::IntegrationTarget::Gsd => "gsd",
     }
 }
 
@@ -1033,6 +1062,7 @@ fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Hermes => &["hermes"],
         crate::api::schema::IntegrationTarget::Qodercli => qodercli_command_names(),
         crate::api::schema::IntegrationTarget::Cursor => cursor_command_names(),
+        crate::api::schema::IntegrationTarget::Gsd => &["gsd"],
     }
 }
 
@@ -1051,6 +1081,7 @@ fn integration_target_supported(target: crate::api::schema::IntegrationTarget) -
                 | crate::api::schema::IntegrationTarget::Droid
                 | crate::api::schema::IntegrationTarget::Kimi
                 | crate::api::schema::IntegrationTarget::Qodercli
+                | crate::api::schema::IntegrationTarget::Gsd
         )
     }
 
@@ -1237,7 +1268,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 13] {
+); 14] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -1303,6 +1334,11 @@ fn integration_specs() -> [(
             crate::api::schema::IntegrationTarget::Cursor,
             cursor_dir().map(|dir| dir.join(CURSOR_HOOK_INSTALL_NAME)),
             CURSOR_INTEGRATION_VERSION,
+        ),
+        (
+            crate::api::schema::IntegrationTarget::Gsd,
+            gsd_extension_dir().map(|dir| dir.join(GSD_EXTENSION_INSTALL_NAME)),
+            GSD_INTEGRATION_VERSION,
         ),
     ]
 }
@@ -1403,6 +1439,20 @@ pub(crate) fn install_pi() -> io::Result<PathBuf> {
 
     let path = dir.join(PI_EXTENSION_INSTALL_NAME);
     fs::write(&path, PI_EXTENSION_ASSET)?;
+    Ok(path)
+}
+
+pub(crate) fn install_gsd() -> io::Result<PathBuf> {
+    let dir = gsd_extension_dir()?;
+    if !dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "gsd extension directory not found at {}. install gsd and create the extensions directory first",
+            dir.display()
+        )));
+    }
+
+    let path = dir.join(GSD_EXTENSION_INSTALL_NAME);
+    fs::write(&path, GSD_EXTENSION_ASSET)?;
     Ok(path)
 }
 
@@ -1886,6 +1936,16 @@ pub(crate) fn uninstall_pi() -> io::Result<PiUninstallResult> {
     let removed_extension = remove_file_if_exists(&extension_path)?;
 
     Ok(PiUninstallResult {
+        extension_path,
+        removed_extension,
+    })
+}
+
+pub(crate) fn uninstall_gsd() -> io::Result<GsdUninstallResult> {
+    let extension_path = gsd_extension_dir()?.join(GSD_EXTENSION_INSTALL_NAME);
+    let removed_extension = remove_file_if_exists(&extension_path)?;
+
+    Ok(GsdUninstallResult {
         extension_path,
         removed_extension,
     })
@@ -3359,6 +3419,10 @@ fn pi_extension_dir() -> io::Result<PathBuf> {
     )
 }
 
+fn gsd_extension_dir() -> io::Result<PathBuf> {
+    Ok(config_dir_from_env_or_home(GSD_AGENT_DIR_ENV_VAR, &[".gsd", "agent"])?.join("extensions"))
+}
+
 fn omp_extension_dir() -> io::Result<PathBuf> {
     Ok(
         config_dir_from_env_or_home(PI_CODING_AGENT_DIR_ENV_VAR, &[".omp", "agent"])?
@@ -3572,6 +3636,7 @@ mod tests {
 
     fn clear_integration_path_env() {
         std::env::remove_var(PI_CODING_AGENT_DIR_ENV_VAR);
+        std::env::remove_var(GSD_AGENT_DIR_ENV_VAR);
         std::env::remove_var(CLAUDE_CONFIG_DIR_ENV_VAR);
         std::env::remove_var(CODEX_HOME_ENV_VAR);
         std::env::remove_var(COPILOT_HOME_ENV_VAR);
@@ -3660,6 +3725,7 @@ mod tests {
         assert!(integration_target_supported(IntegrationTarget::Droid));
         assert!(integration_target_supported(IntegrationTarget::Kimi));
         assert!(integration_target_supported(IntegrationTarget::Qodercli));
+        assert!(integration_target_supported(IntegrationTarget::Gsd));
     }
 
     #[cfg(windows)]
@@ -3681,6 +3747,7 @@ mod tests {
         fs::write(bin.join("hermes.exe"), "").unwrap();
         fs::write(bin.join("cursor-agent.cmd"), "@echo off\r\n").unwrap();
         fs::write(bin.join("devin.cmd"), "@echo off\r\n").unwrap();
+        fs::write(bin.join("gsd.cmd"), "@echo off\r\n").unwrap();
 
         assert!(!integration_target_available(IntegrationTarget::Pi));
         assert!(!integration_target_available(IntegrationTarget::Omp));
@@ -3689,6 +3756,8 @@ mod tests {
         assert!(!integration_target_available(IntegrationTarget::Hermes));
         assert!(!integration_target_available(IntegrationTarget::Cursor));
         assert!(!integration_target_available(IntegrationTarget::Devin));
+        // GSD is supported on Windows but has no installed extension yet
+        assert!(!integration_target_available(IntegrationTarget::Gsd));
 
         if let Some(path) = original_path {
             std::env::set_var("PATH", path);
@@ -3994,6 +4063,104 @@ mod tests {
 
         std::env::remove_var("HOME");
         clear_integration_path_env();
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn install_gsd_writes_embedded_asset_to_gsd_extensions_dir() {
+        let _lock = integration_env_lock();
+        let base = unique_base();
+        let home = base.join("home");
+        let ext_dir = home.join(".gsd/agent/extensions");
+        fs::create_dir_all(&ext_dir).unwrap();
+        std::env::set_var("HOME", &home);
+
+        let path = install_gsd().unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+
+        assert_eq!(path, ext_dir.join(GSD_EXTENSION_INSTALL_NAME));
+        assert_eq!(content, GSD_EXTENSION_ASSET);
+
+        std::env::remove_var("HOME");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn install_gsd_uses_gsd_agent_dir_env() {
+        let _lock = integration_env_lock();
+        let base = unique_base();
+        let agent_dir = base.join("custom-gsd-agent");
+        let ext_dir = agent_dir.join("extensions");
+        fs::create_dir_all(&ext_dir).unwrap();
+        std::env::set_var(GSD_AGENT_DIR_ENV_VAR, &agent_dir);
+
+        let path = install_gsd().unwrap();
+
+        assert_eq!(path, ext_dir.join(GSD_EXTENSION_INSTALL_NAME));
+
+        clear_integration_path_env();
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn install_gsd_expands_tilde_in_gsd_agent_dir_env() {
+        let _lock = integration_env_lock();
+        let base = unique_base();
+        let home = base.join("home");
+        let ext_dir = home.join("custom-gsd-agent/extensions");
+        fs::create_dir_all(&ext_dir).unwrap();
+        std::env::set_var("HOME", &home);
+        std::env::set_var(GSD_AGENT_DIR_ENV_VAR, "~/custom-gsd-agent");
+
+        let path = install_gsd().unwrap();
+
+        assert_eq!(path, ext_dir.join(GSD_EXTENSION_INSTALL_NAME));
+
+        std::env::remove_var("HOME");
+        clear_integration_path_env();
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn install_gsd_errors_when_extension_dir_missing() {
+        let _lock = integration_env_lock();
+        let base = unique_base();
+        let home = base.join("home");
+        fs::create_dir_all(&home).unwrap();
+        std::env::set_var("HOME", &home);
+
+        let err = install_gsd().unwrap_err().to_string();
+
+        assert!(err.contains("gsd extension directory not found"));
+
+        std::env::remove_var("HOME");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn uninstall_gsd_removes_embedded_extension_when_present() {
+        let _lock = integration_env_lock();
+        let base = unique_base();
+        let home = base.join("home");
+        let ext_dir = home.join(".gsd/agent/extensions");
+        fs::create_dir_all(&ext_dir).unwrap();
+        fs::write(
+            ext_dir.join(GSD_EXTENSION_INSTALL_NAME),
+            GSD_EXTENSION_ASSET,
+        )
+        .unwrap();
+        std::env::set_var("HOME", &home);
+
+        let result = uninstall_gsd().unwrap();
+
+        assert_eq!(
+            result.extension_path,
+            ext_dir.join(GSD_EXTENSION_INSTALL_NAME)
+        );
+        assert!(result.removed_extension);
+        assert!(!result.extension_path.exists());
+
+        std::env::remove_var("HOME");
         let _ = fs::remove_dir_all(base);
     }
 


### PR DESCRIPTION
## Summary

Adds a herdr integration for GSD sessions. Once installed, herdr can detect when a GSD agent is active in a pane and surface that state in its UI.

## What changed

**New integration: GSD**

- `src/api/schema/integrations.rs` — Added `Gsd` variant to `IntegrationTarget` enum
- `src/integration/mod.rs` — `install_gsd()` / `uninstall_gsd()` / `dispatch_gsd()` wiring, env-var overrides, integration status reporting, and full test coverage
- `src/integration/assets/gsd/herdr-agent-state.ts` — TypeScript extension that:
  - Connects to the herdr socket (`HERDR_SOCKET_PATH`)
  - Listens to GSD lifecycle events (`session_start`, `agent_start`, `agent_end`, `session_shutdown`)
  - Listens to GSD auto-mode events (`auto:slice_start`, `auto:task_start`, `auto:milestone_start`) and enriches pane state with milestone/slice context
  - Reports agent state via `pane.report_agent()` / `pane.release_agent()`
- `src/cli/integration.rs` — Added `gsd` to CLI install/uninstall commands and help output

## Usage

```bash
herdr integration install gsd
herdr integration uninstall gsd
herdr integration status
```

## Testing

- `cargo check` — clean (0 warnings)
- `cargo nextest run` — 2130 tests passed
- `python3 -m unittest` — 53 maintenance script tests passed
- `cargo build --release` — clean
- `cargo fmt --check` — clean

## Compatibility

- Mirrors the existing `pi` integration pattern exactly — same socket path, same ExtensionAPI, same event surface
- GSD is supported on Windows (no auto-detection, but `HERDR_GSD_AGENT_DIR` env var respected)
- All tests use `integration_env_lock()` for concurrency safety