### PR TITLE
feat: add omp screen detection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __pycache__/
 
 /.wrangler/
 **/.wrangler/
+tmp/
+zig

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -252,6 +252,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("kimi", include_str!("manifests/kimi.toml")),
     ("kiro", include_str!("manifests/kiro.toml")),
     ("opencode", include_str!("manifests/opencode.toml")),
+    ("omp", include_str!("manifests/omp.toml")),
     ("pi", include_str!("manifests/pi.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),
     ("copilot", include_str!("manifests/github-copilot.toml")),

--- a/src/detect/manifests/omp.toml
+++ b/src/detect/manifests/omp.toml
@@ -1,0 +1,53 @@
+id = "omp"
+version = "2026.06.23.5"
+min_engine_version = 2
+updated_at = "2026-06-23T00:00:00Z"
+aliases = ["oh-my-pi"]
+
+# Settings panel: freeze state while user navigates settings
+[[rules]]
+id = "settings_panel"
+state = "unknown"
+priority = 300
+region = "whole_recent"
+skip_state_update = true
+contains = ["╭─ Settings"]
+
+# Blocked: waiting for user selection/confirmation
+[[rules]]
+id = "blocked_prompt"
+state = "blocked"
+priority = 280
+region = "whole_recent"
+visible_blocker = true
+contains = ["up/down navigate", "enter select"]
+
+# Working: Braille spinner character anywhere on screen
+[[rules]]
+id = "spinner_working"
+state = "working"
+priority = 200
+region = "whole_recent"
+visible_working = true
+line_regex = ['^\s*[\x{2800}-\x{28FF}]']
+
+# Idle: prompt box visible, no spinner running
+[[rules]]
+id = "prompt_idle"
+state = "idle"
+priority = 100
+region = "whole_recent"
+visible_idle = true
+contains = ["$ …"]
+not = [
+  { line_regex = ['^\s*[\x{2800}-\x{28FF}]'] },
+]
+
+# Idle: welcome/logout screen (no prompt or spinner)
+[[rules]]
+id = "welcome_idle"
+state = "idle"
+priority = 50
+region = "whole_recent"
+visible_idle = true
+contains = ["Welcome back!"]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -63,7 +63,7 @@ pub enum Agent {
 }
 
 impl Agent {
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 18] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -72,6 +72,7 @@ impl Agent {
         Self::Devin,
         Self::Antigravity,
         Self::Cline,
+        Self::Omp,
         Self::OpenCode,
         Self::GithubCopilot,
         Self::Kimi,


### PR DESCRIPTION
Adds OMP (Oh My Pi) to herdr's agents panel with proper state tracking via screen detection.

- Working: Braille spinner character detection
- Idle: $ … prompt box detection  
- Blocked: selection prompt detection
- Settings panel: state frozen via skip_state_update
- Welcome screen: idle fallback

Closes #775