### PR TITLE
feat: add caveman-code CLI agent integration

### DIFF
--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -269,7 +269,7 @@ In-app settings cover theme, sound, and toast preferences. Herdr writes logs und
 - [install](https://herdr.dev/docs/install/) — install, update, Homebrew, mise, and Nix
 - [session state](https://herdr.dev/docs/session-state/) — detach, restart restore, agent restore, and live handoff
 - [configuration](https://herdr.dev/docs/configuration/) — keybindings, themes, notifications, environment variables
-- [integrations](https://herdr.dev/docs/integrations/) — pi, omp, claude code, codex, cursor agent cli, github copilot cli, droid, kimi code cli, opencode, kilo code cli, hermes, qodercli integrations
+- [integrations](https://herdr.dev/docs/integrations/) — pi, omp, claude code, codex, cursor agent cli, github copilot cli, droid, kimi code cli, opencode, kilo code cli, hermes, qodercli, caveman integrations
 - [`SKILL.md`](./SKILL.md) — reusable agent skill
 - [socket api](https://herdr.dev/docs/socket-api/) — socket protocol and cli reference
 

--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -26,6 +26,7 @@ pub enum IntegrationTarget {
     Hermes,
     Qodercli,
     Cursor,
+    Caveman,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -103,13 +103,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|caveman>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|caveman>"
         );
         return Ok(None);
     }
@@ -128,10 +128,11 @@ fn parse_integration_target(
         "hermes" => IntegrationTarget::Hermes,
         "qodercli" => IntegrationTarget::Qodercli,
         "cursor" => IntegrationTarget::Cursor,
+        "caveman" => IntegrationTarget::Caveman,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, caveman"
             );
             return Ok(None);
         }
@@ -155,6 +156,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install hermes");
     eprintln!("  herdr integration install qodercli");
     eprintln!("  herdr integration install cursor");
+    eprintln!("  herdr integration install caveman");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -168,5 +170,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall hermes");
     eprintln!("  herdr integration uninstall qodercli");
     eprintln!("  herdr integration uninstall cursor");
+    eprintln!("  herdr integration uninstall caveman");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -731,7 +731,7 @@ fn integration_target_arg() -> Arg {
         .required(true)
         .value_parser([
             "pi", "omp", "claude", "codex", "copilot", "devin", "droid", "kimi", "opencode",
-            "kilo", "hermes", "qodercli", "cursor",
+            "kilo", "hermes", "qodercli", "cursor", "caveman",
         ])
 }
 

--- a/src/detect/manifests/caveman.toml
+++ b/src/detect/manifests/caveman.toml
@@ -1,0 +1,13 @@
+id = "caveman"
+version = "2026.07.03.1"
+min_engine_version = 1
+updated_at = "2026-07-03T00:00:00Z"
+aliases = ["caveman-code", "herdr:caveman"]
+
+[[rules]]
+id = "working_literal"
+state = "working"
+priority = 100
+region = "whole_recent"
+visible_working = true
+contains = ["Working..."]

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -2,11 +2,12 @@ use std::io;
 
 use super::registry::{integration_target_label, integration_target_supported};
 use super::targets::{
-    install_claude, install_codex, install_copilot, install_cursor, install_devin, install_droid,
-    install_hermes, install_kilo, install_kimi, install_omp, install_opencode, install_pi,
-    install_qodercli, uninstall_claude, uninstall_codex, uninstall_copilot, uninstall_cursor,
-    uninstall_devin, uninstall_droid, uninstall_hermes, uninstall_kilo, uninstall_kimi,
-    uninstall_omp, uninstall_opencode, uninstall_pi, uninstall_qodercli,
+    install_caveman, install_claude, install_codex, install_copilot, install_cursor, install_devin,
+    install_droid, install_hermes, install_kilo, install_kimi, install_omp, install_opencode,
+    install_pi, install_qodercli, uninstall_caveman, uninstall_claude, uninstall_codex,
+    uninstall_copilot, uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_hermes,
+    uninstall_kilo, uninstall_kimi, uninstall_omp, uninstall_opencode, uninstall_pi,
+    uninstall_qodercli,
 };
 use super::version::{agent_version_requirement, enforce_agent_version};
 use super::{KIMI_MIN_VERSION, PI_EXTENSION_INSTALL_NAME};
@@ -189,6 +190,13 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                 ),
                 format!("updated cursor hooks at {}", installed.hooks_path.display()),
             ]
+        }
+        crate::api::schema::IntegrationTarget::Caveman => {
+            let installed = install_caveman()?;
+            vec![format!(
+                "installed caveman integration to {}",
+                installed.extension_path.display()
+            )]
         }
     };
 
@@ -516,6 +524,20 @@ pub(crate) fn uninstall_target(
                 ));
             }
             messages
+        }
+        crate::api::schema::IntegrationTarget::Caveman => {
+            let result = uninstall_caveman()?;
+            if result.removed_extension {
+                vec![format!(
+                    "removed caveman integration extension at {}",
+                    result.extension_path.display()
+                )]
+            } else {
+                vec![format!(
+                    "no caveman integration extension found at {}",
+                    result.extension_path.display()
+                )]
+            }
         }
     };
 

--- a/src/integration/assets/caveman/herdr-agent-state.ts
+++ b/src/integration/assets/caveman/herdr-agent-state.ts
@@ -1,0 +1,459 @@
+// installed by herdr
+// managed by herdr; reinstalling or updating the integration overwrites this file.
+// add custom hooks/plugins beside this file instead of editing it.
+// HERDR_INTEGRATION_ID=caveman
+// HERDR_INTEGRATION_VERSION=1
+// @ts-nocheck
+
+import { createConnection } from "node:net";
+
+const HERDR_ENV = process.env.HERDR_ENV;
+const socketPath = process.env.HERDR_SOCKET_PATH;
+const paneId = process.env.HERDR_PANE_ID;
+const source = "herdr:caveman";
+
+function enabled() {
+  return HERDR_ENV === "1" && !!socketPath && !!paneId;
+}
+
+let requestQueue = Promise.resolve();
+
+function sendRequestNow(request: unknown): Promise<void> {
+  if (!enabled()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      resolve();
+    };
+
+    const socket = createConnection(socketPath!);
+    socket.on("error", finish);
+    socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+    socket.on("data", finish);
+    socket.on("end", finish);
+    const timeout = setTimeout(finish, 500);
+    timeout.unref?.();
+  });
+}
+
+function sendRequest(request: unknown): Promise<void> {
+  requestQueue = requestQueue.then(
+    () => sendRequestNow(request),
+    () => sendRequestNow(request),
+  );
+  return requestQueue;
+}
+
+type AgentState = "working" | "blocked" | "idle";
+
+type QueuedState = {
+  state: AgentState;
+  message?: string;
+  seq: number;
+};
+
+const idleDebounceMs = parseDurationEnv("HERDR_CAVEMAN_IDLE_DEBOUNCE_MS", 250);
+const retryGraceMs = parseDurationEnv("HERDR_CAVEMAN_RETRY_GRACE_MS", 2500);
+const retryableErrorPattern =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+let reportSeq = Date.now() * 1000;
+let currentAgentSessionId: string | undefined;
+let currentAgentSessionPath: string | undefined;
+
+function nextReportSeq(): number {
+  reportSeq += 1;
+  return reportSeq;
+}
+
+function updateSessionRef(ctx: any): void {
+  try {
+    const file = ctx?.sessionManager?.getSessionFile?.();
+    currentAgentSessionPath =
+      typeof file === "string" && file.startsWith("/") ? file : undefined;
+  } catch {
+    currentAgentSessionPath = undefined;
+  }
+
+  try {
+    const id = ctx?.sessionManager?.getSessionId?.();
+    currentAgentSessionId = typeof id === "string" && id.length > 0 ? id : undefined;
+  } catch {
+    currentAgentSessionId = undefined;
+  }
+}
+
+function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
+  if (currentAgentSessionPath) {
+    return { ...params, agent_session_path: currentAgentSessionPath };
+  }
+  if (currentAgentSessionId) {
+    return { ...params, agent_session_id: currentAgentSessionId };
+  }
+  return params;
+}
+
+function parseDurationEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function currentSessionRef(): Record<string, unknown> | undefined {
+  if (currentAgentSessionPath) {
+    return { agent_session_path: currentAgentSessionPath };
+  }
+  if (currentAgentSessionId) {
+    return { agent_session_id: currentAgentSessionId };
+  }
+  return undefined;
+}
+
+function reportSession(sessionStartSource = "startup"): Promise<void> {
+  const sessionRef = currentSessionRef();
+  if (!sessionRef) {
+    return Promise.resolve();
+  }
+
+  return sendRequest({
+    id: `${source}:session:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.report_agent_session",
+    params: {
+      pane_id: paneId,
+      source,
+      agent: "caveman",
+      seq: nextReportSeq(),
+      session_start_source: sessionStartSource,
+      ...sessionRef,
+    },
+  });
+}
+
+function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<void> {
+  return sendRequest({
+    id: `${source}:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.report_agent",
+    params: withSessionRef({
+      pane_id: paneId,
+      source,
+      agent: "caveman",
+      state,
+      message,
+      seq,
+    }),
+  });
+}
+
+function releaseAgent(): Promise<void> {
+  return sendRequest({
+    id: `${source}:release:${Date.now()}:${Math.random().toString(36).slice(2)}`,
+    method: "pane.release_agent",
+    params: {
+      pane_id: paneId,
+      source,
+      agent: "caveman",
+      seq: nextReportSeq(),
+    },
+  });
+}
+
+function shouldReleaseOnSessionShutdown(event: any): boolean {
+  const reason = event?.reason;
+  return reason === "quit";
+}
+
+let sendInFlight = false;
+let queuedState: QueuedState | undefined;
+
+function queueState(state: AgentState, message?: string): void {
+  queuedState = { state, message, seq: nextReportSeq() };
+  if (!sendInFlight) {
+    void drainStateQueue();
+  }
+}
+
+async function drainStateQueue(): Promise<void> {
+  if (sendInFlight) {
+    return;
+  }
+
+  sendInFlight = true;
+  try {
+    while (queuedState) {
+      const next = queuedState;
+      queuedState = undefined;
+      await sendState(next.state, next.message, next.seq);
+    }
+  } finally {
+    sendInFlight = false;
+    if (queuedState) {
+      void drainStateQueue();
+    }
+  }
+}
+
+function lastAssistantMessage(messages: unknown[]): any | undefined {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i] as any;
+    if (message?.role === "assistant") {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function retryableErrorMessage(event: any): string | undefined {
+  const messages = Array.isArray(event?.messages) ? event.messages : [];
+  const assistant = lastAssistantMessage(messages);
+  if (assistant?.stopReason !== "error") {
+    return undefined;
+  }
+
+  const errorMessage = String(assistant.errorMessage ?? "");
+  if (!retryableErrorPattern.test(errorMessage)) {
+    return undefined;
+  }
+  return errorMessage || "retryable provider error";
+}
+
+function askBlockedMessage(args: any): string {
+  const questions = Array.isArray(args?.questions) ? args.questions : [];
+  const firstQuestion = questions.find((question: any) => typeof question?.question === "string");
+  if (firstQuestion?.question) {
+    return firstQuestion.question;
+  }
+  return "waiting for user input";
+}
+
+export default function (pi) {
+  if (!enabled()) {
+    return;
+  }
+
+  let agentActive = false;
+  let retryHoldActive = false;
+  let failureBlocked = false;
+  let failureMessage: string | undefined;
+  let blockedCount = 0;
+  let blockedMessage: string | undefined;
+  let lastState: AgentState | undefined;
+  let lastMessage: string | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let rootSession = false;
+
+  function clearTimer(timer: ReturnType<typeof setTimeout> | undefined) {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  function clearPendingTimers() {
+    clearTimer(idleTimer);
+    clearTimer(retryTimer);
+    idleTimer = undefined;
+    retryTimer = undefined;
+  }
+
+  function clearFailureState() {
+    retryHoldActive = false;
+    failureBlocked = false;
+    failureMessage = undefined;
+  }
+
+  function desiredState() {
+    if (blockedCount > 0) {
+      return { state: "blocked" as const, message: blockedMessage };
+    }
+    if (failureBlocked) {
+      return { state: "blocked" as const, message: failureMessage };
+    }
+    if (agentActive || retryHoldActive) {
+      return { state: "working" as const, message: undefined };
+    }
+    return { state: "idle" as const, message: undefined };
+  }
+
+  function publishState(force = false) {
+    const next = desiredState();
+    if (!force && next.state === lastState && next.message === lastMessage) {
+      return;
+    }
+    lastState = next.state;
+    lastMessage = next.message;
+    queueState(next.state, next.message);
+  }
+
+  function scheduleIdle() {
+    clearPendingTimers();
+    clearFailureState();
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined;
+      publishState();
+    }, idleDebounceMs);
+    idleTimer.unref?.();
+  }
+
+  function holdForRetry(message: string) {
+    clearPendingTimers();
+    retryHoldActive = true;
+    failureBlocked = false;
+    failureMessage = message;
+    publishState();
+
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined;
+      retryHoldActive = false;
+      failureBlocked = true;
+      publishState();
+    }, retryGraceMs);
+    retryTimer.unref?.();
+  }
+
+  function activateRootSession(ctx: any, sessionStartSource = "startup"): boolean {
+    if (ctx?.hasUI !== true) {
+      return false;
+    }
+    rootSession = true;
+    updateSessionRef(ctx);
+    void reportSession(sessionStartSource);
+    return true;
+  }
+
+  function resetSessionState() {
+    clearPendingTimers();
+    clearFailureState();
+    agentActive = false;
+    blockedCount = 0;
+    blockedMessage = undefined;
+  }
+
+  function activateBlocked(message: string | undefined) {
+    clearPendingTimers();
+    blockedCount += 1;
+    blockedMessage = message;
+    publishState();
+  }
+
+  function deactivateBlocked() {
+    blockedCount = Math.max(0, blockedCount - 1);
+    if (blockedCount === 0) {
+      blockedMessage = undefined;
+    }
+    publishState();
+  }
+
+  pi.events.on("herdr:blocked", (data) => {
+    if (!rootSession) {
+      return;
+    }
+    if (!data?.active) {
+      deactivateBlocked();
+      return;
+    }
+
+    activateBlocked(data.label);
+  });
+
+  pi.on("session_start", (_event, ctx) => {
+    if (!activateRootSession(ctx)) {
+      return;
+    }
+    publishState(true);
+  });
+
+  pi.on("session_switch", (event, ctx) => {
+    if (!activateRootSession(ctx, event?.reason || "resume")) {
+      return;
+    }
+    resetSessionState();
+    publishState(true);
+  });
+
+  pi.on("agent_start", (_event, ctx) => {
+    if (!rootSession && !activateRootSession(ctx)) {
+      return;
+    }
+    updateSessionRef(ctx);
+    void reportSession();
+    clearPendingTimers();
+    clearFailureState();
+    agentActive = true;
+    publishState();
+  });
+
+  pi.on("tool_approval_requested", (event, ctx) => {
+    if (!rootSession && !activateRootSession(ctx)) {
+      return;
+    }
+    const label = event?.reason || `${event?.toolName || "Tool"} approval`;
+    activateBlocked(label);
+  });
+
+  pi.on("tool_approval_resolved", (_event, ctx) => {
+    if (!rootSession && !activateRootSession(ctx)) {
+      return;
+    }
+    deactivateBlocked();
+  });
+
+  pi.on("tool_execution_start", (event, ctx) => {
+    if (event?.toolName !== "ask") {
+      return;
+    }
+    if (!rootSession && !activateRootSession(ctx)) {
+      return;
+    }
+    activateBlocked(askBlockedMessage(event.args));
+  });
+
+  pi.on("tool_execution_end", (event, ctx) => {
+    if (event?.toolName !== "ask") {
+      return;
+    }
+    if (!rootSession && !activateRootSession(ctx)) {
+      return;
+    }
+    deactivateBlocked();
+  });
+
+  pi.on("agent_end", (event) => {
+    if (!rootSession) {
+      return;
+    }
+    if (!agentActive) {
+      return;
+    }
+
+    agentActive = false;
+
+    const retryableMessage = retryableErrorMessage(event);
+    if (retryableMessage) {
+      holdForRetry(retryableMessage);
+      return;
+    }
+
+    scheduleIdle();
+  });
+
+  pi.on("session_shutdown", async (event) => {
+    if (!rootSession) {
+      return;
+    }
+    clearPendingTimers();
+    if (shouldReleaseOnSessionShutdown(event)) {
+      await releaseAgent();
+    }
+  });
+}

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -98,6 +98,14 @@ pub(crate) fn expand_tilde_path(path: PathBuf) -> io::Result<PathBuf> {
     Ok(path)
 }
 
+pub(crate) fn caveman_dir() -> io::Result<PathBuf> {
+    Ok(home_dir()?.join(".cave/agent"))
+}
+
+pub(crate) fn caveman_extension_dir() -> io::Result<PathBuf> {
+    Ok(caveman_dir()?.join("extensions"))
+}
+
 pub(crate) fn opencode_dir() -> io::Result<PathBuf> {
     Ok(home_dir()?.join(".config/opencode"))
 }

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -179,6 +179,9 @@ const QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS: [(&str, &str); 12] = [
 const CURSOR_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const CURSOR_HOOK_ASSET: &str = include_str!("assets/cursor/herdr-agent-state.sh");
 const CURSOR_INTEGRATION_VERSION: u32 = 1;
+const CAVEMAN_EXTENSION_INSTALL_NAME: &str = "herdr-agent-state.ts";
+const CAVEMAN_EXTENSION_ASSET: &str = include_str!("assets/caveman/herdr-agent-state.ts");
+const CAVEMAN_INTEGRATION_VERSION: u32 = 1;
 const INTEGRATION_VERSION_MARKER: &str = "HERDR_INTEGRATION_VERSION=";
 
 pub(crate) const INSTALL_WARNING_PREFIX: &str = "warning:";

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use super::env::caveman_extension_dir;
 use super::env::*;
 
 pub(crate) fn integration_target_label(
@@ -21,6 +22,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Hermes => "hermes",
         crate::api::schema::IntegrationTarget::Qodercli => "qodercli",
         crate::api::schema::IntegrationTarget::Cursor => "cursor",
+        crate::api::schema::IntegrationTarget::Caveman => "caveman",
     }
 }
 
@@ -47,6 +49,7 @@ pub(crate) fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Hermes => &["hermes"],
         crate::api::schema::IntegrationTarget::Qodercli => qodercli_command_names(),
         crate::api::schema::IntegrationTarget::Cursor => cursor_command_names(),
+        crate::api::schema::IntegrationTarget::Caveman => &["caveman", "caveman-code"],
     }
 }
 
@@ -251,7 +254,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 13] {
+); 14] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -320,6 +323,11 @@ fn integration_specs() -> [(
             crate::api::schema::IntegrationTarget::Cursor,
             cursor_dir().map(|dir| dir.join(super::CURSOR_HOOK_INSTALL_NAME)),
             super::CURSOR_INTEGRATION_VERSION,
+        ),
+        (
+            crate::api::schema::IntegrationTarget::Caveman,
+            caveman_extension_dir().map(|dir| dir.join(super::CAVEMAN_EXTENSION_INSTALL_NAME)),
+            super::CAVEMAN_INTEGRATION_VERSION,
         ),
     ]
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -13,30 +13,30 @@ use super::config_edit::{
     remove_simple_command_hook,
 };
 use super::env::{
-    claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir, hermes_dir,
-    hermes_plugin_dir, kilo_dir, kimi_dir, omp_extension_dir, opencode_dir, pi_extension_dir,
-    qodercli_dir,
+    caveman_extension_dir, claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir,
+    hermes_dir, hermes_plugin_dir, kilo_dir, kimi_dir, omp_extension_dir, opencode_dir,
+    pi_extension_dir, qodercli_dir,
 };
 use super::file_ops::{
     make_executable, remove_dir_all_if_exists, remove_file_if_exists, remove_legacy_bash_hook_file,
 };
 use super::types::{
-    ClaudeInstallPaths, ClaudeUninstallResult, CodexInstallPaths, CodexUninstallResult,
-    CopilotInstallPaths, CopilotUninstallResult, CursorInstallPaths, CursorUninstallResult,
-    DevinInstallPaths, DevinUninstallResult, DroidInstallPaths, DroidUninstallResult,
-    HermesInstallPaths, HermesUninstallResult, KiloInstallPaths, KiloUninstallResult,
-    KimiInstallPaths, KimiUninstallResult, OmpInstallPaths, OmpUninstallResult,
-    OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult, QodercliInstallPaths,
-    QodercliUninstallResult,
+    CavemanInstallPaths, CavemanUninstallResult, ClaudeInstallPaths, ClaudeUninstallResult,
+    CodexInstallPaths, CodexUninstallResult, CopilotInstallPaths, CopilotUninstallResult,
+    CursorInstallPaths, CursorUninstallResult, DevinInstallPaths, DevinUninstallResult,
+    DroidInstallPaths, DroidUninstallResult, HermesInstallPaths, HermesUninstallResult,
+    KiloInstallPaths, KiloUninstallResult, KimiInstallPaths, KimiUninstallResult, OmpInstallPaths,
+    OmpUninstallResult, OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult,
+    QodercliInstallPaths, QodercliUninstallResult,
 };
 use super::{
-    CLAUDE_HOOK_ASSET, CLAUDE_HOOK_INSTALL_NAME, CODEX_HOOK_ASSET, CODEX_HOOK_INSTALL_NAME,
-    COPILOT_HOOK_ASSET, COPILOT_HOOK_EVENTS, COPILOT_HOOK_INSTALL_NAME,
-    COPILOT_REMOVED_LIFECYCLE_HOOK_EVENTS, CURSOR_HOOK_ASSET, CURSOR_HOOK_INSTALL_NAME,
-    DEVIN_HOOK_ASSET, DEVIN_HOOK_EVENTS, DEVIN_HOOK_INSTALL_NAME,
-    DEVIN_REMOVED_LIFECYCLE_HOOK_EVENTS, DROID_HOOK_ASSET, DROID_HOOK_EVENTS,
-    DROID_HOOK_INSTALL_NAME, DROID_REMOVED_LIFECYCLE_HOOK_EVENTS, HERMES_PLUGIN_INIT_ASSET,
-    HERMES_PLUGIN_INIT_INSTALL_NAME, HERMES_PLUGIN_MANIFEST_ASSET,
+    CAVEMAN_EXTENSION_ASSET, CAVEMAN_EXTENSION_INSTALL_NAME, CLAUDE_HOOK_ASSET,
+    CLAUDE_HOOK_INSTALL_NAME, CODEX_HOOK_ASSET, CODEX_HOOK_INSTALL_NAME, COPILOT_HOOK_ASSET,
+    COPILOT_HOOK_EVENTS, COPILOT_HOOK_INSTALL_NAME, COPILOT_REMOVED_LIFECYCLE_HOOK_EVENTS,
+    CURSOR_HOOK_ASSET, CURSOR_HOOK_INSTALL_NAME, DEVIN_HOOK_ASSET, DEVIN_HOOK_EVENTS,
+    DEVIN_HOOK_INSTALL_NAME, DEVIN_REMOVED_LIFECYCLE_HOOK_EVENTS, DROID_HOOK_ASSET,
+    DROID_HOOK_EVENTS, DROID_HOOK_INSTALL_NAME, DROID_REMOVED_LIFECYCLE_HOOK_EVENTS,
+    HERMES_PLUGIN_INIT_ASSET, HERMES_PLUGIN_INIT_INSTALL_NAME, HERMES_PLUGIN_MANIFEST_ASSET,
     HERMES_PLUGIN_MANIFEST_INSTALL_NAME, KILO_PLUGIN_ASSET, KILO_PLUGIN_INSTALL_NAME,
     KIMI_HOOK_ASSET, KIMI_HOOK_INSTALL_NAME, OMP_EXTENSION_ASSET, OMP_EXTENSION_INSTALL_NAME,
     OPENCODE_PLUGIN_ASSET, OPENCODE_PLUGIN_INSTALL_NAME, PI_EXTENSION_ASSET,
@@ -56,6 +56,31 @@ pub(crate) fn install_pi() -> io::Result<PathBuf> {
     let path = dir.join(PI_EXTENSION_INSTALL_NAME);
     fs::write(&path, PI_EXTENSION_ASSET)?;
     Ok(path)
+}
+
+pub(crate) fn install_caveman() -> io::Result<CavemanInstallPaths> {
+    let dir = caveman_extension_dir()?;
+    if !dir.is_dir() {
+        if dir.parent().is_some_and(|parent| parent.is_dir()) {
+            fs::create_dir_all(&dir)?;
+        } else {
+            return Err(io::Error::other(format!(
+                "caveman extension directory not found at {}. install caveman and create the extensions directory first",
+                dir.display()
+            )));
+        }
+    }
+
+    if !dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "caveman extension directory not found at {}. install caveman and create the extensions directory first",
+            dir.display()
+        )));
+    }
+
+    let extension_path = dir.join(CAVEMAN_EXTENSION_INSTALL_NAME);
+    fs::write(&extension_path, CAVEMAN_EXTENSION_ASSET)?;
+    Ok(CavemanInstallPaths { extension_path })
 }
 
 pub(crate) fn install_omp() -> io::Result<OmpInstallPaths> {
@@ -538,6 +563,16 @@ pub(crate) fn uninstall_pi() -> io::Result<PiUninstallResult> {
     let removed_extension = remove_file_if_exists(&extension_path)?;
 
     Ok(PiUninstallResult {
+        extension_path,
+        removed_extension,
+    })
+}
+
+pub(crate) fn uninstall_caveman() -> io::Result<CavemanUninstallResult> {
+    let extension_path = caveman_extension_dir()?.join(CAVEMAN_EXTENSION_INSTALL_NAME);
+    let removed_extension = remove_file_if_exists(&extension_path)?;
+
+    Ok(CavemanUninstallResult {
         extension_path,
         removed_extension,
     })

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -3102,3 +3102,223 @@ fn install_cursor_errors_when_config_dir_missing() {
     std::env::remove_var(CURSOR_CONFIG_DIR_ENV_VAR);
     let _ = fs::remove_dir_all(base);
 }
+
+#[test]
+fn install_caveman_writes_embedded_asset_to_caveman_extensions_dir() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let ext_dir = home.join(".cave/agent/extensions");
+    fs::create_dir_all(&ext_dir).unwrap();
+    std::env::set_var("HOME", &home);
+
+    let installed = install_caveman().unwrap();
+    let content = fs::read_to_string(&installed.extension_path).unwrap();
+
+    assert_eq!(
+        installed.extension_path,
+        ext_dir.join(CAVEMAN_EXTENSION_INSTALL_NAME)
+    );
+    assert_eq!(content, CAVEMAN_EXTENSION_ASSET);
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_caveman_creates_extensions_dir_when_agent_dir_exists() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let agent_dir = home.join(".cave/agent");
+    let ext_dir = agent_dir.join("extensions");
+    fs::create_dir_all(&agent_dir).unwrap();
+    std::env::set_var("HOME", &home);
+
+    let installed = install_caveman().unwrap();
+
+    assert_eq!(
+        installed.extension_path,
+        ext_dir.join(CAVEMAN_EXTENSION_INSTALL_NAME)
+    );
+    assert!(ext_dir.is_dir());
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_caveman_is_idempotent() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let ext_dir = home.join(".cave/agent/extensions");
+    fs::create_dir_all(&ext_dir).unwrap();
+    std::env::set_var("HOME", &home);
+
+    let first = install_caveman().unwrap();
+    let second = install_caveman().unwrap();
+
+    assert_eq!(first.extension_path, second.extension_path);
+    assert_eq!(
+        fs::read_to_string(&first.extension_path).unwrap(),
+        CAVEMAN_EXTENSION_ASSET
+    );
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn uninstall_caveman_removes_extension_when_present() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let ext_dir = home.join(".cave/agent/extensions");
+    fs::create_dir_all(&ext_dir).unwrap();
+    fs::write(
+        ext_dir.join(CAVEMAN_EXTENSION_INSTALL_NAME),
+        CAVEMAN_EXTENSION_ASSET,
+    )
+    .unwrap();
+    std::env::set_var("HOME", &home);
+
+    let result = uninstall_caveman().unwrap();
+
+    assert_eq!(
+        result.extension_path,
+        ext_dir.join(CAVEMAN_EXTENSION_INSTALL_NAME)
+    );
+    assert!(result.removed_extension);
+    assert!(!result.extension_path.exists());
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn uninstall_caveman_handles_missing_extension() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let ext_dir = home.join(".cave/agent/extensions");
+    fs::create_dir_all(&ext_dir).unwrap();
+    std::env::set_var("HOME", &home);
+
+    let result = uninstall_caveman().unwrap();
+
+    assert_eq!(
+        result.extension_path,
+        ext_dir.join(CAVEMAN_EXTENSION_INSTALL_NAME)
+    );
+    assert!(!result.removed_extension);
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_caveman_errors_when_extension_dir_missing() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    fs::create_dir_all(&home).unwrap();
+    std::env::set_var("HOME", &home);
+
+    let err = install_caveman().unwrap_err().to_string();
+
+    assert!(err.contains("caveman extension directory not found"));
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn caveman_v1_integration_status_is_current() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let home = base.join("home");
+    let ext_dir = home.join(".cave/agent/extensions");
+    fs::create_dir_all(&ext_dir).unwrap();
+    fs::write(
+        ext_dir.join(CAVEMAN_EXTENSION_INSTALL_NAME),
+        CAVEMAN_EXTENSION_ASSET,
+    )
+    .unwrap();
+    std::env::set_var("HOME", &home);
+
+    let statuses = installed_integration_statuses();
+    let caveman = statuses
+        .iter()
+        .find(|status| status.target == crate::api::schema::IntegrationTarget::Caveman)
+        .expect("caveman integration status");
+    assert_eq!(caveman.state, IntegrationStatusKind::Current);
+    assert_eq!(caveman.installed_version, Some(CAVEMAN_INTEGRATION_VERSION));
+
+    std::env::remove_var("HOME");
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn caveman_extension_asset_contains_required_session_refs() {
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("agent_session_path"));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("agent_session_id"));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("pane.report_agent_session"));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("pane.report_agent\""));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("pane.release_agent"));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("source = \"herdr:caveman\""));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("agent: \"caveman\""));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("HERDR_INTEGRATION_ID=caveman"));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("HERDR_INTEGRATION_VERSION=1"));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("pi.on(\"agent_start\""));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("pi.on(\"agent_end\""));
+    assert!(CAVEMAN_EXTENSION_ASSET.contains("pi.on(\"session_shutdown\""));
+}
+
+#[test]
+fn caveman_extension_releases_only_for_quit_session_shutdown() {
+    let release_policy = CAVEMAN_EXTENSION_ASSET
+        .find("function shouldReleaseOnSessionShutdown")
+        .expect("caveman extension should centralize session shutdown release policy");
+    let quit_check = CAVEMAN_EXTENSION_ASSET
+        .find("reason === \"quit\"")
+        .expect("caveman extension should release only for true quit shutdowns");
+    let shutdown_handler = CAVEMAN_EXTENSION_ASSET
+        .find("pi.on(\"session_shutdown\", async (event)")
+        .expect("caveman extension should inspect the session_shutdown event");
+    let guarded_release = CAVEMAN_EXTENSION_ASSET[shutdown_handler..]
+        .find("if (shouldReleaseOnSessionShutdown(event))")
+        .expect("caveman extension should guard releaseAgent by shutdown reason");
+
+    assert!(release_policy < shutdown_handler);
+    assert!(release_policy < quit_check);
+    assert!(quit_check < shutdown_handler);
+    assert!(guarded_release > 0);
+}
+
+#[test]
+fn caveman_extension_refreshes_session_ref_before_agent_start_state() {
+    let agent_start = CAVEMAN_EXTENSION_ASSET
+        .find("pi.on(\"agent_start\", (_event, ctx)")
+        .expect("caveman extension should receive agent_start context");
+    let handler = &CAVEMAN_EXTENSION_ASSET[agent_start..];
+    let update_session = handler
+        .find("updateSessionRef(ctx);")
+        .expect("caveman extension should refresh the active session on agent_start");
+    let report_session = handler
+        .find("void reportSession();")
+        .expect("caveman extension should report the refreshed session before state");
+    let publish_state = handler
+        .find("publishState();")
+        .expect("caveman extension should publish working state after refreshing session");
+
+    assert!(update_session < report_session);
+    assert!(report_session < publish_state);
+}
+
+#[test]
+fn caveman_command_names_include_both_aliases() {
+    let names = integration_target_command_names(crate::api::schema::IntegrationTarget::Caveman);
+    assert!(names.contains(&"caveman"));
+    assert!(names.contains(&"caveman-code"));
+}

--- a/src/integration/types.rs
+++ b/src/integration/types.rs
@@ -74,11 +74,22 @@ pub(crate) struct CursorInstallPaths {
 }
 
 #[derive(Debug)]
+pub(crate) struct CavemanInstallPaths {
+    pub extension_path: PathBuf,
+}
+
+#[derive(Debug)]
 pub(crate) struct CursorUninstallResult {
     pub hook_path: PathBuf,
     pub hooks_path: PathBuf,
     pub removed_hook_file: bool,
     pub updated_hooks: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct CavemanUninstallResult {
+    pub extension_path: PathBuf,
+    pub removed_extension: bool,
 }
 
 #[derive(Debug)]

--- a/website/agent-detection/caveman.toml
+++ b/website/agent-detection/caveman.toml
@@ -1,0 +1,13 @@
+id = "caveman"
+version = "2026.07.03.1"
+min_engine_version = 1
+updated_at = "2026-07-03T00:00:00Z"
+aliases = ["caveman-code", "herdr:caveman"]
+
+[[rules]]
+id = "working_literal"
+state = "working"
+priority = 100
+region = "whole_recent"
+visible_working = true
+contains = ["Working..."]

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -69,5 +69,9 @@ id = "qodercli"
 path = "qodercli.toml"
 
 [[agents]]
+id = "caveman"
+path = "caveman.toml"
+
+[[agents]]
 id = "copilot"
 path = "github-copilot.toml"


### PR DESCRIPTION
 Adds caveman-code (`caveman`/`caveman-code`) as a CLI integration in herdr, following the
 extension-based pattern used by pi and omp. 

 Discussion: https://github.com/ogulcancelik/herdr/discussions/971




   ## What

   - TypeScript extension asset (`src/integration/assets/caveman/herdr-agent-state.ts`) that
 hooks into caveman's extension API to report agent state (working/blocked/idle) via herdr's
 Unix socket protocol
   - Detection manifest for screen-based agent detection
   - Full install/uninstall/status CLI support

   ## Why

   Caveman is a terminal coding agent with the same extension API as pi/omp (it's a fork). Users
 running caveman in herdr currently have no agent state detection — herdr can't tell when
 caveman is working, waiting for permission, or idle.

   ## How

   - Config dir: `~/.cave/agent/extensions/` (from caveman's `caveConfig.configDir`)
   - Command detection: `["caveman", "caveman-code"]` (npm package registers both binaries)
   - Hooks: `session_start`, `agent_start`, `agent_end`, `tool_approval_requested/resolved`,
 `tool_execution_start/end`, `session_shutdown`
   - Detection manifest: initial rule matching `Working...` literal (needs refinement with live
 pane capture)

   ## Testing

   ```bash
   herdr integration install caveman
   herdr integration status
   herdr integration uninstall caveman
 ```




Demo:

<img width="787" height="730" alt="image" src="https://github.com/user-attachments/assets/d35560a8-179d-425c-a0dd-0b4a22723935" />

<img width="1082" height="859" alt="image" src="https://github.com/user-attachments/assets/82af2952-d496-4744-97ca-a4f4b33bea3c" />
