### PR TITLE
feat: add minimal split-pane borders

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added `ui.pane_borders = "minimal"` to use thin divider lines between split panes instead of boxed borders, with no focus highlight or navigate-mode dimming.
+
 ### Fixed
 - Local Herdr clients no longer treat raw `Ctrl+V` as a clipboard-image paste trigger, so pane apps such as Vim and Neovim receive block-visual `Ctrl+V` even when the desktop clipboard contains an image. `herdr --remote` keeps `keys.remote_image_paste = "ctrl+v"` by default. (#647)
 - Herdr now refreshes cached host terminal colors when terminals report a light/dark color-scheme change, so pane apps that query OSC 10/11 no longer need detach/attach to see updated default colors. Opt-in `[theme].auto_switch` can also switch Herdr's own UI between configured `dark_name` and `light_name` themes. (#675)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -599,6 +599,7 @@ impl App {
             confirm_close: config.ui.confirm_close,
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
+            pane_borders: config.ui.pane_borders,
             pane_history_persistence: config.experimental.pane_history,
             reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
             cjk_ime_agent_filter_configured: !config.experimental.cjk_ime_agents.is_empty(),
@@ -1329,6 +1330,7 @@ impl App {
                 self.state.prompt_new_tab_name = config.ui.prompt_new_tab_name;
                 self.state.show_agent_labels_on_pane_borders =
                     config.ui.show_agent_labels_on_pane_borders;
+                self.state.pane_borders = config.ui.pane_borders;
                 self.state.agent_panel_sort =
                     agent_panel_sort_from_config(config.ui.agent_panel_sort);
                 self.state.agent_panel_scroll = 0;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1362,6 +1362,7 @@ pub struct AppState {
     pub confirm_close: bool,
     pub prompt_new_tab_name: bool,
     pub show_agent_labels_on_pane_borders: bool,
+    pub pane_borders: crate::config::PaneBordersConfig,
     pub pane_history_persistence: bool,
     /// Expose the focused pane's cursor anchor to the outer terminal even when
     /// the pane requested `?25l`. See `[experimental] reveal_hidden_cursor_for_cjk_ime`.
@@ -1716,6 +1717,7 @@ impl AppState {
             confirm_close: true,
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
+            pane_borders: crate::config::PaneBordersConfig::Boxed,
             pane_history_persistence: false,
             reveal_hidden_cursor_for_cjk_ime: false,
             cjk_ime_agent_filter_configured: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub use self::{
     },
     model::{
         validated_sidebar_bounds, AgentPanelSortConfig, Config, ConfigReloadReport,
+        PaneBordersConfig,
         ConfigReloadStatus, KeysConfig, NewTerminalCwdConfig, ShellModeConfig,
         ToastClipboardPosition, ToastConfig, ToastDelivery, ToastHerdrPosition,
         UpdateChannelConfig, MAX_TOAST_DELAY_SECONDS,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -103,6 +103,25 @@ impl AgentPanelSortConfig {
     }
 }
 
+/// Split-pane chrome style. `boxed` draws a border around each pane and
+/// highlights the focused pane. `minimal` uses thin divider lines only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum PaneBordersConfig {
+    #[default]
+    Boxed,
+    Minimal,
+}
+
+impl PaneBordersConfig {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Boxed => "boxed",
+            Self::Minimal => "minimal",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RightClickPassthroughModifierConfig(Option<KeyModifiers>);
 
@@ -446,6 +465,8 @@ pub struct UiConfig {
     pub prompt_new_tab_name: bool,
     /// Show agent labels in split pane borders when no manual pane label is set. Default: false.
     pub show_agent_labels_on_pane_borders: bool,
+    /// Split-pane border style. `boxed` (default) or `minimal` (thin dividers, no focus chrome).
+    pub pane_borders: PaneBordersConfig,
     /// Agent sidebar ordering. Saved values are "spaces" or "priority". Default: "spaces".
     pub agent_panel_sort: AgentPanelSortConfig,
     /// Accent color for highlights, borders, and navigation UI.
@@ -633,6 +654,7 @@ impl Default for UiConfig {
             confirm_close: true,
             prompt_new_tab_name: true,
             show_agent_labels_on_pane_borders: false,
+            pane_borders: PaneBordersConfig::Boxed,
             agent_panel_sort: AgentPanelSortConfig::Spaces,
             accent: "cyan".into(),
             toast: ToastConfig::default(),
@@ -836,6 +858,24 @@ agent_panel_scope = "current"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.ui.agent_panel_sort, AgentPanelSortConfig::Spaces);
+    }
+
+    #[test]
+    fn pane_borders_default_boxed_and_parse() {
+        let default_config = Config::default();
+        assert_eq!(
+            default_config.ui.pane_borders,
+            PaneBordersConfig::Boxed
+        );
+
+        let config: Config = toml::from_str(
+            r#"
+[ui]
+pane_borders = "minimal"
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.ui.pane_borders, PaneBordersConfig::Minimal);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,10 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Show detected/reported agent labels in split pane borders when no manual pane name is set.
 # show_agent_labels_on_pane_borders = false
 
+# Split-pane chrome: "boxed" (default) draws a border around each pane and highlights focus.
+# "minimal" uses thin divider lines only, with no focus border or dimming.
+# pane_borders = "minimal"
+
 # Agent panel ordering: "spaces" (grouped by space) or "priority" (attention queue).
 # "workspaces" is accepted as an alias for "spaces".
 # agent_panel_sort = "spaces"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -244,6 +244,7 @@ fn compute_view_internal(
         terminal_area,
         resize_panes,
         cell_size,
+        &split_borders,
     );
     if resize_panes {
         resize_background_tab_panes_to_terminal_area(
@@ -319,6 +320,7 @@ fn compute_mobile_view(
         terminal_area,
         resize_panes,
         cell_size,
+        &split_borders,
     );
     if resize_panes {
         resize_background_tab_panes_to_terminal_area(

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::Rect,
+    layout::{Direction, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
@@ -10,7 +10,8 @@ use super::scrollbar::{render_pane_scrollbar, should_show_scrollbar};
 use super::widgets::panel_contrast_fg;
 use crate::app::state::Palette;
 use crate::app::{AppState, Mode};
-use crate::layout::PaneInfo;
+use crate::config::PaneBordersConfig;
+use crate::layout::{PaneInfo, SplitBorder};
 use crate::terminal::{TerminalRuntime, TerminalRuntimeRegistry};
 
 pub(crate) fn pane_is_scrolled_back(rt: &TerminalRuntime) -> bool {
@@ -55,11 +56,61 @@ fn stable_terminal_inner_rect(pane_inner: Rect) -> Rect {
     )
 }
 
-fn pane_inner_rect(area: Rect, framed: bool) -> Rect {
-    if framed {
-        Block::default().borders(Borders::ALL).inner(area)
+fn uses_boxed_pane_borders(app: &AppState, multi_pane: bool) -> bool {
+    multi_pane && app.pane_borders == PaneBordersConfig::Boxed
+}
+
+fn pane_overlaps_split_area(pane_rect: Rect, split: &SplitBorder) -> bool {
+    pane_rect.x < split.area.x.saturating_add(split.area.width)
+        && pane_rect.x.saturating_add(pane_rect.width) > split.area.x
+        && pane_rect.y < split.area.y.saturating_add(split.area.height)
+        && pane_rect.y.saturating_add(pane_rect.height) > split.area.y
+}
+
+fn minimal_pane_content_rect(mut rect: Rect, splits: &[SplitBorder]) -> Rect {
+    for split in splits {
+        if !pane_overlaps_split_area(rect, split) {
+            continue;
+        }
+        match split.direction {
+            Direction::Horizontal => {
+                if rect.x == split.pos {
+                    rect.x = rect.x.saturating_add(1);
+                    rect.width = rect.width.saturating_sub(1);
+                }
+            }
+            Direction::Vertical => {
+                if rect.y == split.pos {
+                    rect.y = rect.y.saturating_add(1);
+                    rect.height = rect.height.saturating_sub(1);
+                }
+            }
+        }
+    }
+    rect
+}
+
+fn pane_content_rect(
+    app: &AppState,
+    multi_pane: bool,
+    pane_rect: Rect,
+    splits: &[SplitBorder],
+    focused_and_terminal_active: bool,
+) -> Rect {
+    if uses_boxed_pane_borders(app, multi_pane) {
+        let border_set = if focused_and_terminal_active {
+            ratatui::symbols::border::THICK
+        } else {
+            ratatui::symbols::border::PLAIN
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(border_set);
+        block.inner(pane_rect)
+    } else if multi_pane && app.pane_borders == PaneBordersConfig::Minimal {
+        minimal_pane_content_rect(pane_rect, splits)
     } else {
-        area
+        pane_rect
     }
 }
 
@@ -106,11 +157,18 @@ pub(super) fn resize_tab_panes(
     cell_size: crate::kitty_graphics::HostCellSize,
 ) {
     let multi_pane = tab.layout.pane_count() > 1;
+    let splits = tab.layout.splits(area);
 
     if tab.zoomed {
         let focused_id = tab.layout.focused();
         if let Some((terminal_id, rt)) = runtime_for_tab_pane(terminal_runtimes, tab, focused_id) {
-            let pane_inner = pane_inner_rect(area, multi_pane);
+            let pane_inner = pane_content_rect(
+                app,
+                multi_pane,
+                area,
+                &splits,
+                true,
+            );
             let inner_rect = stable_terminal_inner_rect(pane_inner);
             if !app.direct_attach_resize_locks.contains(terminal_id) {
                 rt.resize(
@@ -125,11 +183,13 @@ pub(super) fn resize_tab_panes(
     }
 
     for info in tab.layout.panes(area) {
-        let pane_inner = if multi_pane {
-            Block::default().borders(Borders::ALL).inner(info.rect)
-        } else {
-            area
-        };
+        let pane_inner = pane_content_rect(
+            app,
+            multi_pane,
+            info.rect,
+            &splits,
+            info.is_focused,
+        );
 
         if let Some((terminal_id, rt)) = runtime_for_tab_pane(terminal_runtimes, tab, info.id) {
             let inner_rect = stable_terminal_inner_rect(pane_inner);
@@ -152,6 +212,7 @@ pub(super) fn compute_pane_infos(
     area: Rect,
     resize_panes: bool,
     cell_size: crate::kitty_graphics::HostCellSize,
+    split_borders: &[SplitBorder],
 ) -> Vec<PaneInfo> {
     let Some(ws_idx) = app.active else {
         return Vec::new();
@@ -165,7 +226,7 @@ pub(super) fn compute_pane_infos(
 
     if ws.zoomed {
         let focused_id = ws.layout.focused();
-        let pane_inner = pane_inner_rect(area, multi_pane);
+        let pane_inner = pane_content_rect(app, multi_pane, area, split_borders, true);
         let mut inner_rect = pane_inner;
         let mut scrollbar_rect = None;
         if let Some(rt) = app.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, focused_id) {
@@ -195,19 +256,13 @@ pub(super) fn compute_pane_infos(
     let mut pane_infos = ws.layout.panes(area);
 
     for info in &mut pane_infos {
-        let pane_inner = if multi_pane {
-            let border_set = if info.is_focused && terminal_active {
-                ratatui::symbols::border::THICK
-            } else {
-                ratatui::symbols::border::PLAIN
-            };
-            let block = Block::default()
-                .borders(Borders::ALL)
-                .border_set(border_set);
-            block.inner(info.rect)
-        } else {
-            area
-        };
+        let pane_inner = pane_content_rect(
+            app,
+            multi_pane,
+            info.rect,
+            split_borders,
+            info.is_focused && terminal_active,
+        );
 
         let mut inner_rect = pane_inner;
         let mut scrollbar_rect = None;
@@ -254,7 +309,7 @@ pub(super) fn render_panes(
 
     for info in &app.view.pane_infos {
         if let Some(rt) = app.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, info.id) {
-            if multi_pane {
+            if uses_boxed_pane_borders(app, multi_pane) {
                 let (border_style, border_set) = if info.is_focused && terminal_active {
                     (
                         Style::default().fg(app.palette.accent),
@@ -296,7 +351,10 @@ pub(super) fn render_panes(
             rt.render(frame, info.inner_rect, show_cursor);
             render_pane_scrollbar(app, frame, info, rt);
 
-            let should_dim = !info.is_focused && multi_pane && !terminal_active;
+            let should_dim = app.pane_borders == PaneBordersConfig::Boxed
+                && !info.is_focused
+                && multi_pane
+                && !terminal_active;
             if should_dim {
                 let inner = info.inner_rect;
                 let buf = frame.buffer_mut();
@@ -318,6 +376,37 @@ pub(super) fn render_panes(
                 app.host_terminal_theme,
             );
             render_copy_mode_cursor(app, frame, info);
+        }
+    }
+
+    render_pane_dividers(app, frame, multi_pane);
+}
+
+fn render_pane_dividers(app: &AppState, frame: &mut Frame, multi_pane: bool) {
+    if !multi_pane || app.pane_borders != PaneBordersConfig::Minimal {
+        return;
+    }
+
+    let style = Style::default().fg(app.palette.surface_dim);
+    let buf = frame.buffer_mut();
+    for split in &app.view.split_borders {
+        match split.direction {
+            Direction::Horizontal => {
+                let x = split.pos;
+                for y in split.area.y..split.area.y.saturating_add(split.area.height) {
+                    let cell = &mut buf[(x, y)];
+                    cell.set_symbol("│");
+                    cell.set_style(style);
+                }
+            }
+            Direction::Vertical => {
+                let y = split.pos;
+                for x in split.area.x..split.area.x.saturating_add(split.area.width) {
+                    let cell = &mut buf[(x, y)];
+                    cell.set_symbol("─");
+                    cell.set_style(style);
+                }
+            }
         }
     }
 }
@@ -547,6 +636,7 @@ mod tests {
             area,
             false,
             crate::kitty_graphics::HostCellSize::default(),
+            &[],
         );
         let info = &infos[0];
 
@@ -576,12 +666,63 @@ mod tests {
             area,
             false,
             crate::kitty_graphics::HostCellSize::default(),
+            &[],
         );
         let info = &infos[0];
 
         assert_eq!(info.rect, area);
         assert_eq!(info.scrollbar_rect, None);
         assert_eq!(info.inner_rect, Rect::new(10, 3, 39, 8));
+    }
+
+    #[test]
+    fn minimal_pane_content_rect_reserves_divider_column() {
+        let area = Rect::new(10, 3, 40, 8);
+        let mut workspace = Workspace::test_new("test");
+        let _right = workspace.test_split(ratatui::layout::Direction::Horizontal);
+        let splits = workspace.tabs[0].layout.splits(area);
+        let panes = workspace.tabs[0].layout.panes(area);
+        assert_eq!(panes.len(), 2);
+
+        let left = minimal_pane_content_rect(panes[0].rect, &splits);
+        let right = minimal_pane_content_rect(panes[1].rect, &splits);
+
+        assert_eq!(left, panes[0].rect);
+        assert_eq!(right.x, panes[1].rect.x + 1);
+        assert_eq!(right.width, panes[1].rect.width - 1);
+    }
+
+    #[tokio::test]
+    async fn minimal_pane_borders_use_full_height_without_box_inset() {
+        let mut app = AppState::test_new();
+        app.pane_borders = PaneBordersConfig::Minimal;
+        let mut workspace = Workspace::test_new("test");
+        let right = workspace.test_split(ratatui::layout::Direction::Vertical);
+        workspace.tabs[0].runtimes.insert(
+            right,
+            TerminalRuntime::test_with_scrollback_bytes(40, 8, 1024, b"ready\n"),
+        );
+        app.workspaces = vec![workspace];
+        app.active = Some(0);
+
+        let area = Rect::new(10, 3, 40, 8);
+        let splits = app.workspaces[0].tabs[0].layout.splits(area);
+        let terminal_runtimes = TerminalRuntimeRegistry::new();
+        let infos = compute_pane_infos(
+            &app,
+            &terminal_runtimes,
+            area,
+            false,
+            crate::kitty_graphics::HostCellSize::default(),
+            &splits,
+        );
+
+        let bottom = infos.iter().find(|info| info.id == right).expect("bottom pane");
+        assert_eq!(bottom.inner_rect.y, area.y + area.height / 2 + 1);
+        assert_eq!(
+            bottom.inner_rect.height,
+            area.height.saturating_sub(area.height / 2).saturating_sub(1)
+        );
     }
 
     #[tokio::test]
@@ -605,6 +746,7 @@ mod tests {
             area,
             false,
             crate::kitty_graphics::HostCellSize::default(),
+            &[],
         );
         let info = &infos[0];
 
@@ -634,6 +776,7 @@ mod tests {
             area,
             false,
             crate::kitty_graphics::HostCellSize::default(),
+            &[],
         );
         let info = &infos[0];
 
@@ -667,6 +810,7 @@ mod tests {
             area,
             false,
             crate::kitty_graphics::HostCellSize::default(),
+            &[],
         );
         let info = &infos[0];
 


### PR DESCRIPTION
## Summary

- Add `ui.pane_borders = "minimal"` as an opt-in alternative to the default boxed multi-pane chrome.
- Minimal mode draws thin `│` / `─` dividers at split lines, removes per-pane padded borders, and disables focus border highlighting and navigate-mode dimming.
- Default behavior remains unchanged (`boxed`).

## Test plan

- [x] Built locally with `nix develop -c cargo build`
- [x] Verified `pane_borders = "minimal"` in a local test config with multi-pane splits
- [ ] `just check` on maintainer CI
- [ ] Compare `boxed` vs `minimal` with horizontal and vertical splits
- [ ] Confirm pane focus, resize drag, and mouse click targeting still work in minimal mode


Made with [Cursor](https://cursor.com)