### PR TITLE
feat: add floating panes with mouse-driven move and resize

### DIFF
--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -242,6 +242,7 @@ Press `ctrl+b` to enter prefix mode. Default actions are prefix-first and tmux-l
 | `prefix+x` | close pane |
 | `prefix+b` | toggle sidebar |
 | `prefix+z` | zoom pane |
+| `prefix+f` | toggle floating pane |
 | `prefix+r` | resize mode |
 | `prefix+q` | detach |
 

--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -180,6 +180,7 @@ split_vertical = "prefix+v"
 split_horizontal = "prefix+minus"
 close_pane = "prefix+x"
 zoom = "prefix+z"
+toggle_floating_pane = "prefix+f"
 resize_mode = "prefix+r"
 toggle_sidebar = "prefix+b"
 ```

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -263,7 +263,7 @@ impl AppState {
             .workspaces
             .iter()
             .position(|ws| ws.id == target.workspace_id)?;
-        let tab_idx = self.workspaces[ws_idx].find_tab_index_for_pane(target.pane_id)?;
+        let tab_idx = self.workspaces[ws_idx].effective_tab_index_for_pane(target.pane_id)?;
         Some((ws_idx, tab_idx))
     }
 
@@ -296,9 +296,6 @@ impl AppState {
         let Some(ws) = self.workspaces.get(ws_idx) else {
             return false;
         };
-        let Some(tab_idx) = ws.find_tab_index_for_pane(pane_id) else {
-            return false;
-        };
         let previous = self.current_pane_focus_target();
         let target = PaneFocusTarget {
             workspace_id: ws.id.clone(),
@@ -308,16 +305,31 @@ impl AppState {
             return false;
         }
 
+        if ws.floating_pane_states.contains_key(&pane_id) {
+            let active_tab = ws.active_tab;
+            self.switch_workspace_tab(ws_idx, active_tab);
+            if let Some(ws) = self.workspaces.get_mut(ws_idx) {
+                ws.floating.focus(pane_id);
+                self.previous_pane_focus = previous;
+                self.mark_session_dirty();
+                return true;
+            }
+            return false;
+        }
+
+        let Some(tab_idx) = ws.find_tab_index_for_pane(pane_id) else {
+            return false;
+        };
         self.switch_workspace_tab(ws_idx, tab_idx);
-        if let Some(tab) = self
-            .workspaces
-            .get_mut(ws_idx)
-            .and_then(|ws| ws.tabs.get_mut(tab_idx))
-        {
-            tab.layout.focus_pane(pane_id);
-            self.previous_pane_focus = previous;
-            self.mark_session_dirty();
-            return true;
+        if let Some(ws) = self.workspaces.get_mut(ws_idx) {
+            // Focusing a tiled pane takes focus away from any floating pane.
+            ws.floating.hide();
+            if let Some(tab) = ws.tabs.get_mut(tab_idx) {
+                tab.layout.focus_pane(pane_id);
+                self.previous_pane_focus = previous;
+                self.mark_session_dirty();
+                return true;
+            }
         }
         false
     }
@@ -1338,21 +1350,25 @@ impl AppState {
         &self,
         ws_idx: usize,
     ) -> Vec<crate::terminal::TerminalId> {
-        self.workspaces
-            .get(ws_idx)
-            .into_iter()
-            .flat_map(|ws| &ws.tabs)
+        let Some(ws) = self.workspaces.get(ws_idx) else {
+            return Vec::new();
+        };
+        ws.tabs
+            .iter()
             .flat_map(|tab| tab.panes.values())
+            .chain(ws.floating_pane_states.values())
             .map(|pane| pane.attached_terminal_id.clone())
             .collect()
     }
 
     pub(crate) fn pane_ids_for_workspace(&self, ws_idx: usize) -> Vec<PaneId> {
-        self.workspaces
-            .get(ws_idx)
-            .into_iter()
-            .flat_map(|ws| &ws.tabs)
+        let Some(ws) = self.workspaces.get(ws_idx) else {
+            return Vec::new();
+        };
+        ws.tabs
+            .iter()
             .flat_map(|tab| tab.layout.pane_ids())
+            .chain(ws.floating_pane_states.keys().copied())
             .collect()
     }
 
@@ -1399,7 +1415,10 @@ impl AppState {
                     tab.panes
                         .values()
                         .any(|pane| pane.attached_terminal_id == terminal_id)
-                })
+                }) || ws
+                    .floating_pane_states
+                    .values()
+                    .any(|pane| pane.attached_terminal_id == terminal_id)
             });
             if !still_attached
                 && self.terminals.remove(&terminal_id).is_some()
@@ -1627,7 +1646,7 @@ impl AppState {
         let Some(target) = self.previous_pane_focus.clone() else {
             return;
         };
-        let Some((ws_idx, tab_idx)) = self.pane_focus_target_indices(&target) else {
+        let Some((ws_idx, _tab_idx)) = self.pane_focus_target_indices(&target) else {
             self.previous_pane_focus = None;
             return;
         };
@@ -1637,15 +1656,8 @@ impl AppState {
             return;
         }
 
-        self.switch_workspace_tab(ws_idx, tab_idx);
-        if let Some(tab) = self
-            .workspaces
-            .get_mut(ws_idx)
-            .and_then(|ws| ws.tabs.get_mut(tab_idx))
-        {
-            tab.layout.focus_pane(target.pane_id);
+        if self.focus_pane_in_workspace(ws_idx, target.pane_id) {
             self.previous_pane_focus = current;
-            self.mark_session_dirty();
         }
     }
 
@@ -1765,6 +1777,25 @@ impl AppState {
     /// Close the focused pane. Returns true when the close was deferred to confirmation.
     pub fn close_pane(&mut self) -> bool {
         let active = self.active;
+
+        // Check if a floating pane is focused first
+        if let Some(ws_idx) = active {
+            let floating_id = self
+                .workspaces
+                .get(ws_idx)
+                .and_then(|ws| ws.floating.focused);
+            if let Some(floating_id) = floating_id {
+                let terminal_id = self
+                    .workspaces
+                    .get_mut(ws_idx)
+                    .and_then(|ws| ws.remove_floating_pane(floating_id));
+                self.remove_plugin_pane_records([floating_id]);
+                self.remove_unattached_terminal_ids(terminal_id);
+                self.mark_session_dirty();
+                return false;
+            }
+        }
+
         if active.is_some_and(|ws_idx| {
             self.close_focused_pane_would_close_workspace(ws_idx)
                 && self.workspace_close_would_close_worktree_group(ws_idx)
@@ -1805,6 +1836,94 @@ impl AppState {
             self.remove_unattached_terminal_ids(terminal_ids);
         }
         false
+    }
+
+    /// Create a new floating pane in the active workspace.
+    pub fn new_floating_pane(
+        &mut self,
+        terminal_runtimes: &mut crate::terminal::TerminalRuntimeRegistry,
+    ) {
+        let Some(ws_idx) = self.active else {
+            return;
+        };
+        let terminal_area = self.view.terminal_area;
+
+        let follow_cwd = self.workspaces.get(ws_idx).and_then(|ws| {
+            ws.active_tab().and_then(|tab| {
+                tab.cwd_for_pane(tab.layout.focused(), &self.terminals, terminal_runtimes)
+            })
+        });
+        let cwd = Some(super::creation::resolve_new_terminal_cwd(
+            &self.new_terminal_cwd,
+            follow_cwd,
+        ));
+
+        let default_pos =
+            crate::layout::floating::FloatingPanePosition::default_in_area(terminal_area)
+                .clamp_to_area(terminal_area);
+        let inner = crate::ui::panes::pane_inner_rect(
+            default_pos.to_rect(terminal_area),
+            ratatui::widgets::Borders::ALL,
+        );
+
+        let Some(ws) = self.workspaces.get_mut(ws_idx) else {
+            return;
+        };
+        let Ok(new_pane) = ws.create_floating_pane(
+            inner.height,
+            inner.width,
+            cwd,
+            self.pane_scrollback_limit_bytes,
+            self.host_terminal_theme,
+            crate::pane::PaneShellConfig::new(&self.default_shell, self.shell_mode),
+            Vec::new(),
+            terminal_area,
+        ) else {
+            return;
+        };
+
+        let new_id = new_pane.pane_id;
+        terminal_runtimes.insert(new_pane.terminal.id.clone(), new_pane.runtime);
+
+        self.remove_alias_shadowed_by_new_pane(new_id);
+        self.terminals
+            .insert(new_pane.terminal.id.clone(), new_pane.terminal);
+        self.mark_session_dirty();
+        self.mode = Mode::Terminal;
+    }
+
+    /// Hide a visible floating pane or show a hidden one. Returns true when an
+    /// existing pane handled the toggle; callers should create one on false.
+    pub fn toggle_floating_pane_visibility(&mut self) -> bool {
+        let Some(ws_idx) = self.active else {
+            return true;
+        };
+        let Some(ws) = self.workspaces.get_mut(ws_idx) else {
+            return true;
+        };
+        if ws.floating.is_empty() {
+            return false;
+        }
+
+        if ws.floating.visible {
+            ws.floating.hide();
+        } else {
+            ws.floating.show();
+        }
+        self.mark_session_dirty();
+        true
+    }
+
+    /// Toggle floating pane visibility, creating a floating pane when none
+    /// exists in the active workspace.
+    pub fn toggle_floating_pane(
+        &mut self,
+        terminal_runtimes: &mut crate::terminal::TerminalRuntimeRegistry,
+    ) {
+        if !self.toggle_floating_pane_visibility() {
+            self.new_floating_pane(terminal_runtimes);
+        }
+        self.mode = Mode::Terminal;
     }
 
     /// Close the active tab. Returns true when the close was deferred to confirmation.
@@ -2848,7 +2967,7 @@ impl AppState {
         let ws_idx = self
             .workspaces
             .iter()
-            .position(|ws| ws.find_tab_index_for_pane(pane_id).is_some());
+            .position(|ws| ws.pane_state(pane_id).is_some());
 
         let Some(ws_idx) = ws_idx else {
             warn!(pane = pane_id.raw(), "PaneDied for unknown pane");
@@ -2871,7 +2990,12 @@ impl AppState {
             .retain(|_, alias| *alias != pane_id);
         let should_close_workspace = {
             let ws = &mut self.workspaces[ws_idx];
-            ws.remove_pane(pane_id)
+            if ws.floating_pane_states.contains_key(&pane_id) {
+                ws.remove_floating_pane(pane_id);
+                false
+            } else {
+                ws.remove_pane(pane_id)
+            }
         };
         self.mark_session_dirty();
 
@@ -2955,6 +3079,93 @@ mod tests {
             notification_context(&state.workspaces[0], "__herdr_projects__", 0, root),
             "__herdr_projects__ · 1"
         );
+    }
+
+    #[test]
+    fn closing_floating_pane_queues_terminal_shutdown() {
+        let mut state = app_with_workspaces(&["floating"]);
+        let floating_id = state.workspaces[0].test_add_floating_pane();
+        let terminal_id = state.workspaces[0]
+            .terminal_id(floating_id)
+            .cloned()
+            .expect("floating pane has a terminal");
+        state.terminals.insert(
+            terminal_id.clone(),
+            crate::terminal::TerminalState::new(terminal_id.clone(), "/".into()),
+        );
+
+        // Floating pane is focused, so close_pane should target it.
+        assert_eq!(state.workspaces[0].floating.focused, Some(floating_id));
+        let deferred = state.close_pane();
+
+        assert!(!deferred);
+        assert!(state.workspaces[0].pane_state(floating_id).is_none());
+        assert!(state.workspaces[0].floating.is_empty());
+        assert!(state.terminal_runtime_shutdowns.contains(&terminal_id));
+        assert!(!state.terminals.contains_key(&terminal_id));
+        state.workspaces[0].assert_invariants_for_test();
+    }
+
+    #[test]
+    fn pane_died_closes_floating_pane() {
+        let mut state = app_with_workspaces(&["floating"]);
+        let tiled_id = state.workspaces[0].tabs[0].root_pane;
+        let floating_id = state.workspaces[0].test_add_floating_pane();
+        let terminal_id = state.workspaces[0]
+            .terminal_id(floating_id)
+            .cloned()
+            .expect("floating pane has a terminal");
+        state.terminals.insert(
+            terminal_id.clone(),
+            crate::terminal::TerminalState::new(terminal_id.clone(), "/".into()),
+        );
+
+        state.handle_app_event(AppEvent::PaneDied {
+            pane_id: floating_id,
+        });
+
+        assert!(state.workspaces[0].pane_state(floating_id).is_none());
+        assert!(state.workspaces[0].floating.is_empty());
+        assert_eq!(state.workspaces[0].focused_pane_id(), Some(tiled_id));
+        assert!(state.terminal_runtime_shutdowns.contains(&terminal_id));
+        assert!(!state.terminals.contains_key(&terminal_id));
+        state.workspaces[0].assert_invariants_for_test();
+    }
+
+    #[test]
+    fn toggle_floating_pane_visibility_hides_and_shows_existing_pane() {
+        let mut state = app_with_workspaces(&["floating"]);
+        let floating_id = state.workspaces[0].test_add_floating_pane();
+
+        assert!(state.toggle_floating_pane_visibility());
+        assert!(!state.workspaces[0].floating.visible);
+        assert_eq!(state.workspaces[0].floating.focused, None);
+
+        assert!(state.toggle_floating_pane_visibility());
+        assert!(state.workspaces[0].floating.visible);
+        assert_eq!(state.workspaces[0].floating.focused, Some(floating_id));
+    }
+
+    #[test]
+    fn toggle_floating_pane_visibility_reports_missing_pane() {
+        let mut state = app_with_workspaces(&["floating"]);
+
+        assert!(!state.toggle_floating_pane_visibility());
+    }
+
+    #[test]
+    fn focusing_tiled_pane_hides_visible_floating_pane() {
+        let mut state = app_with_workspaces(&["floating"]);
+        state.workspaces[0].test_split(Direction::Horizontal);
+        let tiled_id = state.workspaces[0].tabs[0].root_pane;
+        let floating_id = state.workspaces[0].test_add_floating_pane();
+
+        assert!(state.focus_pane_in_workspace(0, tiled_id));
+
+        assert!(!state.workspaces[0].floating.visible);
+        assert_eq!(state.workspaces[0].floating.focused, None);
+        assert_eq!(state.workspaces[0].focused_pane_id(), Some(tiled_id));
+        assert!(state.workspaces[0].pane_state(floating_id).is_some());
     }
 
     fn selected_word(row: &str, col: u16) -> Option<String> {

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -154,6 +154,25 @@ impl App {
                     });
                 }
             }
+            if self.find_pane(*pane_id).is_some_and(|(ws_idx, _)| {
+                self.state
+                    .workspaces
+                    .get(ws_idx)
+                    .is_some_and(|ws| ws.floating_pane_states.contains_key(pane_id))
+            }) {
+                self.overlay_panes.remove(pane_id);
+                let previous_toast = self.state.toast.clone();
+                let pane_updates = self.state.handle_app_event(ev);
+                for update in &pane_updates {
+                    self.refresh_new_herdr_toast_context_for_update(update, &previous_toast);
+                    self.emit_pane_state_update(update);
+                }
+                self.sync_toast_deadline(previous_toast);
+                self.shutdown_detached_terminal_runtimes();
+                self.render_dirty.store(true, Ordering::Release);
+                self.render_notify.notify_one();
+                return;
+            }
         }
 
         let released_agent = if let AppEvent::HookAgentReleased {
@@ -387,9 +406,17 @@ impl App {
     }
 
     fn runtime_exit_action(&self, pane_id: crate::layout::PaneId) -> RuntimeExitAction {
-        let Some((_, pane_state)) = self.find_pane(pane_id) else {
+        let Some((ws_idx, pane_state)) = self.find_pane(pane_id) else {
             return RuntimeExitAction::ClosePane;
         };
+        if self
+            .state
+            .workspaces
+            .get(ws_idx)
+            .is_some_and(|ws| ws.floating_pane_states.contains_key(&pane_id))
+        {
+            return RuntimeExitAction::ClosePane;
+        }
         let Some(terminal) = self.state.terminals.get(&pane_state.attached_terminal_id) else {
             return RuntimeExitAction::ClosePane;
         };

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1150,7 +1150,7 @@ impl App {
             .state
             .workspaces
             .get(ws_idx)
-            .and_then(|ws| ws.find_tab_index_for_pane(pane_id))
+            .and_then(|ws| ws.effective_tab_index_for_pane(pane_id))
         else {
             return pane_not_found(id, &params.pane_id);
         };

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -221,6 +221,7 @@ impl App {
                 .tabs
                 .iter()
                 .flat_map(|tab| tab.layout.pane_ids().into_iter())
+                .chain(ws.floating.order.iter().copied())
                 .filter_map(|pane_id| self.pane_info(ws_idx, pane_id))
                 .collect())
         } else {
@@ -233,6 +234,7 @@ impl App {
                     ws.tabs
                         .iter()
                         .flat_map(|tab| tab.layout.pane_ids().into_iter())
+                        .chain(ws.floating.order.iter().copied())
                         .filter_map(move |pane_id| self.pane_info(ws_idx, pane_id))
                 })
                 .collect())
@@ -350,7 +352,7 @@ impl App {
         let ws = self.state.workspaces.get(ws_idx)?;
         let pane = ws.pane_state(pane_id)?;
         let terminal = self.state.terminals.get(&pane.attached_terminal_id)?;
-        let tab_idx = ws.find_tab_index_for_pane(pane_id)?;
+        let tab_idx = ws.effective_tab_index_for_pane(pane_id)?;
         let focused = self.state.active == Some(ws_idx)
             && ws.active_tab == tab_idx
             && ws
@@ -363,10 +365,10 @@ impl App {
             workspace_id: self.public_workspace_id(ws_idx),
             tab_id: self.public_tab_id(ws_idx, tab_idx)?,
             focused,
-            cwd: ws.tabs[tab_idx]
+            cwd: ws
                 .cwd_for_pane(pane_id, &self.state.terminals, &self.terminal_runtimes)
                 .map(|cwd| cwd.display().to_string()),
-            foreground_cwd: ws.tabs[tab_idx]
+            foreground_cwd: ws
                 .foreground_cwd_for_pane(pane_id, &self.terminal_runtimes)
                 .map(|cwd| cwd.display().to_string()),
             label: terminal.manual_label.clone(),

--- a/src/app/ids.rs
+++ b/src/app/ids.rs
@@ -45,7 +45,7 @@ impl App {
     ) -> Option<crate::pane::PaneLaunchEnv> {
         let workspace_id = self.public_workspace_id(ws_idx);
         let ws = self.state.workspaces.get(ws_idx)?;
-        let tab_idx = ws.find_tab_index_for_pane(pane_id)?;
+        let tab_idx = ws.effective_tab_index_for_pane(pane_id)?;
         let tab_id = self.public_tab_id(ws_idx, tab_idx)?;
         let pane_id = self.public_pane_id(ws_idx, pane_id)?;
         Some(

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -401,6 +401,10 @@ impl App {
             self.last_pane_click = None;
             return None;
         };
+        if !mouse::rect_contains(info.inner_rect, mouse.column, mouse.row) {
+            self.last_pane_click = None;
+            return None;
+        }
 
         Some(PaneClickState {
             pane_id: info.id,

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -579,6 +579,104 @@ impl AppState {
                         return None;
                     }
                 } else if let Some(info) = self.pane_at(mouse.column, mouse.row).cloned() {
+                    // Floating panes are handled separately: they are not part
+                    // of any tab layout, so focus and drag go through the
+                    // workspace-level floating state, not the tiled focus path.
+                    if let Some(floating_info) = self
+                        .view
+                        .floating_pane_infos
+                        .iter()
+                        .find(|p| p.id == info.id)
+                        .cloned()
+                    {
+                        // Clicking a floating pane focuses it and raises it.
+                        let previous = self.current_pane_focus_target();
+                        if let Some(ws_idx) = self.active {
+                            if let Some(ws) = self.workspaces.get_mut(ws_idx) {
+                                ws.floating.focus(floating_info.id);
+                            }
+                            self.record_pane_focus_change(previous, ws_idx, floating_info.id);
+                        }
+                        if self.mode != Mode::Terminal {
+                            self.mode = Mode::Terminal;
+                        }
+
+                        let on_border = mouse.column == floating_info.rect.x
+                            || mouse.column == floating_info.rect.x + floating_info.rect.width - 1
+                            || mouse.row == floating_info.rect.y
+                            || mouse.row == floating_info.rect.y + floating_info.rect.height - 1;
+                        let on_corner = (mouse.column
+                            == floating_info.rect.x + floating_info.rect.width - 1
+                            || mouse.column == floating_info.rect.x + floating_info.rect.width - 2)
+                            && (mouse.row == floating_info.rect.y + floating_info.rect.height - 1
+                                || mouse.row
+                                    == floating_info.rect.y + floating_info.rect.height - 2);
+                        if on_corner {
+                            // Start resize drag from bottom-right corner.
+                            // Capture the starting cursor and pane size so the
+                            // resize tracks origin + total delta rather than
+                            // snapping the corner to the raw cursor position.
+                            let origin = self
+                                .active
+                                .and_then(|ws_idx| self.workspaces.get(ws_idx))
+                                .and_then(|ws| ws.floating.positions.get(&floating_info.id))
+                                .map(|pos| (pos.width, pos.height))
+                                .unwrap_or((0, 0));
+                            self.drag = Some(DragState {
+                                target: DragTarget::FloatingPaneResize {
+                                    pane_id: floating_info.id,
+                                    start_col: mouse.column,
+                                    start_row: mouse.row,
+                                    origin_width: origin.0,
+                                    origin_height: origin.1,
+                                },
+                            });
+                            return None;
+                        } else if on_border {
+                            // Start move drag from border. Capture the pane's
+                            // current origin so the move tracks origin + total
+                            // delta rather than accumulating per-event deltas.
+                            let origin = self
+                                .active
+                                .and_then(|ws_idx| self.workspaces.get(ws_idx))
+                                .and_then(|ws| ws.floating.positions.get(&floating_info.id))
+                                .map(|pos| (pos.x, pos.y))
+                                .unwrap_or((0, 0));
+                            self.drag = Some(DragState {
+                                target: DragTarget::FloatingPaneMove {
+                                    pane_id: floating_info.id,
+                                    start_col: mouse.column,
+                                    start_row: mouse.row,
+                                    origin_x: origin.0,
+                                    origin_y: origin.1,
+                                },
+                            });
+                            return None;
+                        }
+
+                        if !rect_contains(info.inner_rect, mouse.column, mouse.row) {
+                            return None;
+                        }
+
+                        // Content click: forward to the pane / begin selection.
+                        if self.forward_pane_mouse_button(terminal_runtimes, &info, mouse) {
+                            self.selection = None;
+                            self.selection_autoscroll = None;
+                            return None;
+                        }
+                        let (row, col) = (
+                            mouse.row - info.inner_rect.y,
+                            mouse.column - info.inner_rect.x,
+                        );
+                        self.selection = Some(Selection::anchor(
+                            info.id,
+                            row,
+                            col,
+                            self.pane_scroll_metrics(terminal_runtimes, info.id),
+                        ));
+                        return None;
+                    }
+
                     self.focus_pane(info.id);
                     if self.mode != Mode::Terminal {
                         self.mode = Mode::Terminal;
@@ -752,6 +850,76 @@ impl AppState {
                         DragTarget::ReleaseNotesScrollbar { .. }
                         | DragTarget::ProductAnnouncementScrollbar { .. }
                         | DragTarget::KeybindHelpScrollbar { .. } => {}
+                        DragTarget::FloatingPaneMove {
+                            pane_id,
+                            start_col,
+                            start_row,
+                            origin_x,
+                            origin_y,
+                        } => {
+                            // Track origin + total delta so the pane follows the
+                            // cursor instead of accelerating from re-applied deltas.
+                            let pane_id = *pane_id;
+                            let dx = mouse.column as i16 - *start_col as i16;
+                            let dy = mouse.row as i16 - *start_row as i16;
+                            let area = self.view.terminal_area;
+                            let new_x = (*origin_x as i32 + dx as i32)
+                                .clamp(0, area.width.saturating_sub(1) as i32)
+                                as u16;
+                            let new_y = (*origin_y as i32 + dy as i32)
+                                .clamp(0, area.height.saturating_sub(1) as i32)
+                                as u16;
+                            if let Some(ws) = self.active.and_then(|i| self.workspaces.get_mut(i)) {
+                                if let Some(pos) = ws.floating.positions.get(&pane_id).copied() {
+                                    ws.floating.set_position_clamped(
+                                        pane_id,
+                                        crate::layout::floating::FloatingPanePosition {
+                                            x: new_x,
+                                            y: new_y,
+                                            ..pos
+                                        },
+                                        area,
+                                    );
+                                }
+                            }
+                        }
+                        DragTarget::FloatingPaneResize {
+                            pane_id,
+                            start_col,
+                            start_row,
+                            origin_width,
+                            origin_height,
+                        } => {
+                            // Track origin size + total delta so the corner
+                            // follows the cursor smoothly instead of snapping.
+                            let pane_id = *pane_id;
+                            let dw = mouse.column as i16 - *start_col as i16;
+                            let dh = mouse.row as i16 - *start_row as i16;
+                            let area = self.view.terminal_area;
+                            if let Some(ws) = self.active.and_then(|i| self.workspaces.get_mut(i)) {
+                                if let Some(pos) = ws.floating.positions.get(&pane_id).copied() {
+                                    let new_w = (*origin_width as i32 + dw as i32).clamp(
+                                        crate::layout::floating::FloatingPanePosition::MIN_WIDTH
+                                            as i32,
+                                        area.width.saturating_sub(pos.x) as i32,
+                                    ) as u16;
+                                    let new_h = (*origin_height as i32 + dh as i32).clamp(
+                                        crate::layout::floating::FloatingPanePosition::MIN_HEIGHT
+                                            as i32,
+                                        area.height.saturating_sub(pos.y) as i32,
+                                    ) as u16;
+                                    ws.floating.set_position_clamped(
+                                        pane_id,
+                                        crate::layout::floating::FloatingPanePosition {
+                                            width: new_w,
+                                            height: new_h,
+                                            ..pos
+                                        },
+                                        area,
+                                    );
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1308,6 +1476,16 @@ impl AppState {
     }
 
     pub(super) fn pane_at(&self, col: u16, row: u16) -> Option<&PaneInfo> {
+        // Check floating panes first (top-most has priority)
+        for p in self.view.floating_pane_infos.iter().rev() {
+            if col >= p.rect.x
+                && col < p.rect.x + p.rect.width
+                && row >= p.rect.y
+                && row < p.rect.y + p.rect.height
+            {
+                return Some(p);
+            }
+        }
         self.view.pane_infos.iter().find(|p| {
             col >= p.inner_rect.x
                 && col < p.inner_rect.x + p.inner_rect.width
@@ -1322,7 +1500,11 @@ impl AppState {
     }
 
     pub(crate) fn pane_info_by_id(&self, pane_id: crate::layout::PaneId) -> Option<&PaneInfo> {
-        self.view.pane_infos.iter().find(|info| info.id == pane_id)
+        self.view
+            .pane_infos
+            .iter()
+            .chain(self.view.floating_pane_infos.iter())
+            .find(|info| info.id == pane_id)
     }
 
     pub(super) fn pane_frame_at(&self, col: u16, row: u16) -> Option<&PaneInfo> {
@@ -1736,7 +1918,7 @@ pub(super) fn wheel_routing(input_state: crate::pane::InputState) -> WheelRoutin
     }
 }
 
-fn rect_contains(rect: Rect, col: u16, row: u16) -> bool {
+pub(super) fn rect_contains(rect: Rect, col: u16, row: u16) -> bool {
     rect.width > 0
         && rect.height > 0
         && col >= rect.x
@@ -2986,6 +3168,67 @@ mod tests {
 
         let after = capture_snapshot(&app.state);
         assert_ne!(root_layout_ratio(&before), root_layout_ratio(&after));
+    }
+
+    #[test]
+    fn clicking_floating_pane_top_border_starts_move_without_selection_underflow() {
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let floating_id = ws.test_add_floating_pane();
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 40));
+        let info = app
+            .state
+            .view
+            .floating_pane_infos
+            .iter()
+            .find(|info| info.id == floating_id)
+            .expect("floating pane info")
+            .clone();
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            info.rect.x + 2,
+            info.rect.y,
+        ));
+
+        assert!(app.state.selection.is_none());
+        assert!(matches!(
+            app.state.drag.as_ref().map(|drag| &drag.target),
+            Some(DragTarget::FloatingPaneMove { pane_id, .. }) if *pane_id == floating_id
+        ));
+    }
+
+    #[test]
+    fn pane_info_by_id_resolves_floating_panes() {
+        // Selection drag/copy resolve pane geometry through pane_info_by_id.
+        // Floating panes are not in view.pane_infos, so the lookup must also
+        // search floating_pane_infos or selection inside a floating pane
+        // silently fails to track and copies nothing.
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("test");
+        let floating_id = ws.test_add_floating_pane();
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 40));
+
+        assert!(
+            app.state
+                .view
+                .pane_infos
+                .iter()
+                .all(|info| info.id != floating_id),
+            "floating pane should not be in tiled pane_infos"
+        );
+
+        let info = app
+            .state
+            .pane_info_by_id(floating_id)
+            .expect("pane_info_by_id should resolve floating pane");
+        assert_eq!(info.id, floating_id);
     }
 
     #[test]

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -187,9 +187,11 @@ impl App {
                     if let Some(public_pane_id) = self.public_pane_id(ws_idx, pane_id) {
                         env.push(("HERDR_ACTIVE_PANE_ID".to_string(), public_pane_id));
                     }
-                    if let Some(pane_cwd) = workspace.active_tab().and_then(|tab| {
-                        tab.cwd_for_pane(pane_id, &self.state.terminals, &self.terminal_runtimes)
-                    }) {
+                    if let Some(pane_cwd) = workspace.cwd_for_pane(
+                        pane_id,
+                        &self.state.terminals,
+                        &self.terminal_runtimes,
+                    ) {
                         env.push((
                             "HERDR_ACTIVE_PANE_CWD".to_string(),
                             pane_cwd.display().to_string(),
@@ -606,6 +608,7 @@ pub(crate) enum NavigateAction {
     CyclePaneNext,
     CyclePanePrevious,
     LastPane,
+    ToggleFloatingPane,
     Help,
     Settings,
     ReloadConfig,
@@ -708,6 +711,7 @@ fn action_for_key(
         (&kb.split_horizontal, NavigateAction::SplitHorizontal),
         (&kb.close_pane, NavigateAction::ClosePane),
         (&kb.zoom, NavigateAction::Zoom),
+        (&kb.toggle_floating_pane, NavigateAction::ToggleFloatingPane),
         (&kb.resize_mode, NavigateAction::EnterResizeMode),
         (&kb.toggle_sidebar, NavigateAction::ToggleSidebar),
         (&kb.reload_config, NavigateAction::ReloadConfig),
@@ -928,6 +932,10 @@ pub(super) fn execute_navigate_action_in_context(
         }
         NavigateAction::LastPane => {
             state.last_pane();
+            leave_navigate_mode(state);
+        }
+        NavigateAction::ToggleFloatingPane => {
+            state.toggle_floating_pane(terminal_runtimes);
             leave_navigate_mode(state);
         }
         NavigateAction::Help => super::modal::open_keybind_help(state),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -561,6 +561,7 @@ impl App {
                 mobile_menu_hit_area: Rect::default(),
                 toast_hit_area: Rect::default(),
                 pane_infos: Vec::new(),
+                floating_pane_infos: Vec::new(),
                 split_borders: Vec::new(),
             },
             drag: None,
@@ -4149,6 +4150,28 @@ last_pane = "prefix+tab"
 
         assert_eq!(app.state.active, Some(1));
         assert_eq!(app.state.workspaces[1].focused_pane_id(), Some(second_root));
+    }
+
+    #[test]
+    fn route_client_input_prefix_f_toggles_existing_floating_pane() {
+        let mut app = test_app();
+        app.state.workspaces = vec![Workspace::test_new("test")];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        let floating_id = app.state.workspaces[0].test_add_floating_pane();
+
+        app.route_client_input(vec![0x02, b'f']);
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert!(!app.state.workspaces[0].floating.visible);
+        assert_eq!(app.state.workspaces[0].floating.focused, None);
+
+        app.route_client_input(vec![0x02, b'f']);
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert!(app.state.workspaces[0].floating.visible);
+        assert_eq!(app.state.workspaces[0].floating.focused, Some(floating_id));
     }
 
     #[tokio::test]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -741,6 +741,7 @@ pub struct ViewState {
     pub mobile_menu_hit_area: Rect,
     pub toast_hit_area: Rect,
     pub pane_infos: Vec<PaneInfo>,
+    pub floating_pane_infos: Vec<PaneInfo>,
     pub split_borders: Vec<SplitBorder>,
 }
 
@@ -1036,6 +1037,20 @@ pub(crate) enum DragTarget {
     },
     SidebarDivider,
     SidebarSectionDivider,
+    FloatingPaneMove {
+        pane_id: crate::layout::PaneId,
+        start_col: u16,
+        start_row: u16,
+        origin_x: u16,
+        origin_y: u16,
+    },
+    FloatingPaneResize {
+        pane_id: crate::layout::PaneId,
+        start_col: u16,
+        start_row: u16,
+        origin_width: u16,
+        origin_height: u16,
+    },
 }
 
 /// Active mouse drag on a split border or sidebar divider.
@@ -1681,6 +1696,7 @@ impl AppState {
                 mobile_menu_hit_area: Rect::default(),
                 toast_hit_area: Rect::default(),
                 pane_infos: Vec::new(),
+                floating_pane_infos: Vec::new(),
                 split_borders: Vec::new(),
             },
             drag: None,
@@ -1790,6 +1806,15 @@ impl AppState {
                             TerminalState::new(pane.attached_terminal_id.clone(), cwd),
                         );
                     }
+                }
+            }
+            for pane in ws.floating_pane_states.values() {
+                if !self.terminals.contains_key(&pane.attached_terminal_id) {
+                    let cwd = ws.identity_cwd.clone();
+                    self.terminals.insert(
+                        pane.attached_terminal_id.clone(),
+                        TerminalState::new(pane.attached_terminal_id.clone(), cwd),
+                    );
                 }
             }
         }

--- a/src/app/terminal_targets.rs
+++ b/src/app/terminal_targets.rs
@@ -135,7 +135,7 @@ impl App {
         pane_id: crate::layout::PaneId,
     ) -> Option<TerminalTarget> {
         let ws = self.state.workspaces.get(ws_idx)?;
-        let tab_idx = ws.find_tab_index_for_pane(pane_id)?;
+        let tab_idx = ws.effective_tab_index_for_pane(pane_id)?;
         let terminal_id = ws.terminal_id(pane_id)?.to_string();
         Some(TerminalTarget {
             ws_idx,
@@ -153,7 +153,7 @@ impl App {
         pane_id: crate::layout::PaneId,
     ) -> Option<TerminalTargetCandidate> {
         let ws = self.state.workspaces.get(ws_idx)?;
-        let tab_idx = ws.find_tab_index_for_pane(pane_id)?;
+        let tab_idx = ws.effective_tab_index_for_pane(pane_id)?;
         let pane = ws.pane_state(pane_id)?;
         let terminal = self.state.terminals.get(&pane.attached_terminal_id)?;
         Some(TerminalTargetCandidate {
@@ -161,7 +161,7 @@ impl App {
             pane_id: self.public_pane_id(ws_idx, pane_id)?,
             workspace_id: self.public_workspace_id(ws_idx),
             tab_id: self.public_tab_id(ws_idx, tab_idx)?,
-            cwd: ws.tabs[tab_idx]
+            cwd: ws
                 .cwd_for_pane(pane_id, &self.state.terminals, &self.terminal_runtimes)
                 .map(|cwd| cwd.display().to_string()),
             agent_status: pane_agent_status(terminal.state, pane.seen),

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -333,6 +333,7 @@ pub struct Keybinds {
     pub split_horizontal: ActionKeybinds,
     pub close_pane: ActionKeybinds,
     pub zoom: ActionKeybinds,
+    pub toggle_floating_pane: ActionKeybinds,
     pub resize_mode: ActionKeybinds,
     pub toggle_sidebar: ActionKeybinds,
     pub custom_commands: Vec<CustomCommandKeybind>,
@@ -495,6 +496,7 @@ impl Config {
             split_horizontal: empty_action!(),
             close_pane: empty_action!(),
             zoom: empty_action!(),
+            toggle_floating_pane: empty_action!(),
             resize_mode: empty_action!(),
             toggle_sidebar: empty_action!(),
             custom_commands: Vec::new(),
@@ -636,6 +638,7 @@ impl Config {
             apply_action!(keybinds.split_horizontal, split_horizontal, source);
             apply_action!(keybinds.close_pane, close_pane, source);
             apply_action!(keybinds.zoom, zoom, source);
+            apply_action!(keybinds.toggle_floating_pane, toggle_floating_pane, source);
             apply_action!(keybinds.resize_mode, resize_mode, source);
             apply_action!(keybinds.toggle_sidebar, toggle_sidebar, source);
 
@@ -2041,6 +2044,46 @@ switch_tab = "prefix+?"
             vec![BindingTrigger::Prefix((
                 KeyCode::Char('l'),
                 KeyModifiers::SHIFT
+            ))]
+        );
+        assert_eq!(
+            binding_triggers(&kb.toggle_floating_pane),
+            vec![BindingTrigger::Prefix((
+                KeyCode::Char('f'),
+                KeyModifiers::empty()
+            ))]
+        );
+    }
+
+    #[test]
+    fn legacy_floating_keybind_names_configure_toggle_floating_pane() {
+        let create_alias: Config = toml::from_str(
+            r#"
+[keys]
+new_floating_pane = "prefix+shift+f"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            binding_triggers(&create_alias.keybinds().toggle_floating_pane),
+            vec![BindingTrigger::Prefix((
+                KeyCode::Char('f'),
+                KeyModifiers::SHIFT
+            ))]
+        );
+
+        let focus_alias: Config = toml::from_str(
+            r#"
+[keys]
+toggle_floating_focus = "ctrl+alt+f"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            binding_triggers(&focus_alias.keybinds().toggle_floating_pane),
+            vec![BindingTrigger::Direct((
+                KeyCode::Char('f'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT
             ))]
         );
     }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -393,6 +393,9 @@ pub struct KeysConfig {
     /// Toggle zoom for the focused pane. Default: "prefix+z"
     #[serde(alias = "fullscreen")]
     pub zoom: BindingConfig,
+    /// Toggle a floating pane. Default: "prefix+f"
+    #[serde(alias = "new_floating_pane", alias = "toggle_floating_focus")]
+    pub toggle_floating_pane: BindingConfig,
     /// Enter resize mode. Default: "prefix+r"
     pub resize_mode: BindingConfig,
     /// Toggle sidebar collapse. Default: "prefix+b"
@@ -511,6 +514,12 @@ pub(crate) struct KeysConfigOverlay {
     close_pane: Option<BindingConfig>,
     #[serde(alias = "fullscreen", skip_serializing_if = "Option::is_none")]
     zoom: Option<BindingConfig>,
+    #[serde(
+        alias = "new_floating_pane",
+        alias = "toggle_floating_focus",
+        skip_serializing_if = "Option::is_none"
+    )]
+    toggle_floating_pane: Option<BindingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     resize_mode: Option<BindingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -589,6 +598,7 @@ impl<'de> Deserialize<'de> for KeysConfig {
         apply_field!(split_horizontal);
         apply_field!(close_pane);
         apply_field!(zoom);
+        apply_field!(toggle_floating_pane);
         apply_field!(resize_mode);
         apply_field!(toggle_sidebar);
         apply_field!(indexed);
@@ -687,6 +697,7 @@ impl KeysConfig {
         copy_effective_action_field!(split_horizontal, keybinds.split_horizontal);
         copy_effective_action_field!(close_pane, keybinds.close_pane);
         copy_effective_action_field!(zoom, keybinds.zoom);
+        copy_effective_action_field!(toggle_floating_pane, keybinds.toggle_floating_pane);
         copy_effective_action_field!(resize_mode, keybinds.resize_mode);
         copy_effective_action_field!(toggle_sidebar, keybinds.toggle_sidebar);
         copy_user_field!(indexed);
@@ -938,6 +949,7 @@ impl Default for KeysConfig {
             split_horizontal: BindingConfig::one("prefix+minus"),
             close_pane: BindingConfig::one("prefix+x"),
             zoom: BindingConfig::one("prefix+z"),
+            toggle_floating_pane: BindingConfig::one("prefix+f"),
             resize_mode: BindingConfig::one("prefix+r"),
             toggle_sidebar: BindingConfig::one("prefix+b"),
             indexed: IndexedKeysConfig::default(),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,5 +1,7 @@
 //! BSP tree layout for tiling panes within a workspace.
 
+pub mod floating;
+
 use std::cmp::Reverse;
 
 use ratatui::{

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1,0 +1,507 @@
+//! Floating pane layout: workspace-level panes that overlay tiled content.
+
+use std::collections::HashMap;
+
+use ratatui::{layout::Rect, widgets::Borders};
+
+use super::{PaneId, PaneInfo};
+
+/// A floating pane's absolute position within the terminal area, in cells.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FloatingPanePosition {
+    /// Top-left x offset relative to the terminal area.
+    pub x: u16,
+    /// Top-left y offset relative to the terminal area.
+    pub y: u16,
+    /// Width in cells.
+    pub width: u16,
+    /// Height in cells.
+    pub height: u16,
+}
+
+impl FloatingPanePosition {
+    pub fn clamp_to_area(self, area: Rect) -> Self {
+        let width = self.width.min(area.width);
+        let height = self.height.min(area.height);
+        let max_x = area.width.saturating_sub(width);
+        let max_y = area.height.saturating_sub(height);
+        let x = self.x.min(max_x);
+        let y = self.y.min(max_y);
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub fn to_rect(self, area: Rect) -> Rect {
+        let clamped = self.clamp_to_area(area);
+        Rect::new(
+            area.x + clamped.x,
+            area.y + clamped.y,
+            clamped.width,
+            clamped.height,
+        )
+    }
+
+    pub fn default_in_area(area: Rect) -> Self {
+        let w = ((area.width as f32) * 0.6) as u16;
+        let h = ((area.height as f32) * 0.6) as u16;
+        let width = w.max(Self::MIN_WIDTH).min(area.width);
+        let height = h.max(Self::MIN_HEIGHT).min(area.height);
+        let x = area.width.saturating_sub(width) / 2;
+        let y = area.height.saturating_sub(height) / 2;
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub const MIN_WIDTH: u16 = 10;
+    pub const MIN_HEIGHT: u16 = 5;
+}
+
+/// Collection of floating panes at the workspace level.
+#[derive(Debug, Clone, Default)]
+pub struct FloatingPanes {
+    /// Rendering order (back to front). Last pane in the vec is on top.
+    pub order: Vec<PaneId>,
+    /// Absolute positions in terminal-area cell coordinates.
+    pub positions: HashMap<PaneId, FloatingPanePosition>,
+    /// Currently focused floating pane, if any.
+    pub focused: Option<PaneId>,
+    /// Whether floating panes are currently visible.
+    pub visible: bool,
+}
+
+impl FloatingPanes {
+    pub fn is_empty(&self) -> bool {
+        self.order.is_empty()
+    }
+
+    /// Add a new floating pane at a default centered position.
+    pub fn add(&mut self, pane_id: PaneId, area: Rect) {
+        let pos = FloatingPanePosition::default_in_area(area);
+        self.positions.insert(pane_id, pos);
+        self.order.push(pane_id);
+        self.focused = Some(pane_id);
+        if !self.visible {
+            self.visible = true;
+        }
+    }
+
+    /// Remove a floating pane by id.
+    pub fn remove(&mut self, pane_id: PaneId) -> bool {
+        if !self.order.contains(&pane_id) {
+            return false;
+        }
+        self.order.retain(|id| *id != pane_id);
+        self.positions.remove(&pane_id);
+        if self.focused == Some(pane_id) {
+            self.focused = self.order.last().copied();
+        }
+        true
+    }
+
+    /// Focus a specific floating pane, bringing it to the top.
+    pub fn focus(&mut self, pane_id: PaneId) {
+        if !self.order.contains(&pane_id) {
+            return;
+        }
+        self.focused = Some(pane_id);
+        self.order.retain(|id| *id != pane_id);
+        self.order.push(pane_id);
+    }
+
+    /// Clear focus on floating panes (return focus to tiled layout).
+    #[cfg(test)]
+    pub fn clear_focus(&mut self) {
+        self.focused = None;
+    }
+
+    /// Hide all floating panes and return focus to tiled layout.
+    pub fn hide(&mut self) {
+        self.visible = false;
+        self.focused = None;
+    }
+
+    /// Show floating panes and focus the top-most pane.
+    pub fn show(&mut self) {
+        if let Some(pane_id) = self.order.last().copied() {
+            self.visible = true;
+            self.focus(pane_id);
+        }
+    }
+
+    /// Move the focused floating pane by a delta in cells.
+    #[cfg(test)]
+    pub fn move_focused(&mut self, dx: i16, dy: i16, area: Rect) -> bool {
+        let Some(focused_id) = self.focused else {
+            return false;
+        };
+        let Some(pos) = self.positions.get_mut(&focused_id) else {
+            return false;
+        };
+        let new_x = (pos.x as i32 + dx as i32).clamp(0, area.width.saturating_sub(1) as i32) as u16;
+        let new_y =
+            (pos.y as i32 + dy as i32).clamp(0, area.height.saturating_sub(1) as i32) as u16;
+        if new_x != pos.x || new_y != pos.y {
+            pos.x = new_x;
+            pos.y = new_y;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Resize the focused floating pane by a delta.
+    #[cfg(test)]
+    pub fn resize_focused(&mut self, dw: i16, dh: i16, area: Rect) -> bool {
+        let Some(focused_id) = self.focused else {
+            return false;
+        };
+        let Some(pos) = self.positions.get_mut(&focused_id) else {
+            return false;
+        };
+        let new_w = (pos.width as i32 + dw as i32).clamp(
+            FloatingPanePosition::MIN_WIDTH as i32,
+            area.width.saturating_sub(pos.x) as i32,
+        ) as u16;
+        let new_h = (pos.height as i32 + dh as i32).clamp(
+            FloatingPanePosition::MIN_HEIGHT as i32,
+            area.height.saturating_sub(pos.y) as i32,
+        ) as u16;
+        if new_w != pos.width || new_h != pos.height {
+            pos.width = new_w;
+            pos.height = new_h;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Set the position of a specific floating pane.
+    pub fn set_position(&mut self, pane_id: PaneId, pos: FloatingPanePosition) -> bool {
+        if !self.order.contains(&pane_id) {
+            return false;
+        }
+        self.positions.insert(pane_id, pos);
+        true
+    }
+
+    /// Set a pane position while keeping the whole pane inside the terminal
+    /// area. This is for user-driven move/resize operations; render-time
+    /// clamping remains non-mutating so stored geometry survives temporary
+    /// small client sizes.
+    pub fn set_position_clamped(
+        &mut self,
+        pane_id: PaneId,
+        pos: FloatingPanePosition,
+        area: Rect,
+    ) -> bool {
+        self.set_position(pane_id, pos.clamp_to_area(area))
+    }
+
+    /// Compute PaneInfo for each floating pane within the terminal area.
+    pub fn pane_infos(&self, area: Rect) -> Vec<PaneInfo> {
+        if !self.visible {
+            return Vec::new();
+        }
+        self.order
+            .iter()
+            .filter_map(|&id| {
+                let pos = self.positions.get(&id)?;
+                let rect = pos.to_rect(area);
+                if rect.width < FloatingPanePosition::MIN_WIDTH
+                    || rect.height < FloatingPanePosition::MIN_HEIGHT
+                {
+                    return None;
+                }
+                let borders = Borders::ALL;
+                let inner_rect = crate::ui::panes::pane_inner_rect(rect, borders);
+                Some(PaneInfo {
+                    id,
+                    rect,
+                    inner_rect,
+                    scrollbar_rect: None,
+                    borders,
+                    is_focused: self.focused == Some(id),
+                })
+            })
+            .collect()
+    }
+
+    /// Check whether any floating pane has focus.
+    #[cfg(test)]
+    pub fn has_focus(&self) -> bool {
+        self.focused.is_some()
+    }
+
+    /// Resize all floating pane terminals to their computed inner rects.
+    pub fn resize_terminals(
+        &self,
+        area: Rect,
+        terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+        app: &crate::app::AppState,
+        ws_idx: usize,
+        cell_size: crate::kitty_graphics::HostCellSize,
+    ) {
+        for info in self.pane_infos(area) {
+            let pane_inner = crate::ui::panes::pane_inner_rect(info.rect, info.borders);
+            if let Some(rt) = app.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, info.id)
+            {
+                let terminal_id = app
+                    .workspaces
+                    .get(ws_idx)
+                    .and_then(|ws| ws.pane_state(info.id))
+                    .map(|ps| &ps.attached_terminal_id);
+                let locked = terminal_id
+                    .as_ref()
+                    .is_some_and(|tid| app.direct_attach_resize_locks.contains(tid));
+                if !locked {
+                    rt.resize(
+                        pane_inner.height,
+                        pane_inner.width,
+                        cell_size.width_px,
+                        cell_size.height_px,
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    fn pid(id: u32) -> PaneId {
+        PaneId::from_raw(id)
+    }
+
+    fn test_area() -> Rect {
+        Rect::new(0, 0, 100, 40)
+    }
+
+    #[test]
+    fn default_position_centers_in_area() {
+        let pos = FloatingPanePosition::default_in_area(test_area());
+        assert_eq!(pos.width, 60);
+        assert_eq!(pos.height, 24);
+        assert_eq!(pos.x, 20);
+        assert_eq!(pos.y, 8);
+    }
+
+    #[test]
+    fn default_position_clamps_small_area() {
+        let small = Rect::new(0, 0, 15, 8);
+        let pos = FloatingPanePosition::default_in_area(small);
+        assert!(pos.width >= FloatingPanePosition::MIN_WIDTH);
+        assert!(pos.height >= FloatingPanePosition::MIN_HEIGHT);
+    }
+
+    #[test]
+    fn add_pane_sets_focus_and_visibility() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        assert_eq!(fp.order, vec![pid(1)]);
+        assert_eq!(fp.focused, Some(pid(1)));
+        assert!(fp.visible);
+        assert!(fp.positions.contains_key(&pid(1)));
+    }
+
+    #[test]
+    fn remove_pane_updates_focus() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.add(pid(2), test_area());
+        fp.focus(pid(1));
+        assert_eq!(fp.focused, Some(pid(1)));
+        fp.remove(pid(1));
+        assert_eq!(fp.focused, Some(pid(2)));
+        assert_eq!(fp.order, vec![pid(2)]);
+    }
+
+    #[test]
+    fn remove_last_pane_clears_focus() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.remove(pid(1));
+        assert!(fp.order.is_empty());
+        assert_eq!(fp.focused, None);
+    }
+
+    #[test]
+    fn focus_brings_to_top() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.add(pid(2), test_area());
+        fp.add(pid(3), test_area());
+        assert_eq!(fp.order, vec![pid(1), pid(2), pid(3)]);
+        fp.focus(pid(1));
+        assert_eq!(fp.order, vec![pid(2), pid(3), pid(1)]);
+        assert_eq!(fp.focused, Some(pid(1)));
+    }
+
+    #[test]
+    fn move_focused_clamps_to_area() {
+        let mut fp = FloatingPanes::default();
+        let area = test_area();
+        fp.add(pid(1), area);
+        fp.move_focused(-100, -100, area);
+        let pos = fp.positions[&pid(1)];
+        assert_eq!(pos.x, 0);
+        assert_eq!(pos.y, 0);
+    }
+
+    #[test]
+    fn resize_focused_respects_min_size() {
+        let mut fp = FloatingPanes::default();
+        let area = test_area();
+        fp.add(pid(1), area);
+        fp.resize_focused(-100, -100, area);
+        let pos = fp.positions[&pid(1)];
+        assert_eq!(pos.width, FloatingPanePosition::MIN_WIDTH);
+        assert_eq!(pos.height, FloatingPanePosition::MIN_HEIGHT);
+    }
+
+    #[test]
+    fn pane_infos_filters_when_not_visible() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.visible = false;
+        assert!(fp.pane_infos(test_area()).is_empty());
+    }
+
+    #[test]
+    fn pane_infos_clamps_to_area() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.positions.insert(
+            pid(1),
+            FloatingPanePosition {
+                x: 0,
+                y: 0,
+                width: 200,
+                height: 200,
+            },
+        );
+        let infos = fp.pane_infos(test_area());
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].rect, test_area());
+    }
+
+    #[test]
+    fn clamp_moves_oversized_pane_inside_area() {
+        let pos = FloatingPanePosition {
+            x: 64,
+            y: 20,
+            width: 193,
+            height: 59,
+        };
+        let clamped = pos.clamp_to_area(Rect::new(0, 0, 80, 24));
+
+        assert_eq!(clamped.x, 0);
+        assert_eq!(clamped.y, 0);
+        assert_eq!(clamped.width, 80);
+        assert_eq!(clamped.height, 24);
+    }
+
+    #[test]
+    fn clamp_preserves_size_when_moving_near_edge() {
+        let pos = FloatingPanePosition {
+            x: 95,
+            y: 39,
+            width: 60,
+            height: 24,
+        };
+        let clamped = pos.clamp_to_area(test_area());
+
+        assert_eq!(
+            clamped,
+            FloatingPanePosition {
+                x: 40,
+                y: 16,
+                width: 60,
+                height: 24,
+            }
+        );
+    }
+
+    #[test]
+    fn set_position_is_absolute_and_idempotent() {
+        // Drag-move computes origin + total delta and calls set_position each
+        // event. Re-applying the same target must not accumulate (no drift).
+        let mut fp = FloatingPanes::default();
+        let area = test_area();
+        fp.add(pid(1), area);
+        let origin = fp.positions[&pid(1)];
+
+        let target = FloatingPanePosition {
+            x: origin.x + 5,
+            y: origin.y + 3,
+            ..origin
+        };
+        fp.set_position(pid(1), target);
+        let after_first = fp.positions[&pid(1)];
+        fp.set_position(pid(1), target);
+        let after_second = fp.positions[&pid(1)];
+
+        assert_eq!(after_first, target);
+        assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn clear_focus_returns_none() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        assert!(fp.has_focus());
+        fp.clear_focus();
+        assert!(!fp.has_focus());
+    }
+
+    #[test]
+    fn hide_clears_focus_and_visibility() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+
+        fp.hide();
+
+        assert!(!fp.visible);
+        assert_eq!(fp.focused, None);
+    }
+
+    #[test]
+    fn show_focuses_topmost_pane() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.add(pid(2), test_area());
+        fp.focus(pid(1));
+        fp.hide();
+
+        fp.show();
+
+        assert!(fp.visible);
+        assert_eq!(fp.focused, Some(pid(1)));
+    }
+
+    #[test]
+    fn has_focus_is_false_when_focused_is_none() {
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        fp.focused = None;
+        assert!(!fp.has_focus());
+    }
+
+    #[test]
+    fn is_empty_when_no_panes() {
+        assert!(FloatingPanes::default().is_empty());
+        let mut fp = FloatingPanes::default();
+        fp.add(pid(1), test_area());
+        assert!(!fp.is_empty());
+    }
+}

--- a/src/persist/restore.rs
+++ b/src/persist/restore.rs
@@ -418,6 +418,8 @@ fn restore_workspace(
             next_public_tab_number,
             active_tab: snap.active_tab.min(tabs.len().saturating_sub(1)),
             tabs,
+            floating: crate::layout::floating::FloatingPanes::default(),
+            floating_pane_states: HashMap::new(),
             #[cfg(test)]
             test_runtimes: HashMap::new(),
         })

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -2901,6 +2901,18 @@ impl HeadlessServer {
         let Some(ws_idx) = self.app.state.active else {
             retained_fallback!("no_active_workspace");
         };
+        // Floating panes overlay the tiled grid and are not part of
+        // `pane_infos`; the retained patch path only tracks tiled panes, so
+        // fall back to a full render whenever any floating pane is visible.
+        if self
+            .app
+            .state
+            .workspaces
+            .get(ws_idx)
+            .is_some_and(|ws| ws.floating.visible && !ws.floating.is_empty())
+        {
+            retained_fallback!("floating_panes_visible");
+        }
         let pane_infos = self.app.state.view.pane_infos.clone();
         if pane_infos.is_empty() {
             retained_fallback!("no_pane_info");

--- a/src/server/render_stream.rs
+++ b/src/server/render_stream.rs
@@ -383,6 +383,24 @@ pub(crate) fn visible_hyperlinks(
     }
     links
 }
+/// The pane info that owns the host cursor: the focused floating pane (drawn
+/// on top) when one is focused, otherwise the focused tiled pane. Both the TUI
+/// and server render paths consider floating panes part of the focus chain, so
+/// the host cursor must follow them too.
+fn focused_pane_info_for_cursor(app_state: &AppState) -> Option<&crate::layout::PaneInfo> {
+    let focused_floating = app_state
+        .active
+        .and_then(|ws_idx| app_state.workspaces.get(ws_idx))
+        .and_then(|ws| ws.floating.focused);
+    if let Some(floating_id) = focused_floating {
+        return app_state
+            .view
+            .floating_pane_infos
+            .iter()
+            .find(|info| info.id == floating_id);
+    }
+    app_state.view.pane_infos.iter().find(|info| info.is_focused)
+}
 
 pub(crate) fn focused_terminal_cursor(
     app_state: &AppState,
@@ -393,11 +411,7 @@ pub(crate) fn focused_terminal_cursor(
     }
 
     let ws_idx = app_state.active?;
-    let info = app_state
-        .view
-        .pane_infos
-        .iter()
-        .find(|info| info.is_focused)?;
+    let info = focused_pane_info_for_cursor(app_state)?;
     if !app_state.pane_exposes_host_cursor(ws_idx, info.id) {
         return None;
     }
@@ -467,12 +481,7 @@ fn focused_terminal_owns_host_cursor(
     let Some(ws_idx) = app_state.active else {
         return false;
     };
-    let Some(info) = app_state
-        .view
-        .pane_infos
-        .iter()
-        .find(|info| info.is_focused)
-    else {
+    let Some(info) = focused_pane_info_for_cursor(app_state) else {
         return false;
     };
     if !app_state.pane_exposes_host_cursor(ws_idx, info.id) {
@@ -495,12 +504,7 @@ fn focused_terminal_suppresses_host_cursor(
     let Some(ws_idx) = app_state.active else {
         return false;
     };
-    let Some(info) = app_state
-        .view
-        .pane_infos
-        .iter()
-        .find(|info| info.is_focused)
-    else {
+    let Some(info) = focused_pane_info_for_cursor(app_state) else {
         return false;
     };
     if !app_state.pane_exposes_host_cursor(ws_idx, info.id) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,7 +11,7 @@ mod menus;
 mod mobile;
 mod navigator;
 mod onboarding;
-mod panes;
+pub(crate) mod panes;
 mod release_notes;
 mod scrollbar;
 mod settings;
@@ -273,6 +273,26 @@ fn compute_view_internal(
         })
         .unwrap_or_default();
 
+    let floating_pane_infos = app
+        .active
+        .and_then(|i| app.workspaces.get(i))
+        .map(|ws| ws.floating.pane_infos(terminal_area))
+        .unwrap_or_default();
+
+    if resize_panes {
+        if let Some(ws_idx) = app.active {
+            if let Some(ws) = app.workspaces.get(ws_idx) {
+                ws.floating.resize_terminals(
+                    terminal_area,
+                    terminal_runtimes,
+                    app,
+                    ws_idx,
+                    cell_size,
+                );
+            }
+        }
+    }
+
     app.view = crate::app::ViewState {
         layout: ViewLayout::Desktop,
         sidebar_rect: sidebar_area,
@@ -287,6 +307,7 @@ fn compute_view_internal(
         mobile_menu_hit_area: Rect::default(),
         toast_hit_area,
         pane_infos,
+        floating_pane_infos,
         split_borders,
     };
 }
@@ -340,6 +361,26 @@ fn compute_mobile_view(
             cell_size,
         );
     }
+    let floating_pane_infos = app
+        .active
+        .and_then(|i| app.workspaces.get(i))
+        .map(|ws| ws.floating.pane_infos(terminal_area))
+        .unwrap_or_default();
+
+    if resize_panes {
+        if let Some(ws_idx) = app.active {
+            if let Some(ws) = app.workspaces.get(ws_idx) {
+                ws.floating.resize_terminals(
+                    terminal_area,
+                    terminal_runtimes,
+                    app,
+                    ws_idx,
+                    cell_size,
+                );
+            }
+        }
+    }
+
     let header_hits = compute_mobile_header_hit_areas(app, header_rect);
 
     let toast_hit_area = app
@@ -362,6 +403,7 @@ fn compute_mobile_view(
         mobile_menu_hit_area: header_hits.menu,
         toast_hit_area,
         pane_infos,
+        floating_pane_infos,
         split_borders,
     };
 }

--- a/src/ui/keybind_help.rs
+++ b/src/ui/keybind_help.rs
@@ -135,6 +135,10 @@ pub(super) fn keybind_help_groups(app: &AppState) -> Vec<HelpGroup> {
         help_entry(keybind_label(&kb.edit_scrollback), "edit scrollback"),
         help_entry(keybind_label(&kb.copy_mode), "copy mode"),
         help_entry(keybind_label(&kb.zoom), "zoom pane"),
+        help_entry(
+            keybind_label(&kb.toggle_floating_pane),
+            "toggle floating pane",
+        ),
         help_entry(keybind_label(&kb.resize_mode), "resize mode"),
         help_entry(keybind_label(&kb.toggle_sidebar), "toggle sidebar"),
         help_entry(keybind_label(&kb.focus_pane_left), "focus pane left"),

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -39,6 +39,7 @@ pub(super) fn render_prefix_overlay(app: &AppState, frame: &mut Frame, area: Rec
         .add_modifier(Modifier::BOLD);
 
     let workspace_picker = prefix_rhs_label(&app.keybinds.workspace_picker);
+    let floating = prefix_rhs_label(&app.keybinds.toggle_floating_pane);
     let help = prefix_rhs_label(&app.keybinds.help);
     let prefix = crate::config::format_key_combo((app.prefix_code, app.prefix_mods));
 
@@ -51,6 +52,8 @@ pub(super) fn render_prefix_overlay(app: &AppState, frame: &mut Frame, area: Rec
         Span::styled(" send prefix  ", dim),
         Span::styled(workspace_picker, key),
         Span::styled(" workspace nav  ", dim),
+        Span::styled(floating, key),
+        Span::styled(" floating pane  ", dim),
         Span::styled(help, key),
         Span::styled(" keybinds", dim),
     ]);

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -10,6 +10,7 @@ use super::scrollbar::{render_pane_scrollbar, should_show_scrollbar};
 use super::widgets::panel_contrast_fg;
 use crate::app::state::Palette;
 use crate::app::{AppState, Mode};
+use crate::layout::floating::FloatingPanePosition;
 use crate::layout::PaneInfo;
 use crate::terminal::{TerminalRuntime, TerminalRuntimeRegistry};
 
@@ -362,6 +363,31 @@ pub(super) fn render_panes(
     }
 
     render_pane_borders(app, ws, frame);
+
+    // Render floating panes on top of tiled content
+    for info in &app.view.floating_pane_infos {
+        if let Some(rt) = app.runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, info.id) {
+            let show_cursor = info.is_focused
+                && terminal_active
+                && !pane_is_scrolled_back(rt)
+                && app.pane_exposes_host_cursor(ws_idx, info.id);
+            let pane_inner = pane_inner_rect(info.rect, info.borders);
+            rt.render(frame, pane_inner, show_cursor);
+            render_pane_scrollbar(app, frame, info, rt);
+
+            render_selection_highlight(
+                &app.selection,
+                frame,
+                info.id,
+                pane_inner,
+                rt.scroll_metrics(),
+                &app.palette,
+                app.host_terminal_theme,
+            );
+            render_copy_mode_cursor(app, frame, info);
+        }
+    }
+    render_floating_pane_borders(app, ws, frame);
 }
 
 #[derive(Clone, Copy, Default)]
@@ -419,6 +445,72 @@ fn render_pane_borders(app: &AppState, ws: &crate::workspace::Workspace, frame: 
     }
 
     render_pane_border_titles(app, ws, frame);
+}
+
+/// Render borders (and titles) for floating panes. Floating panes never share
+/// edges with the tiled grid, so each is drawn as an independent box reusing
+/// the same line-cell machinery and title rendering as tiled panes.
+fn render_floating_pane_borders(
+    app: &AppState,
+    ws: &crate::workspace::Workspace,
+    frame: &mut Frame,
+) {
+    if !app.pane_borders || app.view.floating_pane_infos.is_empty() {
+        return;
+    }
+
+    let mut cells = std::collections::HashMap::<(u16, u16), LineCell>::new();
+    for info in &app.view.floating_pane_infos {
+        if info.rect.width < FloatingPanePosition::MIN_WIDTH
+            || info.rect.height < FloatingPanePosition::MIN_HEIGHT
+        {
+            continue;
+        }
+        add_pane_border_cells(&mut cells, info);
+    }
+
+    let buf = frame.buffer_mut();
+    let area = buf.area;
+    for ((x, y), line) in cells {
+        if x < area.x
+            || x >= area.x.saturating_add(area.width)
+            || y < area.y
+            || y >= area.y.saturating_add(area.height)
+        {
+            continue;
+        }
+        let symbol = line_cell_symbol(line);
+        if symbol.is_empty() {
+            continue;
+        }
+        let focused = app
+            .view
+            .floating_pane_infos
+            .iter()
+            .any(|info| info.is_focused && line_touches_pane(x, y, info, true));
+        let color = if focused {
+            app.palette.accent
+        } else {
+            app.palette.overlay0
+        };
+        let cell = &mut buf[(x, y)];
+        cell.set_symbol(symbol);
+        cell.set_style(Style::default().fg(color));
+    }
+
+    // Titles, drawn after borders so they overwrite the top edge.
+    let buf = frame.buffer_mut();
+    let area = buf.area;
+    for info in &app.view.floating_pane_infos {
+        if info.rect.width < FloatingPanePosition::MIN_WIDTH
+            || info.rect.height < FloatingPanePosition::MIN_HEIGHT
+        {
+            continue;
+        }
+        if let Some(title) = pane_border_title_for(app, ws, info) {
+            render_pane_border_title(app, buf, area, info, &title);
+        }
+    }
 }
 
 fn add_split_border_cells(
@@ -546,45 +638,65 @@ fn render_pane_border_titles(app: &AppState, ws: &crate::workspace::Workspace, f
     let buf = frame.buffer_mut();
     let area = buf.area;
     for info in &app.view.pane_infos {
-        if !info.borders.contains(Borders::TOP) || info.rect.width <= 4 {
-            continue;
-        }
-        let Some(title) = ws
-            .pane_state(info.id)
-            .and_then(|pane| app.terminals.get(&pane.attached_terminal_id))
-            .and_then(|terminal| terminal.border_label(app.show_agent_labels_on_pane_borders))
-            .and_then(|label| pane_border_title(&label, info.rect.width, info.is_focused))
-        else {
+        let Some(title) = pane_border_title_for(app, ws, info) else {
             continue;
         };
-        let y = info.rect.y;
-        if y < area.y || y >= area.y.saturating_add(area.height) {
-            continue;
+        render_pane_border_title(app, buf, area, info, &title);
+    }
+}
+
+/// Resolve the border title string for a pane, honoring width and the
+/// `show_agent_labels_on_pane_borders` setting. Returns `None` when no title
+/// should be drawn (top border absent, pane too narrow, or no label).
+fn pane_border_title_for(
+    app: &AppState,
+    ws: &crate::workspace::Workspace,
+    info: &PaneInfo,
+) -> Option<String> {
+    if !info.borders.contains(Borders::TOP) || info.rect.width <= 4 {
+        return None;
+    }
+    ws.pane_state(info.id)
+        .and_then(|pane| app.terminals.get(&pane.attached_terminal_id))
+        .and_then(|terminal| terminal.border_label(app.show_agent_labels_on_pane_borders))
+        .and_then(|label| pane_border_title(&label, info.rect.width, info.is_focused))
+}
+
+/// Draw a resolved title onto a single pane's top border.
+fn render_pane_border_title(
+    app: &AppState,
+    buf: &mut ratatui::buffer::Buffer,
+    area: Rect,
+    info: &PaneInfo,
+    title: &str,
+) {
+    let y = info.rect.y;
+    if y < area.y || y >= area.y.saturating_add(area.height) {
+        return;
+    }
+    for (idx, ch) in title.chars().enumerate() {
+        let x = info.rect.x.saturating_add(1).saturating_add(idx as u16);
+        if x >= area.x.saturating_add(area.width)
+            || x >= info
+                .rect
+                .x
+                .saturating_add(info.rect.width)
+                .saturating_sub(1)
+        {
+            break;
         }
-        for (idx, ch) in title.chars().enumerate() {
-            let x = info.rect.x.saturating_add(1).saturating_add(idx as u16);
-            if x >= area.x.saturating_add(area.width)
-                || x >= info
-                    .rect
-                    .x
-                    .saturating_add(info.rect.width)
-                    .saturating_sub(1)
-            {
-                break;
-            }
-            let color = if info.is_focused {
-                app.palette.accent
-            } else {
-                app.palette.overlay0
-            };
-            let mut style = Style::default().fg(color);
-            if info.is_focused {
-                style = style.add_modifier(Modifier::BOLD);
-            }
-            let cell = &mut buf[(x, y)];
-            cell.set_symbol(&ch.to_string());
-            cell.set_style(style);
+        let color = if info.is_focused {
+            app.palette.accent
+        } else {
+            app.palette.overlay0
+        };
+        let mut style = Style::default().fg(color);
+        if info.is_focused {
+            style = style.add_modifier(Modifier::BOLD);
         }
+        let cell = &mut buf[(x, y)];
+        cell.set_symbol(&ch.to_string());
+        cell.set_style(style);
     }
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -163,6 +163,12 @@ pub struct Workspace {
     pub(crate) next_public_tab_number: usize,
     pub tabs: Vec<Tab>,
     pub active_tab: usize,
+    /// Floating panes visible across all tabs in this workspace.
+    pub floating: crate::layout::floating::FloatingPanes,
+    /// Viewport/terminal state for floating panes. Separate from `floating`,
+    /// which holds only serializable layout (positions/order/focus). Floating
+    /// panes are not owned by any tab, so their `PaneState` lives here.
+    pub(crate) floating_pane_states: HashMap<PaneId, PaneState>,
     #[cfg(test)]
     pub(crate) test_runtimes: HashMap<PaneId, TerminalRuntime>,
 }
@@ -221,6 +227,8 @@ impl Workspace {
             next_public_tab_number: 2,
             tabs: vec![tab],
             active_tab: 0,
+            floating: crate::layout::floating::FloatingPanes::default(),
+            floating_pane_states: HashMap::new(),
             #[cfg(test)]
             test_runtimes: HashMap::new(),
         }
@@ -402,6 +410,8 @@ impl Workspace {
                 next_public_tab_number: 2,
                 tabs: vec![tab],
                 active_tab: 0,
+                floating: crate::layout::floating::FloatingPanes::default(),
+                floating_pane_states: HashMap::new(),
                 #[cfg(test)]
                 test_runtimes: HashMap::new(),
             },
@@ -433,6 +443,60 @@ impl Workspace {
                 .clone()
                 .unwrap_or_else(|| (tab_idx + 1).to_string()),
         )
+    }
+
+    pub fn focused_tiled_pane_id(&self) -> Option<PaneId> {
+        self.active_tab().map(|tab| tab.layout.focused())
+    }
+
+    pub fn effective_tab_index_for_pane(&self, pane_id: PaneId) -> Option<usize> {
+        self.find_tab_index_for_pane(pane_id).or_else(|| {
+            self.floating_pane_states
+                .contains_key(&pane_id)
+                .then_some(self.active_tab)
+        })
+    }
+
+    pub fn cwd_for_pane(
+        &self,
+        pane_id: PaneId,
+        terminals: &HashMap<TerminalId, TerminalState>,
+        terminal_runtimes: &TerminalRuntimeRegistry,
+    ) -> Option<PathBuf> {
+        if let Some(tab_idx) = self.find_tab_index_for_pane(pane_id) {
+            return self
+                .tabs
+                .get(tab_idx)?
+                .cwd_for_pane(pane_id, terminals, terminal_runtimes);
+        }
+
+        let terminal_id = self.terminal_id(pane_id)?;
+        terminal_runtimes
+            .get(terminal_id)
+            .and_then(|rt| rt.cwd())
+            .or_else(|| {
+                terminals
+                    .get(terminal_id)
+                    .map(|terminal| terminal.cwd.clone())
+            })
+    }
+
+    pub fn foreground_cwd_for_pane(
+        &self,
+        pane_id: PaneId,
+        terminal_runtimes: &TerminalRuntimeRegistry,
+    ) -> Option<PathBuf> {
+        if let Some(tab_idx) = self.find_tab_index_for_pane(pane_id) {
+            return self
+                .tabs
+                .get(tab_idx)?
+                .foreground_cwd_for_pane(pane_id, terminal_runtimes);
+        }
+
+        let terminal_id = self.terminal_id(pane_id)?;
+        terminal_runtimes
+            .get(terminal_id)
+            .and_then(|rt| rt.foreground_cwd())
     }
 
     pub fn switch_tab(&mut self, idx: usize) {
@@ -629,6 +693,82 @@ impl Workspace {
             )?;
         self.register_new_pane_with_number(new_pane.pane_id, pane_number);
         Ok(new_pane)
+    }
+
+    /// Create a floating pane that overlays the tiled content. Unlike a split,
+    /// the new pane is not placed in any tab's layout tree; its `PaneState`
+    /// lives in `floating_pane_states` and its position in `floating`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_floating_pane(
+        &mut self,
+        rows: u16,
+        cols: u16,
+        cwd: Option<PathBuf>,
+        scrollback_limit_bytes: usize,
+        host_terminal_theme: crate::terminal_theme::TerminalTheme,
+        shell_config: crate::pane::PaneShellConfig<'_>,
+        extra_env: Vec<(String, String)>,
+        area: ratatui::layout::Rect,
+    ) -> std::io::Result<crate::workspace::tab::NewPane> {
+        let pane_number = self.next_public_pane_number;
+        let tab_number = self
+            .active_tab()
+            .map(|tab| tab.number)
+            .expect("workspace must always have at least one tab");
+        let launch_env = self.launch_env_for_new_pane(tab_number, pane_number, extra_env);
+
+        let (events, render_notify, render_dirty) = {
+            let tab = self
+                .active_tab()
+                .expect("workspace must always have at least one tab");
+            (
+                tab.events.clone(),
+                tab.render_notify.clone(),
+                tab.render_dirty.clone(),
+            )
+        };
+
+        let new_id = PaneId::alloc();
+        let actual_cwd =
+            cwd.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| "/".into()));
+        let runtime = TerminalRuntime::spawn(
+            new_id,
+            rows,
+            cols,
+            actual_cwd.clone(),
+            scrollback_limit_bytes,
+            host_terminal_theme,
+            shell_config,
+            &launch_env,
+            events,
+            render_notify,
+            render_dirty,
+        )?;
+        let terminal_id = TerminalId::alloc();
+        let terminal = TerminalState::new(terminal_id.clone(), actual_cwd);
+        self.floating_pane_states
+            .insert(new_id, PaneState::new(terminal_id));
+        self.floating.add(new_id, area);
+        self.register_new_pane_with_number(new_id, pane_number);
+        Ok(crate::workspace::tab::NewPane {
+            pane_id: new_id,
+            terminal,
+            runtime,
+        })
+    }
+
+    /// Remove a floating pane and its viewport state. Returns the detached
+    /// terminal id so the caller can tear down the runtime/terminal metadata.
+    pub fn remove_floating_pane(&mut self, pane_id: PaneId) -> Option<TerminalId> {
+        if !self.floating.remove(pane_id) {
+            return None;
+        }
+        let terminal_id = self
+            .floating_pane_states
+            .remove(&pane_id)
+            .map(|pane| pane.attached_terminal_id);
+        self.unregister_pane(pane_id);
+        terminal_id
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1104,18 +1244,35 @@ impl Workspace {
     }
 
     pub fn pane_state(&self, pane_id: PaneId) -> Option<&PaneState> {
-        self.tabs.iter().find_map(|tab| tab.panes.get(&pane_id))
+        self.tabs
+            .iter()
+            .find_map(|tab| tab.panes.get(&pane_id))
+            .or_else(|| self.floating_pane_states.get(&pane_id))
     }
 
     pub fn terminal_id(&self, pane_id: PaneId) -> Option<&TerminalId> {
-        self.tabs.iter().find_map(|tab| tab.terminal_id(pane_id))
+        self.tabs
+            .iter()
+            .find_map(|tab| tab.terminal_id(pane_id))
+            .or_else(|| {
+                self.floating_pane_states
+                    .get(&pane_id)
+                    .map(|pane| &pane.attached_terminal_id)
+            })
     }
 
     pub fn focused_pane_id(&self) -> Option<PaneId> {
-        self.active_tab().map(|tab| tab.layout.focused())
+        self.floating
+            .focused
+            .or_else(|| self.focused_tiled_pane_id())
     }
 
     pub fn close_pane(&mut self, pane_id: PaneId) -> bool {
+        if self.floating_pane_states.contains_key(&pane_id) {
+            self.remove_floating_pane(pane_id);
+            return false;
+        }
+
         let tab_idx = match self.find_tab_index_for_pane(pane_id) {
             Some(idx) => idx,
             None => return false,
@@ -1209,6 +1366,8 @@ impl Workspace {
             next_public_tab_number: 2,
             tabs: vec![tab],
             active_tab: 0,
+            floating: crate::layout::floating::FloatingPanes::default(),
+            floating_pane_states: HashMap::new(),
             test_runtimes: HashMap::new(),
         }
     }
@@ -1222,6 +1381,18 @@ impl Workspace {
         let new_id = tab.layout.split_focused(direction);
         tab.panes
             .insert(new_id, PaneState::new(TerminalId::alloc()));
+        self.register_new_pane(new_id);
+        new_id
+    }
+
+    /// Create a floating pane backed by viewport state only (no PTY), mirroring
+    /// `create_floating_pane` for state-level tests.
+    pub(crate) fn test_add_floating_pane(&mut self) -> PaneId {
+        let new_id = PaneId::alloc();
+        self.floating_pane_states
+            .insert(new_id, PaneState::new(TerminalId::alloc()));
+        self.floating
+            .add(new_id, ratatui::layout::Rect::new(0, 0, 80, 24));
         self.register_new_pane(new_id);
         new_id
     }
@@ -1371,6 +1542,40 @@ impl Workspace {
             }
         }
 
+        // Floating panes are live panes too: they own a public number and a
+        // terminal, but must never overlap with any tab's pane ids.
+        for (pane_id, pane) in &self.floating_pane_states {
+            assert!(
+                live_panes.insert(*pane_id),
+                "workspace {} floating pane {:?} also appears in a tab",
+                self.id,
+                pane_id
+            );
+            assert!(
+                self.public_pane_numbers.contains_key(pane_id),
+                "workspace {} live floating pane {:?} has no public pane number",
+                self.id,
+                pane_id
+            );
+            assert!(
+                terminal_ids.insert(pane.attached_terminal_id.clone()),
+                "workspace {} terminal {} is attached to multiple panes",
+                self.id,
+                pane.attached_terminal_id
+            );
+        }
+
+        // The floating layout order/positions must match the owned states.
+        let floating_state_ids: std::collections::HashSet<_> =
+            self.floating_pane_states.keys().copied().collect();
+        let floating_layout_ids: std::collections::HashSet<_> =
+            self.floating.order.iter().copied().collect();
+        assert_eq!(
+            floating_state_ids, floating_layout_ids,
+            "workspace {} floating layout order must match floating pane states",
+            self.id
+        );
+
         assert!(
             self.next_public_tab_number > 0,
             "workspace {} next_public_tab_number must be greater than 0",
@@ -1428,6 +1633,43 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn floating_pane_state_is_resolvable_and_outside_tabs() {
+        let mut ws = Workspace::test_new("floating");
+        let tiled_root = ws.active_tab().expect("tab").layout.focused();
+        let floating_id = ws.test_add_floating_pane();
+
+        // The floating pane resolves through the shared lookups.
+        assert!(ws.pane_state(floating_id).is_some());
+        assert!(ws.terminal_id(floating_id).is_some());
+
+        // It is not part of any tab's layout.
+        assert!(ws.find_tab_index_for_pane(floating_id).is_none());
+        let layout_panes = ws.active_tab().expect("tab").layout.pane_ids();
+        assert!(!layout_panes.contains(&floating_id));
+        assert!(layout_panes.contains(&tiled_root));
+
+        // Focus falls through to the floating pane.
+        assert_eq!(ws.focused_pane_id(), Some(floating_id));
+
+        ws.assert_invariants_for_test();
+    }
+
+    #[test]
+    fn remove_floating_pane_returns_terminal_and_clears_state() {
+        let mut ws = Workspace::test_new("floating");
+        let floating_id = ws.test_add_floating_pane();
+        let terminal_id = ws.terminal_id(floating_id).cloned();
+
+        let removed = ws.remove_floating_pane(floating_id);
+        assert_eq!(removed, terminal_id);
+        assert!(ws.pane_state(floating_id).is_none());
+        assert!(!ws.public_pane_numbers.contains_key(&floating_id));
+        assert!(ws.floating.is_empty());
+
+        ws.assert_invariants_for_test();
+    }
 
     #[test]
     fn generated_workspace_ids_are_short_base32_handles() {


### PR DESCRIPTION
## Summary

Add **floating panes** — workspace-level overlay terminals that sit above the tiled BSP layout, similar to floating windows in i3/sway. They are not owned by any single tab; they persist across tab switches and can be shown/hidden without losing state.

## Motivation

Herdr's BSP tiling is great for persistent splits, but many workflows need a temporary overlay — a quick scratch terminal, a reference output, or a monitoring dashboard — without disturbing the established layout. Floating panes solve this without creating tab noise or reshuffling splits.

## User Experience

| Action | Interaction |
|---|---|
| Toggle floating pane | `prefix+f` — creates one if none exists, otherwise toggles visibility |
| Focus | Click on it |
| Focus tiled pane while floating visible | Click tiled area — floating hides automatically |
| Move | Drag its border |
| Resize | Drag its bottom-right corner |
| Close | `prefix+x` when focused, or process exits |

- Default position: centered at 60% × 60% of terminal area (min 10×5 cells)
- Default keybinding: `prefix+f` (configurable, also accepts `new_floating_pane` / `toggle_floating_focus` aliases)
- Floating panes follow you across tab switches

## What's Included

- New `src/layout/floating.rs` module — position model + pane collection
- `Workspace` — floating pane fields, CRUD, lifecycle, invariant checks
- `AppState` — create, toggle visibility, focus, close, died-cleanup
- `focus_pane()` — floating-aware focus with auto-hide when tiled is clicked
- Mouse interaction — click-to-focus, border-drag-move, corner-drag-resize, z-order hit testing
- UI rendering — floating pane borders, titles, terminal content rendered on top of tiled grid
- Host cursor — resolves through floating pane when focused
- Headless server — retained-render fallback when floating panes visible
- Config — `toggle_floating_pane` keybind with TOML aliases for backward compatibility
- Comprehensive unit tests — focus, visibility, move, resize, clamping, z-order, lifecycle

## Files Changed

25 files changed, +1633 / -103

## What Remains (Future PRs)

- Persistence — floating pane geometry/state not yet serialized for session restore
- Keyboard move/resize — only mouse drag currently supported
- Agent detection — should the detector read floating panes?
- Sidebar & tab integration — visibility in sidebar pane list, tab-based navigation
- Configurable defaults — default size ratio, position, min/max limits
- Documentation — user guide, config reference, keybinding docs