### PR TITLE
fix: terminate pane processes on windows tab close

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1139,8 +1139,9 @@ fn shutdown_pane_processes(
             std::time::Duration::from_millis(250),
         ),
     ] {
-        crate::platform::signal_processes(&pids, signal);
-        if wait_for_processes_to_exit(&pids, child_pid, child_wait_completed, grace) {
+        if crate::platform::signal_processes(&pids, signal)
+            && wait_for_processes_to_exit(&pids, child_pid, child_wait_completed, grace)
+        {
             info!(
                 pane = pane_id.raw(),
                 pid = child_pid,

--- a/src/platform/fallback.rs
+++ b/src/platform/fallback.rs
@@ -48,7 +48,9 @@ pub fn session_processes(_child_pid: u32) -> Vec<u32> {
 }
 
 /// Unsupported platform stub.
-pub fn signal_processes(_pids: &[u32], _signal: Signal) {}
+pub fn signal_processes(_pids: &[u32], _signal: Signal) -> bool {
+    true
+}
 
 /// Unsupported platform stub.
 pub fn process_exists(_pid: u32) -> bool {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -313,7 +313,7 @@ pub fn session_processes(child_pid: u32) -> Vec<u32> {
     pids
 }
 
-pub fn signal_processes(pids: &[u32], signal: Signal) {
+pub fn signal_processes(pids: &[u32], signal: Signal) -> bool {
     let sig = match signal {
         Signal::Hangup => libc::SIGHUP,
         Signal::Terminate => libc::SIGTERM,
@@ -328,6 +328,7 @@ pub fn signal_processes(pids: &[u32], signal: Signal) {
             libc::kill(pid as i32, sig);
         }
     }
+    true
 }
 
 pub fn process_exists(pid: u32) -> bool {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -930,7 +930,7 @@ fn collect_positive_pids(pids: Vec<libc::pid_t>, count: usize) -> Vec<u32> {
         .collect()
 }
 
-pub fn signal_processes(pids: &[u32], signal: Signal) {
+pub fn signal_processes(pids: &[u32], signal: Signal) -> bool {
     let sig = match signal {
         Signal::Hangup => libc::SIGHUP,
         Signal::Terminate => libc::SIGTERM,
@@ -945,6 +945,7 @@ pub fn signal_processes(pids: &[u32], signal: Signal) {
             libc::kill(pid as libc::c_int, sig);
         }
     }
+    true
 }
 
 pub fn process_exists(pid: u32) -> bool {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -23,7 +23,7 @@ use windows_sys::{
             },
             Threading::{
                 GetExitCodeProcess, OpenProcess, TerminateProcess, PROCESS_BASIC_INFORMATION,
-                PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ,
+                PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, PROCESS_VM_READ,
             },
         },
         UI::Shell::{CommandLineToArgvW, ShellExecuteW},
@@ -357,19 +357,20 @@ fn session_processes_from_entries(child_pid: u32, entries: &[WindowsProcessEntry
     pids
 }
 
-pub fn signal_processes(pids: &[u32], signal: Signal) {
+pub fn signal_processes(pids: &[u32], signal: Signal) -> bool {
     if signal == Signal::Hangup {
-        return;
+        return false;
     }
 
     for &pid in pids {
-        let Some(process) = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION) else {
+        let Some(process) = ProcessHandle::open(pid, PROCESS_TERMINATE) else {
             continue;
         };
         unsafe {
             TerminateProcess(process.0, 1);
         }
     }
+    true
 }
 
 pub fn process_exists(pid: u32) -> bool {


### PR DESCRIPTION
TerminateProcess needs PROCESS_TERMINATE access, but handles were opened with PROCESS_QUERY_LIMITED_INFORMATION only, so pane processes silently survived shutdown and every grace period ran to its 250ms timeout, stalling the event loop for ~750ms per pane. Open handles with PROCESS_TERMINATE and skip the grace wait for signals the platform does not deliver (hangup on windows).

refs #945