### PR TITLE
feat: make navigator confirm key configurable

### DIFF
--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -211,7 +211,11 @@ pub(crate) fn handle_navigator_key(
                 state.clamp_navigator_selection_from(terminal_runtimes);
             }
         }
-        KeyCode::Enter => {
+        _ if state
+            .keybinds
+            .navigator_confirm
+            .matches_direct_key(TerminalKey::from(key)) =>
+        {
             state.accept_navigator_selection_from(terminal_runtimes);
         }
         KeyCode::Char('/') => {

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -271,6 +271,7 @@ pub struct Keybinds {
     pub close_workspace: ActionKeybinds,
     pub workspace_picker: ActionKeybinds,
     pub goto: ActionKeybinds,
+    pub navigator_confirm: ActionKeybinds,
     pub detach: ActionKeybinds,
     pub reload_config: ActionKeybinds,
     pub open_notification_target: ActionKeybinds,
@@ -390,6 +391,8 @@ impl Config {
         let mut navigate_registry = BindingRegistry::new(prefix);
         navigate_registry.reserve_direct(prefix, "keys.prefix");
         reserve_navigate_runtime_keys(&mut navigate_registry);
+        let mut navigator_registry = BindingRegistry::new(prefix);
+        reserve_navigator_runtime_keys(&mut navigator_registry);
 
         macro_rules! action {
             ($field:literal, $config:expr) => {
@@ -451,6 +454,12 @@ impl Config {
             close_workspace: action!("keys.close_workspace", &self.keys.close_workspace),
             workspace_picker: action!("keys.workspace_picker", &self.keys.workspace_picker),
             goto: action!("keys.goto", &self.keys.goto),
+            navigator_confirm: parse_navigate_bindings(
+                "keys.navigator_confirm",
+                &self.keys.navigator_confirm,
+                &mut navigator_registry,
+                &mut diagnostics,
+            ),
             detach: action!("keys.detach", &self.keys.detach),
             reload_config: action!("keys.reload_config", &self.keys.reload_config),
             open_notification_target: action!(
@@ -577,6 +586,30 @@ fn reserve_navigate_runtime_keys(registry: &mut BindingRegistry) {
             (KeyCode::Char(idx), KeyModifiers::empty()),
             "navigate reserved keys",
         );
+    }
+}
+
+fn reserve_navigator_runtime_keys(registry: &mut BindingRegistry) {
+    for combo in [
+        (KeyCode::Esc, KeyModifiers::empty()),
+        (KeyCode::Char('/'), KeyModifiers::empty()),
+        (KeyCode::Char(' '), KeyModifiers::empty()),
+        (KeyCode::Char('j'), KeyModifiers::empty()),
+        (KeyCode::Char('k'), KeyModifiers::empty()),
+        (KeyCode::Char('a'), KeyModifiers::empty()),
+        (KeyCode::Char('b'), KeyModifiers::empty()),
+        (KeyCode::Char('w'), KeyModifiers::empty()),
+        (KeyCode::Char('i'), KeyModifiers::empty()),
+        (KeyCode::Char('d'), KeyModifiers::empty()),
+        (KeyCode::Char('d'), KeyModifiers::CONTROL),
+        (KeyCode::Char('u'), KeyModifiers::CONTROL),
+        (KeyCode::Up, KeyModifiers::empty()),
+        (KeyCode::Down, KeyModifiers::empty()),
+        (KeyCode::Home, KeyModifiers::empty()),
+        (KeyCode::End, KeyModifiers::empty()),
+        (KeyCode::Backspace, KeyModifiers::empty()),
+    ] {
+        registry.reserve_direct(combo, "navigator reserved keys");
     }
 }
 

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -312,6 +312,8 @@ pub struct KeysConfig {
     pub workspace_picker: BindingConfig,
     /// Open the session navigator. Default: "prefix+g"
     pub goto: BindingConfig,
+    /// Confirm the selected item in the navigator modal. Enter is the default. Unset disables the binding.
+    pub navigator_confirm: BindingConfig,
     /// Move workspace selection up in navigate mode. Default: "up".
     pub navigate_workspace_up: BindingConfig,
     /// Move workspace selection down in navigate mode. Default: "down".
@@ -567,6 +569,7 @@ impl Default for KeysConfig {
             close_workspace: BindingConfig::one("prefix+shift+d"),
             workspace_picker: BindingConfig::one("prefix+w"),
             goto: BindingConfig::one("prefix+g"),
+            navigator_confirm: BindingConfig::one("enter"),
             navigate_workspace_up: BindingConfig::one("up"),
             navigate_workspace_down: BindingConfig::one("down"),
             navigate_pane_left: BindingConfig::one("h"),


### PR DESCRIPTION
## Summary

- Adds `keys.navigator_confirm` config field (default: `"enter"`) to control which key confirms the selected item in the session navigator modal (`prefix+g`)
- Moves the hardcoded `Enter` arm in `handle_navigator_key` to a keybind check, so the key is fully replaceable
- Adds `reserve_navigator_runtime_keys` to reject bindings that conflict with hardcoded navigator shortcuts (`j`, `k`, `/`, `space`, filter chars, etc.)

## Usage

```toml
[keys]
navigator_confirm = ["enter", "o"]
```

## Test plan

- [ ] CI passes
- [ ] Open navigator (`prefix+g`), confirm selection with `enter` — works as before
- [ ] Set `navigator_confirm = "o"`, confirm selection with `o` — switches workspace
- [ ] Set `navigator_confirm = "j"` — config diagnostic rejects it as a reserved key