### PR TITLE
feat: add interactive keybind help filtering

### DIFF
--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -1,0 +1,494 @@
+use crate::{
+    app::{
+        input::{can_execute_navigate_action, ActionContext, NavigateAction},
+        state::{text_matches_query, AppState},
+        Mode,
+    },
+    config::{ActionKeybinds, Keybinds},
+    terminal::TerminalRuntimeRegistry,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum KeybindCommandGroup {
+    Global,
+    Navigation,
+    WorkspacesTabs,
+    Panes,
+    Custom,
+}
+
+impl KeybindCommandGroup {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Navigation => "navigation",
+            Self::WorkspacesTabs => "workspaces / tabs",
+            Self::Panes => "panes",
+            Self::Custom => "custom",
+        }
+    }
+
+    fn order(self) -> u8 {
+        match self {
+            Self::Global => 0,
+            Self::Navigation => 1,
+            Self::WorkspacesTabs => 2,
+            Self::Panes => 3,
+            Self::Custom => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeybindCommand {
+    Navigate(NavigateAction),
+    CustomCommand(usize),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct KeybindCommandEntry {
+    pub group: KeybindCommandGroup,
+    pub label: String,
+    pub shortcuts: String,
+    pub command: KeybindCommand,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct KeybindHelpEntry {
+    pub group: KeybindCommandGroup,
+    pub label: String,
+    pub shortcuts: String,
+    pub command: KeybindCommand,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum KeybindHelpRow {
+    Spacer,
+    Header(KeybindCommandGroup),
+    Entry(usize),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct KeybindHelpModel {
+    pub entries: Vec<KeybindHelpEntry>,
+    pub rows: Vec<KeybindHelpRow>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NavigateCommandSpec {
+    group: KeybindCommandGroup,
+    label: &'static str,
+    action: NavigateAction,
+}
+
+const NAVIGATE_COMMAND_SPECS: &[NavigateCommandSpec] = &[
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Global,
+        label: "keybinds",
+        action: NavigateAction::Help,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Global,
+        label: "settings",
+        action: NavigateAction::Settings,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Global,
+        label: "reload config",
+        action: NavigateAction::ReloadConfig,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Global,
+        label: "open notification target",
+        action: NavigateAction::OpenNotificationTarget,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Global,
+        label: "detach",
+        action: NavigateAction::Detach,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Navigation,
+        label: "workspace navigation",
+        action: NavigateAction::WorkspacePicker,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Navigation,
+        label: "session navigator",
+        action: NavigateAction::OpenNavigator,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "new workspace",
+        action: NavigateAction::NewWorkspace,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "new worktree",
+        action: NavigateAction::NewWorktree,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "open worktree",
+        action: NavigateAction::OpenWorktree,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "delete worktree checkout",
+        action: NavigateAction::RemoveWorktree,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "rename workspace",
+        action: NavigateAction::RenameWorkspace,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "close workspace",
+        action: NavigateAction::CloseWorkspace,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "previous workspace",
+        action: NavigateAction::PreviousWorkspace,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "next workspace",
+        action: NavigateAction::NextWorkspace,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "previous agent",
+        action: NavigateAction::PreviousAgent,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "next agent",
+        action: NavigateAction::NextAgent,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "new tab",
+        action: NavigateAction::NewTab,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "rename tab",
+        action: NavigateAction::RenameTab,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "previous tab",
+        action: NavigateAction::PreviousTab,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "next tab",
+        action: NavigateAction::NextTab,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::WorkspacesTabs,
+        label: "close tab",
+        action: NavigateAction::CloseTab,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "split vertical",
+        action: NavigateAction::SplitVertical,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "split horizontal",
+        action: NavigateAction::SplitHorizontal,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "close pane",
+        action: NavigateAction::ClosePane,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "rename pane",
+        action: NavigateAction::RenamePane,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "edit scrollback",
+        action: NavigateAction::EditScrollback,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "copy mode",
+        action: NavigateAction::CopyMode,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "zoom pane",
+        action: NavigateAction::Zoom,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "resize mode",
+        action: NavigateAction::EnterResizeMode,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "toggle sidebar",
+        action: NavigateAction::ToggleSidebar,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "focus pane left",
+        action: NavigateAction::FocusPaneLeft,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "focus pane down",
+        action: NavigateAction::FocusPaneDown,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "focus pane up",
+        action: NavigateAction::FocusPaneUp,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "focus pane right",
+        action: NavigateAction::FocusPaneRight,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "cycle pane next",
+        action: NavigateAction::CyclePaneNext,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "cycle pane previous",
+        action: NavigateAction::CyclePanePrevious,
+    },
+    NavigateCommandSpec {
+        group: KeybindCommandGroup::Panes,
+        label: "last pane",
+        action: NavigateAction::LastPane,
+    },
+];
+
+pub(crate) fn keybind_help_action_context(state: &AppState) -> ActionContext {
+    if state.keybind_help.origin_mode == Mode::Navigate {
+        ActionContext::Navigate
+    } else {
+        ActionContext::Prefix
+    }
+}
+
+pub(crate) fn build_keybind_help_model(state: &AppState) -> KeybindHelpModel {
+    let query = state.keybind_help.query.trim().to_lowercase();
+    let context = keybind_help_action_context(state);
+    let mut entries: Vec<KeybindHelpEntry> = all_entries(state, context)
+        .into_iter()
+        .filter_map(|entry| {
+            if !entry.enabled {
+                return None;
+            }
+            let haystack = format!(
+                "{} {} {}",
+                entry.group.label(),
+                entry.shortcuts.to_lowercase(),
+                entry.label.to_lowercase()
+            );
+            if !query.is_empty() && !keybind_help_matches_query(&query, &haystack) {
+                return None;
+            }
+            Some(KeybindHelpEntry {
+                group: entry.group,
+                label: entry.label,
+                shortcuts: entry.shortcuts,
+                command: entry.command,
+            })
+        })
+        .collect();
+
+    entries.sort_by(|a, b| {
+        a.group
+            .order()
+            .cmp(&b.group.order())
+            .then_with(|| a.label.to_lowercase().cmp(&b.label.to_lowercase()))
+    });
+
+    let mut rows = Vec::new();
+    let mut last_group = None;
+    for (idx, entry) in entries.iter().enumerate() {
+        if last_group != Some(entry.group) {
+            if last_group.is_some() {
+                rows.push(KeybindHelpRow::Spacer);
+            }
+            rows.push(KeybindHelpRow::Header(entry.group));
+            last_group = Some(entry.group);
+        }
+        rows.push(KeybindHelpRow::Entry(idx));
+    }
+    KeybindHelpModel { entries, rows }
+}
+
+fn keybind_help_matches_query(query: &str, haystack: &str) -> bool {
+    if text_matches_query(query, haystack) {
+        return true;
+    }
+
+    let compact_query: String = query.split_whitespace().collect();
+    if compact_query.is_empty() {
+        return false;
+    }
+    let compact_haystack: String = haystack.split_whitespace().collect();
+    compact_haystack.contains(&compact_query)
+}
+
+pub(crate) fn normalize_keybind_help_selection(state: &mut AppState, model: &KeybindHelpModel) {
+    if model.entries.is_empty() {
+        state.keybind_help.selected = 0;
+        return;
+    }
+    state.keybind_help.selected = state
+        .keybind_help
+        .selected
+        .min(model.entries.len().saturating_sub(1));
+}
+
+pub(crate) fn keybind_help_selected_row(
+    model: &KeybindHelpModel,
+    selected: usize,
+) -> Option<usize> {
+    model.rows.iter().position(|row| match row {
+        KeybindHelpRow::Entry(idx) => *idx == selected,
+        KeybindHelpRow::Header(_) | KeybindHelpRow::Spacer => false,
+    })
+}
+
+fn keybind_label(bindings: &ActionKeybinds) -> String {
+    bindings.label().unwrap_or_else(|| "unset".to_string())
+}
+
+fn keybinds_for_navigate_action(kb: &Keybinds, action: NavigateAction) -> Option<&ActionKeybinds> {
+    match action {
+        NavigateAction::Help => Some(&kb.help),
+        NavigateAction::Settings => Some(&kb.settings),
+        NavigateAction::ReloadConfig => Some(&kb.reload_config),
+        NavigateAction::OpenNotificationTarget => Some(&kb.open_notification_target),
+        NavigateAction::Detach => Some(&kb.detach),
+        NavigateAction::WorkspacePicker => Some(&kb.workspace_picker),
+        NavigateAction::OpenNavigator => Some(&kb.goto),
+        NavigateAction::NewWorkspace => Some(&kb.new_workspace),
+        NavigateAction::NewWorktree => Some(&kb.new_worktree),
+        NavigateAction::OpenWorktree => Some(&kb.open_worktree),
+        NavigateAction::RemoveWorktree => Some(&kb.remove_worktree),
+        NavigateAction::RenameWorkspace => Some(&kb.rename_workspace),
+        NavigateAction::CloseWorkspace => Some(&kb.close_workspace),
+        NavigateAction::PreviousWorkspace => Some(&kb.previous_workspace),
+        NavigateAction::NextWorkspace => Some(&kb.next_workspace),
+        NavigateAction::PreviousAgent => Some(&kb.previous_agent),
+        NavigateAction::NextAgent => Some(&kb.next_agent),
+        NavigateAction::NewTab => Some(&kb.new_tab),
+        NavigateAction::RenameTab => Some(&kb.rename_tab),
+        NavigateAction::PreviousTab => Some(&kb.previous_tab),
+        NavigateAction::NextTab => Some(&kb.next_tab),
+        NavigateAction::CloseTab => Some(&kb.close_tab),
+        NavigateAction::SplitVertical => Some(&kb.split_vertical),
+        NavigateAction::SplitHorizontal => Some(&kb.split_horizontal),
+        NavigateAction::ClosePane => Some(&kb.close_pane),
+        NavigateAction::RenamePane => Some(&kb.rename_pane),
+        NavigateAction::EditScrollback => Some(&kb.edit_scrollback),
+        NavigateAction::CopyMode => Some(&kb.copy_mode),
+        NavigateAction::Zoom => Some(&kb.zoom),
+        NavigateAction::EnterResizeMode => Some(&kb.resize_mode),
+        NavigateAction::ToggleSidebar => Some(&kb.toggle_sidebar),
+        NavigateAction::FocusPaneLeft => Some(&kb.focus_pane_left),
+        NavigateAction::FocusPaneDown => Some(&kb.focus_pane_down),
+        NavigateAction::FocusPaneUp => Some(&kb.focus_pane_up),
+        NavigateAction::FocusPaneRight => Some(&kb.focus_pane_right),
+        NavigateAction::CyclePaneNext => Some(&kb.cycle_pane_next),
+        NavigateAction::CyclePanePrevious => Some(&kb.cycle_pane_previous),
+        NavigateAction::LastPane => Some(&kb.last_pane),
+        NavigateAction::SwitchWorkspace(_)
+        | NavigateAction::SwitchTab(_)
+        | NavigateAction::FocusAgent(_)
+        | NavigateAction::SwapPaneLeft
+        | NavigateAction::SwapPaneDown
+        | NavigateAction::SwapPaneUp
+        | NavigateAction::SwapPaneRight => None,
+    }
+}
+
+fn all_entries(state: &AppState, context: ActionContext) -> Vec<KeybindCommandEntry> {
+    let mut entries = Vec::new();
+    for spec in NAVIGATE_COMMAND_SPECS {
+        let Some(bindings) = keybinds_for_navigate_action(&state.keybinds, spec.action) else {
+            continue;
+        };
+        let command = KeybindCommand::Navigate(spec.action);
+        let (enabled, _) = can_execute_keybind_command(state, command, context, None);
+        entries.push(KeybindCommandEntry {
+            group: spec.group,
+            label: spec.label.to_string(),
+            shortcuts: keybind_label(bindings),
+            command,
+            enabled,
+        });
+    }
+
+    for (idx, binding) in state.keybinds.custom_commands.iter().enumerate() {
+        let command = KeybindCommand::CustomCommand(idx);
+        let (enabled, _) = can_execute_keybind_command(state, command, context, None);
+        entries.push(KeybindCommandEntry {
+            group: KeybindCommandGroup::Custom,
+            label: binding
+                .description
+                .clone()
+                .unwrap_or_else(|| binding.command.clone()),
+            shortcuts: keybind_label(&binding.bindings),
+            command,
+            enabled,
+        });
+    }
+
+    entries
+}
+
+pub(crate) fn can_execute_keybind_command(
+    state: &AppState,
+    command: KeybindCommand,
+    context: ActionContext,
+    terminal_runtimes: Option<&TerminalRuntimeRegistry>,
+) -> (bool, Option<String>) {
+    match command {
+        KeybindCommand::CustomCommand(_) => {
+            if state.active.is_none() {
+                (false, Some("no active workspace".to_string()))
+            } else {
+                (true, None)
+            }
+        }
+        KeybindCommand::Navigate(action) => {
+            can_execute_navigate_action(state, terminal_runtimes, action, context)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn close_pane_unavailable_without_workspace() {
+        let state = AppState::test_new();
+        let (enabled, reason) = can_execute_keybind_command(
+            &state,
+            KeybindCommand::Navigate(NavigateAction::ClosePane),
+            ActionContext::Prefix,
+            None,
+        );
+        assert!(!enabled);
+        assert_eq!(reason.as_deref(), Some("no active workspace"));
+    }
+}

--- a/src/app/input/command_palette.rs
+++ b/src/app/input/command_palette.rs
@@ -1,0 +1,215 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::app::{
+    command_palette::{
+        build_keybind_help_model, can_execute_keybind_command, keybind_help_action_context,
+        keybind_help_selected_row, normalize_keybind_help_selection, KeybindCommand,
+        KeybindHelpModel, KeybindHelpRow,
+    },
+    state::{AppState, ToastKind, ToastNotification},
+    App, Mode,
+};
+
+impl App {
+    fn execute_command_with_feedback(
+        &mut self,
+        command: KeybindCommand,
+        enabled: bool,
+        reason: Option<String>,
+        context: crate::app::input::ActionContext,
+    ) {
+        if !enabled {
+            let previous_toast = self.state.toast.clone();
+            self.state.toast = Some(ToastNotification {
+                kind: ToastKind::NeedsAttention,
+                title: "command unavailable".to_string(),
+                context: reason.unwrap_or_else(|| "not available in this context".to_string()),
+                position: None,
+                target: None,
+            });
+            self.sync_toast_deadline(previous_toast);
+            return;
+        }
+
+        match command {
+            KeybindCommand::Navigate(action) => {
+                super::navigate::execute_navigate_action_in_context(
+                    &mut self.state,
+                    &mut self.terminal_runtimes,
+                    action,
+                    context,
+                );
+            }
+            KeybindCommand::CustomCommand(index) => {
+                if let Some(binding) = self.state.keybinds.custom_commands.get(index).cloned() {
+                    self.launch_custom_command(binding, context);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn handle_keybind_help_key(&mut self, key: KeyEvent) {
+        let model = build_keybind_help_model(&self.state);
+        normalize_keybind_help_selection(&mut self.state, &model);
+        let page = (self
+            .state
+            .keybind_help_body_rect()
+            .unwrap_or_default()
+            .height
+            / 2)
+        .max(1) as usize;
+
+        if self.state.keybind_help.search_focused {
+            match key.code {
+                KeyCode::Esc => {
+                    self.state.keybind_help.search_focused = false;
+                    self.state.keybind_help.query.clear();
+                }
+                KeyCode::Backspace => {
+                    self.state.keybind_help.query.pop();
+                }
+                KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
+                    self.state.keybind_help.query.clear();
+                }
+                KeyCode::Char(ch)
+                    if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT =>
+                {
+                    self.state.keybind_help.query.push(ch);
+                }
+                _ => self.handle_keybind_help_navigation_or_action(key, &model, page),
+            }
+        } else {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('?') => super::modal::leave_modal(&mut self.state),
+                KeyCode::Char('/') => self.state.keybind_help.search_focused = true,
+                _ => self.handle_keybind_help_navigation_or_action(key, &model, page),
+            }
+        }
+
+        normalize_keybind_help_selection_with_scroll(&mut self.state);
+    }
+
+    fn handle_keybind_help_navigation_or_action(
+        &mut self,
+        key: KeyEvent,
+        model: &KeybindHelpModel,
+        page: usize,
+    ) {
+        let max_idx = model.entries.len().saturating_sub(1);
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.state.keybind_help.selected =
+                    self.state.keybind_help.selected.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.state.keybind_help.selected = self
+                    .state
+                    .keybind_help
+                    .selected
+                    .saturating_add(1)
+                    .min(max_idx);
+            }
+            KeyCode::PageUp => {
+                self.state.keybind_help.selected =
+                    self.state.keybind_help.selected.saturating_sub(page);
+            }
+            KeyCode::PageDown => {
+                self.state.keybind_help.selected = self
+                    .state
+                    .keybind_help
+                    .selected
+                    .saturating_add(page)
+                    .min(max_idx);
+            }
+            KeyCode::Home => {
+                self.state.keybind_help.selected = 0;
+            }
+            KeyCode::End => {
+                self.state.keybind_help.selected = max_idx;
+            }
+            KeyCode::Enter => {
+                if let Some(entry) = model.entries.get(self.state.keybind_help.selected).cloned() {
+                    if self.execute_keybind_help_command(entry.command)
+                        && self.state.mode == Mode::KeybindHelp
+                    {
+                        super::modal::leave_modal(&mut self.state);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub(super) fn keybind_help_hover_row(&mut self, row: usize) {
+        let model = build_keybind_help_model(&self.state);
+        let Some(visible_row) = model
+            .rows
+            .get(self.state.keybind_help.scroll as usize + row)
+        else {
+            return;
+        };
+        if let KeybindHelpRow::Entry(idx) = visible_row {
+            self.state.keybind_help.selected = *idx;
+        }
+    }
+
+    pub(super) fn keybind_help_click_row(&mut self, row: usize) {
+        let model = build_keybind_help_model(&self.state);
+        let Some(visible_row) = model
+            .rows
+            .get(self.state.keybind_help.scroll as usize + row)
+        else {
+            return;
+        };
+        if let KeybindHelpRow::Entry(idx) = visible_row {
+            self.state.keybind_help.selected = *idx;
+            if let Some(entry) = model.entries.get(*idx).cloned() {
+                if self.execute_keybind_help_command(entry.command)
+                    && self.state.mode == Mode::KeybindHelp
+                {
+                    super::modal::leave_modal(&mut self.state);
+                }
+            }
+        }
+    }
+
+    fn execute_keybind_help_command(&mut self, command: KeybindCommand) -> bool {
+        let context = keybind_help_action_context(&self.state);
+        let (enabled, reason) = can_execute_keybind_command(
+            &self.state,
+            command,
+            context,
+            Some(&self.terminal_runtimes),
+        );
+        self.execute_command_with_feedback(command, enabled, reason, context);
+        enabled
+    }
+}
+
+pub(crate) fn insert_keybind_help_search_text(state: &mut AppState, text: &str) {
+    if state.mode != Mode::KeybindHelp || !state.keybind_help.search_focused {
+        return;
+    }
+    state.keybind_help.query.push_str(text);
+    normalize_keybind_help_selection_with_scroll(state);
+}
+
+fn normalize_keybind_help_selection_with_scroll(state: &mut AppState) {
+    let model = build_keybind_help_model(state);
+    normalize_keybind_help_selection(state, &model);
+    state.scroll_keybind_help(0);
+    if let Some(selected_row) = keybind_help_selected_row(&model, state.keybind_help.selected) {
+        let viewport = state.keybind_help_body_rect().unwrap_or_default().height as usize;
+        if selected_row < state.keybind_help.scroll as usize {
+            state.keybind_help.scroll = selected_row as u16;
+        } else {
+            let visible_end = state.keybind_help.scroll.saturating_add(viewport as u16) as usize;
+            if selected_row >= visible_end {
+                state.keybind_help.scroll = selected_row
+                    .saturating_add(1)
+                    .saturating_sub(viewport)
+                    .min(u16::MAX as usize) as u16;
+            }
+        }
+    }
+}

--- a/src/app/input/copy_mode.rs
+++ b/src/app/input/copy_mode.rs
@@ -16,6 +16,11 @@ impl App {
         if key.kind == KeyEventKind::Release {
             return;
         }
+        if self.state.is_prefix_key(key) {
+            self.state.command_mode_return = Some(Mode::Copy);
+            self.state.mode = Mode::Prefix;
+            return;
+        }
         self.state.update_dismissed = true;
         self.state
             .handle_copy_mode_key(&self.terminal_runtimes, key);
@@ -1047,5 +1052,18 @@ mod tests {
         }
         assert_eq!(app.state.mode, Mode::Terminal);
         assert!(app.state.copy_mode.is_none());
+    }
+
+    #[tokio::test]
+    async fn copy_mode_prefix_key_enters_prefix_mode_with_copy_return_target() {
+        let (mut app, _) = app_with_copy_screen(b"alpha\n");
+        app.state.enter_copy_mode(&app.terminal_runtimes);
+        app.state.prefix_code = KeyCode::Char('b');
+        app.state.prefix_mods = KeyModifiers::CONTROL;
+
+        app.handle_copy_mode_key(TerminalKey::new(KeyCode::Char('b'), KeyModifiers::CONTROL));
+
+        assert_eq!(app.state.mode, Mode::Prefix);
+        assert_eq!(app.state.command_mode_return, Some(Mode::Copy));
     }
 }

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -33,6 +33,7 @@ fn modified_url_click_modifier_matches_terminal_mouse_reporting() {
     assert_eq!(modified_url_click_modifier(), KeyModifiers::CONTROL);
 }
 
+mod command_palette;
 mod copy_mode;
 mod modal;
 mod mouse;
@@ -46,10 +47,11 @@ mod terminal;
 pub(crate) use self::{
     modal::{
         handle_confirm_close_key, handle_context_menu_key, handle_global_menu_key,
-        handle_keybind_help_key, handle_navigator_key, handle_rename_key, handle_resize_key,
-        insert_navigator_search_text, insert_rename_input_text,
+        handle_navigator_key, handle_rename_key, handle_resize_key, insert_navigator_search_text,
+        insert_rename_input_text,
     },
     navigate::terminal_direct_navigation_action,
+    navigate::{can_execute_navigate_action, ActionContext, NavigateAction},
     settings::open_settings_at,
 };
 use self::{
@@ -102,7 +104,7 @@ impl App {
                 }
                 Mode::Settings => self.handle_settings_key(key_event),
                 Mode::GlobalMenu => handle_global_menu_key(&mut self.state, key_event),
-                Mode::KeybindHelp => handle_keybind_help_key(&mut self.state, key_event),
+                Mode::KeybindHelp => self.handle_keybind_help_key(key_event),
                 Mode::Navigator => {
                     handle_navigator_key(&mut self.state, &self.terminal_runtimes, key_event)
                 }
@@ -154,6 +156,10 @@ impl App {
                     return false;
                 }
                 insert_navigator_search_text(&mut self.state, &self.terminal_runtimes, text);
+                true
+            }
+            Mode::KeybindHelp => {
+                self::command_palette::insert_keybind_help_search_text(&mut self.state, text);
                 true
             }
             _ => false,
@@ -464,6 +470,7 @@ pub(crate) fn modal_paste_target_active(state: &AppState) -> bool {
             .as_ref()
             .is_some_and(|open| open.search_focused),
         Mode::Navigator => state.navigator.search_focused,
+        Mode::KeybindHelp => state.keybind_help.search_focused,
         _ => false,
     }
 }

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -96,6 +96,10 @@ pub(super) fn open_global_menu(state: &mut AppState) {
 
 pub(super) fn open_keybind_help(state: &mut AppState) {
     state.keybind_help.scroll = 0;
+    state.keybind_help.query.clear();
+    state.keybind_help.search_focused = false;
+    state.keybind_help.selected = 0;
+    state.keybind_help.origin_mode = state.mode;
     state.mode = Mode::KeybindHelp;
 }
 
@@ -292,19 +296,6 @@ pub(crate) fn insert_navigator_search_text(
     state.navigator.state_filter = None;
     state.navigator.query.push_str(text);
     state.clamp_navigator_selection_from(terminal_runtimes);
-}
-
-pub(crate) fn handle_keybind_help_key(state: &mut AppState, key: KeyEvent) {
-    match key.code {
-        KeyCode::Up | KeyCode::Char('k') => state.scroll_keybind_help(-1),
-        KeyCode::Down | KeyCode::Char('j') => state.scroll_keybind_help(1),
-        KeyCode::PageUp => state.scroll_keybind_help(-8),
-        KeyCode::PageDown => state.scroll_keybind_help(8),
-        KeyCode::Home => state.keybind_help.scroll = 0,
-        KeyCode::End => state.keybind_help.scroll = state.keybind_help_max_scroll(),
-        KeyCode::Esc | KeyCode::Enter | KeyCode::Char('?') => leave_modal(state),
-        _ => {}
-    }
 }
 
 pub(super) fn open_rename_workspace(

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -750,12 +750,197 @@ pub(super) fn execute_navigate_action(state: &mut AppState, action: NavigateActi
     );
 }
 
-pub(super) fn execute_navigate_action_in_context(
+pub(crate) fn can_execute_navigate_action(
+    state: &AppState,
+    terminal_runtimes: Option<&TerminalRuntimeRegistry>,
+    action: NavigateAction,
+    context: ActionContext,
+) -> (bool, Option<String>) {
+    let active_workspace = state.active.and_then(|idx| state.workspaces.get(idx));
+    let has_active_workspace = active_workspace.is_some();
+    let has_active_tab = active_workspace.is_some_and(|ws| !ws.tabs.is_empty());
+    let has_multiple_tabs = active_workspace.is_some_and(|ws| ws.tabs.len() > 1);
+    let has_focused_pane = active_workspace
+        .and_then(|ws| ws.focused_pane_id())
+        .is_some();
+    let has_toast_target = state
+        .toast
+        .as_ref()
+        .is_some_and(|toast| toast.target.is_some());
+
+    match action {
+        NavigateAction::NewWorkspace
+        | NavigateAction::Help
+        | NavigateAction::Settings
+        | NavigateAction::ReloadConfig
+        | NavigateAction::Detach
+        | NavigateAction::WorkspacePicker => (true, None),
+        NavigateAction::OpenNotificationTarget => {
+            if has_toast_target {
+                (true, None)
+            } else {
+                (false, Some("no notification target".to_string()))
+            }
+        }
+        NavigateAction::SwitchWorkspace(idx) => {
+            if state.workspace_at_visible_position(idx).is_some() {
+                (true, None)
+            } else {
+                (false, Some("indexed shortcut only".to_string()))
+            }
+        }
+        NavigateAction::SwitchTab(idx) => {
+            if active_workspace.is_some_and(|ws| idx < ws.tabs.len()) {
+                (true, None)
+            } else {
+                (false, Some("indexed shortcut only".to_string()))
+            }
+        }
+        NavigateAction::FocusAgent(_) => (true, None),
+        NavigateAction::OpenWorktree | NavigateAction::NewWorktree => {
+            let Some(ws_idx) = workspace_action_target(state, context) else {
+                return (false, Some("no active workspace".to_string()));
+            };
+            if !workspace_can_start_worktree_action_with_context(state, terminal_runtimes, ws_idx) {
+                return (
+                    false,
+                    Some("managed linked worktrees cannot create sibling worktrees".to_string()),
+                );
+            }
+            (true, None)
+        }
+        NavigateAction::RemoveWorktree => {
+            let Some(ws_idx) = workspace_action_target(state, context) else {
+                return (false, Some("no active workspace".to_string()));
+            };
+            let Some(ws) = state.workspaces.get(ws_idx) else {
+                return (false, Some("no active workspace".to_string()));
+            };
+            if ws
+                .worktree_space()
+                .is_some_and(|space| space.is_linked_worktree)
+            {
+                (true, None)
+            } else {
+                (
+                    false,
+                    Some("active workspace is not a managed worktree".to_string()),
+                )
+            }
+        }
+        NavigateAction::RenameWorkspace | NavigateAction::CloseWorkspace => {
+            if workspace_action_target(state, context).is_some() {
+                (true, None)
+            } else {
+                (false, Some("no active workspace".to_string()))
+            }
+        }
+        NavigateAction::OpenNavigator
+        | NavigateAction::PreviousWorkspace
+        | NavigateAction::NextWorkspace
+        | NavigateAction::PreviousAgent
+        | NavigateAction::NextAgent
+        | NavigateAction::NewTab => {
+            if has_active_workspace {
+                (true, None)
+            } else {
+                (false, Some("no active workspace".to_string()))
+            }
+        }
+        NavigateAction::RenameTab => {
+            if has_active_tab {
+                (true, None)
+            } else {
+                (false, Some("no active tab".to_string()))
+            }
+        }
+        NavigateAction::PreviousTab | NavigateAction::NextTab => {
+            if has_active_tab {
+                (true, None)
+            } else {
+                (false, Some("no active workspace".to_string()))
+            }
+        }
+        NavigateAction::CloseTab => {
+            if !has_active_workspace {
+                (false, Some("no active workspace".to_string()))
+            } else if !has_multiple_tabs {
+                (false, Some("cannot close the last tab".to_string()))
+            } else {
+                (true, None)
+            }
+        }
+        NavigateAction::RenamePane | NavigateAction::ClosePane | NavigateAction::EditScrollback => {
+            if !has_active_workspace {
+                (false, Some("no active workspace".to_string()))
+            } else if !has_focused_pane {
+                (false, Some("no focused pane".to_string()))
+            } else {
+                (true, None)
+            }
+        }
+        NavigateAction::FocusPaneLeft
+        | NavigateAction::FocusPaneDown
+        | NavigateAction::FocusPaneUp
+        | NavigateAction::FocusPaneRight
+        | NavigateAction::SwapPaneLeft
+        | NavigateAction::SwapPaneDown
+        | NavigateAction::SwapPaneUp
+        | NavigateAction::SwapPaneRight
+        | NavigateAction::SplitVertical
+        | NavigateAction::SplitHorizontal
+        | NavigateAction::CopyMode
+        | NavigateAction::Zoom
+        | NavigateAction::EnterResizeMode
+        | NavigateAction::ToggleSidebar
+        | NavigateAction::CyclePaneNext
+        | NavigateAction::CyclePanePrevious
+        | NavigateAction::LastPane => {
+            if has_active_workspace {
+                (true, None)
+            } else {
+                (false, Some("no active workspace".to_string()))
+            }
+        }
+    }
+}
+
+fn workspace_can_start_worktree_action_with_context(
+    state: &AppState,
+    terminal_runtimes: Option<&TerminalRuntimeRegistry>,
+    ws_idx: usize,
+) -> bool {
+    let Some(ws) = state.workspaces.get(ws_idx) else {
+        return false;
+    };
+    if ws
+        .worktree_space()
+        .is_some_and(|space| space.is_linked_worktree)
+    {
+        return false;
+    }
+    let git_space = if let Some(terminal_runtimes) = terminal_runtimes {
+        ws.git_space().cloned().or_else(|| {
+            ws.resolved_identity_cwd_from(&state.terminals, terminal_runtimes)
+                .as_deref()
+                .and_then(crate::workspace::git_space_metadata)
+        })
+    } else {
+        ws.git_space().cloned()
+    };
+    !git_space.is_some_and(|space| space.is_linked_worktree)
+}
+
+pub(crate) fn execute_navigate_action_in_context(
     state: &mut AppState,
     terminal_runtimes: &mut TerminalRuntimeRegistry,
     action: NavigateAction,
     context: ActionContext,
 ) {
+    if !can_execute_navigate_action(state, Some(&*terminal_runtimes), action, context).0 {
+        return;
+    }
+
     let previous_mode = state.mode;
     match action {
         NavigateAction::NewWorkspace => {
@@ -763,17 +948,13 @@ pub(super) fn execute_navigate_action_in_context(
             leave_navigate_mode(state);
         }
         NavigateAction::NewWorktree => {
-            if let Some(ws_idx) = workspace_action_target(state, context)
-                .filter(|idx| workspace_can_start_worktree_action(state, terminal_runtimes, *idx))
-            {
+            if let Some(ws_idx) = workspace_action_target(state, context) {
                 state.request_new_linked_worktree = Some(ws_idx);
                 leave_navigate_mode(state);
             }
         }
         NavigateAction::OpenWorktree => {
-            if let Some(ws_idx) = workspace_action_target(state, context)
-                .filter(|idx| workspace_can_start_worktree_action(state, terminal_runtimes, *idx))
-            {
+            if let Some(ws_idx) = workspace_action_target(state, context) {
                 state.request_open_existing_worktree = Some(ws_idx);
                 leave_navigate_mode(state);
             }
@@ -960,28 +1141,6 @@ fn workspace_action_target(state: &AppState, context: ActionContext) -> Option<u
     (idx < state.workspaces.len()).then_some(idx)
 }
 
-fn workspace_can_start_worktree_action(
-    state: &AppState,
-    terminal_runtimes: &TerminalRuntimeRegistry,
-    ws_idx: usize,
-) -> bool {
-    let Some(ws) = state.workspaces.get(ws_idx) else {
-        return false;
-    };
-    if ws
-        .worktree_space()
-        .is_some_and(|space| space.is_linked_worktree)
-    {
-        return false;
-    }
-    let git_space = ws.git_space().cloned().or_else(|| {
-        ws.resolved_identity_cwd_from(&state.terminals, terminal_runtimes)
-            .as_deref()
-            .and_then(crate::workspace::git_space_metadata)
-    });
-    !git_space.is_some_and(|space| space.is_linked_worktree)
-}
-
 fn leave_navigate_mode(state: &mut AppState) {
     if state.active.is_some() {
         state.mode = Mode::Terminal;
@@ -1009,11 +1168,7 @@ fn finish_custom_command_context(
 }
 
 fn leave_command_mode(state: &mut AppState) {
-    state.mode = if state.active.is_some() {
-        Mode::Terminal
-    } else {
-        Mode::Navigate
-    };
+    state.leave_command_mode();
 }
 
 fn write_scrollback_temp_file(content: &str) -> io::Result<std::path::PathBuf> {

--- a/src/app/input/overlays.rs
+++ b/src/app/input/overlays.rs
@@ -194,6 +194,14 @@ impl App {
 
         if self.state.mode == Mode::KeybindHelp {
             match mouse.kind {
+                MouseEventKind::Moved => {
+                    if let Some(row) = self
+                        .state
+                        .keybind_help_row_index_at(mouse.column, mouse.row)
+                    {
+                        self.keybind_help_hover_row(row);
+                    }
+                }
                 MouseEventKind::Down(MouseButton::Left)
                     if self
                         .state
@@ -217,6 +225,11 @@ impl App {
                                     .set_keybind_help_offset_from_bottom(offset_from_bottom);
                             }
                         }
+                    } else if let Some(row) = self
+                        .state
+                        .keybind_help_row_index_at(mouse.column, mouse.row)
+                    {
+                        self.keybind_help_click_row(row);
                     } else {
                         let rect = self.state.keybind_help_popup_rect();
                         let inside = mouse.column >= rect.x
@@ -628,7 +641,7 @@ impl AppState {
             && row < button.y + button.height
     }
 
-    fn keybind_help_body_rect(&self) -> Option<Rect> {
+    pub(crate) fn keybind_help_body_rect(&self) -> Option<Rect> {
         let inner = self.keybind_help_modal_inner()?;
         if inner.height < 6 || inner.width < 4 {
             return None;
@@ -636,14 +649,24 @@ impl AppState {
         Some(crate::ui::modal_stack_areas(inner, 2, 1, 0, 1).content)
     }
 
+    pub(crate) fn keybind_help_row_index_at(&self, col: u16, row: u16) -> Option<usize> {
+        let body = self.keybind_help_body_rect()?;
+        let metrics = self.keybind_help_scroll_metrics()?;
+        let text_area = crate::ui::release_notes_scrollbar_rect(body, metrics)
+            .map(|_| Rect::new(body.x, body.y, body.width.saturating_sub(1), body.height))
+            .unwrap_or(body);
+        if !rect_contains(text_area, col, row) {
+            return None;
+        }
+        Some(row.saturating_sub(text_area.y) as usize)
+    }
+
     fn keybind_help_scroll_metrics(&self) -> Option<crate::pane::ScrollMetrics> {
         let body = self.keybind_help_body_rect()?;
         let viewport_rows = body.height.max(1) as usize;
-        let wrap_width = body.width.max(1) as usize;
-        let total_rows = crate::ui::keybind_help_lines(self)
-            .into_iter()
-            .map(|(width, _)| width.max(1).div_ceil(wrap_width))
-            .sum::<usize>();
+        let total_rows = crate::app::command_palette::build_keybind_help_model(self)
+            .rows
+            .len();
         let max_offset_from_bottom = total_rows.saturating_sub(viewport_rows);
         Some(crate::pane::ScrollMetrics {
             offset_from_bottom: max_offset_from_bottom

--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -72,6 +72,7 @@ impl App {
         }
 
         if self.state.is_prefix_key(key) {
+            self.state.command_mode_return = None;
             self.state.mode = Mode::Prefix;
             return None;
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,6 +9,7 @@ mod agent_resume;
 mod agents;
 mod api;
 mod api_helpers;
+pub(crate) mod command_palette;
 mod config_io;
 mod creation;
 mod ids;
@@ -539,7 +540,13 @@ impl App {
                     preview: announcement.preview,
                 }
             }),
-            keybind_help: state::KeybindHelpState { scroll: 0 },
+            keybind_help: state::KeybindHelpState {
+                scroll: 0,
+                query: String::new(),
+                search_focused: false,
+                selected: 0,
+                origin_mode: mode,
+            },
             navigator: state::NavigatorState::default(),
             copy_mode: None,
             workspace_scroll: 0,
@@ -642,6 +649,7 @@ impl App {
             plugin_commands_in_flight: 0,
             global_menu: state::MenuListState::new(0),
             host_terminal_theme: crate::terminal_theme::TerminalTheme::default(),
+            command_mode_return: None,
             session_dirty: false,
             terminal_runtime_shutdowns: Vec::new(),
         };
@@ -1617,7 +1625,7 @@ impl App {
                 );
             }
             Mode::KeybindHelp => {
-                input::handle_keybind_help_key(&mut self.state, key_event);
+                self.handle_keybind_help_key(key_event);
             }
             Mode::GlobalMenu => {
                 input::handle_global_menu_key(&mut self.state, key_event);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1246,6 +1246,10 @@ pub struct ProductAnnouncementState {
 
 pub struct KeybindHelpState {
     pub scroll: u16,
+    pub query: String,
+    pub search_focused: bool,
+    pub selected: usize,
+    pub origin_mode: Mode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1425,6 +1429,8 @@ pub struct AppState {
     pub global_menu: MenuListState,
     /// Resolved host terminal default colors for theming embedded panes.
     pub host_terminal_theme: TerminalTheme,
+    /// Optional return target when leaving prefix-driven command modes.
+    pub(crate) command_mode_return: Option<Mode>,
     /// Set when a persisted session snapshot would change.
     pub session_dirty: bool,
     /// Terminal runtimes that should be shut down by the app/runtime layer
@@ -1513,6 +1519,16 @@ impl AppState {
 
     pub fn is_prefix_key(&self, key: crate::input::TerminalKey) -> bool {
         crate::config::terminal_key_matches_combo(key, (self.prefix_code, self.prefix_mods))
+    }
+
+    pub(crate) fn leave_command_mode(&mut self) {
+        if let Some(mode) = self.command_mode_return.take() {
+            self.mode = mode;
+        } else if self.active.is_some() {
+            self.mode = Mode::Terminal;
+        } else {
+            self.mode = Mode::Navigate;
+        }
     }
 
     pub fn estimate_pane_size(&self) -> (u16, u16) {
@@ -1659,7 +1675,13 @@ impl AppState {
             name_input_replace_on_type: false,
             release_notes: None,
             product_announcement: None,
-            keybind_help: KeybindHelpState { scroll: 0 },
+            keybind_help: KeybindHelpState {
+                scroll: 0,
+                query: String::new(),
+                search_focused: false,
+                selected: 0,
+                origin_mode: Mode::Terminal,
+            },
             navigator: NavigatorState::default(),
             copy_mode: None,
             workspace_scroll: 0,
@@ -1771,6 +1793,7 @@ impl AppState {
             plugin_commands_in_flight: 0,
             global_menu: MenuListState::new(0),
             host_terminal_theme: TerminalTheme::default(),
+            command_mode_return: None,
             session_dirty: false,
             terminal_runtime_shutdowns: Vec::new(),
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -25,6 +25,8 @@ use self::dialogs::{
     render_confirm_close_overlay, render_new_linked_worktree_overlay,
     render_open_existing_worktree_overlay, render_remove_worktree_overlay, render_rename_overlay,
 };
+#[cfg(test)]
+pub(crate) use self::keybind_help::keybind_help_lines;
 use self::keybind_help::render_keybind_help_overlay;
 use self::menus::{
     render_context_menu, render_copy_mode_overlay, render_global_launcher_menu,
@@ -79,7 +81,6 @@ pub(crate) use self::{
     },
 };
 pub(crate) use self::{
-    keybind_help::keybind_help_lines,
     mobile::{
         mobile_switcher_areas, mobile_switcher_max_scroll, mobile_switcher_target_at,
         mobile_switcher_workspace_doc_range, MobileSwitcherTarget,

--- a/src/ui/keybind_help.rs
+++ b/src/ui/keybind_help.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use std::borrow::Cow;
 
 use ratatui::{
@@ -14,19 +15,27 @@ use super::widgets::{
     modal_stack_areas, panel_contrast_fg, render_action_button, render_modal_header,
     render_modal_shell,
 };
-use crate::app::AppState;
+use crate::app::{
+    command_palette::{build_keybind_help_model, keybind_help_selected_row, KeybindHelpRow},
+    AppState,
+};
 
+#[cfg(test)]
 pub(super) type HelpEntry = (String, Cow<'static, str>);
+#[cfg(test)]
 pub(super) type HelpGroup = (&'static str, Vec<HelpEntry>);
 
+#[cfg(test)]
 fn help_entry(key: impl Into<String>, label: &'static str) -> HelpEntry {
     (key.into(), Cow::Borrowed(label))
 }
 
+#[cfg(test)]
 fn keybind_label(bindings: &crate::config::ActionKeybinds) -> String {
     bindings.label().unwrap_or_else(|| "unset".to_string())
 }
 
+#[cfg(test)]
 fn indexed_label(bindings: &[crate::config::IndexedKeybind]) -> String {
     if bindings.is_empty() {
         return "unset".to_string();
@@ -59,6 +68,7 @@ fn indexed_range_prefix(bindings: &[crate::config::IndexedKeybind]) -> Option<&s
     Some(prefix)
 }
 
+#[cfg(test)]
 pub(super) fn keybind_help_groups(app: &AppState) -> Vec<HelpGroup> {
     let kb = &app.keybinds;
     let mut groups = Vec::new();
@@ -181,6 +191,7 @@ pub(super) fn keybind_help_groups(app: &AppState) -> Vec<HelpGroup> {
     groups
 }
 
+#[cfg(test)]
 pub(crate) fn keybind_help_lines(app: &AppState) -> Vec<(usize, Line<'static>)> {
     let heading_style = Style::default()
         .fg(app.palette.accent)
@@ -246,9 +257,15 @@ pub(super) fn render_keybind_help_overlay(app: &AppState, frame: &mut Frame) {
             .bg(app.palette.accent)
             .add_modifier(Modifier::BOLD),
     );
+    let query_hint = if app.keybind_help.search_focused {
+        format!("search: {}", app.keybind_help.query)
+    } else if app.keybind_help.query.is_empty() {
+        "available commands and configured shortcuts (press / to filter)".to_string()
+    } else {
+        format!("search: {}", app.keybind_help.query)
+    };
     frame.render_widget(
-        Paragraph::new(" available commands and configured shortcuts")
-            .style(Style::default().fg(app.palette.overlay1)),
+        Paragraph::new(format!(" {query_hint}")).style(Style::default().fg(app.palette.overlay1)),
         header_rows[1],
     );
 
@@ -272,15 +289,70 @@ pub(super) fn render_keybind_help_overlay(app: &AppState, frame: &mut Frame) {
         })
         .unwrap_or(body_area);
 
-    let body = Paragraph::new(
-        keybind_help_lines(app)
-            .into_iter()
-            .map(|(_, line)| line)
-            .collect::<Vec<_>>(),
-    )
-    .wrap(Wrap { trim: false })
-    .scroll((app.keybind_help.scroll, 0));
-    frame.render_widget(body, text_area);
+    let model = build_keybind_help_model(app);
+    let start = app.keybind_help.scroll as usize;
+    let end = model
+        .rows
+        .len()
+        .min(start.saturating_add(text_area.height as usize));
+    let selected_row = keybind_help_selected_row(&model, app.keybind_help.selected);
+
+    for (visible_idx, row) in model.rows[start..end].iter().enumerate() {
+        let y = text_area.y + visible_idx as u16;
+        let row_rect = Rect::new(text_area.x, y, text_area.width, 1);
+        match row {
+            KeybindHelpRow::Spacer => {
+                frame.render_widget(Paragraph::new(""), row_rect);
+            }
+            KeybindHelpRow::Header(group) => {
+                frame.render_widget(
+                    Paragraph::new(format!(" {}", group.label())).style(
+                        Style::default()
+                            .fg(app.palette.accent)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    row_rect,
+                );
+            }
+            KeybindHelpRow::Entry(entry_idx) => {
+                let Some(entry) = model.entries.get(*entry_idx) else {
+                    continue;
+                };
+                let row_absolute = start + visible_idx;
+                let is_selected = selected_row == Some(row_absolute);
+                let bg = if is_selected {
+                    app.palette.accent
+                } else {
+                    app.palette.panel_bg
+                };
+                let key_style = if is_selected {
+                    Style::default()
+                        .fg(panel_contrast_fg(&app.palette))
+                        .bg(bg)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                        .fg(app.palette.mauve)
+                        .bg(bg)
+                        .add_modifier(Modifier::BOLD)
+                };
+                let label_style = if is_selected {
+                    Style::default().fg(panel_contrast_fg(&app.palette)).bg(bg)
+                } else {
+                    Style::default().fg(app.palette.text).bg(bg)
+                };
+                let padded_key = format!(" {:<28} ", entry.shortcuts);
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![
+                        Span::styled(padded_key, key_style),
+                        Span::styled(entry.label.clone(), label_style),
+                    ]))
+                    .wrap(Wrap { trim: false }),
+                    row_rect,
+                );
+            }
+        }
+    }
     if let Some(track) = track {
         render_scrollbar(
             frame,
@@ -294,14 +366,17 @@ pub(super) fn render_keybind_help_overlay(app: &AppState, frame: &mut Frame) {
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled(" scroll ", Style::default().fg(app.palette.overlay0)),
-            Span::styled("wheel ↑↓", Style::default().fg(app.palette.text)),
+            Span::styled("search", Style::default().fg(app.palette.overlay0)),
+            Span::styled(" / ", Style::default().fg(app.palette.text)),
             Span::styled("  ·  ", Style::default().fg(app.palette.overlay0)),
-            Span::styled("jump", Style::default().fg(app.palette.overlay0)),
-            Span::styled(" pgup / pgdn ", Style::default().fg(app.palette.text)),
+            Span::styled("move", Style::default().fg(app.palette.overlay0)),
+            Span::styled(" ↑↓ / ctrl+n,p ", Style::default().fg(app.palette.text)),
+            Span::styled("  ·  ", Style::default().fg(app.palette.overlay0)),
+            Span::styled("run", Style::default().fg(app.palette.overlay0)),
+            Span::styled(" enter ", Style::default().fg(app.palette.text)),
             Span::styled("  ·  ", Style::default().fg(app.palette.overlay0)),
             Span::styled("close", Style::default().fg(app.palette.overlay0)),
-            Span::styled(" esc / enter ", Style::default().fg(app.palette.text)),
+            Span::styled(" esc ", Style::default().fg(app.palette.text)),
         ])),
         stack.footer.unwrap_or_default(),
     );


### PR DESCRIPTION
PS. It's an AI generated PRD and code. I've tried to do it cleanly

## Problem Statement

see: https://github.com/ogulcancelik/herdr/discussions/819

Users need a fast way to discover and run existing keybound actions from one place, without memorizing all shortcuts. The previous keybind help overlay was read-only, so users had to close it and perform actions elsewhere. This created friction during navigation, especially when users were unsure whether an action was available in the current workspace/tab/pane context.

The current goal is to make keybind help interactive (search, select, execute) while keeping behavior consistent with existing Herdr mode and modal interaction patterns.

## Solution

The keybind help overlay now acts as an interactive command surface:

- Users can filter commands with `/` and typed/pasted text.
- Users can navigate results with keyboard and mouse.
- Users can execute the selected command with `Enter` or mouse click.
- If a command is unavailable in current context, users get a clear toast message.

This is delivered without introducing a separate user-facing command palette mode. Instead, keybind help is backed by a shared command catalog/model and shared availability evaluation.

## User Stories

1. As a keyboard-first user, I want to press `?` and immediately browse available keybound actions, so that I can discover features quickly.
2. As a user, I want to press `/` inside keybind help to focus search, so that I can filter the list without leaving the overlay.
3. As a user editing a search query, I want `Backspace` to remove characters, so that I can refine filtering naturally.
4. As a user editing a search query, I want `Ctrl+u` to clear the query, so that I can restart filtering quickly.
5. As a user in focused search, I want `Esc` to exit search focus and clear the query, so that I can return to list navigation predictably.
6. As a user not in search focus, I want `Esc` (or `?`) to close keybind help, so that modal behavior remains consistent.
7. As a user, I want search matching to work across command label, group label, and shortcut label, so that I can find actions from multiple cues.
8. As a user, I want search to be case-insensitive and whitespace-tolerant, so that filtering is forgiving.
9. As a user, I want keybind help to show only commands that are currently executable, so that the list stays actionable.
10. As a user, I want commands grouped (global, navigation, workspaces/tabs, panes, custom), so that discovery remains structured.
11. As a user, I want visible spacing and headers between groups, so that the list is readable while scrolling.
12. As a user, I want a highlighted selected row, so that I always know what `Enter` will execute.
13. As a user, I want to move selection with `Up/Down`, `j/k`, `PageUp/PageDown`, `Home/End`, so that navigation matches terminal expectations.
14. As a user, I want selection to auto-clamp when filtering shrinks the list, so that the overlay never points to an invalid row.
15. As a user, I want mouse hover to update selection, so that pointer interaction feels direct.
16. As a user, I want mouse click on a row to execute the command, so that mouse-first usage is supported.
17. As a user, I want command execution context to respect the mode from which keybind help was opened (navigate vs prefix semantics), so that outcomes are consistent.
18. As a user, I want a clear “command unavailable” toast with reason when execution cannot proceed, so that failures are understandable.
19. As a user, I want footer hints to advertise search, movement, run, and close controls, so that usage is self-discoverable.
20. As a maintainer, I want command metadata and availability checks centralized, so that render/input/execute logic stays synchronized.
21. As a maintainer, I want keybind help row mapping and selection normalization to be deterministic, so that behavior is testable.
22. As a maintainer, I want modal paste handling to work when keybind-help search is focused, so that text-input behavior is consistent across overlays.
23. As a maintainer, I want copy-mode prefix handoff behavior preserved when returning through command flows, so that mode transitions remain coherent.

## Implementation Decisions

- Introduced a dedicated command catalog/model module for interactive keybind help, including:
  - command groups,
  - command entries,
  - grouped row model (`entries + rows`) used by render and hit-testing.
- Added a table-driven command specification for built-in navigation actions to avoid repetitive per-command construction logic.
- Kept custom commands dynamically appended from user keybind configuration.
- Introduced a shared `can_execute` flow:
  - one path for keybind-help command availability,
  - one path for navigate-action availability,
  - same reason strings used for feedback.
- Added runtime-aware availability checks where needed (for worktree eligibility), while keeping a state-only fallback for UI model construction.
- Unified keybind-help action context derivation from origin mode to preserve expected navigate vs prefix behavior.
- Reworked keybind-help input handling into a dedicated input module handling:
  - search focus/editing,
  - keyboard list navigation,
  - execute-on-enter,
  - selection/scroll normalization.
- Reworked keybind-help render path to draw from the model rows rather than from static text lines.
- Added row hit-testing for mouse hover/click based on content area and scrollbar geometry.
- Preserved existing modal structure and visual language (modal shell/header/footer), while updating helper text to match interactive behavior.
- Added shared command-mode return handling in state to support prefix-driven transitions cleanly.

## Testing Decisions

- A good test should validate externally observable behavior (visible rows, selection movement, mode transitions, action side effects, and feedback), not internal iteration details.
- Priority test surfaces:
  - command catalog/model building (grouping, filtering, row mapping, selection normalization),
  - shared command availability (`can_execute`) and reason messages,
  - keybind-help input behavior (search focus transitions, keyboard movement, execute flow),
  - mouse interaction (row hover/click resolution),
  - mode-return semantics around prefix/copy/help transitions.
- Prior art in this codebase:
  - state-first unit tests using `AppState::test_new()` and workspace test helpers,
  - input-handler tests validating mode transitions,
  - overlay geometry and scrollbar interaction tests in existing modal/overlay flows.

## Out of Scope

- Reintroducing a standalone command palette modal/mode.
- Ranking/relevance heuristics beyond current fuzzy-like text matching.
- New protocol/server wire changes unrelated to local TUI keybind-help behavior.
- Broad UX redesign for other overlays (settings, navigator, release notes).
- Stable docs publication changes.

## Further Notes

- This PRD reflects delivered behavior from the current keybind-help interactive filtering/execution implementation, replacing the outdated assumptions in the previous PRD.
- Important correction vs old PRD: unavailable commands are not rendered as dimmed rows; currently only executable commands are listed.
- The command catalog remains a core module even without a separate command palette UI because it is now the single source for keybind-help command modeling.