### PR TITLE
feat(ui): make focused split-pane border weight configurable

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -219,6 +219,15 @@ fn agent_panel_sort_from_config(
     }
 }
 
+fn active_pane_border_from_config(
+    border: crate::config::ActivePaneBorderConfig,
+) -> state::ActivePaneBorderStyle {
+    match border {
+        crate::config::ActivePaneBorderConfig::Thick => state::ActivePaneBorderStyle::Thick,
+        crate::config::ActivePaneBorderConfig::Plain => state::ActivePaneBorderStyle::Plain,
+    }
+}
+
 /// Parse the configured agent name list into a deduplicated set of `Agent`
 /// values. Unknown agent names are silently dropped so a typo cannot disable
 /// other valid entries.
@@ -595,6 +604,7 @@ impl App {
             confirm_close: config.ui.confirm_close,
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
+            active_pane_border: active_pane_border_from_config(config.ui.active_pane_border),
             pane_history_persistence: config.experimental.pane_history,
             reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
             cjk_ime_agent_filter_configured: !config.experimental.cjk_ime_agents.is_empty(),
@@ -1321,6 +1331,8 @@ impl App {
                 self.state.prompt_new_tab_name = config.ui.prompt_new_tab_name;
                 self.state.show_agent_labels_on_pane_borders =
                     config.ui.show_agent_labels_on_pane_borders;
+                self.state.active_pane_border =
+                    active_pane_border_from_config(config.ui.active_pane_border);
                 self.state.agent_panel_sort =
                     agent_panel_sort_from_config(config.ui.agent_panel_sort);
                 self.state.agent_panel_scroll = 0;
@@ -2180,6 +2192,20 @@ mod tests {
         let app = App::new(&config, true, None, api_rx, crate::api::EventHub::default());
 
         assert_eq!(app.state.agent_panel_sort, state::AgentPanelSort::Priority);
+    }
+
+    #[test]
+    fn startup_uses_configured_active_pane_border() {
+        let mut config = Config::default();
+        config.ui.active_pane_border = crate::config::ActivePaneBorderConfig::Plain;
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let app = App::new(&config, true, None, api_rx, crate::api::EventHub::default());
+
+        assert_eq!(
+            app.state.active_pane_border,
+            state::ActivePaneBorderStyle::Plain
+        );
     }
 
     #[test]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -839,6 +839,15 @@ pub enum AgentPanelSort {
     Priority,
 }
 
+/// Border line weight for the focused split pane. The focused pane always uses
+/// the accent color; this only selects the glyph set.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ActivePaneBorderStyle {
+    #[default]
+    Thick,
+    Plain,
+}
+
 // ---------------------------------------------------------------------------
 // Settings UI state
 // ---------------------------------------------------------------------------
@@ -1351,6 +1360,7 @@ pub struct AppState {
     /// Ratio of sidebar height allocated to the workspaces section.
     pub sidebar_section_split: f32,
     pub agent_panel_sort: AgentPanelSort,
+    pub active_pane_border: ActivePaneBorderStyle,
     pub next_agent_state_change_seq: u64,
     /// Capture mouse input for Herdr's own mouse UI. When false, Herdr only
     /// captures mouse while the focused pane app requests mouse reporting.
@@ -1448,6 +1458,10 @@ impl AppState {
 
     pub fn agent_border_labels_enabled(&self) -> bool {
         self.show_agent_labels_on_pane_borders
+    }
+
+    pub fn active_pane_border_style(&self) -> ActivePaneBorderStyle {
+        self.active_pane_border
     }
 
     pub fn pane_history_persistence_enabled(&self) -> bool {
@@ -1707,6 +1721,7 @@ impl AppState {
             sidebar_collapsed: false,
             sidebar_section_split: 0.5,
             agent_panel_sort: AgentPanelSort::Spaces,
+            active_pane_border: ActivePaneBorderStyle::Thick,
             next_agent_state_change_seq: 0,
             mouse_capture: true,
             right_click_passthrough_modifiers: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,8 @@ pub use self::{
         IndexedKeybind, Keybinds, LiveKeybindConfig,
     },
     model::{
-        validated_sidebar_bounds, AgentPanelSortConfig, Config, ConfigReloadReport,
-        ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, ShellModeConfig,
+        validated_sidebar_bounds, ActivePaneBorderConfig, AgentPanelSortConfig, Config,
+        ConfigReloadReport, ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, ShellModeConfig,
         ToastClipboardPosition, ToastConfig, ToastDelivery, ToastHerdrPosition,
         UpdateChannelConfig, MAX_TOAST_DELAY_SECONDS,
     },

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -103,6 +103,18 @@ impl AgentPanelSortConfig {
     }
 }
 
+/// Border style used for the focused pane in a split layout. The focused pane
+/// always uses the accent color; this only controls the line weight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ActivePaneBorderConfig {
+    /// Heavy line weight (current default).
+    #[default]
+    Thick,
+    /// Regular line weight, matching unfocused panes but keeping the accent color.
+    Plain,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RightClickPassthroughModifierConfig(Option<KeyModifiers>);
 
@@ -448,6 +460,9 @@ pub struct UiConfig {
     pub show_agent_labels_on_pane_borders: bool,
     /// Agent sidebar ordering. Saved values are "spaces" or "priority". Default: "spaces".
     pub agent_panel_sort: AgentPanelSortConfig,
+    /// Border line weight for the focused split pane. "thick" (default) or "plain".
+    /// The focused pane keeps the accent color either way.
+    pub active_pane_border: ActivePaneBorderConfig,
     /// Accent color for highlights, borders, and navigation UI.
     /// Accepts hex (#89b4fa), named colors (cyan, blue), or RGB (rgb(137,180,250)).
     pub accent: String,
@@ -634,6 +649,7 @@ impl Default for UiConfig {
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
             agent_panel_sort: AgentPanelSortConfig::Spaces,
+            active_pane_border: ActivePaneBorderConfig::Thick,
             accent: "cyan".into(),
             toast: ToastConfig::default(),
             sound: SoundConfig::default(),
@@ -836,6 +852,28 @@ agent_panel_scope = "current"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.ui.agent_panel_sort, AgentPanelSortConfig::Spaces);
+    }
+
+    #[test]
+    fn active_pane_border_defaults_to_thick_and_parses() {
+        assert_eq!(
+            Config::default().ui.active_pane_border,
+            ActivePaneBorderConfig::Thick
+        );
+
+        let toml = r#"
+[ui]
+active_pane_border = "plain"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.ui.active_pane_border, ActivePaneBorderConfig::Plain);
+
+        let toml = r#"
+[ui]
+active_pane_border = "thick"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.ui.active_pane_border, ActivePaneBorderConfig::Thick);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,10 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # "workspaces" is accepted as an alias for "spaces".
 # agent_panel_sort = "spaces"
 
+# Border line weight for the focused split pane: "thick" (default) or "plain".
+# The focused pane keeps the accent color either way; "plain" only drops the heavy glyphs.
+# active_pane_border = "thick"
+
 # Accent color for highlights, borders, and navigation UI.
 # Accepts: hex (#89b4fa), named colors (cyan, blue, magenta), or rgb(r,g,b)
 # accent = "cyan"

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use super::scrollbar::{render_pane_scrollbar, should_show_scrollbar};
 use super::widgets::panel_contrast_fg;
-use crate::app::state::Palette;
+use crate::app::state::{ActivePaneBorderStyle, Palette};
 use crate::app::{AppState, Mode};
 use crate::layout::PaneInfo;
 use crate::terminal::{TerminalRuntime, TerminalRuntimeRegistry};
@@ -256,10 +256,11 @@ pub(super) fn render_panes(
         if let Some(rt) = app.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, info.id) {
             if multi_pane {
                 let (border_style, border_set) = if info.is_focused && terminal_active {
-                    (
-                        Style::default().fg(app.palette.accent),
-                        ratatui::symbols::border::THICK,
-                    )
+                    let focused_set = match app.active_pane_border_style() {
+                        ActivePaneBorderStyle::Thick => ratatui::symbols::border::THICK,
+                        ActivePaneBorderStyle::Plain => ratatui::symbols::border::PLAIN,
+                    };
+                    (Style::default().fg(app.palette.accent), focused_set)
                 } else if info.is_focused {
                     (
                         Style::default().fg(app.palette.accent),


### PR DESCRIPTION
Add a [ui] active_pane_border option ("thick" default, "plain") controlling the focused split-pane border glyph weight. The focused pane keeps the accent color in both cases; "plain" drops the heavy line to match the regular border. The setting is applied on startup and on config hot-reload.