### PR TITLE
fix: use active pane color for border intersections

### DIFF
--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -399,13 +399,11 @@ fn render_pane_borders(app: &AppState, ws: &crate::workspace::Workspace, frame: 
         {
             continue;
         }
-        let focused_touching = app
+        let focused = app
             .view
             .pane_infos
             .iter()
             .any(|info| info.is_focused && line_touches_pane(x, y, info, app.pane_gaps));
-        let branch_cell = !app.pane_gaps && line_cell_degree(line) >= 3;
-        let focused = focused_touching && !branch_cell;
         let symbol = line_cell_symbol(line);
         if symbol.is_empty() {
             continue;
@@ -588,10 +586,6 @@ fn render_pane_border_titles(app: &AppState, ws: &crate::workspace::Workspace, f
             cell.set_style(style);
         }
     }
-}
-
-fn line_cell_degree(line: LineCell) -> u8 {
-    line.up as u8 + line.down as u8 + line.left as u8 + line.right as u8
 }
 
 fn line_cell_symbol(line: LineCell) -> &'static str {
@@ -994,7 +988,7 @@ mod tests {
 
         let buffer = terminal.backend().buffer();
         assert_eq!(buffer[(2, 2)].symbol(), "┼");
-        assert_eq!(buffer[(2, 2)].style().fg, Some(app.palette.overlay0));
+        assert_eq!(buffer[(2, 2)].style().fg, Some(app.palette.accent));
         assert_eq!(buffer[(2, 1)].symbol(), "│");
         assert_eq!(buffer[(2, 1)].style().fg, Some(app.palette.accent));
     }


### PR DESCRIPTION
Refs #728

## Issue

When pane_gaps is false and pane_borders is on, adjacent panes share border lines correctly, but the corner where those lines meet doesn't inherit the focused pane's accent color.

## Fix
Remove the branch_cell / line_cell_degree guard. Let line_touches_pane drive the color decision.

 All tests pass:
 - 2,180 unit tests: all passed, 0 failed
 - Integration tests: all passed across all test binaries
 - clippy: clean (no warnings)
 - fmt: clean