### PR TITLE
Support middle-click paste

### DIFF
--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -831,13 +831,10 @@ impl AppState {
                 }
             }
 
-            MouseEventKind::Up(MouseButton::Middle) | MouseEventKind::Drag(MouseButton::Middle)
-                if !in_sidebar =>
-            {
-                if let Some(info) = self.pane_mouse_target(mouse.column, mouse.row).cloned() {
-                    let _ = self.forward_pane_mouse_button(terminal_runtimes, &info, mouse);
-                }
-            }
+            MouseEventKind::Down(MouseButton::Middle)
+            | MouseEventKind::Up(MouseButton::Middle)
+            | MouseEventKind::Drag(MouseButton::Middle)
+                if !in_sidebar => {}
 
             MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
                 if self.on_tab_bar(mouse.column, mouse.row) =>

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -150,6 +150,16 @@ impl App {
                 true
             }
             crate::raw_input::RawInputEvent::Mouse(mouse) => {
+                if matches!(
+                    mouse.kind,
+                    crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Middle)
+                ) {
+                    if let Some(text) = crate::platform::read_clipboard_text() {
+                        self.handle_paste(text).await;
+                    }
+                    return true;
+                }
+
                 if self.state.mouse_capture {
                     self.handle_mouse(mouse);
                 } else {


### PR DESCRIPTION
Middle-click currently gets captured by Herdr mouse handling, so host-terminal middle-click paste never reaches the pane.\n\nThis treats middle-button down as a clipboard paste and consumes the matching middle mouse events instead of forwarding a partial middle gesture to pane apps.\n\nTested:\n- cargo test route_client_input_pastes_bracketed_text_into_rename_modal