### PR TITLE
fix: support protocol versions 14 and 15

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -192,7 +192,7 @@ fn protocol_label(protocol: Option<u32>) -> String {
 
 fn compatibility_label(protocol: Option<u32>) -> &'static str {
     match protocol {
-        Some(protocol) if protocol == crate::protocol::PROTOCOL_VERSION => "yes",
+        Some(protocol) if crate::protocol::protocol_version_supported(protocol) => "yes",
         Some(_) => "no",
         None => "unknown",
     }
@@ -276,7 +276,7 @@ fn server_status_json(server: &ServerRuntimeStatus) -> ServerStatusJson {
                     live_handoff: capabilities.live_handoff,
                     detached_server_daemon: capabilities.detached_server_daemon,
                 }),
-            compatible: protocol.map(|value| value == crate::protocol::PROTOCOL_VERSION),
+            compatible: protocol.map(crate::protocol::protocol_version_supported),
             socket: api::socket_path().display().to_string(),
             session: crate::session::active_name(),
             restart_needed: restart_needed_bool(server),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -41,7 +41,7 @@ use crate::protocol::MAX_CLIPBOARD_IMAGE_PAYLOAD;
 use crate::protocol::{
     self, AttachScrollDirection, AttachScrollSource, ClientKeybindings, ClientLaunchMode,
     ClientMessage, NotifyKind, RenderEncoding, ServerMessage, MAX_FRAME_SIZE,
-    MAX_GRAPHICS_FRAME_SIZE, PROTOCOL_VERSION,
+    MAX_GRAPHICS_FRAME_SIZE, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 use crate::server::socket_paths::client_socket_path;
 
@@ -662,6 +662,7 @@ fn is_remote_client_process() -> bool {
 const LOCAL_HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(unix)]
 const REMOTE_HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(60);
+const SERVER_STATUS_PROTOCOL_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
 
 fn handshake_read_timeout() -> Duration {
     #[cfg(unix)]
@@ -682,6 +683,27 @@ fn requested_keybindings() -> ClientKeybindings {
             .map(|keys_toml| ClientKeybindings::Local { keys_toml })
             .unwrap_or(ClientKeybindings::Server),
         _ => ClientKeybindings::Server,
+    }
+}
+
+fn preferred_client_protocol_version(required_min_version: u32) -> u32 {
+    let Ok(Some(status)) = crate::api::read_runtime_status_at(
+        &crate::api::socket_path(),
+        SERVER_STATUS_PROTOCOL_PROBE_TIMEOUT,
+    ) else {
+        return PROTOCOL_VERSION;
+    };
+
+    let Some(server_protocol) = status.protocol else {
+        return PROTOCOL_VERSION;
+    };
+
+    if server_protocol >= required_min_version
+        && protocol::protocol_version_supported(server_protocol)
+    {
+        server_protocol
+    } else {
+        PROTOCOL_VERSION
     }
 }
 
@@ -718,6 +740,7 @@ fn set_handshake_recv_timeout(
 /// response. Returns Ok(()) on success, or an error if the server rejects us.
 fn do_handshake(
     stream: &mut LocalStream,
+    protocol_version: u32,
     cols: u16,
     rows: u16,
     cell_width_px: u32,
@@ -731,7 +754,7 @@ fn do_handshake(
 
     // Send Hello.
     let hello = ClientMessage::Hello {
-        version: PROTOCOL_VERSION,
+        version: protocol_version,
         cols,
         rows,
         cell_width_px,
@@ -911,6 +934,7 @@ fn connect_terminal_session_stream(
 
     match do_handshake(
         &mut stream,
+        preferred_client_protocol_version(PROTOCOL_VERSION),
         cols,
         rows,
         0,
@@ -1142,6 +1166,7 @@ fn run_client_with_mode(
     // Perform handshake while the stream is still in blocking mode.
     let negotiated_encoding = match do_handshake(
         &mut stream,
+        preferred_client_protocol_version(MIN_SUPPORTED_PROTOCOL_VERSION),
         cols,
         rows,
         cell_width_px,
@@ -2034,6 +2059,67 @@ mod tests {
                 restore_env_var(key, value);
             }
         }
+    }
+
+    #[cfg(unix)]
+    fn preferred_protocol_with_fake_status(server_protocol: u32, required_min_version: u32) -> u32 {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = std::path::PathBuf::from(format!(
+            "/tmp/hcp-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("s");
+        let listener = UnixListener::bind(&path).unwrap();
+        let path_string = path.to_string_lossy().to_string();
+        let _env = EnvVarGuard::set(crate::api::SOCKET_PATH_ENV_VAR, &path_string);
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().unwrap())
+                .read_line(&mut request)
+                .unwrap();
+            assert!(request.contains("ping"));
+            let body = format!(
+                "{{\"id\":\"client:status\",\"result\":{{\"type\":\"pong\",\"version\":\"0.5.5\",\"protocol\":{server_protocol}}}}}\n"
+            );
+            stream.write_all(body.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let selected = preferred_client_protocol_version(required_min_version);
+        let _ = handle.join();
+        let _ = std::fs::remove_dir_all(dir);
+        selected
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preferred_client_protocol_version_downgrades_to_supported_running_server() {
+        let _guard = env_lock().lock().unwrap();
+        assert_eq!(
+            preferred_protocol_with_fake_status(
+                MIN_SUPPORTED_PROTOCOL_VERSION,
+                MIN_SUPPORTED_PROTOCOL_VERSION,
+            ),
+            MIN_SUPPORTED_PROTOCOL_VERSION
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preferred_client_protocol_version_keeps_current_for_v15_only_features() {
+        let _guard = env_lock().lock().unwrap();
+        assert_eq!(
+            preferred_protocol_with_fake_status(MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION),
+            PROTOCOL_VERSION
+        );
     }
 
     #[test]

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -12,8 +12,16 @@ use serde::{Deserialize, Serialize};
 // Protocol constants
 // ---------------------------------------------------------------------------
 
+/// Oldest protocol version accepted by this build.
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 14;
+
 /// Current protocol version. Bumped when wire format changes incompatibly.
 pub const PROTOCOL_VERSION: u32 = 15;
+
+/// Returns whether a protocol version is supported by this build.
+pub fn protocol_version_supported(version: u32) -> bool {
+    (MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION).contains(&version)
+}
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.
@@ -899,10 +907,9 @@ pub enum VersionCheck {
 ///
 /// Current rules:
 /// - Version 0 (pre-persistence client) is always rejected.
-/// - Matching major versions are accepted.
+/// - Versions in the supported range are accepted.
 /// - A client with a newer version than the server is rejected.
-/// - A client with an older version than the server is rejected
-///   (backward compatibility is not yet supported).
+/// - A client older than the minimum supported version is rejected.
 pub fn check_client_version(client_version: u32) -> VersionCheck {
     if client_version == 0 {
         return VersionCheck::Incompatible(
@@ -910,11 +917,11 @@ pub fn check_client_version(client_version: u32) -> VersionCheck {
         );
     }
 
-    if client_version == PROTOCOL_VERSION {
+    if protocol_version_supported(client_version) {
         VersionCheck::Compatible
-    } else if client_version < PROTOCOL_VERSION {
+    } else if client_version < MIN_SUPPORTED_PROTOCOL_VERSION {
         VersionCheck::Incompatible(format!(
-            "client version {client_version} is older than server version {PROTOCOL_VERSION}; please upgrade your herdr client"
+            "client version {client_version} is older than the minimum supported version {MIN_SUPPORTED_PROTOCOL_VERSION}; please upgrade your herdr client"
         ))
     } else {
         VersionCheck::Incompatible(format!(
@@ -1605,7 +1612,7 @@ mod tests {
     // ---- Version negotiation ----
 
     #[test]
-    fn version_compatible() {
+    fn current_version_compatible() {
         assert_eq!(
             check_client_version(PROTOCOL_VERSION),
             VersionCheck::Compatible
@@ -1613,8 +1620,16 @@ mod tests {
     }
 
     #[test]
+    fn minimum_supported_version_compatible() {
+        assert_eq!(
+            check_client_version(MIN_SUPPORTED_PROTOCOL_VERSION),
+            VersionCheck::Compatible
+        );
+    }
+
+    #[test]
     fn version_older_client_rejected() {
-        let result = check_client_version(PROTOCOL_VERSION - 1);
+        let result = check_client_version(MIN_SUPPORTED_PROTOCOL_VERSION - 1);
         assert!(matches!(result, VersionCheck::Incompatible(_)));
         if let VersionCheck::Incompatible(msg) = result {
             assert!(msg.contains("older"), "error should mention older version");

--- a/src/server/autodetect.rs
+++ b/src/server/autodetect.rs
@@ -155,7 +155,10 @@ fn validate_running_server_compatibility() -> io::Result<()> {
         )));
     };
 
-    if status.protocol == Some(crate::protocol::PROTOCOL_VERSION) {
+    if status
+        .protocol
+        .is_some_and(crate::protocol::protocol_version_supported)
+    {
         return Ok(());
     }
 
@@ -531,6 +534,35 @@ test "$sid" = "$$"
             err.to_string().contains("status API is unavailable"),
             "unexpected error: {err}"
         );
+        std::env::remove_var(crate::api::SOCKET_PATH_ENV_VAR);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn validate_running_server_compatibility_accepts_min_supported_protocol() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = unique_test_dir("min-protocol");
+        let path = dir.join("api.sock");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::env::set_var(crate::api::SOCKET_PATH_ENV_VAR, &path);
+        let listener = UnixListener::bind(&path).unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().unwrap())
+                .read_line(&mut request)
+                .unwrap();
+            assert!(request.contains("ping"));
+            let body = format!(
+                "{{\"id\":\"autodetect:server:status\",\"result\":{{\"type\":\"pong\",\"version\":\"0.5.5\",\"protocol\":{}}}}}\n",
+                crate::protocol::MIN_SUPPORTED_PROTOCOL_VERSION
+            );
+            stream.write_all(body.as_bytes()).unwrap();
+            stream.flush().unwrap();
+        });
+
+        validate_running_server_compatibility().unwrap();
+        let _ = handle.join();
         std::env::remove_var(crate::api::SOCKET_PATH_ENV_VAR);
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/server/client_transport.rs
+++ b/src/server/client_transport.rs
@@ -1111,6 +1111,73 @@ new_tab = "ctrl+notakey"
     }
 
     #[test]
+    fn handshake_accepts_min_supported_protocol_version() {
+        let (mut client_stream, server_stream, _path) =
+            local_stream_pair("client-handshake-min-protocol");
+        let (server_event_tx, mut server_event_rx) = mpsc::channel(4);
+        let should_quit = Arc::new(AtomicBool::new(false));
+        let handshake_quit = should_quit.clone();
+        let handle = std::thread::spawn(move || {
+            handle_client_handshake(server_stream, 42, &server_event_tx, &handshake_quit)
+        });
+
+        protocol::write_message(
+            &mut client_stream,
+            &ClientMessage::Hello {
+                version: crate::protocol::MIN_SUPPORTED_PROTOCOL_VERSION,
+                cols: 100,
+                rows: 30,
+                cell_width_px: 8,
+                cell_height_px: 16,
+                requested_encoding: RenderEncoding::SemanticFrame,
+                keybindings: ClientKeybindings::Server,
+                launch_mode: ClientLaunchMode::App,
+            },
+        )
+        .expect("write hello");
+
+        let welcome: ServerMessage =
+            protocol::read_message(&mut client_stream, MAX_FRAME_SIZE).expect("read welcome");
+        match welcome {
+            ServerMessage::Welcome {
+                version,
+                encoding,
+                error,
+            } => {
+                assert_eq!(version, PROTOCOL_VERSION);
+                assert_eq!(encoding, RenderEncoding::SemanticFrame);
+                assert_eq!(error, None);
+            }
+            other => panic!("expected Welcome, got {other:?}"),
+        }
+
+        match server_event_rx
+            .blocking_recv()
+            .expect("client connected event")
+        {
+            ServerEvent::ClientConnected {
+                client_id,
+                cols,
+                rows,
+                writer,
+                ..
+            } => {
+                assert_eq!(client_id, 42);
+                assert_eq!((cols, rows), (100, 30));
+                drop(writer);
+            }
+            other => panic!("expected ClientConnected, got {other:?}"),
+        }
+
+        drop(client_stream);
+        should_quit.store(true, Ordering::Release);
+        handle
+            .join()
+            .expect("handshake thread join")
+            .expect("handshake thread result");
+    }
+
+    #[test]
     fn handshake_marks_terminal_attach_launch_mode() {
         let (mut client_stream, server_stream, _path) =
             local_stream_pair("client-handshake-terminal-attach");

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -303,7 +303,7 @@ fn ping_over_socket_returns_version() {
     assert_eq!(value["result"]["type"], "pong");
     assert_eq!(value["result"]["version"], env!("CARGO_PKG_VERSION"));
     // Intentionally hardcoded so wire protocol bumps require updating this test.
-    // Changing this value means old clients/servers are no longer compatible.
+    // Changing this value means the advertised current protocol changed.
     assert_eq!(value["result"]["protocol"], 15);
 
     cleanup_spawned_herdr(child, base);


### PR DESCRIPTION
## Summary
- accept both protocol versions 14 and 15 during client/server handshake
- mark v14 and v15 servers as compatible in status/autodetect
- downgrade normal client Hello to a running v14 server while keeping v15 for v15-only observe/control streams
- add direct handshake and status/client-selection coverage

## Validation
- `ZIG=/tmp/herdr-zig-noop cargo test -q protocol::wire::tests`
- `ZIG=/tmp/herdr-zig-noop cargo test -q server::client_transport::tests::handshake_accepts_min_supported_protocol_version`
- `ZIG=/tmp/herdr-zig-noop cargo test -q client::tests::preferred_client_protocol_version`
- `ZIG=/tmp/herdr-zig-noop cargo test -q server::autodetect::tests::validate_running_server_compatibility`

Note: plain local `cargo test` is blocked by installed Zig 0.16.0 while vendored libghostty-vt requires Zig 0.15.2. Full suite with cached libghostty artifact compiled and ran: 2347 passed, 6 unrelated existing/environment failures.