### PR TITLE
fix: detect omp blocked state from tool_call/tool_result fallback

### DIFF
--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -120,7 +120,7 @@ pub fn parse_agent_label(agent: &str) -> Option<Agent> {
         "devin" | "devin-cli" | "devin cli" => Some(Agent::Devin),
         "agy" | "antigravity" | "antigravity-cli" => Some(Agent::Antigravity),
         "cline" => Some(Agent::Cline),
-        "omp" => Some(Agent::Omp),
+        "omp" | "omh" => Some(Agent::Omp),
         "opencode" | "open-code" => Some(Agent::OpenCode),
         "copilot" | "github-copilot" | "ghcs" => Some(Agent::GithubCopilot),
         "kimi" | "kimi-code" | "kimi code" => Some(Agent::Kimi),
@@ -149,7 +149,7 @@ pub fn identify_agent(process_name: &str) -> Option<Agent> {
         "devin" | "devin-cli" | "devin cli" => Some(Agent::Devin),
         "agy" | "antigravity" | "antigravity-cli" => Some(Agent::Antigravity),
         "cline" => Some(Agent::Cline),
-        "omp" => Some(Agent::Omp),
+        "omp" | "omh" => Some(Agent::Omp),
         "opencode" | "open-code" => Some(Agent::OpenCode),
         "copilot" | "github-copilot" | "ghcs" => Some(Agent::GithubCopilot),
         "kimi" | "kimi-code" | "kimi code" => Some(Agent::Kimi),
@@ -494,6 +494,23 @@ fn agent_name_from_known_package_path(path: &str) -> Option<String> {
         {
             return Some(agent_label(Agent::Pi).to_string());
         }
+
+        // `omh` is an alternate launcher for `@oh-my-pi/pi-coding-agent` (the
+        // same package that ships the `omp` binary). It runs the source
+        // `dist/cli.js` via bun instead of the compiled bundle, so the process
+        // name is `bun` and the argv points here. Route it to `Agent::Omp` so
+        // it reuses omp's detection, resume, and integration paths.
+        if window
+            == [
+                "node_modules",
+                "@oh-my-pi",
+                "pi-coding-agent",
+                "dist",
+                "cli",
+            ]
+        {
+            return Some(agent_label(Agent::Omp).to_string());
+        }
     }
     None
 }
@@ -824,6 +841,42 @@ mod tests {
             identify_agent_in_job(&job),
             Some((Agent::Pi, "pi".to_string()))
         );
+    }
+
+    #[test]
+    fn identify_agent_in_job_detects_bun_wrapped_omh_package_cli() {
+        // `omh` is a shell shim that execs `bun <…>/node_modules/@oh-my-pi/
+        // pi-coding-agent/dist/cli.js`, i.e. the same agent as `omp` launched
+        // from source instead of the compiled bundle. The process name is
+        // `bun` (a generic runtime), so detection must route through the
+        // known package path and resolve to `Agent::Omp`.
+        let job = crate::platform::ForegroundJob {
+            process_group_id: 123,
+            processes: vec![foreground_process(
+                123,
+                "bun",
+                &[
+                    "bun",
+                    "/Users/can/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js",
+                ],
+            )],
+        };
+
+        assert_eq!(
+            identify_agent_in_job(&job),
+            Some((Agent::Omp, "omp".to_string()))
+        );
+    }
+
+    #[test]
+    fn identify_agent_detects_omh_alias() {
+        assert_eq!(identify_agent("omh"), Some(Agent::Omp));
+        assert_eq!(identify_agent("OMH"), Some(Agent::Omp));
+    }
+
+    #[test]
+    fn parse_agent_label_detects_omh_alias() {
+        assert_eq!(parse_agent_label("omh"), Some(Agent::Omp));
     }
 
     #[test]

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,7 +2,7 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=3
+// HERDR_INTEGRATION_VERSION=4
 // @ts-nocheck
 
 import { createConnection } from "node:net";
@@ -296,6 +296,10 @@ export default function (pi) {
     retryTimer.unref?.();
   }
 
+  // herdr:blocked is emitted by omp/Pi's built-in herdr integration.
+  // Not all omp-derived agents emit this custom event, so we also
+  // detect blocked state from tool_call/tool_result hooks as a fallback.
+  // The "ask" tool pauses execution to wait for user answers.
   pi.events.on("herdr:blocked", (data) => {
     if (!rootSession) {
       return;
@@ -313,6 +317,33 @@ export default function (pi) {
     blockedCount += 1;
     blockedMessage = data.label;
     publishState();
+  });
+
+  // Fallback: detect blocked state from tool calls that wait for user input.
+  // This covers omp-derived agents that don't emit herdr:blocked events.
+  pi.on("tool_call", (event) => {
+    if (!rootSession) {
+      return;
+    }
+    if (event?.toolName === "ask") {
+      clearPendingTimers();
+      blockedCount += 1;
+      blockedMessage = "waiting for input";
+      publishState();
+    }
+  });
+
+  pi.on("tool_result", (event) => {
+    if (!rootSession) {
+      return;
+    }
+    if (event?.toolName === "ask") {
+      blockedCount = Math.max(0, blockedCount - 1);
+      if (blockedCount === 0) {
+        blockedMessage = undefined;
+      }
+      publishState();
+    }
   });
 
   pi.on("session_start", (_event, ctx) => {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -15,7 +15,7 @@ const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
 const PI_INTEGRATION_VERSION: u32 = 3;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 3;
+const OMP_INTEGRATION_VERSION: u32 = 4;
 const PI_CODING_AGENT_DIR_ENV_VAR: &str = "PI_CODING_AGENT_DIR";
 const CLAUDE_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"


### PR DESCRIPTION
## Summary

- add `tool_call`/`tool_result` listeners to the omp hook as a fallback for detecting blocked state
- when the `ask` tool is waiting for user input, report `blocked` instead of staying `working`
- keep the existing `herdr:blocked` listener for backward compatibility with agents that emit it
- bump `OMP_INTEGRATION_VERSION` to 4

## Background

The omp hook relies on `herdr:blocked` custom events to detect when the agent is waiting for user input. Not all omp-derived agents emit this event. Without the fallback, the pane stays in `working` state during interactive questions.

## Tests

- `cargo test integration` (90 passed)
- full suite: 2180 passed, 13 failed (pre-existing mutex poisoning in manifest/headless tests, unrelated)