### PR TITLE
fix: preserve terminal underline styles

### DIFF
--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -345,6 +345,7 @@ pub struct CellStyle {
     pub fg_color: Option<CellColor>,
     pub bg_color: Option<CellColor>,
     pub underline_color: Option<CellColor>,
+    pub underline_style: crate::protocol::UnderlineStyle,
     pub bold: bool,
     pub italic: bool,
     pub faint: bool,
@@ -353,7 +354,6 @@ pub struct CellStyle {
     pub invisible: bool,
     pub strikethrough: bool,
     pub overline: bool,
-    pub underlined: bool,
 }
 
 impl From<ffi::GhosttyStyle> for CellStyle {
@@ -362,6 +362,7 @@ impl From<ffi::GhosttyStyle> for CellStyle {
             fg_color: cell_color_from_style_color(value.fg_color),
             bg_color: cell_color_from_style_color(value.bg_color),
             underline_color: cell_color_from_style_color(value.underline_color),
+            underline_style: underline_style_from_raw(value.underline),
             bold: value.bold,
             italic: value.italic,
             faint: value.faint,
@@ -370,8 +371,28 @@ impl From<ffi::GhosttyStyle> for CellStyle {
             invisible: value.invisible,
             strikethrough: value.strikethrough,
             overline: value.overline,
-            underlined: value.underline != 0,
         }
+    }
+}
+
+fn underline_style_from_raw(value: std::os::raw::c_int) -> crate::protocol::UnderlineStyle {
+    match value as ffi::GhosttySgrUnderline {
+        ffi::GhosttySgrUnderline_GHOSTTY_SGR_UNDERLINE_SINGLE => {
+            crate::protocol::UnderlineStyle::Single
+        }
+        ffi::GhosttySgrUnderline_GHOSTTY_SGR_UNDERLINE_DOUBLE => {
+            crate::protocol::UnderlineStyle::Double
+        }
+        ffi::GhosttySgrUnderline_GHOSTTY_SGR_UNDERLINE_CURLY => {
+            crate::protocol::UnderlineStyle::Curly
+        }
+        ffi::GhosttySgrUnderline_GHOSTTY_SGR_UNDERLINE_DOTTED => {
+            crate::protocol::UnderlineStyle::Dotted
+        }
+        ffi::GhosttySgrUnderline_GHOSTTY_SGR_UNDERLINE_DASHED => {
+            crate::protocol::UnderlineStyle::Dashed
+        }
+        _ => crate::protocol::UnderlineStyle::None,
     }
 }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -2418,6 +2418,13 @@ impl PaneRuntime {
         self.terminal.visible_hyperlinks(area)
     }
 
+    pub fn visible_underline_styles(
+        &self,
+        area: Rect,
+    ) -> Vec<((u16, u16), crate::protocol::UnderlineStyle)> {
+        self.terminal.visible_underline_styles(area)
+    }
+
     pub fn kitty_image_placements_with_data_filter<F>(
         &self,
         needs_data: F,

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -250,6 +250,13 @@ impl PaneTerminal {
         self.ghostty.visible_hyperlinks(area)
     }
 
+    pub fn visible_underline_styles(
+        &self,
+        area: Rect,
+    ) -> Vec<((u16, u16), crate::protocol::UnderlineStyle)> {
+        self.ghostty.visible_underline_styles(area)
+    }
+
     pub fn kitty_image_placements_with_data_filter<F>(
         &self,
         needs_data: F,
@@ -1156,6 +1163,17 @@ impl GhosttyPaneTerminal {
             .unwrap_or_default()
     }
 
+    pub fn visible_underline_styles(
+        &self,
+        area: Rect,
+    ) -> Vec<((u16, u16), crate::protocol::UnderlineStyle)> {
+        self.core
+            .lock()
+            .ok()
+            .and_then(|mut core| ghostty_visible_underline_styles(&mut core, area).ok())
+            .unwrap_or_default()
+    }
+
     pub fn kitty_image_placements_with_data_filter<F>(
         &self,
         needs_data: F,
@@ -1511,7 +1529,11 @@ fn ghostty_collect_dirty_patch(
                     Ok(symbol) => symbol.to_owned(),
                     Err(_) => ghostty_blank_symbol_for_width(basic.wide).to_owned(),
                 };
-                patch_cells.push(cell_data_from_style(symbol, style));
+                patch_cells.push(cell_data_from_style(
+                    symbol,
+                    style,
+                    basic.style.underline_style,
+                ));
                 x += 1;
             }
             while x < area_width {
@@ -1580,6 +1602,36 @@ fn ghostty_visible_hyperlinks(
         y += 1;
     }
     Ok(links)
+}
+
+fn ghostty_visible_underline_styles(
+    core: &mut GhosttyPaneCore,
+    area: Rect,
+) -> Result<Vec<((u16, u16), crate::protocol::UnderlineStyle)>, crate::ghostty::Error> {
+    let GhosttyPaneCore {
+        terminal,
+        render_state,
+        ..
+    } = core;
+    render_state.update(terminal)?;
+    let mut row_iterator = crate::ghostty::RowIterator::new()?;
+    let mut row_cells = crate::ghostty::RowCells::new()?;
+    let mut rows = render_state.populate_row_iterator(&mut row_iterator)?;
+    let mut styles = Vec::new();
+    let mut y = 0u16;
+    while y < area.height && rows.next() {
+        let mut cells = rows.populate_cells(&mut row_cells)?;
+        let mut x = 0u16;
+        while x < area.width && cells.next() {
+            let style = cells.basic_data()?.style.underline_style;
+            if style != crate::protocol::UnderlineStyle::None {
+                styles.push(((area.x + x, area.y + y), style));
+            }
+            x += 1;
+        }
+        y += 1;
+    }
+    Ok(styles)
 }
 
 fn ghostty_visible_text(core: &mut GhosttyPaneCore) -> Result<String, crate::ghostty::Error> {
@@ -1840,10 +1892,15 @@ fn blank_cell_data(default_fg: Option<Color>, default_bg: Option<Color>) -> Cell
     cell_data_from_style(
         " ".to_string(),
         ghostty_default_style(default_fg, default_bg),
+        crate::protocol::UnderlineStyle::None,
     )
 }
 
-fn cell_data_from_style(symbol: String, style: Style) -> CellData {
+fn cell_data_from_style(
+    symbol: String,
+    style: Style,
+    underline_style: crate::protocol::UnderlineStyle,
+) -> CellData {
     CellData {
         symbol: if symbol.is_empty() {
             " ".to_string()
@@ -1852,7 +1909,11 @@ fn cell_data_from_style(symbol: String, style: Style) -> CellData {
         },
         fg: crate::protocol::color_to_u32(style.fg.unwrap_or(Color::Reset)),
         bg: crate::protocol::color_to_u32(style.bg.unwrap_or(Color::Reset)),
+        underline_color: crate::protocol::color_to_u32(
+            style.underline_color.unwrap_or(Color::Reset),
+        ),
         modifier: crate::protocol::modifier_to_u16(style.add_modifier),
+        underline_style,
         skip: false,
         hyperlink: None,
     }
@@ -1926,7 +1987,7 @@ fn ghostty_cell_style(
     if basic.style.blink {
         modifiers |= Modifier::SLOW_BLINK;
     }
-    if basic.style.underlined {
+    if basic.style.underline_style != crate::protocol::UnderlineStyle::None {
         modifiers |= Modifier::UNDERLINED;
     }
     if basic.style.strikethrough {
@@ -3609,25 +3670,30 @@ mod tests {
         let pane = GhosttyPaneTerminal::new(terminal, tx.clone()).unwrap();
         let pane_id = PaneId::from_raw(1);
 
-        let result =
-            pane.process_pty_bytes(pane_id, 0, b"\x1bP+q6E6F7065;536D756C78;4D7\x1b\\", &tx);
+        let result = pane.process_pty_bytes(pane_id, 0, b"\x1bP+q6E6F7065;4D7\x1b\\", &tx);
 
         assert!(result.terminal_responses.is_empty());
         assert!(rx.try_recv().is_err());
     }
 
     #[test]
-    fn process_pty_bytes_returns_underline_color_xtgettcap_query_responses() {
+    fn process_pty_bytes_returns_underline_xtgettcap_query_responses() {
         let (tx, mut rx) = mpsc::channel(4);
         let terminal = crate::ghostty::Terminal::new(20, 5, 0).unwrap();
         let pane = GhosttyPaneTerminal::new(terminal, tx.clone()).unwrap();
         let pane_id = PaneId::from_raw(1);
 
-        let result = pane.process_pty_bytes(pane_id, 0, b"\x1bP+q5375;536574756C63\x1b\\", &tx);
+        let result = pane.process_pty_bytes(
+            pane_id,
+            0,
+            b"\x1bP+q536D756C78;5375;536574756C63\x1b\\",
+            &tx,
+        );
 
         assert_eq!(
             result.terminal_responses,
             vec![
+                expected_xtgettcap_response("536D756C78", Some(b"\\E[4:%p1%dm")),
                 expected_xtgettcap_response("5375", None),
                 expected_xtgettcap_response(
                     "536574756C63",
@@ -3657,6 +3723,37 @@ mod tests {
         let style = terminal.backend().buffer()[(0, 0)].style();
         assert!(style.add_modifier.contains(Modifier::UNDERLINED));
         assert_eq!(style.underline_color, Some(Color::Rgb(17, 34, 51)));
+    }
+
+    #[test]
+    fn dirty_patch_preserves_curly_underline_style() {
+        let (tx, _rx) = mpsc::channel(4);
+        let terminal = crate::ghostty::Terminal::new(20, 5, 0).unwrap();
+        let pane = GhosttyPaneTerminal::new(terminal, tx).unwrap();
+        let backend = ratatui::backend::TestBackend::new(20, 5);
+        let mut ratatui_terminal = ratatui::Terminal::new(backend).unwrap();
+        ratatui_terminal
+            .draw(|frame| pane.render(frame, Rect::new(0, 0, 20, 5), false))
+            .unwrap();
+        {
+            let mut core = pane.core.lock().unwrap();
+            core.terminal.write(b"\x1b[4:3;58:2::255:0:0mU");
+        }
+
+        let patch = match pane.collect_dirty_patch(20, 5) {
+            TerminalDirtyPatchOutcome::Patch(patch) => patch,
+            other => panic!("expected dirty patch, got {other:?}"),
+        };
+
+        assert_eq!(
+            patch.rows[0].1[0].underline_style,
+            crate::protocol::UnderlineStyle::Curly
+        );
+        assert_eq!(
+            patch.rows[0].1[0].underline_color,
+            crate::protocol::color_to_u32(Color::Rgb(255, 0, 0))
+        );
+        assert_ne!(patch.rows[0].1[0].modifier & Modifier::UNDERLINED.bits(), 0);
     }
 
     #[test]

--- a/src/pane/xtgettcap.rs
+++ b/src/pane/xtgettcap.rs
@@ -175,13 +175,14 @@ fn xtgettcap_response(cap_hex: &[u8]) -> Option<Bytes> {
 
 fn xtgettcap_value(cap_hex: &[u8]) -> Option<Option<&'static [u8]>> {
     // Mirror only the Ghostty terminfo capabilities that this pane path can
-    // stand behind. Smulx is intentionally absent until underline shapes render.
+    // stand behind.
     match cap_hex {
         b"5463" => Some(None),
         b"524742" => Some(Some(b"8")),
         b"73657472676266" => Some(Some(b"\\E[38:2:%p1%d:%p2%d:%p3%dm")),
         b"73657472676262" => Some(Some(b"\\E[48:2:%p1%d:%p2%d:%p3%dm")),
         b"4D73" => Some(Some(b"\\E]52;%p1%s;%p2%s\\007")),
+        b"536D756C78" => Some(Some(b"\\E[4:%p1%dm")),
         b"5375" => Some(None),
         b"536574756C63" => Some(Some(
             b"\\E[58:2::%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m",
@@ -255,9 +256,23 @@ mod tests {
     fn tracker_ignores_unsupported_capabilities() {
         let mut tracker = XtgettcapQueryTracker::default();
 
-        tracker.observe(b"\x1bP+q536D756C78;6E6F7065\x1b\\");
+        tracker.observe(b"\x1bP+q6E6F7065\x1b\\");
 
         assert!(response_bytes(tracker.drain_pending()).is_empty());
+    }
+
+    #[test]
+    fn tracker_returns_styled_underline_capability() {
+        let mut tracker = XtgettcapQueryTracker::default();
+
+        tracker.observe(b"\x1bP+q536D756C78\x1b\\");
+
+        assert_eq!(
+            response_bytes(tracker.drain_pending()),
+            vec![Bytes::from_static(
+                b"\x1bP1+r536D756C78=5C455B343A25703125646D\x1b\\"
+            )]
+        );
     }
 
     #[test]

--- a/src/protocol/render_ansi.rs
+++ b/src/protocol/render_ansi.rs
@@ -31,7 +31,7 @@ use std::io::Write;
 
 use unicode_width::UnicodeWidthStr;
 
-use crate::protocol::{CellData, FrameData};
+use crate::protocol::{CellData, FrameData, UnderlineStyle};
 
 /// Bytes produced by a [`BlitEncoder`] for one terminal frame.
 pub(crate) struct EncodedBlit {
@@ -263,6 +263,40 @@ fn color_to_sgr_bg(val: u32) -> String {
     }
 }
 
+/// Converts a packed u32 color to an underline color SGR fragment.
+fn color_to_sgr_underline(val: u32) -> Option<String> {
+    match val >> 24 {
+        0x00 => match val & 0xFF {
+            0x00 => None,
+            0x01 => Some("58;5;0".to_owned()),
+            0x02 => Some("58;5;1".to_owned()),
+            0x03 => Some("58;5;2".to_owned()),
+            0x04 => Some("58;5;3".to_owned()),
+            0x05 => Some("58;5;4".to_owned()),
+            0x06 => Some("58;5;5".to_owned()),
+            0x07 => Some("58;5;6".to_owned()),
+            0x08 => Some("58;5;7".to_owned()),
+            0x09 => Some("58;5;8".to_owned()),
+            0x0A => Some("58;5;9".to_owned()),
+            0x0B => Some("58;5;10".to_owned()),
+            0x0C => Some("58;5;11".to_owned()),
+            0x0D => Some("58;5;12".to_owned()),
+            0x0E => Some("58;5;13".to_owned()),
+            0x0F => Some("58;5;14".to_owned()),
+            0x10 => Some("58;5;15".to_owned()),
+            _ => None,
+        },
+        0x01 => Some(format!("58;5;{}", val & 0xFF)),
+        0x02 => {
+            let r = (val >> 16) & 0xFF;
+            let g = (val >> 8) & 0xFF;
+            let b = val & 0xFF;
+            Some(format!("58;2;{r};{g};{b}"))
+        }
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Modifier → SGR
 // ---------------------------------------------------------------------------
@@ -315,14 +349,42 @@ fn modifier_to_sgr_parts(val: u16) -> Vec<&'static str> {
     parts
 }
 
+fn underline_style_to_sgr_part(style: UnderlineStyle, modifier: u16) -> Option<&'static str> {
+    if style == UnderlineStyle::None {
+        const UNDERLINED: u16 = 1 << 3;
+        return (modifier & UNDERLINED != 0).then_some("4");
+    }
+    match style {
+        UnderlineStyle::None => None,
+        UnderlineStyle::Single => Some("4"),
+        UnderlineStyle::Double => Some("4:2"),
+        UnderlineStyle::Curly => Some("4:3"),
+        UnderlineStyle::Dotted => Some("4:4"),
+        UnderlineStyle::Dashed => Some("4:5"),
+    }
+}
+
 /// Builds a complete SGR escape sequence for a cell's style.
-fn build_sgr(fg: u32, bg: u32, modifier: u16) -> String {
+fn build_sgr(
+    fg: u32,
+    bg: u32,
+    underline_color: u32,
+    modifier: u16,
+    underline_style: UnderlineStyle,
+) -> String {
     let mut parts = vec!["0".to_owned()];
     parts.extend(
         modifier_to_sgr_parts(modifier)
             .into_iter()
+            .filter(|part| *part != "4")
             .map(str::to_owned),
     );
+    if let Some(underline) = underline_style_to_sgr_part(underline_style, modifier) {
+        parts.push(underline.to_owned());
+    }
+    if let Some(underline_color) = color_to_sgr_underline(underline_color) {
+        parts.push(underline_color);
+    }
     parts.push(color_to_sgr_fg(fg));
     parts.push(color_to_sgr_bg(bg));
     format!("\x1b[{}m", parts.join(";"))
@@ -338,7 +400,9 @@ fn cells_equal(a: &CellData, b: &CellData) -> bool {
     a.symbol == b.symbol
         && a.fg == b.fg
         && a.bg == b.bg
+        && a.underline_color == b.underline_color
         && a.modifier == b.modifier
+        && a.underline_style == b.underline_style
         && a.hyperlink == b.hyperlink
     // Skip flag is only for ratatui internal use, not visual.
 }
@@ -574,7 +638,13 @@ fn write_all_cells(writer: &mut impl Write, frame: &FrameData) {
             let _ = write!(writer, "\x1b[{};{}H", row + 1, col + 1);
 
             // Set style.
-            let sgr = build_sgr(cell.fg, cell.bg, cell.modifier);
+            let sgr = build_sgr(
+                cell.fg,
+                cell.bg,
+                cell.underline_color,
+                cell.modifier,
+                cell.underline_style,
+            );
             let _ = writer.write_all(sgr.as_bytes());
 
             write_hyperlink_if_changed(
@@ -664,7 +734,13 @@ fn write_cell(
 
     let _ = write!(writer, "\x1b[{};{}H", row + 1, col + 1);
 
-    let sgr = build_sgr(cell.fg, cell.bg, cell.modifier);
+    let sgr = build_sgr(
+        cell.fg,
+        cell.bg,
+        cell.underline_color,
+        cell.modifier,
+        cell.underline_style,
+    );
     if sgr != *last_sgr {
         let _ = writer.write_all(sgr.as_bytes());
         *last_sgr = sgr;
@@ -684,7 +760,9 @@ fn cells_visually_equal(
     cell.symbol == prev_cell.symbol
         && cell.fg == prev_cell.fg
         && cell.bg == prev_cell.bg
+        && cell.underline_color == prev_cell.underline_color
         && cell.modifier == prev_cell.modifier
+        && cell.underline_style == prev_cell.underline_style
         && sanitized_cell_hyperlink_uri(sanitized_hyperlinks, cell)
             == sanitized_cell_hyperlink_uri(prev_sanitized_hyperlinks, prev_cell)
     // Skip flag is only for ratatui internal use, not visual.
@@ -755,7 +833,9 @@ mod tests {
             symbol: symbol.to_owned(),
             fg,
             bg,
+            underline_color: 0,
             modifier,
+            underline_style: UnderlineStyle::None,
             skip: false,
             hyperlink: None,
         }
@@ -828,7 +908,7 @@ mod tests {
 
     #[test]
     fn build_sgr_produces_valid_sequence() {
-        let sgr = build_sgr(0x00_00_00_02, 0x00_00_00_01, 1); // fg=Red, bg=Black, bold
+        let sgr = build_sgr(0x00_00_00_02, 0x00_00_00_01, 0, 1, UnderlineStyle::None); // fg=Red, bg=Black, bold
         assert!(sgr.starts_with("\x1b["));
         assert!(sgr.ends_with("m"));
         assert!(sgr.contains("0")); // reset existing style first
@@ -839,7 +919,38 @@ mod tests {
 
     #[test]
     fn build_sgr_resets_previous_modifiers_when_cell_is_plain() {
-        assert_eq!(build_sgr(0x00_00_00_00, 0x00_00_00_00, 0), "\x1b[0;39;49m");
+        assert_eq!(
+            build_sgr(0x00_00_00_00, 0x00_00_00_00, 0, 0, UnderlineStyle::None),
+            "\x1b[0;39;49m"
+        );
+    }
+
+    #[test]
+    fn build_sgr_preserves_curly_underline_style() {
+        assert_eq!(
+            build_sgr(
+                0x00_00_00_00,
+                0x00_00_00_00,
+                0,
+                1 << 3,
+                UnderlineStyle::Curly
+            ),
+            "\x1b[0;4:3;39;49m"
+        );
+    }
+
+    #[test]
+    fn build_sgr_preserves_curly_underline_color() {
+        assert_eq!(
+            build_sgr(
+                0x00_00_00_00,
+                0x00_00_00_00,
+                0x02_FF_00_00,
+                1 << 3,
+                UnderlineStyle::Curly
+            ),
+            "\x1b[0;4:3;58;2;255;0;0;39;49m"
+        );
     }
 
     #[test]

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 14;
+pub const PROTOCOL_VERSION: u32 = 15;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.
@@ -412,12 +412,30 @@ pub struct CellData {
     pub fg: u32,
     /// Background color as a packed u32.
     pub bg: u32,
+    /// Underline color as a packed u32, or reset when no underline color is set.
+    #[serde(default)]
+    pub underline_color: u32,
     /// Bitmask of style modifiers (bold, italic, etc.).
     pub modifier: u16,
+    /// Underline style, separate from ratatui's flat `UNDERLINED` modifier.
+    #[serde(default)]
+    pub underline_style: UnderlineStyle,
     /// Whether this cell should be skipped during diff-based rendering.
     pub skip: bool,
     /// Index into `FrameData::hyperlinks` for this cell's OSC 8 target, if any.
     pub hyperlink: Option<u32>,
+}
+
+/// Terminal underline style encoded by SGR 4 subparameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum UnderlineStyle {
+    #[default]
+    None,
+    Single,
+    Double,
+    Curly,
+    Dotted,
+    Dashed,
 }
 
 /// Cursor shape encoded as a DECSCUSR parameter.
@@ -507,7 +525,14 @@ impl FrameData {
                     symbol: cell.symbol().to_owned(),
                     fg: color_to_u32(cell.fg),
                     bg: color_to_u32(cell.bg),
+                    underline_color: color_to_u32(cell.underline_color),
                     modifier: modifier_to_u16(cell.modifier),
+                    underline_style: if cell.modifier.contains(ratatui::style::Modifier::UNDERLINED)
+                    {
+                        UnderlineStyle::Single
+                    } else {
+                        UnderlineStyle::None
+                    },
                     skip: cell.skip,
                     hyperlink,
                 });
@@ -935,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn client_message_wire_tags_preserve_protocol_14_order() {
+    fn client_message_wire_tags_preserve_protocol_15_order() {
         fn tag(msg: &ClientMessage) -> u8 {
             *bincode::serde::encode_to_vec(msg, bincode::config::standard())
                 .unwrap()
@@ -1173,7 +1198,9 @@ mod tests {
                     symbol: "H".into(),
                     fg: color_to_u32(Color::Red),
                     bg: color_to_u32(Color::Black),
+                    underline_color: color_to_u32(Color::Reset),
                     modifier: Modifier::BOLD.bits(),
+                    underline_style: UnderlineStyle::None,
                     skip: false,
                     hyperlink: None,
                 },
@@ -1181,7 +1208,9 @@ mod tests {
                     symbol: "i".into(),
                     fg: color_to_u32(Color::Green),
                     bg: color_to_u32(Color::Reset),
+                    underline_color: color_to_u32(Color::Reset),
                     modifier: Modifier::ITALIC.bits(),
+                    underline_style: UnderlineStyle::None,
                     skip: false,
                     hyperlink: None,
                 },
@@ -1189,7 +1218,9 @@ mod tests {
                     symbol: "!".into(),
                     fg: color_to_u32(Color::Rgb(255, 128, 0)),
                     bg: color_to_u32(Color::Indexed(220)),
+                    underline_color: color_to_u32(Color::Red),
                     modifier: (Modifier::BOLD | Modifier::UNDERLINED).bits(),
+                    underline_style: UnderlineStyle::Single,
                     skip: false,
                     hyperlink: Some(0),
                 },
@@ -1197,7 +1228,9 @@ mod tests {
                     symbol: " ".into(),
                     fg: color_to_u32(Color::Reset),
                     bg: color_to_u32(Color::Reset),
+                    underline_color: color_to_u32(Color::Reset),
                     modifier: Modifier::empty().bits(),
+                    underline_style: UnderlineStyle::None,
                     skip: true,
                     hyperlink: None,
                 },
@@ -1205,7 +1238,9 @@ mod tests {
                     symbol: "→".into(), // multi-byte grapheme
                     fg: color_to_u32(Color::Cyan),
                     bg: color_to_u32(Color::Blue),
+                    underline_color: color_to_u32(Color::Reset),
                     modifier: Modifier::REVERSED.bits(),
+                    underline_style: UnderlineStyle::None,
                     skip: false,
                     hyperlink: None,
                 },
@@ -1213,7 +1248,9 @@ mod tests {
                     symbol: "🦀".into(), // emoji, wide grapheme cluster
                     fg: color_to_u32(Color::Yellow),
                     bg: color_to_u32(Color::Magenta),
+                    underline_color: color_to_u32(Color::Reset),
                     modifier: Modifier::empty().bits(),
+                    underline_style: UnderlineStyle::None,
                     skip: false,
                     hyperlink: None,
                 },
@@ -1375,7 +1412,9 @@ mod tests {
                 },
                 fg: color_to_u32(Color::Rgb((i % 256) as u8, ((i / 256) % 256) as u8, 128)),
                 bg: color_to_u32(Color::Indexed((i % 256) as u8)),
+                underline_color: color_to_u32(Color::Reset),
                 modifier: ((i % 16) as u16),
+                underline_style: UnderlineStyle::None,
                 skip: i % 100 == 0,
                 hyperlink: None,
             })
@@ -1725,7 +1764,9 @@ mod tests {
                     symbol: "X".into(),
                     fg: 0,
                     bg: 0,
+                    underline_color: 0,
                     modifier: 0,
+                    underline_style: UnderlineStyle::None,
                     skip: false,
                     hyperlink: None,
                 };

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -3112,10 +3112,18 @@ impl HeadlessServer {
                         hyperlinks_started,
                     );
                     let frame_started = crate::render_prof::timer();
-                    let frame = FrameData::from_ratatui_buffer_with_hyperlinks(
+                    let mut frame = FrameData::from_ratatui_buffer_with_hyperlinks(
                         &buffer,
                         cursor,
                         &hyperlinks,
+                    );
+                    let underline_styles = crate::server::render_stream::visible_underline_styles(
+                        &self.app.state,
+                        &self.app.terminal_runtimes,
+                    );
+                    crate::server::render_stream::apply_terminal_underline_styles(
+                        &mut frame,
+                        &underline_styles,
                     );
                     crate::render_prof::duration_since("full_render.frame_build", frame_started);
                     frame
@@ -3147,10 +3155,15 @@ impl HeadlessServer {
                         hyperlinks_started,
                     );
                     let frame_started = crate::render_prof::timer();
-                    let frame = FrameData::from_ratatui_buffer_with_hyperlinks(
+                    let mut frame = FrameData::from_ratatui_buffer_with_hyperlinks(
                         &buffer,
                         cursor,
                         &hyperlinks,
+                    );
+                    let underline_styles = runtime.visible_underline_styles(area);
+                    crate::server::render_stream::apply_terminal_underline_styles(
+                        &mut frame,
+                        &underline_styles,
                     );
                     crate::render_prof::duration_since("full_render.frame_build", frame_started);
                     frame
@@ -6671,6 +6684,42 @@ next_tab = ""
                 .expect("full frame"),
         );
         assert_frame_data_eq(&retained_frame, &full_frame);
+    }
+
+    #[tokio::test]
+    async fn retained_pty_update_preserves_foreground_color() {
+        let initial = b"aaaa";
+        let update = b"\r\x1b[38;5;171mZ\x1b[0m";
+        let (mut server, client_rx, pane_id) = retained_test_server(initial);
+
+        server.render_and_stream();
+        let _ = client_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("initial baseline");
+
+        server
+            .app
+            .state
+            .runtime_for_pane_in_workspace(&server.app.terminal_runtimes, 0, pane_id)
+            .expect("runtime")
+            .test_process_pty_bytes(update);
+
+        assert!(server.render_retained_pty_update_and_stream());
+
+        let frame = read_server_frame(
+            client_rx
+                .recv_timeout(Duration::from_millis(100))
+                .expect("retained frame"),
+        );
+        let cell = frame
+            .cells
+            .iter()
+            .find(|cell| cell.symbol == "Z")
+            .expect("updated colored cell");
+        assert_eq!(
+            cell.fg,
+            crate::protocol::color_to_u32(ratatui::style::Color::Indexed(171))
+        );
     }
 
     #[tokio::test]

--- a/src/server/render_stream.rs
+++ b/src/server/render_stream.rs
@@ -6,7 +6,9 @@ use ratatui::layout::{Position, Rect, Size};
 use crate::app::state::AppState;
 use crate::app::Mode;
 use crate::protocol::render_ansi::{BlitEncoder, EncodedBlit};
-use crate::protocol::{CursorState, FrameData, RenderEncoding, ServerMessage, TerminalFrame};
+use crate::protocol::{
+    CursorState, FrameData, RenderEncoding, ServerMessage, TerminalFrame, UnderlineStyle,
+};
 use crate::terminal::TerminalRuntimeRegistry;
 
 /// Per-client render baseline for the negotiated render encoding.
@@ -384,6 +386,53 @@ pub(crate) fn visible_hyperlinks(
     links
 }
 
+pub(crate) fn visible_underline_styles(
+    app_state: &AppState,
+    terminal_runtimes: &TerminalRuntimeRegistry,
+) -> Vec<((u16, u16), UnderlineStyle)> {
+    let Some(ws_idx) = app_state.active else {
+        return Vec::new();
+    };
+    let Some(tab) = app_state
+        .workspaces
+        .get(ws_idx)
+        .and_then(crate::workspace::Workspace::active_tab)
+    else {
+        return Vec::new();
+    };
+
+    let mut styles = Vec::new();
+    for info in &app_state.view.pane_infos {
+        if let Some(runtime) = tab
+            .terminal_id(info.id)
+            .and_then(|terminal_id| terminal_runtimes.get(terminal_id))
+        {
+            styles.extend(runtime.visible_underline_styles(info.inner_rect));
+        }
+    }
+    styles
+}
+
+pub(crate) fn apply_terminal_underline_styles(
+    frame: &mut FrameData,
+    styles: &[((u16, u16), UnderlineStyle)],
+) {
+    const UNDERLINED: u16 = 1 << 3;
+    let width = usize::from(frame.width);
+    for &((x, y), style) in styles {
+        if x >= frame.width || y >= frame.height {
+            continue;
+        }
+        let idx = usize::from(y) * width + usize::from(x);
+        let Some(cell) = frame.cells.get_mut(idx) else {
+            continue;
+        };
+        if cell.modifier & UNDERLINED != 0 {
+            cell.underline_style = style;
+        }
+    }
+}
+
 pub(crate) fn focused_terminal_cursor(
     app_state: &AppState,
     terminal_runtimes: &TerminalRuntimeRegistry,
@@ -510,4 +559,48 @@ fn focused_terminal_suppresses_host_cursor(
     app_state
         .runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, info.id)
         .is_some_and(crate::terminal::TerminalRuntime::synchronized_output_active)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::Modifier;
+
+    use super::*;
+    use crate::protocol::CellData;
+
+    fn cell(modifier: u16) -> CellData {
+        CellData {
+            symbol: "x".to_owned(),
+            fg: 0,
+            bg: 0,
+            underline_color: 0,
+            modifier,
+            underline_style: UnderlineStyle::None,
+            skip: false,
+            hyperlink: None,
+        }
+    }
+
+    #[test]
+    fn apply_terminal_underline_styles_only_updates_underlined_cells() {
+        let mut frame = FrameData {
+            cells: vec![cell(Modifier::UNDERLINED.bits()), cell(0)],
+            width: 2,
+            height: 1,
+            cursor: None,
+            hyperlinks: Vec::new(),
+            graphics: Vec::new(),
+        };
+
+        apply_terminal_underline_styles(
+            &mut frame,
+            &[
+                ((0, 0), UnderlineStyle::Curly),
+                ((1, 0), UnderlineStyle::Dotted),
+            ],
+        );
+
+        assert_eq!(frame.cells[0].underline_style, UnderlineStyle::Curly);
+        assert_eq!(frame.cells[1].underline_style, UnderlineStyle::None);
+    }
 }

--- a/src/terminal/runtime.rs
+++ b/src/terminal/runtime.rs
@@ -327,6 +327,13 @@ impl TerminalRuntime {
         self.0.visible_hyperlinks(area)
     }
 
+    pub fn visible_underline_styles(
+        &self,
+        area: Rect,
+    ) -> Vec<((u16, u16), crate::protocol::UnderlineStyle)> {
+        self.0.visible_underline_styles(area)
+    }
+
     pub fn kitty_image_placements_with_data_filter<F>(
         &self,
         needs_data: F,

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -827,10 +827,12 @@ mod tests {
     #[test]
     fn pane_border_renderer_places_adjacent_cjk_by_display_width() {
         let mut app = AppState::test_new();
+        let ws = Workspace::test_new("test");
+        let pane_id = ws.tabs[0].root_pane;
         app.mode = Mode::Terminal;
         app.view.terminal_area = Rect::new(0, 0, 12, 3);
         app.view.pane_infos = vec![PaneInfo {
-            id: PaneId::from_raw(1),
+            id: pane_id,
             rect: Rect::new(0, 0, 12, 3),
             inner_rect: Rect::default(),
             scrollbar_rect: None,
@@ -838,10 +840,7 @@ mod tests {
             is_focused: false,
         }];
 
-        let ws = Workspace::test_new("test");
-        let terminal_id = ws.tabs[0].panes[&PaneId::from_raw(1)]
-            .attached_terminal_id
-            .clone();
+        let terminal_id = ws.tabs[0].panes[&pane_id].attached_terminal_id.clone();
         let mut terminal_state = TerminalState::new(terminal_id.clone(), "/tmp".into());
         terminal_state.set_manual_label("1 模块组织（已定）".into());
         app.terminals.insert(terminal_id, terminal_state);

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -304,7 +304,7 @@ fn ping_over_socket_returns_version() {
     assert_eq!(value["result"]["version"], env!("CARGO_PKG_VERSION"));
     // Intentionally hardcoded so wire protocol bumps require updating this test.
     // Changing this value means old clients/servers are no longer compatible.
-    assert_eq!(value["result"]["protocol"], 14);
+    assert_eq!(value["result"]["protocol"], 15);
 
     cleanup_spawned_herdr(child, base);
 }

--- a/tests/cli_wrapper.rs
+++ b/tests/cli_wrapper.rs
@@ -1441,7 +1441,7 @@ fn status_commands_report_client_and_server_versions() {
         "stdout: {full_stdout}"
     );
     assert!(
-        full_stdout.contains("  protocol: 14"),
+        full_stdout.contains("  protocol: 15"),
         "stdout: {full_stdout}"
     );
     assert!(full_stdout.contains("server:\n"), "stdout: {full_stdout}");
@@ -1474,7 +1474,7 @@ fn status_commands_report_client_and_server_versions() {
         "stdout: {server_stdout}"
     );
     assert!(
-        server_stdout.contains("protocol: 14"),
+        server_stdout.contains("protocol: 15"),
         "stdout: {server_stdout}"
     );
 
@@ -1486,7 +1486,7 @@ fn status_commands_report_client_and_server_versions() {
         "stdout: {client_stdout}"
     );
     assert!(
-        client_stdout.contains("protocol: 14"),
+        client_stdout.contains("protocol: 15"),
         "stdout: {client_stdout}"
     );
     assert!(
@@ -1496,7 +1496,7 @@ fn status_commands_report_client_and_server_versions() {
 
     let full_json = run_cli_json(&socket_path, &["status", "--json"]);
     assert_eq!(full_json["client"]["version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(full_json["client"]["protocol"], 14);
+    assert_eq!(full_json["client"]["protocol"], 15);
     assert_eq!(full_json["server"]["status"], "running");
     assert_eq!(full_json["server"]["running"], true);
     assert_eq!(full_json["server"]["compatible"], true);
@@ -1510,12 +1510,12 @@ fn status_commands_report_client_and_server_versions() {
     let server_json = run_cli_json(&socket_path, &["status", "server", "--json"]);
     assert_eq!(server_json["status"], "running");
     assert_eq!(server_json["version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(server_json["protocol"], 14);
+    assert_eq!(server_json["protocol"], 15);
     assert_eq!(server_json["compatible"], true);
 
     let client_json = run_cli_json(&socket_path, &["status", "client", "--json"]);
     assert_eq!(client_json["version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(client_json["protocol"], 14);
+    assert_eq!(client_json["protocol"], 15);
     assert!(client_json["binary"]
         .as_str()
         .is_some_and(|path| !path.is_empty()));

--- a/tests/client_mode.rs
+++ b/tests/client_mode.rs
@@ -220,7 +220,9 @@ struct CellWire {
     symbol: String,
     fg: u32,
     bg: u32,
+    underline_color: u32,
     modifier: u16,
+    underline_style: u32,
     skip: bool,
     hyperlink: Option<u32>,
 }
@@ -275,7 +277,14 @@ fn frame_contains_text(frame: &FrameWire, needle: &str) -> bool {
     let mut text = String::new();
     for row in frame.cells.chunks(width) {
         for cell in row {
-            let _ = (cell.fg, cell.bg, cell.modifier, cell.skip);
+            let _ = (
+                cell.fg,
+                cell.bg,
+                cell.underline_color,
+                cell.modifier,
+                cell.underline_style,
+                cell.skip,
+            );
             text.push_str(&cell.symbol);
         }
         text.push('\n');
@@ -311,8 +320,8 @@ fn client_connects_and_receives_frame() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14, "server should report protocol version 14");
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15, "server should report protocol version 15");
     assert!(
         error.is_none(),
         "handshake should not have error: {:?}",
@@ -379,8 +388,8 @@ fn client_sees_headless_startup_config_diagnostic() {
 
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     stream
@@ -595,8 +604,8 @@ fn client_receives_frame_after_pane_output() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     read_next_frame_payload(&mut stream, Duration::from_secs(10))
@@ -710,8 +719,8 @@ fn graceful_shutdown_sends_server_shutdown_to_client() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frame(s).
@@ -809,8 +818,8 @@ fn client_receives_notify_on_agent_state_change() {
     // Connect as a client and perform handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frame(s).

--- a/tests/cross_area.rs
+++ b/tests/cross_area.rs
@@ -517,7 +517,9 @@ struct CellWire {
     symbol: String,
     fg: u32,
     bg: u32,
+    underline_color: u32,
     modifier: u16,
+    underline_style: u32,
     skip: bool,
     hyperlink: Option<u32>,
 }
@@ -557,7 +559,14 @@ fn frame_contains_text(frame: &FrameWire, needle: &str) -> bool {
     let mut text = String::new();
     for row in frame.cells.chunks(width) {
         for cell in row {
-            let _ = (cell.fg, cell.bg, cell.modifier, cell.skip);
+            let _ = (
+                cell.fg,
+                cell.bg,
+                cell.underline_color,
+                cell.modifier,
+                cell.underline_style,
+                cell.skip,
+            );
             text.push_str(&cell.symbol);
         }
         text.push('\n');
@@ -687,7 +696,7 @@ fn cross_area_detach_and_reattach_preserves_state() {
 
     // Local attach (client A).
     let mut client_a = UnixStream::connect(&client_socket).expect("client A should connect");
-    client_handshake(&mut client_a, 14, 100, 30);
+    client_handshake(&mut client_a, 15, 100, 30);
     assert!(wait_for_frame(&mut client_a, Duration::from_secs(2)));
 
     // Use herdr: create a workspace and write output into its pane.
@@ -724,7 +733,7 @@ fn cross_area_detach_and_reattach_preserves_state() {
 
     // Reattach from another terminal/session (client B).
     let mut client_b = UnixStream::connect(&client_socket).expect("client B should connect");
-    client_handshake(&mut client_b, 14, 80, 24);
+    client_handshake(&mut client_b, 15, 80, 24);
     assert!(
         wait_for_frame(&mut client_b, Duration::from_secs(5)),
         "reattached client should receive frame"
@@ -780,7 +789,7 @@ fn cross_area_agent_process_survives_detach_and_reattach() {
     wait_for_socket(&client_socket, Duration::from_secs(10));
 
     let mut client_a = UnixStream::connect(&client_socket).expect("client A should connect");
-    client_handshake(&mut client_a, 14, 100, 30);
+    client_handshake(&mut client_a, 15, 100, 30);
     assert!(wait_for_frame(&mut client_a, Duration::from_secs(2)));
 
     let created = workspace_create(&api_socket, "agent-persist");
@@ -833,7 +842,7 @@ fn cross_area_agent_process_survives_detach_and_reattach() {
 
     // Reattach and ensure client-side state reflects the persisted working status.
     let mut client_b = UnixStream::connect(&client_socket).expect("client B should connect");
-    client_handshake(&mut client_b, 14, 80, 24);
+    client_handshake(&mut client_b, 15, 80, 24);
     let saw_working_on_client =
         wait_for_frame_matching(&mut client_b, Duration::from_secs(5), |frame| {
             frame_contains_text(frame, "working")
@@ -878,7 +887,7 @@ fn cross_area_client_and_api_workspace_views_are_consistent() {
     wait_for_socket(&client_socket, Duration::from_secs(10));
 
     let mut client = UnixStream::connect(&client_socket).expect("client should connect");
-    client_handshake(&mut client, 14, 100, 30);
+    client_handshake(&mut client, 15, 100, 30);
     assert!(wait_for_frame(&mut client, Duration::from_secs(2)));
     drain_server_messages(&mut client, Duration::from_millis(300));
 
@@ -941,9 +950,9 @@ fn cross_area_two_clients_shared_view_and_single_detach_stability() {
     wait_for_socket(&client_socket, Duration::from_secs(10));
 
     let mut client_a = UnixStream::connect(&client_socket).expect("client A should connect");
-    client_handshake(&mut client_a, 14, 110, 30);
+    client_handshake(&mut client_a, 15, 110, 30);
     let mut client_b = UnixStream::connect(&client_socket).expect("client B should connect");
-    client_handshake(&mut client_b, 14, 100, 30);
+    client_handshake(&mut client_b, 15, 100, 30);
 
     assert!(wait_for_frame(&mut client_a, Duration::from_secs(2)));
     assert!(wait_for_frame(&mut client_b, Duration::from_secs(2)));
@@ -1112,7 +1121,7 @@ fn cross_area_server_kill_then_restart_and_reconnect() {
 
     let mut reconnect_client =
         UnixStream::connect(&client_socket).expect("new client should connect after restart");
-    client_handshake(&mut reconnect_client, 14, 80, 24);
+    client_handshake(&mut reconnect_client, 15, 80, 24);
     assert!(
         wait_for_frame(&mut reconnect_client, Duration::from_secs(5)),
         "new client should receive frame after restart"

--- a/tests/detach_reattach.rs
+++ b/tests/detach_reattach.rs
@@ -276,8 +276,8 @@ fn navigate_q_detaches_client_and_server_persists() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frames.
@@ -338,8 +338,8 @@ fn explicit_detach_message_causes_clean_disconnect() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frames.
@@ -397,8 +397,8 @@ fn reattach_after_detach_shows_current_state() {
     // --- Client A ---
     let mut stream_a = UnixStream::connect(&client_socket).expect("client A should connect");
     let (version, error) =
-        client_handshake(&mut stream_a, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream_a, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frames.
@@ -436,8 +436,8 @@ fn reattach_after_detach_shows_current_state() {
     // --- Client B (reattach) ---
     let mut stream_b = UnixStream::connect(&client_socket).expect("client B should connect");
     let (version, error) =
-        client_handshake(&mut stream_b, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream_b, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(
         error.is_none(),
         "reattach handshake should succeed: {:?}",
@@ -516,8 +516,8 @@ fn processes_survive_during_and_after_detach() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frames.
@@ -555,8 +555,8 @@ fn processes_survive_during_and_after_detach() {
     // Reattach — verify we can connect and receive a frame.
     let mut stream_b = UnixStream::connect(&client_socket).expect("should reattach");
     let (version, error) =
-        client_handshake(&mut stream_b, 14, 80, 24).expect("reattach handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream_b, 15, 80, 24).expect("reattach handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Verify the reattached client receives a frame.
@@ -604,8 +604,8 @@ fn server_persists_after_client_connection_drop() {
     // Connect and handshake.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect");
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Drain initial frames.
@@ -631,8 +631,8 @@ fn server_persists_after_client_connection_drop() {
     // Reattach — verify we can connect and handshake again.
     let mut stream_b = UnixStream::connect(&client_socket).expect("should reattach");
     let (version, error) =
-        client_handshake(&mut stream_b, 14, 80, 24).expect("reattach handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream_b, 15, 80, 24).expect("reattach handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "reattach should succeed: {:?}", error);
 
     cleanup_spawned_herdr(spawned, base);
@@ -653,8 +653,8 @@ fn detached_output_preserves_last_attached_pty_size() {
 
     let mut stream = UnixStream::connect(&client_socket).expect("client should connect");
     let (version, error) =
-        client_handshake(&mut stream, 14, 120, 40).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream, 15, 120, 40).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
     drain_messages(&mut stream);
 
@@ -722,8 +722,8 @@ fn output_accumulated_while_detached_visible_on_reattach() {
     // Connect and handshake client A.
     let mut stream_a = UnixStream::connect(&client_socket).expect("client A should connect");
     let (version, error) =
-        client_handshake(&mut stream_a, 14, 80, 24).expect("handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream_a, 15, 80, 24).expect("handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Detach client A immediately.
@@ -780,8 +780,8 @@ fn output_accumulated_while_detached_visible_on_reattach() {
     // --- Client B (reattach) ---
     let mut stream_b = UnixStream::connect(&client_socket).expect("client B should connect");
     let (version, error) =
-        client_handshake(&mut stream_b, 14, 80, 24).expect("reattach handshake should succeed");
-    assert_eq!(version, 14);
+        client_handshake(&mut stream_b, 15, 80, 24).expect("reattach handshake should succeed");
+    assert_eq!(version, 15);
     assert!(error.is_none(), "{:?}", error);
 
     // Client B should receive a frame with the current state.

--- a/tests/multi_client.rs
+++ b/tests/multi_client.rs
@@ -566,7 +566,7 @@ fn client_handshake(
 
 fn connect_raw_client(client_socket: &Path, cols: u16, rows: u16) -> UnixStream {
     let mut stream = UnixStream::connect(client_socket).expect("should connect to client socket");
-    client_handshake(&mut stream, 14, cols, rows).expect("handshake should succeed");
+    client_handshake(&mut stream, 15, cols, rows).expect("handshake should succeed");
     stream
 }
 
@@ -606,7 +606,9 @@ struct CellWire {
     symbol: String,
     fg: u32,
     bg: u32,
+    underline_color: u32,
     modifier: u16,
+    underline_style: u32,
     skip: bool,
     hyperlink: Option<u32>,
 }
@@ -729,7 +731,14 @@ fn frame_text(frame: &FrameWire) -> String {
 
     for row in frame.cells.chunks(row_width) {
         for cell in row {
-            let _ = (cell.fg, cell.bg, cell.modifier, cell.skip);
+            let _ = (
+                cell.fg,
+                cell.bg,
+                cell.underline_color,
+                cell.modifier,
+                cell.underline_style,
+                cell.skip,
+            );
             full_text.push_str(&cell.symbol);
         }
         full_text.push('\n');

--- a/tests/server_headless.rs
+++ b/tests/server_headless.rs
@@ -595,9 +595,9 @@ fn client_handshake_succeeds() {
 
     // Send Hello with the current protocol version, 80 cols, 24 rows.
     let (version, error) =
-        client_handshake(&mut stream, 14, 80, 24).expect("handshake should succeed");
+        client_handshake(&mut stream, 15, 80, 24).expect("handshake should succeed");
 
-    assert_eq!(version, 14, "server should report protocol version 14");
+    assert_eq!(version, 15, "server should report protocol version 15");
     assert!(
         error.is_none(),
         "handshake should not have an error: {:?}",
@@ -626,7 +626,7 @@ fn client_handshake_rejects_incompatible_version() {
     let (version, error) = client_handshake(&mut stream, 0, 80, 24)
         .expect("should read Welcome response even on rejection");
 
-    assert_eq!(version, 14, "server should report its version 14");
+    assert_eq!(version, 15, "server should report its version 15");
     assert!(
         error.is_some(),
         "version 0 should be rejected with an error"
@@ -651,10 +651,10 @@ fn client_handshake_clamps_small_terminal_size() {
     // Send Hello with 0x0 terminal size — should be clamped.
     let mut stream = UnixStream::connect(&client_socket).expect("should connect to client socket");
 
-    let (version, error) = client_handshake(&mut stream, 14, 0, 0)
+    let (version, error) = client_handshake(&mut stream, 15, 0, 0)
         .expect("handshake with 0x0 should succeed (server clamps)");
 
-    assert_eq!(version, 14);
+    assert_eq!(version, 15);
     assert!(
         error.is_none(),
         "0x0 size should be accepted (clamped): {:?}",
@@ -714,9 +714,9 @@ fn no_hello_client_closed_within_five_seconds() {
     // Verify the server is still healthy — a proper client can still connect.
     let mut good_stream =
         UnixStream::connect(&client_socket).expect("should connect after no-hello client");
-    let (version, error) = client_handshake(&mut good_stream, 14, 80, 24)
+    let (version, error) = client_handshake(&mut good_stream, 15, 80, 24)
         .expect("proper handshake should still work after no-hello client");
-    assert_eq!(version, 14);
+    assert_eq!(version, 15);
     assert!(error.is_none());
 
     // API should still work.


### PR DESCRIPTION
refs #895
Before:
<img width="780" height="531" alt="Screenshot 2026-06-30 at 14 38 45" src="https://github.com/user-attachments/assets/1f57954c-fb59-475c-a0e7-4287dcdc5b1c" />

After:
<img width="598" height="382" alt="Screenshot 2026-06-30 at 14 39 07" src="https://github.com/user-attachments/assets/c925b080-ea89-4bf6-8af1-9fc4a6441629" />

