### PR TITLE
feat: open source paths from pane output

### DIFF
--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -320,7 +320,7 @@ The agent panel shows all agents across all spaces. `agent_panel_sort` can be `s
 
 `confirm_close` controls whether closing a workspace asks for confirmation. `prompt_new_tab_name` controls whether new tabs ask for a label first.
 
-Set `mouse_capture = false` if you want your terminal to handle normal clicks, such as command-clicking URLs. With mouse capture enabled, Ctrl-click opens pane links when your terminal sends that modified click to Herdr. This includes macOS; Cmd-click is not reported separately from plain click while Herdr captures mouse input. Use Shift-Ctrl-click on Linux or Shift-Cmd-click on macOS for the terminal-native bypass path.
+Set `mouse_capture = false` if you want your terminal to handle normal clicks, such as command-clicking URLs. With mouse capture enabled, Ctrl-click opens pane links when your terminal sends that modified click to Herdr. This includes OSC 8 hyperlinks, visible `http://` or `https://` URLs, and existing source paths such as `src/main.rs:42` in pane output. Source paths open in `$EDITOR` inside a temporary zoomed pane. On macOS, Cmd-click is not reported separately from plain click while Herdr captures mouse input. Use Shift-Ctrl-click on Linux or Shift-Cmd-click on macOS for the terminal-native bypass path.
 
 Set `right_click_passthrough_modifier = "ctrl"` if you want Ctrl-right-click, hold, and drag gestures inside mouse-reporting pane apps to reach the app instead of opening Herdr's pane menu. The default is empty, which disables this passthrough. Supported modifiers are `ctrl`, `alt`, `cmd`, `super`, `meta`, and `hyper`; `shift` is rejected because many terminals reserve Shift+mouse for their own mouse bypass.
 

--- a/docs/next/website/src/content/docs/quick-start.mdx
+++ b/docs/next/website/src/content/docs/quick-start.mdx
@@ -19,7 +19,7 @@ When a session has no workspaces, Herdr opens one automatically. A workspace is 
 
 Herdr is mouse-native, so start by clicking. Click panes, tabs, workspaces, and agents to focus them. Drag split borders to resize. Right-click for context menus, including splitting panes and creating tabs. Drag-select text to copy it to your clipboard; double-click a token to copy it directly. Copying does not require Ctrl+C.
 
-Ctrl-click opens pane links when your terminal sends the modified click to Herdr. This works for OSC 8 hyperlinks and visible `http://` or `https://` URLs. On macOS, use Ctrl-click for Herdr-handled pane links while mouse capture is enabled; Cmd-click is only available through the terminal-native bypass path, such as Shift-Cmd-click or `ui.mouse_capture = false`.
+Ctrl-click opens pane links when your terminal sends the modified click to Herdr. This works for OSC 8 hyperlinks, visible `http://` or `https://` URLs, and existing source paths such as `src/main.rs:42` in pane output. Source paths open in `$EDITOR` inside a temporary zoomed pane. On macOS, use Ctrl-click for Herdr-handled pane links while mouse capture is enabled; Cmd-click is only available through the terminal-native bypass path, such as Shift-Cmd-click or `ui.mouse_capture = false`.
 
 If you configure `ui.right_click_passthrough_modifier`, that modifier plus right-click sends right-click, hold, and drag gestures to mouse-reporting pane apps.
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,6 +1,8 @@
 //! Pure state mutations on AppState.
 //! These don't need channels, async, or PTY runtime.
 
+use std::path::{Path, PathBuf};
+
 use tracing::{info, warn};
 
 use crate::detect::{Agent, AgentState};
@@ -1986,6 +1988,39 @@ impl AppState {
         url_at_column(&row_text, col).map(str::to_owned)
     }
 
+    pub(crate) fn source_path_at_pane_cell(
+        &self,
+        terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+        pane_id: crate::layout::PaneId,
+        viewport_row: u16,
+        col: u16,
+    ) -> Option<SourcePathTarget> {
+        let ws_idx = self
+            .active
+            .filter(|idx| self.workspaces.get(*idx).is_some())?;
+        let ws = self.workspaces.get(ws_idx)?;
+        let info = self.pane_info_by_id(pane_id)?;
+        if viewport_row >= info.inner_rect.height || col >= info.inner_rect.width {
+            return None;
+        }
+
+        let rt = self.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, pane_id)?;
+        let metrics = self.pane_scroll_metrics(terminal_runtimes, pane_id);
+        let row_selection = Selection::range(
+            pane_id,
+            viewport_row,
+            0,
+            info.inner_rect.width.saturating_sub(1),
+            metrics,
+        );
+        let row_text = rt.extract_selection(&row_selection)?;
+        let cwd = ws
+            .active_tab()
+            .and_then(|tab| tab.cwd_for_pane(pane_id, &self.terminals, terminal_runtimes))
+            .or_else(|| ws.resolved_identity_cwd_from(&self.terminals, terminal_runtimes))?;
+        source_path_at_column(&row_text, col, &cwd)
+    }
+
     pub fn copy_selection(&mut self, terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry) {
         let mut sel = match self.selection.take() {
             Some(sel) => sel,
@@ -2068,6 +2103,82 @@ pub(crate) fn url_at_column(row: &str, col: u16) -> Option<&str> {
     let start_byte = byte_index_for_cell(row, span.start);
     let end_byte = byte_index_after_cell(row, span.end);
     safe_web_url(row.get(start_byte..end_byte)?)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourcePathTarget {
+    pub path: PathBuf,
+    pub line: Option<u32>,
+    pub column: Option<u32>,
+}
+
+pub(crate) fn source_path_at_column(row: &str, col: u16, cwd: &Path) -> Option<SourcePathTarget> {
+    let cells = text_cells(row);
+    let clicked_idx = cell_index_at_column(&cells, col)?;
+    let span = quoted_path_span_at_column(&cells, clicked_idx)
+        .or_else(|| source_path_token_span_at_column(&cells, clicked_idx))?;
+    let start_byte = byte_index_for_cell(row, span.start);
+    let end_byte = byte_index_after_cell(row, span.end);
+    let raw = row.get(start_byte..end_byte)?;
+    parse_source_path_target(raw, cwd)
+}
+
+fn source_path_token_span_at_column(cells: &[TextCell], clicked_idx: usize) -> Option<CellSpan> {
+    let mut span = token_span_at_column(cells, clicked_idx)?;
+    while span.start > 0 && cells[span.start - 1].ch == '.' {
+        span.start -= 1;
+    }
+    Some(span)
+}
+
+fn parse_source_path_target(raw: &str, cwd: &Path) -> Option<SourcePathTarget> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.starts_with("http://") || raw.starts_with("https://") {
+        return None;
+    }
+    let raw = raw.strip_prefix("file://").unwrap_or(raw);
+    let raw = raw.strip_prefix("b/").or_else(|| raw.strip_prefix("a/")).unwrap_or(raw);
+    let (path_part, line, column) = split_source_location(raw);
+    if !looks_like_source_path(path_part) {
+        return None;
+    }
+    let path = PathBuf::from(path_part);
+    let resolved = if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    };
+    resolved.is_file().then_some(SourcePathTarget {
+        path: resolved,
+        line,
+        column,
+    })
+}
+
+fn split_source_location(raw: &str) -> (&str, Option<u32>, Option<u32>) {
+    let Some((path_and_line, column_text)) = raw.rsplit_once(':') else {
+        return (raw, None, None);
+    };
+    let Ok(column) = column_text.parse::<u32>() else {
+        return (raw, None, None);
+    };
+    let Some((path_text, line_text)) = path_and_line.rsplit_once(':') else {
+        return (path_and_line, Some(column), None);
+    };
+    match line_text.parse::<u32>() {
+        Ok(line) => (path_text, Some(line), Some(column)),
+        Err(_) => (path_and_line, Some(column), None),
+    }
+}
+
+fn looks_like_source_path(path: &str) -> bool {
+    if path.is_empty() || path.contains('\0') {
+        return false;
+    }
+    path.starts_with('/')
+        || path.starts_with("./")
+        || path.starts_with("../")
+        || path.contains('/')
 }
 
 fn token_span_at_column(cells: &[TextCell], clicked_idx: usize) -> Option<CellSpan> {
@@ -2966,6 +3077,14 @@ mod tests {
         url_at_column(row, col_of(row, click))
     }
 
+    fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!("herdr-{name}-{}-{nanos}", std::process::id()))
+    }
+
     fn text_in_cell_range(row: &str, start_col: u16, end_col: u16) -> String {
         text_cells(row)
             .into_iter()
@@ -3132,6 +3251,36 @@ mod tests {
         ] {
             assert_selects_nothing(row, click);
         }
+    }
+
+    #[test]
+    fn source_path_click_resolves_existing_relative_file_with_line_column() {
+        let dir = unique_temp_dir("source-path-click");
+        let source_dir = dir.join("src/app");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let file = source_dir.join("actions.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+
+        let row = "modified src/app/actions.rs:42:7";
+        let target =
+            source_path_at_column(row, col_of(row, "actions"), &dir).expect("source path");
+
+        assert_eq!(target.path, file);
+        assert_eq!(target.line, Some(42));
+        assert_eq!(target.column, Some(7));
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn source_path_click_ignores_missing_files() {
+        let dir = unique_temp_dir("missing-source-path-click");
+        std::fs::create_dir_all(&dir).unwrap();
+        let row = "modified src/app/missing.rs:42";
+
+        assert_eq!(source_path_at_column(row, col_of(row, "missing"), &dir), None);
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -323,25 +323,91 @@ impl App {
         };
         let viewport_row = mouse.row.saturating_sub(info.inner_rect.y);
         let col = mouse.column.saturating_sub(info.inner_rect.x);
-        let Some(url) =
+        if let Some(url) =
             self.state
                 .url_at_pane_cell(&self.terminal_runtimes, info.id, viewport_row, col)
+        {
+            self.last_pane_click = None;
+            match self.invoke_plugin_link_handler_for_url(&url, info.id) {
+                Ok(true) => return true,
+                Ok(false) => {}
+                Err(err) => {
+                    tracing::warn!(err = %err, url = %url, "failed to invoke plugin link handler");
+                }
+            }
+            if let Err(err) = crate::platform::open_url(&url) {
+                tracing::warn!(err = %err, url = %url, "failed to open pane URL");
+            }
+            return true;
+        }
+
+        let Some(target) =
+            self.state
+                .source_path_at_pane_cell(&self.terminal_runtimes, info.id, viewport_row, col)
         else {
             return false;
         };
 
         self.last_pane_click = None;
-        match self.invoke_plugin_link_handler_for_url(&url, info.id) {
-            Ok(true) => return true,
-            Ok(false) => {}
-            Err(err) => {
-                tracing::warn!(err = %err, url = %url, "failed to invoke plugin link handler");
-            }
-        }
-        if let Err(err) = crate::platform::open_url(&url) {
-            tracing::warn!(err = %err, url = %url, "failed to open pane URL");
+        if let Err(err) = self.open_source_path_in_editor(target) {
+            tracing::warn!(err = %err, "failed to open source path");
         }
         true
+    }
+
+    fn open_source_path_in_editor(
+        &mut self,
+        target: crate::app::actions::SourcePathTarget,
+    ) -> std::io::Result<()> {
+        #[cfg(not(unix))]
+        {
+            let _ = target;
+            return Err(std::io::Error::other(
+                "opening source paths from pane output is only supported on Unix",
+            ));
+        }
+
+        #[cfg(unix)]
+        {
+            let mut location = target.path.display().to_string();
+            if let Some(line) = target.line {
+                location.push(':');
+                location.push_str(&line.to_string());
+                if let Some(column) = target.column {
+                    location.push(':');
+                    location.push_str(&column.to_string());
+                }
+            }
+            let mut env = vec![
+                (
+                    "HERDR_CLICKED_FILE".to_string(),
+                    target.path.display().to_string(),
+                ),
+                ("HERDR_CLICKED_LOCATION".to_string(), location.clone()),
+            ];
+            if let Some(line) = target.line {
+                env.push(("HERDR_CLICKED_LINE".to_string(), line.to_string()));
+            }
+            if let Some(column) = target.column {
+                env.push(("HERDR_CLICKED_COLUMN".to_string(), column.to_string()));
+            }
+            let command = r#"editor=${EDITOR:-vi}
+if [ -n "${HERDR_CLICKED_LINE:-}" ]; then
+  case "$editor" in
+    *code*|*cursor*) eval "$editor --goto \"\$HERDR_CLICKED_LOCATION\"" ;;
+    *) eval "$editor +\"\$HERDR_CLICKED_LINE\" \"\$HERDR_CLICKED_FILE\"" ;;
+  esac
+else
+  eval "$editor \"\$HERDR_CLICKED_FILE\""
+fi"#;
+            self.spawn_overlay_argv_command(
+                &["/bin/sh".into(), "-lc".into(), command.into()],
+                target.path.parent().map(std::path::Path::to_path_buf),
+                env,
+                Vec::new(),
+            )
+            .map(|_| ())
+        }
     }
 
     fn handle_pane_double_click(&mut self, mouse: MouseEvent) -> bool {

--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -578,6 +578,43 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ctrl_click_existing_source_path_opens_editor_pane() {
+        let source_path = unique_temp_path("source-click.rs");
+        std::fs::write(&source_path, "fn main() {}\n").unwrap();
+        let output_path = unique_temp_path("source-click-output");
+        let line = format!("modified {}:42:7", source_path.display());
+        let (mut app, info) = app_with_screen_bytes(line.as_bytes());
+        let col = line.find("source-click").expect("path segment") as u16;
+
+        let previous_editor = std::env::var_os("EDITOR");
+        std::env::set_var(
+            "EDITOR",
+            format!(
+                "sh -c 'printf \"%s|%s\" \"$1\" \"$2\" > {}' sh",
+                output_path.display()
+            ),
+        );
+        app.handle_mouse(modified_mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            info.inner_rect.x + col,
+            info.inner_rect.y,
+            KeyModifiers::CONTROL,
+        ));
+        match previous_editor {
+            Some(value) => std::env::set_var("EDITOR", value),
+            None => std::env::remove_var("EDITOR"),
+        }
+
+        let output = wait_for_file(&output_path);
+        assert_eq!(output, format!("+42|{}", source_path.display()));
+        assert!(app.state.workspaces[0].tabs[0].zoomed);
+
+        let _ = std::fs::remove_file(source_path);
+        let _ = std::fs::remove_file(output_path);
+    }
+
     #[tokio::test]
     async fn double_click_highlight_clears_after_short_delay() {
         let (mut app, info) = app_with_screen_bytes(b"copied");


### PR DESCRIPTION
## Summary

- add Ctrl-click fallback for existing source paths in pane output
- support `path`, `path:line`, and `path:line:column` forms
- open matched files in `$EDITOR` inside a temporary zoomed pane, using `--goto` for VS Code/Cursor-style editors and `+line` for terminal editors
- document the behavior in next docs

## Why

Coding agents frequently print changed files and diagnostics as source paths. Letting Herdr open those paths directly makes review/navigation faster without adding a separate diff UI.

## Validation

- `git diff --check`
- Added targeted Rust tests for path parsing and Ctrl-click editor-pane behavior
- Not run locally: `cargo test` / `just ci` because this environment does not have `cargo`, `rustc`, `just`, or `nix` installed.

## Contributor note

I understand Herdr requires maintainer alignment/approval for first-time contributors. Opening as draft for discussion; happy to move this through the preferred Discussion/issue approval path if needed.
