### PR TITLE
Prompt for workspace name when creating a workspace

### DIFF
--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -317,6 +317,7 @@ pub(super) fn open_rename_workspace(
     terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
     ws_idx: usize,
 ) {
+    state.creating_new_workspace = false;
     state.selected = ws_idx;
     state.rename_pane_target = None;
     state.name_input =
@@ -325,7 +326,34 @@ pub(super) fn open_rename_workspace(
     state.mode = Mode::RenameWorkspace;
 }
 
+pub(crate) fn open_new_workspace_dialog(
+    state: &mut AppState,
+    terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
+    ws_idx: usize,
+) {
+    state.creating_new_workspace = true;
+    state.creating_new_tab = false;
+    state.requested_new_tab_name = None;
+    state.selected = ws_idx;
+    state.rename_pane_target = None;
+    state.name_input =
+        state.workspaces[ws_idx].display_name_from(&state.terminals, terminal_runtimes);
+    state.name_input_replace_on_type = true;
+    state.mode = Mode::RenameWorkspace;
+}
+
+impl App {
+    pub(crate) fn open_new_workspace_dialog_for_active(&mut self) {
+        if let Some(ws_idx) = self.state.active {
+            if ws_idx < self.state.workspaces.len() {
+                open_new_workspace_dialog(&mut self.state, &self.terminal_runtimes, ws_idx);
+            }
+        }
+    }
+}
+
 pub(super) fn open_rename_active_tab(state: &mut AppState, replace_on_type: bool) {
+    state.creating_new_workspace = false;
     state.creating_new_tab = false;
     state.requested_new_tab_name = None;
     state.rename_pane_target = None;
@@ -346,6 +374,7 @@ pub(super) fn open_rename_pane(state: &mut AppState, pane_id: crate::layout::Pan
         return;
     };
     let terminal = state.terminals.get(&pane.attached_terminal_id);
+    state.creating_new_workspace = false;
     state.creating_new_tab = false;
     state.requested_new_tab_name = None;
     state.rename_pane_target = Some(pane_id);
@@ -365,6 +394,7 @@ fn next_new_tab_default_name(state: &AppState) -> String {
 }
 
 pub(super) fn open_new_tab_dialog(state: &mut AppState) {
+    state.creating_new_workspace = false;
     state.creating_new_tab = true;
     state.requested_new_tab_name = None;
     state.rename_pane_target = None;
@@ -501,6 +531,7 @@ pub(super) fn apply_rename_action(state: &mut AppState, action: ModalAction) {
                 }
                 _ => {}
             }
+            state.creating_new_workspace = false;
             state.creating_new_tab = false;
             state.rename_pane_target = None;
             state.name_input.clear();
@@ -512,6 +543,7 @@ pub(super) fn apply_rename_action(state: &mut AppState, action: ModalAction) {
             state.name_input_replace_on_type = false;
         }
         ModalAction::Cancel => {
+            state.creating_new_workspace = false;
             state.creating_new_tab = false;
             state.requested_new_tab_name = None;
             state.rename_pane_target = None;
@@ -1274,6 +1306,7 @@ impl App {
 }
 
 fn cancel_rename_modal(state: &mut AppState) {
+    state.creating_new_workspace = false;
     state.creating_new_tab = false;
     state.requested_new_tab_name = None;
     state.rename_pane_target = None;

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -118,7 +118,7 @@ impl App {
                         },
                     ),
                 );
-                leave_navigate_mode(&mut self.state);
+                self.open_new_workspace_dialog_for_active();
             }
             NavigateAction::NewWorktree => {
                 if let Some(ws_idx) = workspace_action_target(&self.state, context).filter(|idx| {
@@ -2335,7 +2335,10 @@ last_pane = "prefix+tab"
         app.handle_navigate_key(TerminalKey::new(KeyCode::Char('N'), KeyModifiers::empty()));
 
         assert_eq!(app.state.workspaces.len(), 2);
-        assert_eq!(app.state.mode, Mode::Terminal);
+        assert_eq!(app.state.mode, Mode::RenameWorkspace);
+        assert!(app.state.creating_new_workspace);
+        assert_eq!(app.state.selected, 1);
+        assert!(app.state.name_input_replace_on_type);
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -518,6 +518,7 @@ impl App {
             request_reload_config: false,
             request_client_config_reload: false,
             request_clipboard_write: None,
+            creating_new_workspace: false,
             creating_new_tab: false,
             requested_new_tab_name: None,
             rename_pane_target: None,
@@ -898,6 +899,7 @@ impl App {
                         },
                     ),
                 );
+                self.open_new_workspace_dialog_for_active();
                 needs_render = true;
             }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1297,6 +1297,7 @@ pub struct AppState {
     /// Set when UI interaction requested a clipboard write that must be
     /// handled by the outer App/event loop instead of directly from AppState.
     pub request_clipboard_write: Option<Vec<u8>>,
+    pub creating_new_workspace: bool,
     pub creating_new_tab: bool,
     pub requested_new_tab_name: Option<String>,
     pub rename_pane_target: Option<PaneId>,
@@ -1648,6 +1649,7 @@ impl AppState {
             request_reload_config: false,
             request_client_config_reload: false,
             request_clipboard_write: None,
+            creating_new_workspace: false,
             creating_new_tab: false,
             requested_new_tab_name: None,
             rename_pane_target: None,

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -636,6 +636,8 @@ impl HeadlessServer {
                     message = %error.message,
                     "failed to create workspace"
                 );
+            } else {
+                self.app.open_new_workspace_dialog_for_active();
             }
             needs_render = true;
             crate::render_prof::event("full_render_cause.deferred_new_workspace");
@@ -4286,6 +4288,9 @@ mod tests {
 
         assert!(server.handle_deferred_requests_headless());
         assert!(!server.app.state.request_new_workspace);
+        assert_eq!(server.app.state.mode, app::Mode::RenameWorkspace);
+        assert!(server.app.state.creating_new_workspace);
+        assert!(server.app.state.name_input_replace_on_type);
         assert_eq!(
             event_hub
                 .events_after(0)

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -43,6 +43,7 @@ pub(super) fn render_rename_overlay(app: &AppState, frame: &mut Frame, area: Rec
     super::dim_background(frame, area);
 
     let title = match app.mode {
+        Mode::RenameWorkspace if app.creating_new_workspace => "new workspace",
         Mode::RenameWorkspace => "rename workspace",
         Mode::RenameTab if app.creating_new_tab => "new tab",
         Mode::RenameTab => "rename tab",


### PR DESCRIPTION
  ## Summary

  - Prompt for a workspace name immediately after creating a new workspace
  - Reuse the existing rename modal flow, with a `new workspace` title and replace-on-type behavior
  - Cover both regular app flow and headless/persistent server deferred workspace creation


<img width="3024" height="1826" alt="image" src="https://github.com/user-attachments/assets/614313ab-fca9-448f-9591-22267b4eb1df" />


  ## Testing

  - `ZIG=/opt/homebrew/opt/zig@0.15/bin/zig cargo test --locked navigate_mode_matches_legacy_uppercase_shifted_letter`
  - `ZIG=/opt/homebrew/opt/zig@0.15/bin/zig cargo test --locked headless_deferred_workspace_create_uses_runtime_events`

