### PR TITLE
feat: add agent read-state controls and panel close menu

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added agent panel right-click **Mark as read** / **Mark as unread** / **Close** actions, plus matching `agent.mark_read` / `agent.mark_unread` socket API methods and `herdr agent mark-read` / `herdr agent mark-unread` CLI commands. Mark actions update read state without navigation; **Close** navigates to the pane and closes it.
+
 ## [0.7.0] - 2026-06-15
 
 ### Added

--- a/docs/next/website/src/content/docs/cli-reference.mdx
+++ b/docs/next/website/src/content/docs/cli-reference.mdx
@@ -203,6 +203,8 @@ herdr agent read <target> [--source visible|recent|recent-unwrapped|detection] [
 herdr agent send <target> <text>
 herdr agent rename <target> <name>|--clear
 herdr agent focus <target>
+herdr agent mark-read <target>
+herdr agent mark-unread <target>
 herdr agent wait <target> --status <idle|working|blocked|unknown> [--timeout MS]
 herdr agent attach <target> [--takeover]
 herdr agent start <name> [--cwd PATH] [--workspace ID] [--tab ID] [--split right|down] [--env KEY=VALUE] [--focus|--no-focus] -- <argv...>
@@ -213,6 +215,8 @@ herdr agent explain --file PATH --agent LABEL [--json|--verbose]
 Agent targets can be terminal IDs, unique agent names, detected or reported agent labels, or legacy pane IDs. Names and labels are agent identities. Terminal IDs and legacy pane IDs are low-level escape hatches.
 
 `agent read` reads the resolved terminal stream. `agent send` writes literal text to that stream. `agent get`, `agent focus`, `agent wait`, and `agent attach` require the resolved terminal to have agent identity. `agent rename` can assign that identity.
+
+`agent mark-read` and `agent mark-unread` update the pane seen state for an agent whose effective status is `done` or `idle`. They do not change focus or navigate to the target pane. Marking a working, blocked, or unknown agent returns `agent_not_idle`. Marking the currently focused agent is a no-op.
 
 `agent explain` asks the running server to classify the same bottom-buffer detection snapshot used by screen detection, so live output reflects the server's active manifest cache. Because this uses the `agent.explain` socket method, restart or hand off to an updated server after upgrading Herdr before using live explain. Use `--file PATH --agent LABEL` to explain a saved fixture locally instead. The default output shows the agent, final state, manifest source and version, matched rule with its region evidence, and any fallback, skip, or warning reasons. Add `--verbose` for visible evidence flags, cached remote version, local override shadowing, remote update status, and the full evaluated-rules list with matcher and region evidence. Add `--json` for issue reports or tests.
 

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -88,7 +88,7 @@ Raw socket method names use dot notation:
 | Tab | `tab.create`, `tab.list`, `tab.get`, `tab.focus`, `tab.rename`, `tab.close` |
 | Pane | `pane.split`, `pane.swap`, `pane.move`, `pane.zoom`, `pane.layout`, `pane.process_info`, `pane.neighbor`, `pane.edges`, `pane.focus_direction`, `pane.resize`, `pane.list`, `pane.current`, `pane.get`, `pane.rename`, `pane.send_text`, `pane.send_keys`, `pane.send_input`, `pane.read`, `pane.report_agent`, `pane.report_agent_session`, `pane.report_metadata`, `pane.clear_agent_authority`, `pane.release_agent`, `pane.close`, `pane.wait_for_output` |
 | Layout | `layout.export`, `layout.apply` |
-| Agent | `agent.list`, `agent.get`, `agent.read`, `agent.explain`, `agent.send`, `agent.rename`, `agent.focus`, `agent.start` |
+| Agent | `agent.list`, `agent.get`, `agent.read`, `agent.explain`, `agent.send`, `agent.rename`, `agent.focus`, `agent.mark_read`, `agent.mark_unread`, `agent.start` |
 | Events | `events.subscribe`, `events.wait` |
 | Integrations | `integration.install`, `integration.uninstall` |
 | Plugins | `plugin.link`, `plugin.list`, `plugin.unlink`, `plugin.enable`, `plugin.disable`, `plugin.action.list`, `plugin.action.invoke`, `plugin.log.list`, `plugin.pane.open`, `plugin.pane.focus`, `plugin.pane.close` |
@@ -535,6 +535,15 @@ Session-only official integrations report native session references with `pane.r
 If no native session reference is stored, the field is omitted.
 
 `pane.get`, `pane.list`, `agent.get`, and `agent.list` also expose `foreground_cwd` when Herdr can resolve the cwd of the process currently controlling the pane PTY. The existing `cwd` field remains the pane/workspace cwd used for labels, follow-cwd behavior, and restored session state.
+
+`agent.mark_read` and `agent.mark_unread` update the pane seen state for an agent whose effective status is `done` or `idle`. They do not change focus or navigate to the target pane. Marking a working, blocked, or unknown agent returns `agent_not_idle`. Marking the currently focused agent is a no-op.
+
+```json
+{"id":"req_mark_read","method":"agent.mark_read","params":{"target":"reviewer"}}
+{"id":"req_mark_unread","method":"agent.mark_unread","params":{"target":"reviewer"}}
+```
+
+Both methods return `type: "agent_info"` with the updated `agent_status`. `mark_read` moves an unseen done agent to `idle`; `mark_unread` moves a seen idle agent back to `done`.
 
 Use `pane.report_metadata` when a user hook wants to customize presentation without taking over lifecycle state from a Herdr integration.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -38,6 +38,8 @@ pub(crate) fn request_changes_ui(request: &Request) -> bool {
             | Method::LayoutApply(_)
             | Method::AgentRename(_)
             | Method::AgentFocus(_)
+            | Method::AgentMarkRead(_)
+            | Method::AgentMarkUnread(_)
             | Method::AgentStart(_)
             | Method::PaneSplit(_)
             | Method::PaneSwap(_)

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -105,6 +105,10 @@ pub enum Method {
     AgentRename(AgentRenameParams),
     #[serde(rename = "agent.focus")]
     AgentFocus(AgentTarget),
+    #[serde(rename = "agent.mark_read")]
+    AgentMarkRead(AgentTarget),
+    #[serde(rename = "agent.mark_unread")]
+    AgentMarkUnread(AgentTarget),
     #[serde(rename = "agent.start")]
     AgentStart(AgentStartParams),
     #[serde(rename = "pane.split")]

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -86,6 +86,34 @@ fn request_round_trips_for_agent_explain() {
 }
 
 #[test]
+fn request_round_trips_for_agent_mark_read() {
+    let request = Request {
+        id: "req_mark_read".into(),
+        method: Method::AgentMarkRead(AgentTarget {
+            target: "pi".into(),
+        }),
+    };
+    let json = serde_json::to_value(&request).unwrap();
+    assert_eq!(json["method"], "agent.mark_read");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, request);
+}
+
+#[test]
+fn request_round_trips_for_agent_mark_unread() {
+    let request = Request {
+        id: "req_mark_unread".into(),
+        method: Method::AgentMarkUnread(AgentTarget {
+            target: "pi".into(),
+        }),
+    };
+    let json = serde_json::to_value(&request).unwrap();
+    assert_eq!(json["method"], "agent.mark_unread");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, request);
+}
+
+#[test]
 fn notification_show_request_parses() {
     let json = r#"{"id":"req_1","method":"notification.show","params":{"title":"build failed","body":"api workspace","position":"top-left","sound":"request"}}"#;
     let request: Request = serde_json::from_str(json).unwrap();

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -304,6 +304,8 @@ fn api_method_name(method: &Method) -> &'static str {
         Method::AgentSend(_) => "agent.send",
         Method::AgentRename(_) => "agent.rename",
         Method::AgentFocus(_) => "agent.focus",
+        Method::AgentMarkRead(_) => "agent.mark_read",
+        Method::AgentMarkUnread(_) => "agent.mark_unread",
         Method::AgentStart(_) => "agent.start",
         Method::PaneSplit(_) => "pane.split",
         Method::PaneSwap(_) => "pane.swap",

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -12,7 +12,7 @@ use crate::workspace::WorkspaceGitStatus;
 use unicode_width::UnicodeWidthChar;
 
 use super::state::{
-    text_matches_query, AgentNotificationDelivery, AppState, Mode, NavigatorRow,
+    text_matches_query, AgentNotificationDelivery, AppState, ContextMenuKind, Mode, NavigatorRow,
     NavigatorStateFilter, NavigatorTarget, PaneFocusTarget, PendingAgentNotification, ToastKind,
     ToastNotification, ToastTarget, ViewLayout,
 };
@@ -243,6 +243,19 @@ pub struct PaneStateUpdate {
     pub presentation: crate::terminal::EffectivePresentation,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeenError {
+    PaneNotFound,
+    NotIdle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
+pub enum SeenChange {
+    Unchanged,
+    Changed(PaneStateUpdate),
+}
+
 // ---------------------------------------------------------------------------
 // Navigator operations
 // ---------------------------------------------------------------------------
@@ -256,6 +269,97 @@ impl AppState {
             workspace_id: ws.id.clone(),
             pane_id,
         })
+    }
+
+    pub(crate) fn pane_agent_terminal_state(
+        &self,
+        ws_idx: usize,
+        pane_id: PaneId,
+    ) -> Option<AgentState> {
+        let pane = self.workspaces.get(ws_idx)?.pane_state(pane_id)?;
+        Some(self.terminals.get(&pane.attached_terminal_id)?.state)
+    }
+
+    pub(crate) fn is_pane_agent_terminal(&self, ws_idx: usize, pane_id: PaneId) -> bool {
+        let pane = match self
+            .workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.pane_state(pane_id))
+        {
+            Some(pane) => pane,
+            None => return false,
+        };
+        self.terminals
+            .get(&pane.attached_terminal_id)
+            .is_some_and(|terminal| terminal.is_agent_terminal())
+    }
+
+    pub(crate) fn refresh_agent_panel_context_menu(&mut self) {
+        let Some((ws_idx, pane_id, seen)) =
+            self.context_menu.as_ref().and_then(|menu| match menu.kind {
+                ContextMenuKind::AgentPanel {
+                    ws_idx, pane_id, ..
+                } => self
+                    .workspaces
+                    .get(ws_idx)
+                    .and_then(|ws| ws.pane_state(pane_id))
+                    .map(|pane| (ws_idx, pane_id, pane.seen)),
+                _ => None,
+            })
+        else {
+            return;
+        };
+
+        let next_mark_item = self.agent_panel_mark_item(ws_idx, pane_id, seen);
+        let Some(menu) = &mut self.context_menu else {
+            return;
+        };
+        let ContextMenuKind::AgentPanel { mark_item, .. } = &mut menu.kind else {
+            return;
+        };
+        if *mark_item == next_mark_item {
+            return;
+        }
+        *mark_item = next_mark_item;
+        let item_count = menu.items().len();
+        if item_count == 0 {
+            menu.list.highlighted = 0;
+        } else if menu.list.highlighted >= item_count {
+            menu.list.highlighted = item_count - 1;
+        }
+    }
+
+    pub(crate) fn agent_panel_mark_item(
+        &self,
+        ws_idx: usize,
+        pane_id: PaneId,
+        seen: bool,
+    ) -> Option<crate::app::state::AgentPanelMarkItem> {
+        use crate::app::state::AgentPanelMarkItem;
+
+        let agent_state = self.pane_agent_terminal_state(ws_idx, pane_id)?;
+        if agent_state != AgentState::Idle {
+            return None;
+        }
+        if !seen {
+            return Some(AgentPanelMarkItem::MarkAsRead);
+        }
+        if self.is_pane_currently_viewed(ws_idx, pane_id) {
+            None
+        } else {
+            Some(AgentPanelMarkItem::MarkAsUnread)
+        }
+    }
+
+    pub(crate) fn is_pane_currently_viewed(&self, ws_idx: usize, pane_id: PaneId) -> bool {
+        let Some(tab_idx) = self
+            .workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.find_tab_index_for_pane(pane_id))
+        else {
+            return false;
+        };
+        self.is_active_pane(ws_idx, tab_idx, pane_id)
     }
 
     fn pane_focus_target_indices(&self, target: &PaneFocusTarget) -> Option<(usize, usize)> {
@@ -1133,6 +1237,100 @@ impl AppState {
             }
         }
         changed
+    }
+
+    pub(crate) fn set_pane_agent_seen(
+        &mut self,
+        ws_idx: usize,
+        pane_id: PaneId,
+        seen: bool,
+    ) -> Result<SeenChange, SeenError> {
+        let (previous_seen, terminal_state) = {
+            let workspace = self.workspaces.get(ws_idx).ok_or(SeenError::PaneNotFound)?;
+            let pane = workspace
+                .pane_state(pane_id)
+                .ok_or(SeenError::PaneNotFound)?;
+            let terminal_id = pane.attached_terminal_id.clone();
+            let previous_seen = pane.seen;
+            let terminal = self
+                .terminals
+                .get(&terminal_id)
+                .ok_or(SeenError::PaneNotFound)?;
+            (previous_seen, terminal.state)
+        };
+
+        if terminal_state != AgentState::Idle {
+            return Err(SeenError::NotIdle);
+        }
+
+        if self.is_pane_currently_viewed(ws_idx, pane_id) {
+            return Ok(SeenChange::Unchanged);
+        }
+
+        if previous_seen == seen {
+            return Ok(SeenChange::Unchanged);
+        }
+
+        let update = self.pane_state_update_for_seen(ws_idx, pane_id, previous_seen, seen)?;
+
+        let pane_found = self.workspaces[ws_idx]
+            .tabs
+            .iter_mut()
+            .find_map(|tab| tab.panes.get_mut(&pane_id));
+        let Some(pane) = pane_found else {
+            return Err(SeenError::PaneNotFound);
+        };
+        pane.seen = seen;
+
+        self.mark_session_dirty();
+
+        if seen
+            && self.toast.as_ref().is_some_and(|toast| {
+                toast
+                    .target
+                    .as_ref()
+                    .is_some_and(|target| target.pane_id == pane_id)
+            })
+        {
+            self.toast = None;
+        }
+
+        Ok(SeenChange::Changed(update))
+    }
+
+    fn pane_state_update_for_seen(
+        &self,
+        ws_idx: usize,
+        pane_id: PaneId,
+        previous_seen: bool,
+        seen: bool,
+    ) -> Result<PaneStateUpdate, SeenError> {
+        let workspace = self.workspaces.get(ws_idx).ok_or(SeenError::PaneNotFound)?;
+        let pane = workspace
+            .pane_state(pane_id)
+            .ok_or(SeenError::PaneNotFound)?;
+        let terminal = self
+            .terminals
+            .get(&pane.attached_terminal_id)
+            .ok_or(SeenError::PaneNotFound)?;
+        let agent_label = terminal.effective_agent_label().map(str::to_string);
+        let known_agent = terminal.effective_known_agent().or(terminal.detected_agent);
+        let presentation = terminal.effective_presentation();
+
+        Ok(PaneStateUpdate {
+            pane_id,
+            ws_idx,
+            previous_agent_label: agent_label.clone(),
+            previous_known_agent: known_agent,
+            previous_state: terminal.state,
+            previous_seen,
+            previous_presentation: presentation.clone(),
+            agent_label,
+            known_agent,
+            state: terminal.state,
+            seen,
+            presentation,
+        })
     }
 
     pub(crate) fn visible_workspace_order(&self) -> Vec<usize> {
@@ -4981,6 +5179,197 @@ mod tests {
         assert_eq!(state.workspaces[0].panes.len(), 1);
         assert!(!state.plugin_panes.contains_key(&closed));
         state.assert_invariants_for_test();
+    }
+
+    #[test]
+    fn set_pane_agent_seen_marks_done_agent_read_without_navigation() {
+        let mut state = app_with_workspaces(&["active", "background"]);
+        state.active = Some(0);
+        state.selected = 0;
+        let bg_pane = *state.workspaces[1].panes.keys().next().unwrap();
+        let bg_terminal_id = state.workspaces[1].panes[&bg_pane]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&bg_terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[1].panes.get_mut(&bg_pane).unwrap().seen = false;
+
+        let change = state
+            .set_pane_agent_seen(1, bg_pane, true)
+            .expect("mark read succeeds");
+
+        assert!(matches!(change, SeenChange::Changed(_)));
+        assert!(state.workspaces[1].panes[&bg_pane].seen);
+        assert_eq!(state.active, Some(0));
+        assert_ne!(
+            state
+                .current_pane_focus_target()
+                .map(|target| target.pane_id),
+            Some(bg_pane),
+        );
+    }
+
+    #[test]
+    fn set_pane_agent_seen_rejects_working_agent() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Working;
+
+        let err = state
+            .set_pane_agent_seen(0, pane_id, true)
+            .expect_err("working agent should fail");
+        assert!(matches!(err, SeenError::NotIdle));
+    }
+
+    #[test]
+    fn agent_panel_mark_item_returns_mark_as_read_for_done_agent() {
+        let mut state = app_with_workspaces(&["active", "background"]);
+        state.active = Some(0);
+        let bg_pane = *state.workspaces[1].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[1].panes[&bg_pane]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[1].panes.get_mut(&bg_pane).unwrap().seen = false;
+
+        assert_eq!(
+            state.agent_panel_mark_item(1, bg_pane, false),
+            Some(crate::app::state::AgentPanelMarkItem::MarkAsRead),
+        );
+    }
+
+    #[test]
+    fn agent_panel_mark_item_returns_mark_as_unread_for_background_idle_seen() {
+        let mut state = app_with_workspaces(&["active", "background"]);
+        state.active = Some(0);
+        let bg_pane = *state.workspaces[1].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[1].panes[&bg_pane]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[1].panes.get_mut(&bg_pane).unwrap().seen = true;
+
+        assert_eq!(
+            state.agent_panel_mark_item(1, bg_pane, true),
+            Some(crate::app::state::AgentPanelMarkItem::MarkAsUnread),
+        );
+    }
+
+    #[test]
+    fn agent_panel_mark_item_returns_none_for_focused_idle_seen() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[0].panes.get_mut(&pane_id).unwrap().seen = true;
+        state.active = Some(0);
+
+        assert_eq!(state.agent_panel_mark_item(0, pane_id, true), None);
+    }
+
+    #[test]
+    fn agent_panel_mark_item_returns_none_for_working_agent() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Working;
+
+        assert_eq!(state.agent_panel_mark_item(0, pane_id, true), None);
+    }
+
+    #[test]
+    fn agent_panel_mark_item_returns_none_for_blocked_agent() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Blocked;
+
+        assert_eq!(state.agent_panel_mark_item(0, pane_id, false), None);
+    }
+
+    #[test]
+    fn agent_panel_mark_item_returns_none_for_unknown_agent() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Unknown;
+
+        assert_eq!(state.agent_panel_mark_item(0, pane_id, false), None);
+    }
+
+    #[test]
+    fn set_pane_agent_seen_noops_for_currently_viewed_pane() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[0].panes.get_mut(&pane_id).unwrap().seen = true;
+        state.active = Some(0);
+        state.selected = 0;
+
+        let change = state
+            .set_pane_agent_seen(0, pane_id, false)
+            .expect("currently viewed pane should no-op mark unread");
+        assert!(matches!(change, SeenChange::Unchanged));
+        assert!(state.workspaces[0].panes[&pane_id].seen);
+    }
+
+    #[test]
+    fn set_pane_agent_seen_is_idempotent() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[0].panes.get_mut(&pane_id).unwrap().seen = true;
+
+        let change = state
+            .set_pane_agent_seen(0, pane_id, true)
+            .expect("idempotent mark read");
+        assert!(matches!(change, SeenChange::Unchanged));
+    }
+
+    #[test]
+    fn set_pane_agent_seen_clears_toast_targeting_pane() {
+        let mut state = app_with_workspaces(&["active", "background"]);
+        state.active = Some(0);
+        state.selected = 0;
+        let bg_pane = *state.workspaces[1].panes.keys().next().unwrap();
+        let bg_terminal_id = state.workspaces[1].panes[&bg_pane]
+            .attached_terminal_id
+            .clone();
+        state.terminals.get_mut(&bg_terminal_id).unwrap().state = AgentState::Idle;
+        state.workspaces[1].panes.get_mut(&bg_pane).unwrap().seen = false;
+        let workspace_id = state.workspaces[1].id.clone();
+        state.toast = Some(ToastNotification {
+            kind: ToastKind::Finished,
+            title: "reviewer finished".into(),
+            context: "background".into(),
+            position: None,
+            target: Some(ToastTarget {
+                workspace_id,
+                pane_id: bg_pane,
+            }),
+        });
+
+        let change = state
+            .set_pane_agent_seen(1, bg_pane, true)
+            .expect("mark read succeeds");
+        assert!(matches!(change, SeenChange::Changed(_)));
+        assert!(state.toast.is_none());
     }
 
     #[test]

--- a/src/app/agents.rs
+++ b/src/app/agents.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use super::{terminal_targets::TerminalTargetError, App, Mode};
-use crate::api::schema::{AgentStartParams, SplitDirection};
+use crate::api::schema::{AgentInfo, AgentStartParams, SplitDirection};
+use crate::app::actions::{SeenChange, SeenError};
 
 impl App {
     pub(super) fn collect_agent_infos(&self) -> Vec<crate::api::schema::AgentInfo> {
@@ -28,6 +29,57 @@ impl App {
         self.agent_info(resolved.ws_idx, resolved.pane_id)
             .ok_or_else(|| TerminalTargetError::NotFound {
                 target: target.to_string(),
+            })
+    }
+
+    pub(super) fn mark_agent_read_target(
+        &mut self,
+        target: &str,
+    ) -> Result<AgentInfo, AgentSeenError> {
+        self.mark_agent_seen_target(target, true)
+    }
+
+    pub(super) fn mark_agent_unread_target(
+        &mut self,
+        target: &str,
+    ) -> Result<AgentInfo, AgentSeenError> {
+        self.mark_agent_seen_target(target, false)
+    }
+
+    fn mark_agent_seen_target(
+        &mut self,
+        target: &str,
+        seen: bool,
+    ) -> Result<AgentInfo, AgentSeenError> {
+        let resolved = self
+            .resolve_terminal_target(target)
+            .map_err(AgentSeenError::Target)?;
+        if !self
+            .state
+            .is_pane_agent_terminal(resolved.ws_idx, resolved.pane_id)
+        {
+            return Err(AgentSeenError::Target(TerminalTargetError::NotFound {
+                target: target.to_string(),
+            }));
+        }
+        match self
+            .state
+            .set_pane_agent_seen(resolved.ws_idx, resolved.pane_id, seen)
+        {
+            Ok(SeenChange::Changed(update)) => self.emit_pane_state_update(&update),
+            Ok(SeenChange::Unchanged) => {}
+            Err(SeenError::NotIdle) => return Err(AgentSeenError::NotIdle),
+            Err(SeenError::PaneNotFound) => {
+                return Err(AgentSeenError::Target(TerminalTargetError::NotFound {
+                    target: target.to_string(),
+                }));
+            }
+        }
+        self.agent_info(resolved.ws_idx, resolved.pane_id)
+            .ok_or_else(|| {
+                AgentSeenError::Target(TerminalTargetError::NotFound {
+                    target: target.to_string(),
+                })
             })
     }
 
@@ -284,6 +336,19 @@ impl App {
         }
     }
 
+    pub(super) fn agent_seen_error_body(
+        &self,
+        err: AgentSeenError,
+    ) -> crate::api::schema::ErrorBody {
+        match err {
+            AgentSeenError::Target(err) => self.agent_target_error_body(err),
+            AgentSeenError::NotIdle => crate::api::schema::ErrorBody {
+                code: "agent_not_idle".into(),
+                message: "mark read/unread is only allowed when the agent is done or idle".into(),
+            },
+        }
+    }
+
     pub(super) fn agent_rename_error_body(
         &self,
         err: AgentRenameError,
@@ -471,4 +536,9 @@ pub(super) enum AgentRenameError {
         name: String,
         candidates: Vec<crate::api::schema::AgentInfo>,
     },
+}
+
+pub(super) enum AgentSeenError {
+    Target(TerminalTargetError),
+    NotIdle,
 }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -793,6 +793,12 @@ impl App {
             Method::AgentList(_) => return self.handle_agent_list(request.id),
             Method::AgentGet(target) => return self.handle_agent_get(request.id, target),
             Method::AgentFocus(target) => return self.handle_agent_focus(request.id, target),
+            Method::AgentMarkRead(target) => {
+                return self.handle_agent_mark_read(request.id, target)
+            }
+            Method::AgentMarkUnread(target) => {
+                return self.handle_agent_mark_unread(request.id, target);
+            }
             Method::AgentRename(params) => return self.handle_agent_rename(request.id, params),
             Method::AgentStart(params) => return self.handle_agent_start(request.id, params),
             Method::AgentRead(params) => return self.handle_agent_read(request.id, params),

--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -36,6 +36,24 @@ impl App {
         encode_success(id, ResponseResult::AgentInfo { agent })
     }
 
+    pub(super) fn handle_agent_mark_read(&mut self, id: String, target: AgentTarget) -> String {
+        let agent = match self.mark_agent_read_target(&target.target) {
+            Ok(agent) => agent,
+            Err(err) => return encode_error_body(id, self.agent_seen_error_body(err)),
+        };
+
+        encode_success(id, ResponseResult::AgentInfo { agent })
+    }
+
+    pub(super) fn handle_agent_mark_unread(&mut self, id: String, target: AgentTarget) -> String {
+        let agent = match self.mark_agent_unread_target(&target.target) {
+            Ok(agent) => agent,
+            Err(err) => return encode_error_body(id, self.agent_seen_error_body(err)),
+        };
+
+        encode_success(id, ResponseResult::AgentInfo { agent })
+    }
+
     pub(super) fn handle_agent_rename(&mut self, id: String, params: AgentRenameParams) -> String {
         let agent = match self.rename_agent_target(&params.target, params.name) {
             Ok(agent) => agent,
@@ -201,4 +219,256 @@ fn agent_not_found(id: String, target: &str) -> String {
         "agent_not_found",
         format!("agent target {target} not found"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        api::schema::{AgentStatus, ErrorResponse, ResponseResult, SuccessResponse},
+        config::Config,
+        detect::{Agent, AgentState},
+        workspace::Workspace,
+    };
+
+    fn test_app() -> App {
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        App::new(
+            &Config::default(),
+            true,
+            None,
+            api_rx,
+            crate::api::EventHub::default(),
+        )
+    }
+
+    fn app_with_named_agent(
+        name: &str,
+        seen: bool,
+        state: AgentState,
+    ) -> (App, String, crate::layout::PaneId) {
+        let mut app = test_app();
+        let mut active = Workspace::test_new("active");
+        let active_root = active.tabs[0].root_pane;
+        let _active_second = active.test_split(ratatui::layout::Direction::Horizontal);
+        active.tabs[0].layout.focus_pane(active_root);
+        let background = Workspace::test_new("background");
+        app.state.workspaces = vec![active, background];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+
+        let bg_pane = app.state.workspaces[1].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[1]
+            .pane_state(bg_pane)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+        {
+            let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+            terminal.set_agent_name(name.into());
+            terminal.set_detected_state(Some(Agent::Pi), state);
+        }
+        app.state.workspaces[1]
+            .panes
+            .get_mut(&bg_pane)
+            .unwrap()
+            .seen = seen;
+
+        (app, name.to_string(), bg_pane)
+    }
+
+    #[test]
+    fn api_agent_mark_read_on_done_agent_returns_idle_without_navigation() {
+        let (mut app, target, bg_pane) = app_with_named_agent("reviewer", false, AgentState::Idle);
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "req");
+        let ResponseResult::AgentInfo { agent } = success.result else {
+            panic!("expected agent info response");
+        };
+        assert_eq!(agent.agent_status, AgentStatus::Idle);
+        assert_eq!(app.state.active, Some(0));
+        assert_ne!(
+            app.state
+                .current_pane_focus_target()
+                .map(|target| target.pane_id),
+            Some(bg_pane),
+        );
+        assert!(app.state.workspaces[1].panes[&bg_pane].seen);
+    }
+
+    #[test]
+    fn api_agent_mark_read_on_working_agent_returns_agent_not_idle() {
+        let (mut app, target, _) = app_with_named_agent("worker", false, AgentState::Working);
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let error: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(error.id, "req");
+        assert_eq!(error.error.code, "agent_not_idle");
+    }
+
+    #[test]
+    fn api_agent_mark_unread_on_idle_seen_agent_returns_done() {
+        let (mut app, target, bg_pane) = app_with_named_agent("reviewer", true, AgentState::Idle);
+
+        let response = app.handle_agent_mark_unread(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "req");
+        let ResponseResult::AgentInfo { agent } = success.result else {
+            panic!("expected agent info response");
+        };
+        assert_eq!(agent.agent_status, AgentStatus::Done);
+        assert!(!app.state.workspaces[1].panes[&bg_pane].seen);
+    }
+
+    #[test]
+    fn api_agent_mark_read_on_currently_viewed_agent_is_noop() {
+        let (mut app, target, pane_id) = app_with_named_agent("reviewer", false, AgentState::Idle);
+        app.state.active = Some(1);
+        app.state.selected = 1;
+        app.state.workspaces[1].tabs[0].layout.focus_pane(pane_id);
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "req");
+        let ResponseResult::AgentInfo { agent } = success.result else {
+            panic!("expected agent info response");
+        };
+        assert_eq!(agent.agent_status, AgentStatus::Done);
+        assert!(!app.state.workspaces[1].panes[&pane_id].seen);
+    }
+
+    #[test]
+    fn api_agent_mark_unread_on_currently_viewed_agent_is_noop() {
+        let (mut app, target, pane_id) = app_with_named_agent("reviewer", true, AgentState::Idle);
+        app.state.active = Some(1);
+        app.state.selected = 1;
+        app.state.workspaces[1].tabs[0].layout.focus_pane(pane_id);
+
+        let response = app.handle_agent_mark_unread(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "req");
+        let ResponseResult::AgentInfo { agent } = success.result else {
+            panic!("expected agent info response");
+        };
+        assert_eq!(agent.agent_status, AgentStatus::Idle);
+        assert!(app.state.workspaces[1].panes[&pane_id].seen);
+    }
+
+    #[test]
+    fn api_agent_mark_read_is_idempotent_when_already_seen() {
+        let (mut app, target, bg_pane) = app_with_named_agent("reviewer", true, AgentState::Idle);
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "req");
+        let ResponseResult::AgentInfo { agent } = success.result else {
+            panic!("expected agent info response");
+        };
+        assert_eq!(agent.agent_status, AgentStatus::Idle);
+        assert!(app.state.workspaces[1].panes[&bg_pane].seen);
+    }
+
+    #[test]
+    fn api_agent_mark_read_on_unknown_target_returns_agent_not_found() {
+        let mut app = test_app();
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: "missing-agent".into(),
+            },
+        );
+
+        let error: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(error.id, "req");
+        assert_eq!(error.error.code, "agent_not_found");
+    }
+
+    #[test]
+    fn api_agent_mark_read_on_blocked_agent_returns_agent_not_idle() {
+        let (mut app, target, _) = app_with_named_agent("blocked", false, AgentState::Blocked);
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: target.clone(),
+            },
+        );
+
+        let error: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(error.id, "req");
+        assert_eq!(error.error.code, "agent_not_idle");
+    }
+
+    #[test]
+    fn api_agent_mark_read_on_non_agent_pane_returns_agent_not_found_without_mutation() {
+        let mut app = test_app();
+        let background = Workspace::test_new("background");
+        app.state.workspaces = vec![background];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        app.state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        app.state.workspaces[0]
+            .panes
+            .get_mut(&pane_id)
+            .unwrap()
+            .seen = false;
+
+        let response = app.handle_agent_mark_read(
+            "req".into(),
+            AgentTarget {
+                target: terminal_id.to_string(),
+            },
+        );
+
+        let error: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(error.id, "req");
+        assert_eq!(error.error.code, "agent_not_found");
+        assert!(!app.state.workspaces[0].panes[&pane_id].seen);
+    }
 }

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -99,6 +99,7 @@ impl App {
                         &mut self.terminal_runtimes,
                         key_event,
                     );
+                    self.emit_pending_pane_state_updates();
                 }
                 Mode::Settings => self.handle_settings_key(key_event),
                 Mode::GlobalMenu => handle_global_menu_key(&mut self.state, key_event),
@@ -307,6 +308,14 @@ impl App {
         } else if self.selection_autoscroll_deadline.is_none() {
             self.selection_autoscroll_deadline =
                 Some(std::time::Instant::now() + super::SELECTION_AUTOSCROLL_INTERVAL);
+        }
+
+        self.emit_pending_pane_state_updates();
+    }
+
+    fn emit_pending_pane_state_updates(&mut self) {
+        for update in self.state.take_pending_pane_state_updates() {
+            self.emit_pane_state_update(&update);
         }
     }
 

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -3,7 +3,8 @@ use ratatui::layout::{Direction, Rect};
 
 use crate::{
     app::state::{
-        AppState, ContextMenuKind, ContextMenuState, MenuListState, Mode, NavigatorStateFilter,
+        AgentPanelMarkItem, AppState, ContextMenuKind, ContextMenuState, MenuListState, Mode,
+        NavigatorStateFilter, ToastKind, ToastNotification,
     },
     input::TerminalKey,
     layout::NavDirection,
@@ -376,6 +377,61 @@ pub(super) fn leave_modal(state: &mut AppState) {
     }
 }
 
+fn agent_panel_seen_toast(state: &mut AppState, title: &str, context: &str) {
+    state.toast = Some(ToastNotification {
+        kind: ToastKind::NeedsAttention,
+        title: title.to_string(),
+        context: context.to_string(),
+        position: None,
+        target: None,
+    });
+}
+
+fn apply_agent_panel_seen_change(
+    state: &mut AppState,
+    ws_idx: usize,
+    pane_id: crate::layout::PaneId,
+    seen: bool,
+) {
+    let expected_mark_item = if seen {
+        AgentPanelMarkItem::MarkAsRead
+    } else {
+        AgentPanelMarkItem::MarkAsUnread
+    };
+    let mark_allowed = state
+        .workspaces
+        .get(ws_idx)
+        .and_then(|ws| ws.pane_state(pane_id))
+        .and_then(|pane| {
+            state
+                .agent_panel_mark_item(ws_idx, pane_id, pane.seen)
+                .filter(|item| *item == expected_mark_item)
+        });
+    if mark_allowed.is_none() {
+        agent_panel_seen_toast(
+            state,
+            "cannot update read state",
+            "agent is no longer idle or already matches that state",
+        );
+        leave_modal(state);
+        return;
+    }
+
+    match state.set_pane_agent_seen(ws_idx, pane_id, seen) {
+        Ok(crate::app::actions::SeenChange::Changed(update)) => {
+            state.queue_pane_state_update(update);
+        }
+        Ok(crate::app::actions::SeenChange::Unchanged) => {}
+        Err(crate::app::actions::SeenError::NotIdle) => {
+            agent_panel_seen_toast(state, "cannot update read state", "agent is still working");
+        }
+        Err(crate::app::actions::SeenError::PaneNotFound) => {
+            agent_panel_seen_toast(state, "cannot update read state", "agent pane not found");
+        }
+    }
+    leave_modal(state);
+}
+
 pub(super) const ONBOARDING_WELCOME_ACTIONS: &[ModalActionSpec<ModalAction>] = &[ModalActionSpec {
     action: ModalAction::Continue,
     bindings: &[ModalKeyBinding::Enter],
@@ -664,6 +720,25 @@ pub(crate) fn handle_confirm_close_key(state: &mut AppState, key: KeyEvent) {
     }
 }
 
+fn close_pane_from_context(
+    state: &mut AppState,
+    ws_idx: usize,
+    tab_idx: usize,
+    pane_id: crate::layout::PaneId,
+) {
+    state.selected = ws_idx;
+    state.active = Some(ws_idx);
+    state.switch_tab(tab_idx);
+    state.focus_pane_in_workspace(ws_idx, pane_id);
+    if !state.close_pane() {
+        state.mode = if state.active.is_some() {
+            Mode::Terminal
+        } else {
+            Mode::Navigate
+        };
+    }
+}
+
 pub(super) fn apply_context_menu_action(
     state: &mut AppState,
     terminal_runtimes: &mut crate::terminal::TerminalRuntimeRegistry,
@@ -851,17 +926,34 @@ pub(super) fn apply_context_menu_action(
             },
             Some("Close pane"),
         ) => {
-            state.selected = ws_idx;
-            state.active = Some(ws_idx);
-            state.switch_tab(tab_idx);
-            state.focus_pane_in_workspace(ws_idx, pane_id);
-            if !state.close_pane() {
-                state.mode = if state.active.is_some() {
-                    Mode::Terminal
-                } else {
-                    Mode::Navigate
-                };
-            }
+            close_pane_from_context(state, ws_idx, tab_idx, pane_id);
+        }
+        (
+            ContextMenuKind::AgentPanel {
+                ws_idx, pane_id, ..
+            },
+            Some("Mark as read"),
+        ) => {
+            apply_agent_panel_seen_change(state, ws_idx, pane_id, true);
+        }
+        (
+            ContextMenuKind::AgentPanel {
+                ws_idx, pane_id, ..
+            },
+            Some("Mark as unread"),
+        ) => {
+            apply_agent_panel_seen_change(state, ws_idx, pane_id, false);
+        }
+        (
+            ContextMenuKind::AgentPanel {
+                ws_idx,
+                tab_idx,
+                pane_id,
+                ..
+            },
+            Some("Close"),
+        ) => {
+            close_pane_from_context(state, ws_idx, tab_idx, pane_id);
         }
         _ => leave_modal(state),
     }

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -5,9 +5,8 @@ use tracing::warn;
 
 use crate::{
     app::state::{
-        AgentPanelScope, AppState, ContextMenuKind, ContextMenuState, DragState, DragTarget,
-        MenuListState, Mode, RightClickPassthroughGesture, TabPressState, ViewLayout,
-        WorkspacePressState,
+        AgentPanelScope, AppState, ContextMenuKind, ContextMenuState, DragState, DragTarget, Mode,
+        RightClickPassthroughGesture, TabPressState, ViewLayout, WorkspacePressState,
     },
     layout::{PaneInfo, SplitBorder},
     selection::Selection,
@@ -364,7 +363,17 @@ impl AppState {
                 }
 
                 if self.mode == Mode::ContextMenu {
-                    let item_idx = self.context_menu_item_at(mouse.column, mouse.row);
+                    let item_idx =
+                        self.context_menu_item_at(mouse.column, mouse.row)
+                            .or_else(|| {
+                                let menu = self.context_menu.as_ref()?;
+                                let rect = self.context_menu_rect()?;
+                                let inside = mouse.column >= rect.x
+                                    && mouse.column < rect.x + rect.width
+                                    && mouse.row >= rect.y
+                                    && mouse.row < rect.y + rect.height;
+                                inside.then_some(menu.list.highlighted)
+                            });
                     if let Some(menu) = self.context_menu.take() {
                         if let Some(idx) = item_idx {
                             apply_context_menu_action(self, terminal_runtimes, menu, idx);
@@ -884,6 +893,7 @@ impl AppState {
             }
 
             MouseEventKind::Moved if self.mode == Mode::ContextMenu => {
+                self.refresh_agent_panel_context_menu();
                 let hovered = self.context_menu_item_at(mouse.column, mouse.row);
                 if let Some(menu) = &mut self.context_menu {
                     menu.list.hover(hovered);
@@ -896,13 +906,29 @@ impl AppState {
                 }
             }
 
-            MouseEventKind::Down(MouseButton::Right) if in_sidebar && !self.sidebar_collapsed => {
+            MouseEventKind::Down(MouseButton::Right) if in_sidebar => {
                 self.workspace_press = None;
                 self.tab_press = None;
-                if self
-                    .workspace_list_scrollbar_target_at(mouse.column, mouse.row)
-                    .is_some()
+                if !self.sidebar_collapsed
+                    && self
+                        .workspace_list_scrollbar_target_at(mouse.column, mouse.row)
+                        .is_some()
                 {
+                    return None;
+                }
+                if let Some((ws_idx, tab_idx, pane_id)) = self.agent_panel_target_at(mouse.row) {
+                    if self.open_agent_panel_context_menu(
+                        ws_idx,
+                        tab_idx,
+                        pane_id,
+                        mouse.column,
+                        mouse.row,
+                    ) {
+                        self.mode = Mode::ContextMenu;
+                        return None;
+                    }
+                }
+                if self.sidebar_collapsed {
                     return None;
                 }
                 if let Some(idx) = self.workspace_at_row(mouse.row) {
@@ -939,12 +965,8 @@ impl AppState {
                             })
                         })
                         .unwrap_or(ContextMenuKind::Workspace { ws_idx: idx });
-                    self.context_menu = Some(ContextMenuState {
-                        kind,
-                        x: mouse.column,
-                        y: mouse.row,
-                        list: MenuListState::new(0),
-                    });
+                    self.context_menu =
+                        Some(ContextMenuState::at_cursor(kind, mouse.column, mouse.row));
                     self.mode = Mode::ContextMenu;
                 }
             }
@@ -955,12 +977,11 @@ impl AppState {
                 if let (Some(ws_idx), Some(tab_idx)) =
                     (self.active, self.tab_at(mouse.column, mouse.row))
                 {
-                    self.context_menu = Some(ContextMenuState {
-                        kind: ContextMenuKind::Tab { ws_idx, tab_idx },
-                        x: mouse.column,
-                        y: mouse.row,
-                        list: MenuListState::new(0),
-                    });
+                    self.context_menu = Some(ContextMenuState::at_cursor(
+                        ContextMenuKind::Tab { ws_idx, tab_idx },
+                        mouse.column,
+                        mouse.row,
+                    ));
                     self.mode = Mode::ContextMenu;
                 }
             }
@@ -985,18 +1006,17 @@ impl AppState {
                         .and_then(|pane| self.terminals.get(&pane.attached_terminal_id))
                         .and_then(|terminal| terminal.manual_label.as_ref())
                         .is_some();
-                    self.context_menu = Some(ContextMenuState {
-                        kind: ContextMenuKind::Pane {
+                    self.context_menu = Some(ContextMenuState::at_cursor(
+                        ContextMenuKind::Pane {
                             ws_idx,
                             tab_idx,
                             pane_id: info.id,
                             source_pane_id,
                             has_manual_label,
                         },
-                        x: mouse.column,
-                        y: mouse.row,
-                        list: MenuListState::new(0),
-                    });
+                        mouse.column,
+                        mouse.row,
+                    ));
                     self.mode = Mode::ContextMenu;
                 }
             }

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -449,6 +449,46 @@ impl AppState {
             && row < rect.y + rect.height
     }
 
+    pub(super) fn agent_panel_target_at(
+        &self,
+        row: u16,
+    ) -> Option<(usize, usize, crate::layout::PaneId)> {
+        if self.sidebar_collapsed {
+            self.collapsed_agent_detail_target_at(row)
+        } else {
+            self.agent_detail_target_at(row)
+        }
+    }
+
+    pub(super) fn open_agent_panel_context_menu(
+        &mut self,
+        ws_idx: usize,
+        tab_idx: usize,
+        pane_id: crate::layout::PaneId,
+        x: u16,
+        y: u16,
+    ) -> bool {
+        let Some(pane) = self
+            .workspaces
+            .get(ws_idx)
+            .and_then(|ws| ws.pane_state(pane_id))
+        else {
+            return false;
+        };
+        let mark_item = self.agent_panel_mark_item(ws_idx, pane_id, pane.seen);
+        self.context_menu = Some(crate::app::state::ContextMenuState::at_agent_panel_cursor(
+            crate::app::state::ContextMenuKind::AgentPanel {
+                ws_idx,
+                tab_idx,
+                pane_id,
+                mark_item,
+            },
+            x,
+            y,
+        ));
+        true
+    }
+
     pub(super) fn agent_detail_target_at(
         &self,
         row: u16,
@@ -496,8 +536,8 @@ mod tests {
 
     use super::super::{app_for_mouse_test, capture_snapshot, mouse, unique_temp_path};
     use crate::{
-        app::state::{AgentPanelScope, DragTarget, Mode},
-        detect::Agent,
+        app::state::{AgentPanelMarkItem, AgentPanelScope, ContextMenuKind, DragTarget, Mode},
+        detect::{Agent, AgentState},
         workspace::Workspace,
     };
 
@@ -958,6 +998,155 @@ mod tests {
             second_pane
         );
         assert_eq!(app.state.mode, Mode::Terminal);
+    }
+
+    #[test]
+    fn right_click_collapsed_agent_row_opens_mark_as_read_menu() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        let first_terminal_id = app.state.workspaces[0].tabs[0].panes[&first_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&first_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Pi);
+        let second_terminal_id = app.state.workspaces[1].tabs[0].panes[&second_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .state = AgentState::Idle;
+        app.state.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&second_pane)
+            .unwrap()
+            .seen = false;
+        app.state.active = Some(1);
+        app.state.selected = 1;
+        app.state.mode = Mode::Terminal;
+        app.state.sidebar_collapsed = true;
+        app.state.view.sidebar_rect = Rect::new(0, 0, 4, 20);
+        app.state.view.terminal_area = Rect::new(4, 0, 80, 20);
+
+        let (_, _, detail_area) =
+            crate::ui::collapsed_sidebar_sections(app.state.view.sidebar_rect);
+        let detail_content_y = detail_area.y;
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x,
+            detail_content_y,
+        ));
+
+        assert_eq!(app.state.mode, Mode::ContextMenu);
+        let menu = app
+            .state
+            .context_menu
+            .as_ref()
+            .expect("collapsed agent panel context menu");
+        assert!(matches!(
+            menu.kind,
+            ContextMenuKind::AgentPanel {
+                ws_idx: 1,
+                tab_idx: 0,
+                pane_id,
+                mark_item: Some(AgentPanelMarkItem::MarkAsRead),
+            } if pane_id == second_pane
+        ));
+    }
+
+    #[test]
+    fn right_click_agent_mark_as_read_shows_toast_when_agent_is_working() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        let first_terminal_id = app.state.workspaces[0].tabs[0].panes[&first_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&first_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Pi);
+        let second_terminal_id = app.state.workspaces[1].tabs[0].panes[&second_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .state = AgentState::Working;
+        app.state.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&second_pane)
+            .unwrap()
+            .seen = false;
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 1, second_pane);
+        let detail_area = app.state.agent_panel_rect();
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x + 2,
+            row,
+        ));
+
+        app.state.context_menu = Some(crate::app::state::ContextMenuState::at_agent_panel_cursor(
+            ContextMenuKind::AgentPanel {
+                ws_idx: 1,
+                tab_idx: 0,
+                pane_id: second_pane,
+                mark_item: Some(AgentPanelMarkItem::MarkAsRead),
+            },
+            detail_area.x + 2,
+            row,
+        ));
+        app.state.mode = Mode::ContextMenu;
+
+        let menu_rect = app.state.context_menu_rect().expect("context menu rect");
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            menu_rect.x + 2,
+            menu_rect.y,
+        ));
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        let toast = app.state.toast.as_ref().expect("working-agent toast");
+        assert_eq!(toast.title, "cannot update read state");
+        assert_eq!(
+            toast.context,
+            "agent is no longer idle or already matches that state"
+        );
+        assert!(!app.state.workspaces[1].tabs[0].panes[&second_pane].seen);
     }
 
     #[test]
@@ -1567,5 +1756,439 @@ mod tests {
         assert!(app.state.drag.is_none());
         let snapshot = capture_snapshot(&app.state);
         assert_eq!(snapshot.sidebar_width, Some(26));
+    }
+
+    fn agent_panel_entry_row(
+        app: &crate::app::input::App,
+        ws_idx: usize,
+        pane_id: crate::layout::PaneId,
+    ) -> u16 {
+        let detail_area = app.state.agent_panel_rect();
+        let metrics = crate::ui::agent_panel_scroll_metrics(&app.state, detail_area);
+        let body = crate::ui::agent_panel_body_rect(
+            detail_area,
+            crate::ui::should_show_scrollbar(metrics),
+        );
+        let mut row_y = body.y;
+        for detail in crate::ui::agent_panel_entries(&app.state)
+            .into_iter()
+            .skip(app.state.agent_panel_scroll)
+        {
+            if detail.ws_idx == ws_idx && detail.pane_id == pane_id {
+                return row_y;
+            }
+            row_y = row_y.saturating_add(2);
+            if row_y < body.y + body.height {
+                row_y = row_y.saturating_add(1);
+            }
+        }
+        panic!("agent panel entry not found for workspace {ws_idx} pane {pane_id:?}");
+    }
+
+    #[test]
+    fn right_click_done_agent_opens_mark_as_read_menu_without_navigation() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        let first_terminal_id = app.state.workspaces[0].tabs[0].panes[&first_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&first_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Pi);
+        let second_terminal_id = app.state.workspaces[1].tabs[0].panes[&second_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .state = AgentState::Idle;
+        app.state.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&second_pane)
+            .unwrap()
+            .seen = false;
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 1, second_pane);
+        let detail_area = app.state.agent_panel_rect();
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x + 2,
+            row,
+        ));
+
+        assert_eq!(app.state.mode, Mode::ContextMenu);
+        let menu = app
+            .state
+            .context_menu
+            .as_ref()
+            .expect("agent panel context menu");
+        assert!(matches!(
+            menu.kind,
+            ContextMenuKind::AgentPanel {
+                ws_idx: 1,
+                tab_idx: 0,
+                pane_id,
+                mark_item: Some(AgentPanelMarkItem::MarkAsRead),
+            } if pane_id == second_pane
+        ));
+        assert_eq!(menu.items(), &["Mark as read", "Close"]);
+
+        let menu_rect = app.state.context_menu_rect().expect("context menu rect");
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            menu_rect.x + 2,
+            menu_rect.y + 1,
+        ));
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert_eq!(app.state.active, Some(0));
+        assert_eq!(app.state.selected, 0);
+        assert!(app.state.workspaces[1].tabs[0].panes[&second_pane].seen);
+    }
+
+    #[test]
+    fn right_click_done_agent_mark_as_read_works_without_mouse_move() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        let first_terminal_id = app.state.workspaces[0].tabs[0].panes[&first_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&first_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Pi);
+        let second_terminal_id = app.state.workspaces[1].tabs[0].panes[&second_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .state = AgentState::Idle;
+        app.state.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&second_pane)
+            .unwrap()
+            .seen = false;
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 1, second_pane);
+        let detail_area = app.state.agent_panel_rect();
+        let click_col = detail_area.x + 2;
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            click_col,
+            row,
+        ));
+
+        assert_eq!(app.state.mode, Mode::ContextMenu);
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            click_col,
+            row,
+        ));
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert_eq!(app.state.active, Some(0));
+        assert_eq!(app.state.selected, 0);
+        assert!(app.state.workspaces[1].tabs[0].panes[&second_pane].seen);
+    }
+
+    #[test]
+    fn right_click_idle_seen_agent_opens_mark_as_unread_menu_without_navigation() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        let first_terminal_id = app.state.workspaces[0].tabs[0].panes[&first_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&first_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Pi);
+        let second_terminal_id = app.state.workspaces[1].tabs[0].panes[&second_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .state = AgentState::Idle;
+        app.state.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&second_pane)
+            .unwrap()
+            .seen = true;
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 1, second_pane);
+        let detail_area = app.state.agent_panel_rect();
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x + 2,
+            row,
+        ));
+
+        assert_eq!(app.state.mode, Mode::ContextMenu);
+        let menu = app
+            .state
+            .context_menu
+            .as_ref()
+            .expect("agent panel context menu");
+        assert!(matches!(
+            menu.kind,
+            ContextMenuKind::AgentPanel {
+                ws_idx: 1,
+                tab_idx: 0,
+                pane_id,
+                mark_item: Some(AgentPanelMarkItem::MarkAsUnread),
+            } if pane_id == second_pane
+        ));
+        assert_eq!(menu.items(), &["Mark as unread", "Close"]);
+
+        let menu_rect = app.state.context_menu_rect().expect("context menu rect");
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            menu_rect.x + 2,
+            menu_rect.y + 1,
+        ));
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert_eq!(app.state.active, Some(0));
+        assert_eq!(app.state.selected, 0);
+        assert!(!app.state.workspaces[1].tabs[0].panes[&second_pane].seen);
+    }
+
+    #[test]
+    fn right_click_working_agent_opens_close_only_menu() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        let first_terminal_id = app.state.workspaces[0].tabs[0].panes[&first_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&first_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Pi);
+        let second_terminal_id = app.state.workspaces[1].tabs[0].panes[&second_pane]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state
+            .terminals
+            .get_mut(&second_terminal_id)
+            .unwrap()
+            .state = AgentState::Working;
+        app.state.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&second_pane)
+            .unwrap()
+            .seen = true;
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 1, second_pane);
+        let detail_area = app.state.agent_panel_rect();
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x + 2,
+            row,
+        ));
+
+        assert_eq!(app.state.mode, Mode::ContextMenu);
+        let menu = app
+            .state
+            .context_menu
+            .as_ref()
+            .expect("agent panel context menu");
+        assert!(matches!(
+            menu.kind,
+            ContextMenuKind::AgentPanel {
+                ws_idx: 1,
+                tab_idx: 0,
+                pane_id,
+                mark_item: None,
+            } if pane_id == second_pane
+        ));
+        assert_eq!(menu.items(), &["Close"]);
+        assert!(app.state.workspaces[1].tabs[0].panes[&second_pane].seen);
+    }
+
+    #[test]
+    fn right_click_focused_idle_agent_opens_close_only_menu() {
+        let mut app = app_for_mouse_test();
+        let workspace = Workspace::test_new("one");
+        let pane_id = workspace.tabs[0].root_pane;
+
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        let terminal_id = app.state.workspaces[0].tabs[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        app.state
+            .terminals
+            .get_mut(&terminal_id)
+            .unwrap()
+            .detected_agent = Some(Agent::Claude);
+        app.state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Idle;
+        app.state.workspaces[0].tabs[0]
+            .panes
+            .get_mut(&pane_id)
+            .unwrap()
+            .seen = true;
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::CurrentWorkspace;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 0, pane_id);
+        let detail_area = app.state.agent_panel_rect();
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x + 2,
+            row,
+        ));
+
+        assert_eq!(app.state.mode, Mode::ContextMenu);
+        let menu = app
+            .state
+            .context_menu
+            .as_ref()
+            .expect("agent panel context menu");
+        assert_eq!(menu.items(), &["Close"]);
+        assert!(matches!(
+            menu.kind,
+            ContextMenuKind::AgentPanel {
+                ws_idx: 0,
+                pane_id: matched_pane,
+                mark_item: None,
+                ..
+            } if matched_pane == pane_id
+        ));
+        assert!(app.state.workspaces[0].tabs[0].panes[&pane_id].seen);
+    }
+
+    #[test]
+    fn right_click_agent_close_navigates_and_closes_pane() {
+        let mut app = app_for_mouse_test();
+        let first = Workspace::test_new("one");
+        let first_pane = first.tabs[0].root_pane;
+        let second = Workspace::test_new("two");
+        let second_pane = second.tabs[0].root_pane;
+
+        app.state.workspaces = vec![first, second];
+        app.state.ensure_test_terminals();
+        for (ws_idx, pane) in [(0, first_pane), (1, second_pane)] {
+            let terminal_id = app.state.workspaces[ws_idx].tabs[0].panes[&pane]
+                .attached_terminal_id
+                .clone();
+            app.state
+                .terminals
+                .get_mut(&terminal_id)
+                .unwrap()
+                .detected_agent = Some(Agent::Claude);
+            app.state.terminals.get_mut(&terminal_id).unwrap().state = AgentState::Working;
+        }
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.agent_panel_scope = AgentPanelScope::AllWorkspaces;
+
+        crate::ui::compute_view(&mut app.state, ratatui::layout::Rect::new(0, 0, 106, 20));
+
+        let row = agent_panel_entry_row(&app, 1, second_pane);
+        let detail_area = app.state.agent_panel_rect();
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            detail_area.x + 2,
+            row,
+        ));
+
+        let menu_rect = app.state.context_menu_rect().expect("context menu rect");
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            menu_rect.x + 2,
+            menu_rect.y + 1,
+        ));
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert_eq!(app.state.workspaces.len(), 1);
+        assert_eq!(app.state.active, Some(0));
+        assert_eq!(app.state.selected, 0);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -572,6 +572,7 @@ impl App {
             host_terminal_theme: crate::terminal_theme::TerminalTheme::default(),
             session_dirty: false,
             terminal_runtime_shutdowns: Vec::new(),
+            pending_pane_state_updates: Vec::new(),
         };
 
         state.terminals = restored_terminals;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1045,6 +1045,12 @@ pub(crate) struct TabPressState {
     pub start_row: u16,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentPanelMarkItem {
+    MarkAsRead,
+    MarkAsUnread,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContextMenuKind {
     Workspace {
@@ -1067,6 +1073,12 @@ pub enum ContextMenuKind {
         source_pane_id: Option<PaneId>,
         has_manual_label: bool,
     },
+    AgentPanel {
+        ws_idx: usize,
+        tab_idx: usize,
+        pane_id: PaneId,
+        mark_item: Option<AgentPanelMarkItem>,
+    },
 }
 
 /// Right-click context menu state.
@@ -1078,6 +1090,24 @@ pub struct ContextMenuState {
 }
 
 impl ContextMenuState {
+    pub fn at_cursor(kind: ContextMenuKind, x: u16, y: u16) -> Self {
+        Self {
+            kind,
+            x,
+            y,
+            list: MenuListState::new(0),
+        }
+    }
+
+    pub fn at_agent_panel_cursor(kind: ContextMenuKind, x: u16, y: u16) -> Self {
+        Self {
+            kind,
+            x,
+            y: y.saturating_sub(1),
+            list: MenuListState::new(0),
+        }
+    }
+
     pub fn items(&self) -> &'static [&'static str] {
         match self.kind {
             ContextMenuKind::Workspace { .. } => &["Rename", "Close"],
@@ -1163,6 +1193,17 @@ impl ContextMenuState {
                 "Zoom",
                 "Close pane",
             ],
+            ContextMenuKind::AgentPanel {
+                mark_item: Some(AgentPanelMarkItem::MarkAsRead),
+                ..
+            } => &["Mark as read", "Close"],
+            ContextMenuKind::AgentPanel {
+                mark_item: Some(AgentPanelMarkItem::MarkAsUnread),
+                ..
+            } => &["Mark as unread", "Close"],
+            ContextMenuKind::AgentPanel {
+                mark_item: None, ..
+            } => &["Close"],
         }
     }
 }
@@ -1410,9 +1451,20 @@ pub struct AppState {
     /// Terminal runtimes that should be shut down by the app/runtime layer
     /// after state has detached their terminal metadata.
     pub(crate) terminal_runtime_shutdowns: Vec<crate::terminal::TerminalId>,
+    pub(crate) pending_pane_state_updates: Vec<crate::app::actions::PaneStateUpdate>,
 }
 
 impl AppState {
+    pub(crate) fn queue_pane_state_update(&mut self, update: crate::app::actions::PaneStateUpdate) {
+        self.pending_pane_state_updates.push(update);
+    }
+
+    pub(crate) fn take_pending_pane_state_updates(
+        &mut self,
+    ) -> Vec<crate::app::actions::PaneStateUpdate> {
+        std::mem::take(&mut self.pending_pane_state_updates)
+    }
+
     pub(crate) fn mark_session_dirty(&mut self) {
         self.session_dirty = true;
     }
@@ -1740,6 +1792,7 @@ impl AppState {
             host_terminal_theme: TerminalTheme::default(),
             session_dirty: false,
             terminal_runtime_shutdowns: Vec::new(),
+            pending_pane_state_updates: Vec::new(),
         }
     }
 
@@ -2055,6 +2108,12 @@ impl AppState {
                     if let Some(source_pane_id) = source_pane_id {
                         assert_live_pane(source_pane_id, "context menu source pane");
                     }
+                }
+                ContextMenuKind::AgentPanel {
+                    ws_idx, pane_id, ..
+                } => {
+                    assert_workspace_index(ws_idx, "context menu agent panel");
+                    assert_live_pane(pane_id, "context menu agent panel pane");
                 }
             }
         }

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -18,6 +18,8 @@ pub(super) fn run_agent_command(args: &[String]) -> std::io::Result<i32> {
         "send" => agent_send(&args[1..]),
         "rename" => agent_rename(&args[1..]),
         "focus" => agent_focus(&args[1..]),
+        "mark-read" => agent_mark_read(&args[1..]),
+        "mark-unread" => agent_mark_unread(&args[1..]),
         "wait" => agent_wait(&args[1..]),
         "attach" => agent_attach(&args[1..]),
         "start" => agent_start(&args[1..]),
@@ -417,6 +419,40 @@ fn agent_focus(args: &[String]) -> std::io::Result<i32> {
     })?)
 }
 
+fn agent_mark_read(args: &[String]) -> std::io::Result<i32> {
+    let Some(target) = args.first() else {
+        eprintln!("usage: herdr agent mark-read <target>");
+        return Ok(2);
+    };
+    if args.len() != 1 {
+        eprintln!("usage: herdr agent mark-read <target>");
+        return Ok(2);
+    }
+    super::print_response(&super::send_request(&Request {
+        id: "cli:agent:mark-read".into(),
+        method: Method::AgentMarkRead(AgentTarget {
+            target: target.clone(),
+        }),
+    })?)
+}
+
+fn agent_mark_unread(args: &[String]) -> std::io::Result<i32> {
+    let Some(target) = args.first() else {
+        eprintln!("usage: herdr agent mark-unread <target>");
+        return Ok(2);
+    };
+    if args.len() != 1 {
+        eprintln!("usage: herdr agent mark-unread <target>");
+        return Ok(2);
+    }
+    super::print_response(&super::send_request(&Request {
+        id: "cli:agent:mark-unread".into(),
+        method: Method::AgentMarkUnread(AgentTarget {
+            target: target.clone(),
+        }),
+    })?)
+}
+
 fn agent_attach(args: &[String]) -> std::io::Result<i32> {
     let (target, takeover) =
         match super::parse_attach_target(args, "usage: herdr agent attach <target> [--takeover]") {
@@ -673,6 +709,8 @@ fn print_agent_help() {
     eprintln!("  herdr agent send <target> <text>");
     eprintln!("  herdr agent rename <target> <name>|--clear");
     eprintln!("  herdr agent focus <target>");
+    eprintln!("  herdr agent mark-read <target>");
+    eprintln!("  herdr agent mark-unread <target>");
     eprintln!("  herdr agent wait <target> --status <idle|working|blocked|unknown> [--timeout MS]");
     eprintln!("  herdr agent attach <target> [--takeover]");
     eprintln!("  herdr agent start <name> [--cwd PATH] [--workspace ID] [--tab ID] [--split right|down] [--env KEY=VALUE] [--focus|--no-focus] -- <argv...>");
@@ -682,4 +720,31 @@ fn print_agent_help() {
     eprintln!(
         "  agent send writes literal text; use pane run when you want command text plus Enter"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn mark_read_requires_single_target() {
+        assert_eq!(agent_mark_read(&args(&[])).unwrap(), 2);
+        assert_eq!(agent_mark_read(&args(&["reviewer", "extra"])).unwrap(), 2);
+    }
+
+    #[test]
+    fn mark_unread_requires_single_target() {
+        assert_eq!(agent_mark_unread(&args(&[])).unwrap(), 2);
+        assert_eq!(agent_mark_unread(&args(&["reviewer", "extra"])).unwrap(), 2);
+    }
+
+    #[test]
+    fn run_agent_command_dispatches_mark_read_subcommands() {
+        assert_eq!(run_agent_command(&args(&["mark-read"])).unwrap(), 2);
+        assert_eq!(run_agent_command(&args(&["mark-unread"])).unwrap(), 2);
+    }
 }

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -966,11 +966,20 @@ fn agent_methods_round_trip_over_socket() {
     let second_reported = send_request(
         &socket_path,
         &format!(
-            r#"{{"id":"agent_second_report","method":"pane.report_agent","params":{{"pane_id":"{}","source":"test","agent":"codex","state":"idle"}}}}"#,
+            r#"{{"id":"agent_second_report","method":"pane.report_agent","params":{{"pane_id":"{}","source":"test","agent":"codex","state":"working"}}}}"#,
             second_pane_id
         ),
     );
     assert_eq!(second_reported["result"]["type"], "ok");
+
+    let second_idle = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"agent_second_idle","method":"pane.report_agent","params":{{"pane_id":"{}","source":"test","agent":"codex","state":"idle"}}}}"#,
+            second_pane_id
+        ),
+    );
+    assert_eq!(second_idle["result"]["type"], "ok");
 
     let second_renamed = send_request(
         &socket_path,
@@ -996,6 +1005,34 @@ fn agent_methods_round_trip_over_socket() {
         r#"{"id":"agent_rename","method":"agent.rename","params":{"target":"reviewer","name":"qa"}}"#,
     );
     assert_eq!(agent_renamed["result"]["agent"]["name"], "qa");
+
+    let qa_before_read = send_request(
+        &socket_path,
+        r#"{"id":"agent_qa_get","method":"agent.get","params":{"target":"qa"}}"#,
+    );
+    assert_eq!(qa_before_read["result"]["agent"]["agent_status"], "done");
+    assert_eq!(qa_before_read["result"]["agent"]["focused"], false);
+
+    let mark_read = send_request(
+        &socket_path,
+        r#"{"id":"agent_mark_read","method":"agent.mark_read","params":{"target":"qa"}}"#,
+    );
+    assert_eq!(mark_read["result"]["agent"]["name"], "qa");
+    assert_eq!(mark_read["result"]["agent"]["agent_status"], "idle");
+    assert_eq!(mark_read["result"]["agent"]["focused"], false);
+
+    let mark_unread = send_request(
+        &socket_path,
+        r#"{"id":"agent_mark_unread","method":"agent.mark_unread","params":{"target":"qa"}}"#,
+    );
+    assert_eq!(mark_unread["result"]["agent"]["agent_status"], "done");
+    assert_eq!(mark_unread["result"]["agent"]["focused"], false);
+
+    let mark_read_working = send_request(
+        &socket_path,
+        r#"{"id":"agent_mark_read_working","method":"agent.mark_read","params":{"target":"worker"}}"#,
+    );
+    assert_eq!(mark_read_working["error"]["code"], "agent_not_idle");
 
     let focused = send_request(
         &socket_path,


### PR DESCRIPTION
Add agent panel right-click Mark as read, Mark as unread, and Close actions plus agent.mark_read / agent.mark_unread socket API methods and CLI mark-read / mark-unread commands. Mark actions update read state without navigation; Close navigates to the pane before closing it.

https://github.com/user-attachments/assets/f7f60bbb-0eb7-4ae3-b0ac-965dac04fec4

