### PR TITLE
Fix Droid hook stdin handling

### DIFF
--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -60,7 +60,7 @@ Custom socket integrations can also report state when they define state that is 
 
 Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Cursor Agent CLI, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, Kilo Code CLI, and MastraCode panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
 
-Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Cursor Agent CLI version `1`, OpenCode version `5`, Kilo Code CLI version `1`, Hermes Agent version `2`, or MastraCode version `1`. Check installed versions with `herdr integration status`.
+Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `3`, Kimi Code CLI version `3`, Qoder CLI version `2`, Cursor Agent CLI version `1`, OpenCode version `5`, Kilo Code CLI version `1`, Hermes Agent version `2`, or MastraCode version `1`. Check installed versions with `herdr integration status`.
 
 ## Pi
 

--- a/docs/next/website/src/content/docs/session-state.mdx
+++ b/docs/next/website/src/content/docs/session-state.mdx
@@ -73,7 +73,7 @@ Native session restore requires these Herdr integration versions or newer:
 | Cursor Agent CLI | `1` | `cursor-agent --resume <id>` |
 | GitHub Copilot CLI | `2` | `copilot --resume=<id>` |
 | Devin CLI | `2` | `devin --resume <id>` |
-| Droid | `2` | `droid --resume <id>` |
+| Droid | `3` | `droid --resume <id>` |
 | Kimi Code CLI | `3` | `kimi --session <id>` |
 | Qoder CLI | `2` | `qodercli --resume <id>` |
 | OpenCode | `5` | `opencode --session <id>` |

--- a/src/integration/assets/droid/herdr-agent-state.ps1
+++ b/src/integration/assets/droid/herdr-agent-state.ps1
@@ -2,7 +2,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=droid
-# HERDR_INTEGRATION_VERSION=2
+# HERDR_INTEGRATION_VERSION=3
 
 param([string]$Action = "")
 

--- a/src/integration/assets/droid/herdr-agent-state.sh
+++ b/src/integration/assets/droid/herdr-agent-state.sh
@@ -3,14 +3,11 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=droid
-# HERDR_INTEGRATION_VERSION=2
+# HERDR_INTEGRATION_VERSION=3
 
 set -eu
 
 action="${1:-}"
-hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-droid-hook.XXXXXX")" || exit 0
-trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
-cat >"$hook_input_file" 2>/dev/null || true
 
 case "$action" in
   session) ;;
@@ -22,7 +19,7 @@ esac
 [ -n "${HERDR_PANE_ID:-}" ] || exit 0
 command -v python3 >/dev/null 2>&1 || exit 0
 
-HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+HERDR_ACTION="$action" python3 - 3<&0 <<'PY'
 import json
 import os
 import random
@@ -32,20 +29,42 @@ import time
 source = "herdr:droid"
 pane_id = os.environ.get("HERDR_PANE_ID")
 socket_path = os.environ.get("HERDR_SOCKET_PATH")
-hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
 
 if not pane_id or not socket_path:
     raise SystemExit(0)
 
-hook_input = {}
-if hook_input_file:
+def read_stdin(timeout=0.2, max_bytes=1024 * 1024):
+    deadline = time.monotonic() + timeout
+    fd = 3
+    chunks = []
+    total = 0
     try:
-        with open(hook_input_file, encoding="utf-8") as handle:
-            content = handle.read()
-        if content.strip():
-            hook_input = json.loads(content)
+        os.set_blocking(fd, False)
     except Exception:
-        hook_input = {}
+        return ""
+    while total < max_bytes:
+        try:
+            chunk = os.read(fd, min(65536, max_bytes - total))
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+            continue
+        except Exception:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    return b"".join(chunks).decode("utf-8", errors="replace")
+
+hook_input = {}
+try:
+    content = read_stdin()
+    if content.strip():
+        hook_input = json.loads(content)
+except Exception:
+    hook_input = {}
 
 session_id = hook_input.get("session_id")
 if not isinstance(session_id, str) or not session_id:

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -125,7 +125,7 @@ const DROID_HOOK_ASSET: &str = if cfg!(windows) {
 } else {
     include_str!("assets/droid/herdr-agent-state.sh")
 };
-const DROID_INTEGRATION_VERSION: u32 = 2;
+const DROID_INTEGRATION_VERSION: u32 = 3;
 const DROID_HOOK_EVENTS: [(&str, &str); 1] = [("SessionStart", "session")];
 const DROID_REMOVED_LIFECYCLE_HOOK_EVENTS: [(&str, &str); 9] = [
     ("SessionStart", "idle"),

--- a/tests/cli_wrapper.rs
+++ b/tests/cli_wrapper.rs
@@ -557,6 +557,52 @@ fn run_devin_hook(
     )
 }
 
+fn run_droid_hook(action: &str, hook_input: &str) -> Option<serde_json::Value> {
+    run_shell_hook(
+        "src/integration/assets/droid/herdr-agent-state.sh",
+        &[action],
+        hook_input,
+    )
+}
+
+fn assert_droid_hook_exits_with_open_stdin() {
+    let base = unique_test_dir();
+    fs::create_dir_all(&base).unwrap();
+    let socket_path = base.join("herdr.sock");
+    let hook_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/integration/assets/droid/herdr-agent-state.sh");
+    let mut child = Command::new("bash")
+        .arg(hook_path)
+        .arg("session")
+        .env("HERDR_ENV", "1")
+        .env("HERDR_SOCKET_PATH", &socket_path)
+        .env("HERDR_PANE_ID", "p_test")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdin = child.stdin.take().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert!(status.success(), "droid hook exited with {status}");
+            drop(stdin);
+            cleanup_test_base(&base);
+            return;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            drop(stdin);
+            cleanup_test_base(&base);
+            panic!("droid hook did not exit while stdin stayed open");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
 fn run_shell_hook(asset_path: &str, args: &[&str], hook_input: &str) -> Option<serde_json::Value> {
     run_shell_hook_with_env(asset_path, args, hook_input, &[])
 }
@@ -750,6 +796,22 @@ fn devin_hook_reports_session_id_from_stdin_without_state() {
     assert_eq!(request["params"]["agent"], "devin");
     assert_eq!(request["params"]["agent_session_id"], "devin-session");
     assert!(request["params"].get("state").is_none());
+}
+
+#[test]
+fn droid_hook_reports_session_id_from_stdin() {
+    let request = run_droid_hook("session", r#"{"session_id":"droid-session"}"#)
+        .expect("droid session start should report session identity");
+
+    assert_eq!(request["method"], "pane.report_agent_session");
+    assert_eq!(request["params"]["agent"], "droid");
+    assert_eq!(request["params"]["agent_session_id"], "droid-session");
+    assert!(request["params"].get("state").is_none());
+}
+
+#[test]
+fn droid_hook_does_not_wait_forever_for_open_stdin() {
+    assert_droid_hook_exits_with_open_stdin();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1036.

Summary:
- stop the Droid hook from blocking on inherited open stdin
- keep session id reporting unchanged when a payload is present
- bump the Droid integration version to 3

Tests:
- `ZIG=/tmp/zig-0.15.2/zig cargo test -q --test cli_wrapper droid_hook -- --nocapture`
- `ZIG=/tmp/zig-0.15.2/zig cargo test -q install_droid -- --nocapture`
- `ZIG=/tmp/zig-0.15.2/zig cargo test -q droid_v1_integration_status_is_outdated -- --nocapture`
