### PR TITLE
feat: add codebuddy agent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __pycache__/
 
 /.wrangler/
 **/.wrangler/
+.idea/
+.serena/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,9 +108,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -126,6 +135,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -242,12 +257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -386,7 +407,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -459,6 +480,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fdeflate"
@@ -569,6 +596,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -736,12 +774,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -773,11 +817,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -854,7 +898,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -866,7 +910,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -879,7 +923,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -967,6 +1011,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1194,31 +1262,35 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools",
  "kasuari",
  "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -1228,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -1240,19 +1312,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -1260,17 +1343,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -1289,7 +1373,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1356,7 +1440,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1585,18 +1669,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1624,6 +1708,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1655,7 +1752,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2077,7 +2174,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2274,7 +2371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -200,6 +200,7 @@ automatic detection works out of the box. process name matching plus terminal ou
 | [github copilot cli](https://github.com/features/copilot) | ✓ | ✓ | ✓ |
 | [qodercli](https://qoder.com/cli) | ✓ | ✓ | ✓ |
 | [kiro cli](https://kiro.dev/docs/cli/) | ✓ | ✓ | — |
+| [codebuddy](https://codebuddy.ai) | ✓ | ✓ | ✓ |
 
 detected but not fully tested: gemini cli, cline.
 
@@ -223,6 +224,7 @@ herdr integration install kilo
 herdr integration install hermes
 herdr integration install qodercli
 herdr integration install cursor
+herdr integration install codebuddy
 ```
 
 see the [integrations docs](https://herdr.dev/docs/integrations/) for setup details.

--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -1512,7 +1512,8 @@
             "kilo",
             "hermes",
             "qodercli",
-            "cursor"
+            "cursor",
+            "codebuddy"
           ],
           "type": "string"
         },
@@ -5927,7 +5928,8 @@
             "kilo",
             "hermes",
             "qodercli",
-            "cursor"
+            "cursor",
+            "codebuddy"
           ],
           "type": "string"
         },

--- a/docs/next/website/src/content/docs/agents.mdx
+++ b/docs/next/website/src/content/docs/agents.mdx
@@ -24,6 +24,7 @@ Automatic detection works out of the box for common coding agents. The important
 | Claude Code | screen manifest | session |
 | Codex | screen manifest | session |
 | Cursor Agent CLI | screen manifest | session |
+| CodeBuddy | lifecycle hooks when installed; otherwise screen manifest | state and session |
 | Amp | screen manifest | none |
 | Grok CLI | screen manifest | none |
 | Antigravity CLI | screen manifest | none |

--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -1,11 +1,11 @@
 ---
 title: Integrations
-description: Install Herdr integrations for Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, Qoder CLI, and Cursor Agent CLI.
+description: Install Herdr integrations for Pi, OMP, Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, Qoder CLI, Cursor Agent CLI, and CodeBuddy.
 ---
 
 Herdr detects supported agents automatically. Official integrations can add native session identity for restore, lifecycle state reports, or both.
 
-Use integrations when you want native agent session restore from Claude Code/Codex/Copilot/Devin-style hooks, direct lifecycle reports from Pi/OMP/Kimi/OpenCode/Kilo/Hermes-style hooks or plugins, or both. See [Agents](/docs/agents/) for the full status authority model.
+Use integrations when you want native agent session restore from Claude Code/Codex/Copilot/Devin/CodeBuddy-style hooks, direct lifecycle reports from Pi/OMP/Kimi/OpenCode/Kilo/Hermes-style hooks or plugins, or both. See [Agents](/docs/agents/) for the full status authority model.
 
 ## Install integrations
 
@@ -25,6 +25,7 @@ herdr integration install kilo
 herdr integration install hermes
 herdr integration install qodercli
 herdr integration install cursor
+herdr integration install codebuddy
 ```
 
 ## Uninstall integrations
@@ -43,6 +44,7 @@ herdr integration uninstall kilo
 herdr integration uninstall hermes
 herdr integration uninstall qodercli
 herdr integration uninstall cursor
+herdr integration uninstall codebuddy
 ```
 
 ## How Herdr uses integrations
@@ -51,14 +53,14 @@ Herdr uses integrations in two different ways:
 
 | Integration type | Agents | Effect |
 | --- | --- | --- |
-| Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
+| Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, CodeBuddy | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
 | Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
 
 Custom socket integrations can also report state when they define state that is not visible in the native terminal UI.
 
-Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Cursor Agent CLI, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, and Kilo Code CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
+Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Cursor Agent CLI, GitHub Copilot CLI, CodeBuddy, Pi, OMP, Hermes Agent, OpenCode, and Kilo Code CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
 
-Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Cursor Agent CLI version `1`, OpenCode version `5`, Kilo Code CLI version `1`, or Hermes Agent version `2`. Check installed versions with `herdr integration status`.
+Native session restore requires current Herdr integrations: Pi integration version `2`, OMP version `3`, Claude Code version `6`, Codex version `5`, GitHub Copilot CLI version `2`, Devin CLI version `2`, Droid version `2`, Kimi Code CLI version `3`, Qoder CLI version `2`, Cursor Agent CLI version `1`, CodeBuddy version `3`, OpenCode version `5`, Kilo Code CLI version `1`, or Hermes Agent version `2`. Check installed versions with `herdr integration status`.
 
 ## Pi
 
@@ -239,6 +241,20 @@ The hook reports session identity through Cursor's `sessionStart` hook while Cur
 Herdr uses `~/.cursor` by default, or `CURSOR_CONFIG_DIR` when set. The Cursor config directory must already exist. Install writes `herdr-agent-state.sh` and adds a Herdr `sessionStart` entry to `hooks.json`. Uninstall removes the matching hook entry and deletes the hook script.
 
 After Cursor emits a session start event, Herdr can use the reported session id to resume the pane with `cursor-agent --resume <id>`. The `cursor-agent` command must be on `PATH` when Herdr restores the pane; Herdr does not launch the generic `agent` command.
+
+## CodeBuddy
+
+Install the CodeBuddy hook:
+
+```bash
+herdr integration install codebuddy
+```
+
+The CodeBuddy hook reports session identity and lifecycle state through the same local socket API used by other integrations. When installed, the hook is the lifecycle authority for `idle`, `working`, and `blocked`; Herdr does not also use screen manifest fallback for that authority.
+
+Herdr uses `~/.codebuddy` by default, or `CODEBUDDY_HOME` when set. The CodeBuddy config directory must already exist. Install writes `hooks/herdr-agent-state.sh`, updates `settings.json` hooks, and registers `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `Stop`, and `Notification` hook entries. Uninstall removes Herdr entries from `settings.json` and deletes the hook script.
+
+After CodeBuddy emits a session-bearing event, Herdr can use the reported session id to resume the pane with `codebuddy --resume <id>`.
 
 ## Custom status labels
 

--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -26,6 +26,7 @@ pub enum IntegrationTarget {
     Hermes,
     Qodercli,
     Cursor,
+    Codebuddy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -103,13 +103,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|codebuddy>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|codebuddy>"
         );
         return Ok(None);
     }
@@ -128,10 +128,11 @@ fn parse_integration_target(
         "hermes" => IntegrationTarget::Hermes,
         "qodercli" => IntegrationTarget::Qodercli,
         "cursor" => IntegrationTarget::Cursor,
+        "codebuddy" => IntegrationTarget::Codebuddy,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, codebuddy"
             );
             return Ok(None);
         }
@@ -155,6 +156,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install hermes");
     eprintln!("  herdr integration install qodercli");
     eprintln!("  herdr integration install cursor");
+    eprintln!("  herdr integration install codebuddy");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -168,5 +170,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall hermes");
     eprintln!("  herdr integration uninstall qodercli");
     eprintln!("  herdr integration uninstall cursor");
+    eprintln!("  herdr integration uninstall codebuddy");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -137,6 +137,7 @@ impl AgentSoundOverrides {
             Some(Agent::Hermes) => self.hermes,
             Some(Agent::Kilo) => self.kilo,
             Some(Agent::Qodercli) => self.qodercli,
+            Some(Agent::Codebuddy) => AgentSoundSetting::Default,
             None => AgentSoundSetting::Default,
         }
     }

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -255,6 +255,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("pi", include_str!("manifests/pi.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),
     ("copilot", include_str!("manifests/github-copilot.toml")),
+    ("codebuddy", include_str!("manifests/codebuddy.toml")),
 ];
 
 static MANIFEST_CACHE: OnceLock<RwLock<ManifestCache>> = OnceLock::new();

--- a/src/detect/manifests/codebuddy.toml
+++ b/src/detect/manifests/codebuddy.toml
@@ -1,0 +1,31 @@
+id = "codebuddy"
+version = "2026.07.06.5"
+min_engine_version = 1
+updated_at = "2026-07-06T00:00:00Z"
+
+[[rules]]
+id = "confirmation_blocked"
+state = "blocked"
+priority = 300
+region = "whole_recent"
+visible_blocker = true
+all = [
+  { contains = ["Enter to select"] },
+  { any = [{ contains = ["↑/↓ to navigate"] }, { contains = ["Esc to cancel"] }] },
+]
+
+[[rules]]
+id = "prompt_idle"
+state = "idle"
+priority = 200
+region = "whole_recent"
+visible_idle = true
+line_regex = ['^\s*> .+↵ send$']
+
+[[rules]]
+id = "working_catchall"
+state = "working"
+priority = 50
+region = "whole_recent"
+visible_working = true
+regex = ['(?s).+']

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -60,10 +60,11 @@ pub enum Agent {
     Hermes,
     Kilo,
     Qodercli,
+    Codebuddy,
 }
 
 impl Agent {
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 18] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -82,6 +83,7 @@ impl Agent {
         Self::Hermes,
         Self::Kilo,
         Self::Qodercli,
+        Self::Codebuddy,
     ];
 }
 
@@ -106,6 +108,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Hermes => "hermes",
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
+        Agent::Codebuddy => "codebuddy",
     }
 }
 
@@ -131,6 +134,7 @@ pub fn parse_agent_label(agent: &str) -> Option<Agent> {
         "hermes" | "hermes-agent" => Some(Agent::Hermes),
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
+        "codebuddy" => Some(Agent::Codebuddy),
         _ => None,
     }
 }
@@ -160,6 +164,7 @@ pub fn identify_agent(process_name: &str) -> Option<Agent> {
         "hermes" | "hermes-agent" => Some(Agent::Hermes),
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
+        "codebuddy" => Some(Agent::Codebuddy),
         _ => None,
     }
 }

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -2,11 +2,12 @@ use std::io;
 
 use super::registry::{integration_target_label, integration_target_supported};
 use super::targets::{
-    install_claude, install_codex, install_copilot, install_cursor, install_devin, install_droid,
-    install_hermes, install_kilo, install_kimi, install_omp, install_opencode, install_pi,
-    install_qodercli, uninstall_claude, uninstall_codex, uninstall_copilot, uninstall_cursor,
-    uninstall_devin, uninstall_droid, uninstall_hermes, uninstall_kilo, uninstall_kimi,
-    uninstall_omp, uninstall_opencode, uninstall_pi, uninstall_qodercli,
+    install_claude, install_codebuddy, install_codex, install_copilot, install_cursor,
+    install_devin, install_droid, install_hermes, install_kilo, install_kimi, install_omp,
+    install_opencode, install_pi, install_qodercli, uninstall_claude, uninstall_codebuddy,
+    uninstall_codex, uninstall_copilot, uninstall_cursor, uninstall_devin, uninstall_droid,
+    uninstall_hermes, uninstall_kilo, uninstall_kimi, uninstall_omp, uninstall_opencode,
+    uninstall_pi, uninstall_qodercli,
 };
 use super::version::{agent_version_requirement, enforce_agent_version};
 use super::{KIMI_MIN_VERSION, PI_EXTENSION_INSTALL_NAME};
@@ -188,6 +189,19 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                     installed.hook_path.display()
                 ),
                 format!("updated cursor hooks at {}", installed.hooks_path.display()),
+            ]
+        }
+        crate::api::schema::IntegrationTarget::Codebuddy => {
+            let installed = install_codebuddy()?;
+            vec![
+                format!(
+                    "installed codebuddy integration hook to {}",
+                    installed.hook_path.display()
+                ),
+                format!(
+                    "ensured codebuddy settings at {}",
+                    installed.settings_path.display()
+                ),
             ]
         }
     };
@@ -513,6 +527,33 @@ pub(crate) fn uninstall_target(
                 messages.push(format!(
                     "no herdr cursor hook entries found in {}",
                     result.hooks_path.display()
+                ));
+            }
+            messages
+        }
+        crate::api::schema::IntegrationTarget::Codebuddy => {
+            let result = uninstall_codebuddy()?;
+            let mut messages = Vec::new();
+            if result.removed_hook_file {
+                messages.push(format!(
+                    "removed codebuddy hook at {}",
+                    result.hook_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no codebuddy hook found at {}",
+                    result.hook_path.display()
+                ));
+            }
+            if result.updated_settings {
+                messages.push(format!(
+                    "removed herdr codebuddy hook entries from {}",
+                    result.settings_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no herdr codebuddy hook entries found in {}",
+                    result.settings_path.display()
                 ));
             }
             messages

--- a/src/integration/assets/codebuddy/herdr-agent-state.ps1
+++ b/src/integration/assets/codebuddy/herdr-agent-state.ps1
@@ -1,0 +1,79 @@
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=codebuddy
+# HERDR_INTEGRATION_VERSION=3
+
+param([string]$Action = "")
+
+if ($Action -notin @("session", "working", "blocked", "idle")) { exit 0 }
+if ($env:HERDR_ENV -ne "1") { exit 0 }
+if ([string]::IsNullOrWhiteSpace($env:HERDR_PANE_ID)) { exit 0 }
+
+$inputText = [Console]::In.ReadToEnd()
+try {
+    $payload = if ([string]::IsNullOrWhiteSpace($inputText)) { $null } else { $inputText | ConvertFrom-Json }
+} catch {
+    exit 0
+}
+
+$hookEventName = "$($payload.hook_event_name)"
+$sessionId = $payload.session_id
+$seq = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+
+function Send-HerdrRequest {
+    param(
+        [string]$Method,
+        [hashtable]$Params
+    )
+    try {
+        $args = @(
+            "pane",
+            $Method,
+            $env:HERDR_PANE_ID
+        )
+        foreach ($key in @("source", "agent", "state", "seq", "agent-session-id", "session-start-source")) {
+            if ($Params.ContainsKey($key)) {
+                $args += @("--$key", "$($Params[$key])")
+            }
+        }
+        & herdr @args 2>$null | Out-Null
+    } catch {
+    }
+}
+
+if ($Action -eq "session") {
+    if ($hookEventName -and $hookEventName -ne "SessionStart") { exit 0 }
+    if ([string]::IsNullOrWhiteSpace($sessionId)) { exit 0 }
+    $sessionParams = @{
+        source = "herdr:codebuddy"
+        agent = "codebuddy"
+        seq = $seq
+        "agent-session-id" = $sessionId
+    }
+    if ($hookEventName -eq "SessionStart" -and $payload.source -is [string] -and -not [string]::IsNullOrWhiteSpace($payload.source)) {
+        $sessionParams["session-start-source"] = "$($payload.source)"
+    }
+    Send-HerdrRequest -Method "report-agent-session" -Params $sessionParams
+    # Also report idle state so Herdr treats the hook as the lifecycle
+    # authority immediately instead of falling back to screen detection.
+    $idleParams = @{
+        source = "herdr:codebuddy"
+        agent = "codebuddy"
+        state = "idle"
+        seq = $seq + 1
+        "agent-session-id" = $sessionId
+    }
+    Send-HerdrRequest -Method "report-agent" -Params $idleParams
+} else {
+    $stateParams = @{
+        source = "herdr:codebuddy"
+        agent = "codebuddy"
+        state = $Action
+        seq = $seq
+    }
+    if (-not [string]::IsNullOrWhiteSpace($sessionId)) {
+        $stateParams["agent-session-id"] = $sessionId
+    }
+    Send-HerdrRequest -Method "report-agent" -Params $stateParams
+}

--- a/src/integration/assets/codebuddy/herdr-agent-state.sh
+++ b/src/integration/assets/codebuddy/herdr-agent-state.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=codebuddy
+# HERDR_INTEGRATION_VERSION=3
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-codebuddy-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session|working|blocked|idle) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:codebuddy"
+agent = "codebuddy"
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+hook_event_name = str(hook_input.get("hook_event_name") or "")
+session_id = hook_input.get("session_id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+
+if action == "session":
+    if hook_event_name and hook_event_name != "SessionStart":
+        raise SystemExit(0)
+    if not agent_session_id:
+        raise SystemExit(0)
+    session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
+    if not isinstance(session_start_source, str) or not session_start_source:
+        session_start_source = None
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": agent,
+        "agent_session_id": agent_session_id,
+        "seq": report_seq,
+    }
+    if session_start_source:
+        params["session_start_source"] = session_start_source
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+    # Also report idle state so Herdr treats the hook as the lifecycle
+    # authority immediately instead of falling back to screen detection.
+    state_request = {
+        "id": f"{source}:idle:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}",
+        "method": "pane.report_agent",
+        "params": {
+            "pane_id": pane_id,
+            "source": source,
+            "agent": agent,
+            "state": "idle",
+            "seq": report_seq + 1,
+            "agent_session_id": agent_session_id,
+        },
+    }
+    for req in (request, state_request):
+        try:
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.settimeout(0.5)
+            client.connect(socket_path)
+            client.sendall((json.dumps(req) + "\n").encode())
+            try:
+                client.recv(4096)
+            except Exception:
+                pass
+            client.close()
+        except Exception:
+            pass
+    raise SystemExit(0)
+else:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": agent,
+        "state": action,
+        "seq": report_seq,
+    }
+    if agent_session_id:
+        params["agent_session_id"] = agent_session_id
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent",
+        "params": params,
+    }
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -16,6 +16,7 @@ pub(crate) const KIMI_CODE_HOME_ENV_VAR: &str = "KIMI_CODE_HOME";
 pub(crate) const COPILOT_HOME_ENV_VAR: &str = "COPILOT_HOME";
 pub(crate) const QODERCLI_CONFIG_DIR_ENV_VAR: &str = "QODER_CONFIG_DIR";
 pub(crate) const CURSOR_CONFIG_DIR_ENV_VAR: &str = "CURSOR_CONFIG_DIR";
+pub(crate) const CODEBUDDY_HOME_ENV_VAR: &str = "CODEBUDDY_HOME";
 
 pub(crate) fn apply_pane_base_env(cmd: &mut CommandBuilder) {
     cmd.env(crate::api::SOCKET_PATH_ENV_VAR, crate::api::socket_path());
@@ -122,6 +123,10 @@ pub(crate) fn qodercli_dir() -> io::Result<PathBuf> {
 
 pub(crate) fn cursor_dir() -> io::Result<PathBuf> {
     config_dir_from_env_or_home(CURSOR_CONFIG_DIR_ENV_VAR, &[".cursor"])
+}
+
+pub(crate) fn codebuddy_dir() -> io::Result<PathBuf> {
+    config_dir_from_env_or_home(CODEBUDDY_HOME_ENV_VAR, &[".codebuddy"])
 }
 
 pub(crate) fn home_dir() -> io::Result<PathBuf> {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -179,6 +179,30 @@ const QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS: [(&str, &str); 12] = [
 const CURSOR_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const CURSOR_HOOK_ASSET: &str = include_str!("assets/cursor/herdr-agent-state.sh");
 const CURSOR_INTEGRATION_VERSION: u32 = 1;
+const CODEBUDDY_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
+    "herdr-agent-state.ps1"
+} else {
+    "herdr-agent-state.sh"
+};
+const CODEBUDDY_HOOK_ASSET: &str = if cfg!(windows) {
+    include_str!("assets/codebuddy/herdr-agent-state.ps1")
+} else {
+    include_str!("assets/codebuddy/herdr-agent-state.sh")
+};
+const CODEBUDDY_INTEGRATION_VERSION: u32 = 3;
+const CODEBUDDY_HOOK_EVENTS: [(&str, &str); 5] = [
+    ("SessionStart", "session"),
+    ("UserPromptSubmit", "working"),
+    ("PreToolUse", "working"),
+    ("Stop", "idle"),
+    ("Notification", "blocked"),
+];
+const CODEBUDDY_REMOVED_LIFECYCLE_HOOK_EVENTS: [(&str, &str); 4] = [
+    ("SessionStart", "idle"),
+    ("UserPromptSubmit", "session"),
+    ("PreToolUse", "session"),
+    ("Stop", "session"),
+];
 const INTEGRATION_VERSION_MARKER: &str = "HERDR_INTEGRATION_VERSION=";
 
 pub(crate) const INSTALL_WARNING_PREFIX: &str = "warning:";

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -21,6 +21,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Hermes => "hermes",
         crate::api::schema::IntegrationTarget::Qodercli => "qodercli",
         crate::api::schema::IntegrationTarget::Cursor => "cursor",
+        crate::api::schema::IntegrationTarget::Codebuddy => "codebuddy",
     }
 }
 
@@ -47,6 +48,7 @@ pub(crate) fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Hermes => &["hermes"],
         crate::api::schema::IntegrationTarget::Qodercli => qodercli_command_names(),
         crate::api::schema::IntegrationTarget::Cursor => cursor_command_names(),
+        crate::api::schema::IntegrationTarget::Codebuddy => &["codebuddy"],
     }
 }
 
@@ -65,6 +67,7 @@ pub(crate) fn integration_target_supported(target: crate::api::schema::Integrati
                 | crate::api::schema::IntegrationTarget::Droid
                 | crate::api::schema::IntegrationTarget::Kimi
                 | crate::api::schema::IntegrationTarget::Qodercli
+                | crate::api::schema::IntegrationTarget::Codebuddy
         )
     }
 
@@ -251,7 +254,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 13] {
+); 14] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -320,6 +323,11 @@ fn integration_specs() -> [(
             crate::api::schema::IntegrationTarget::Cursor,
             cursor_dir().map(|dir| dir.join(super::CURSOR_HOOK_INSTALL_NAME)),
             super::CURSOR_INTEGRATION_VERSION,
+        ),
+        (
+            crate::api::schema::IntegrationTarget::Codebuddy,
+            codebuddy_dir().map(|dir| dir.join("hooks").join(super::CODEBUDDY_HOOK_INSTALL_NAME)),
+            super::CODEBUDDY_INTEGRATION_VERSION,
         ),
     ]
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -13,25 +13,26 @@ use super::config_edit::{
     remove_simple_command_hook,
 };
 use super::env::{
-    claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir, hermes_dir,
-    hermes_plugin_dir, kilo_dir, kimi_dir, omp_extension_dir, opencode_dir, pi_extension_dir,
-    qodercli_dir,
+    claude_dir, codebuddy_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir,
+    hermes_dir, hermes_plugin_dir, kilo_dir, kimi_dir, omp_extension_dir, opencode_dir,
+    pi_extension_dir, qodercli_dir,
 };
 use super::file_ops::{
     make_executable, remove_dir_all_if_exists, remove_file_if_exists, remove_legacy_bash_hook_file,
 };
 use super::types::{
-    ClaudeInstallPaths, ClaudeUninstallResult, CodexInstallPaths, CodexUninstallResult,
-    CopilotInstallPaths, CopilotUninstallResult, CursorInstallPaths, CursorUninstallResult,
-    DevinInstallPaths, DevinUninstallResult, DroidInstallPaths, DroidUninstallResult,
-    HermesInstallPaths, HermesUninstallResult, KiloInstallPaths, KiloUninstallResult,
-    KimiInstallPaths, KimiUninstallResult, OmpInstallPaths, OmpUninstallResult,
-    OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult, QodercliInstallPaths,
-    QodercliUninstallResult,
+    ClaudeInstallPaths, ClaudeUninstallResult, CodebuddyInstallPaths, CodebuddyUninstallResult,
+    CodexInstallPaths, CodexUninstallResult, CopilotInstallPaths, CopilotUninstallResult,
+    CursorInstallPaths, CursorUninstallResult, DevinInstallPaths, DevinUninstallResult,
+    DroidInstallPaths, DroidUninstallResult, HermesInstallPaths, HermesUninstallResult,
+    KiloInstallPaths, KiloUninstallResult, KimiInstallPaths, KimiUninstallResult, OmpInstallPaths,
+    OmpUninstallResult, OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult,
+    QodercliInstallPaths, QodercliUninstallResult,
 };
 use super::{
-    CLAUDE_HOOK_ASSET, CLAUDE_HOOK_INSTALL_NAME, CODEX_HOOK_ASSET, CODEX_HOOK_INSTALL_NAME,
-    COPILOT_HOOK_ASSET, COPILOT_HOOK_EVENTS, COPILOT_HOOK_INSTALL_NAME,
+    CLAUDE_HOOK_ASSET, CLAUDE_HOOK_INSTALL_NAME, CODEBUDDY_HOOK_ASSET, CODEBUDDY_HOOK_EVENTS,
+    CODEBUDDY_HOOK_INSTALL_NAME, CODEBUDDY_REMOVED_LIFECYCLE_HOOK_EVENTS, CODEX_HOOK_ASSET,
+    CODEX_HOOK_INSTALL_NAME, COPILOT_HOOK_ASSET, COPILOT_HOOK_EVENTS, COPILOT_HOOK_INSTALL_NAME,
     COPILOT_REMOVED_LIFECYCLE_HOOK_EVENTS, CURSOR_HOOK_ASSET, CURSOR_HOOK_INSTALL_NAME,
     DEVIN_HOOK_ASSET, DEVIN_HOOK_EVENTS, DEVIN_HOOK_INSTALL_NAME,
     DEVIN_REMOVED_LIFECYCLE_HOOK_EVENTS, DROID_HOOK_ASSET, DROID_HOOK_EVENTS,
@@ -223,6 +224,65 @@ pub(crate) fn install_codex() -> io::Result<CodexInstallPaths> {
         hook_path,
         hooks_path,
         config_path,
+    })
+}
+
+pub(crate) fn install_codebuddy() -> io::Result<CodebuddyInstallPaths> {
+    let dir = codebuddy_dir()?;
+    if !dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "codebuddy directory not found at {}. install codebuddy first",
+            dir.display()
+        )));
+    }
+
+    let hooks_dir = dir.join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+
+    let hook_path = hooks_dir.join(CODEBUDDY_HOOK_INSTALL_NAME);
+    fs::write(&hook_path, CODEBUDDY_HOOK_ASSET)?;
+    make_executable(&hook_path)?;
+
+    let settings_path = dir.join("settings.json");
+    let mut settings = if settings_path.is_file() {
+        serde_json::from_str::<Value>(&fs::read_to_string(&settings_path)?).map_err(|err| {
+            io::Error::other(format!(
+                "failed to parse {}: {err}",
+                settings_path.display()
+            ))
+        })?
+    } else {
+        json!({})
+    };
+
+    let hooks = ensure_hooks_object(
+        &mut settings,
+        &settings_path,
+        "codebuddy settings",
+        "codebuddy settings hooks",
+    )?;
+    for (event, action) in CODEBUDDY_REMOVED_LIFECYCLE_HOOK_EVENTS {
+        remove_hook_commands(hooks, event, &hook_path, Some(action))?;
+    }
+    for (event, action) in CODEBUDDY_HOOK_EVENTS {
+        remove_hook_commands(hooks, event, &hook_path, Some(action))?;
+    }
+    for (event, action) in CODEBUDDY_HOOK_EVENTS {
+        ensure_command_hook(
+            hooks,
+            event,
+            hook_command(&hook_path, Some(action)),
+            10,
+            Some("*"),
+        )?;
+    }
+    remove_legacy_bash_hook_file(&hook_path)?;
+
+    fs::write(&settings_path, serde_json::to_string_pretty(&settings)?)?;
+
+    Ok(CodebuddyInstallPaths {
+        hook_path,
+        settings_path,
     })
 }
 
@@ -655,6 +715,52 @@ pub(crate) fn uninstall_codex() -> io::Result<CodexUninstallResult> {
         config_path,
         removed_hook_file,
         updated_hooks,
+    })
+}
+
+pub(crate) fn uninstall_codebuddy() -> io::Result<CodebuddyUninstallResult> {
+    let codebuddy_dir = codebuddy_dir()?;
+    let hooks_dir = codebuddy_dir.join("hooks");
+    let hook_path = hooks_dir.join(CODEBUDDY_HOOK_INSTALL_NAME);
+    let settings_path = codebuddy_dir.join("settings.json");
+    let mut updated_settings = false;
+
+    if settings_path.is_file() {
+        let mut settings = serde_json::from_str::<Value>(&fs::read_to_string(&settings_path)?)
+            .map_err(|err| {
+                io::Error::other(format!(
+                    "failed to parse {}: {err}",
+                    settings_path.display()
+                ))
+            })?;
+
+        if let Some(hooks) = hooks_object_if_present(
+            &mut settings,
+            &settings_path,
+            "codebuddy settings",
+            "codebuddy settings hooks",
+        )? {
+            for (event, action) in CODEBUDDY_REMOVED_LIFECYCLE_HOOK_EVENTS {
+                updated_settings |= remove_hook_commands(hooks, event, &hook_path, Some(action))?;
+            }
+            for (event, action) in CODEBUDDY_HOOK_EVENTS {
+                updated_settings |= remove_hook_commands(hooks, event, &hook_path, Some(action))?;
+            }
+        }
+
+        if updated_settings {
+            fs::write(&settings_path, serde_json::to_string_pretty(&settings)?)?;
+        }
+    }
+
+    let removed_hook_file =
+        remove_file_if_exists(&hook_path)? | remove_legacy_bash_hook_file(&hook_path)?;
+
+    Ok(CodebuddyUninstallResult {
+        hook_path,
+        settings_path,
+        removed_hook_file,
+        updated_settings,
     })
 }
 

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -1321,6 +1321,266 @@ fn install_codex_errors_when_config_dir_missing() {
 }
 
 #[test]
+fn install_codebuddy_writes_hook_and_updates_settings() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let codebuddy_dir = base.join(".codebuddy");
+    fs::create_dir_all(&codebuddy_dir).unwrap();
+    fs::write(
+        codebuddy_dir.join("settings.json"),
+        r#"{"permissions":{"allow":["Read"]},"hooks":{}}"#,
+    )
+    .unwrap();
+    std::env::set_var(CODEBUDDY_HOME_ENV_VAR, &codebuddy_dir);
+
+    let installed = install_codebuddy().unwrap();
+    let hook_content = fs::read_to_string(&installed.hook_path).unwrap();
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(&installed.settings_path).unwrap()).unwrap();
+
+    assert_eq!(
+        installed.hook_path,
+        codebuddy_dir
+            .join("hooks")
+            .join(CODEBUDDY_HOOK_INSTALL_NAME)
+    );
+    assert_eq!(installed.settings_path, codebuddy_dir.join("settings.json"));
+    assert_eq!(hook_content, CODEBUDDY_HOOK_ASSET);
+    assert!(settings["permissions"]["allow"].is_array());
+    for (event, _) in CODEBUDDY_HOOK_EVENTS {
+        assert!(
+            settings["hooks"].get(event).is_some(),
+            "expected hooks.{event} to be registered"
+        );
+        let command = settings["hooks"][event][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(
+            command.contains(CODEBUDDY_HOOK_INSTALL_NAME),
+            "expected codebuddy {event} hook command to reference hook script"
+        );
+    }
+
+    std::env::remove_var(CODEBUDDY_HOME_ENV_VAR);
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_codebuddy_uses_codebuddy_home_env() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let codebuddy_dir = base.join("custom-codebuddy");
+    fs::create_dir_all(&codebuddy_dir).unwrap();
+    std::env::set_var(CODEBUDDY_HOME_ENV_VAR, &codebuddy_dir);
+
+    let installed = install_codebuddy().unwrap();
+
+    assert_eq!(installed.settings_path, codebuddy_dir.join("settings.json"));
+    assert_eq!(
+        installed.hook_path,
+        codebuddy_dir
+            .join("hooks")
+            .join(CODEBUDDY_HOOK_INSTALL_NAME)
+    );
+
+    clear_integration_path_env();
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_codebuddy_is_idempotent_for_hook_entries() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let codebuddy_dir = base.join(".codebuddy");
+    fs::create_dir_all(&codebuddy_dir).unwrap();
+    std::env::set_var(CODEBUDDY_HOME_ENV_VAR, &codebuddy_dir);
+
+    install_codebuddy().unwrap();
+    install_codebuddy().unwrap();
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(codebuddy_dir.join("settings.json")).unwrap())
+            .unwrap();
+    for (event, _) in CODEBUDDY_HOOK_EVENTS {
+        let entries = settings["hooks"]
+            .get(event)
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("expected hooks.{event} to be present"));
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected hooks.{event} to contain exactly one entry, got {entries:?}"
+        );
+    }
+
+    std::env::remove_var(CODEBUDDY_HOME_ENV_VAR);
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_codebuddy_removes_old_state_hook_entries_and_preserves_user_hooks() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let codebuddy_dir = base.join(".codebuddy");
+    let hooks_dir = codebuddy_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    let hook_path = hooks_dir.join(CODEBUDDY_HOOK_INSTALL_NAME);
+    let settings = serde_json::json!({
+        "hooks": {
+            "UserPromptSubmit": [{
+                "matcher": "*",
+                "hooks": [
+                    {"type": "command", "command": format!("bash '{}' working", hook_path.display()), "timeout": 10},
+                    {"type": "command", "command": "echo keep-user", "timeout": 10}
+                ]
+            }],
+            "Stop": [{
+                "matcher": "*",
+                "hooks": [
+                    {"type": "command", "command": format!("bash '{}' idle", hook_path.display()), "timeout": 10},
+                    {"type": "command", "command": "echo keep-stop", "timeout": 10}
+                ]
+            }]
+        }
+    });
+    fs::write(
+        codebuddy_dir.join("settings.json"),
+        serde_json::to_string_pretty(&settings).unwrap(),
+    )
+    .unwrap();
+    std::env::set_var(CODEBUDDY_HOME_ENV_VAR, &codebuddy_dir);
+
+    install_codebuddy().unwrap();
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(codebuddy_dir.join("settings.json")).unwrap())
+            .unwrap();
+    // User hooks inside the same matcher array as herdr hooks are preserved.
+    assert_eq!(
+        settings["hooks"]["UserPromptSubmit"][0]["hooks"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        settings["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        "echo keep-user"
+    );
+    assert_eq!(
+        settings["hooks"]["Stop"][0]["hooks"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        settings["hooks"]["Stop"][0]["hooks"][0]["command"],
+        "echo keep-stop"
+    );
+    // UserPromptSubmit keeps user hook in its own matcher entry; install adds
+    // a separate herdr matcher entry alongside it.
+    assert_eq!(
+        settings["hooks"]["UserPromptSubmit"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+    // Stop also had a user hook entry; install adds a herdr entry alongside.
+    assert_eq!(settings["hooks"]["Stop"].as_array().unwrap().len(), 2);
+    // Events that only had herdr hooks are reduced to exactly one herdr entry.
+    for (event, _) in CODEBUDDY_HOOK_EVENTS {
+        if event == "UserPromptSubmit" || event == "Stop" {
+            continue;
+        }
+        assert_eq!(
+            settings["hooks"][event].as_array().unwrap().len(),
+            1,
+            "expected hooks.{event} to have exactly one entry after install"
+        );
+    }
+
+    std::env::remove_var(CODEBUDDY_HOME_ENV_VAR);
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn uninstall_codebuddy_removes_herdr_hooks_and_preserves_others() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let codebuddy_dir = base.join(".codebuddy");
+    let hooks_dir = codebuddy_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    let hook_path = hooks_dir.join(CODEBUDDY_HOOK_INSTALL_NAME);
+    fs::write(&hook_path, CODEBUDDY_HOOK_ASSET).unwrap();
+    let mut settings = serde_json::json!({
+        "hooks": {}
+    });
+    for (event, action) in CODEBUDDY_HOOK_EVENTS {
+        settings["hooks"][event] = serde_json::json!([{
+            "matcher": "*",
+            "hooks": [
+                {"type": "command", "command": format!("bash '{}' {}", hook_path.display(), action), "timeout": 10},
+                {"type": "command", "command": format!("echo keep-{}", event), "timeout": 10}
+            ]
+        }]);
+    }
+    fs::write(
+        codebuddy_dir.join("settings.json"),
+        serde_json::to_string_pretty(&settings).unwrap(),
+    )
+    .unwrap();
+    std::env::set_var(CODEBUDDY_HOME_ENV_VAR, &codebuddy_dir);
+
+    let result = uninstall_codebuddy().unwrap();
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(codebuddy_dir.join("settings.json")).unwrap())
+            .unwrap();
+
+    assert!(result.removed_hook_file);
+    assert!(result.updated_settings);
+    assert!(!result.hook_path.exists());
+    // Herdr hook entries are removed, but user hooks (echo keep-...) remain.
+    for (event, _) in CODEBUDDY_HOOK_EVENTS {
+        let entries = settings["hooks"]
+            .get(event)
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("expected hooks.{event} to remain with user hook"));
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected hooks.{event} to keep user hook only"
+        );
+        assert_eq!(
+            entries[0]["hooks"][0]["command"],
+            format!("echo keep-{}", event)
+        );
+    }
+
+    std::env::remove_var(CODEBUDDY_HOME_ENV_VAR);
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
+fn install_codebuddy_errors_when_config_dir_missing() {
+    let _lock = integration_env_lock();
+    let base = unique_base();
+    let missing = base.join(".codebuddy");
+    std::env::set_var(CODEBUDDY_HOME_ENV_VAR, &missing);
+
+    let err = install_codebuddy().unwrap_err().to_string();
+
+    assert!(
+        err.contains("codebuddy directory not found"),
+        "unexpected error: {err}"
+    );
+
+    std::env::remove_var(CODEBUDDY_HOME_ENV_VAR);
+    let _ = fs::remove_dir_all(base);
+}
+
+#[test]
 fn install_kimi_writes_hook_and_updates_config() {
     let _lock = integration_env_lock();
     let base = unique_base();

--- a/src/integration/types.rs
+++ b/src/integration/types.rs
@@ -213,3 +213,17 @@ pub(crate) struct HermesUninstallResult {
     pub removed_plugin_dir: bool,
     pub updated_config: bool,
 }
+
+#[derive(Debug)]
+pub(crate) struct CodebuddyInstallPaths {
+    pub hook_path: PathBuf,
+    pub settings_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct CodebuddyUninstallResult {
+    pub hook_path: PathBuf,
+    pub settings_path: PathBuf,
+    pub removed_hook_file: bool,
+    pub updated_settings: bool,
+}

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -522,7 +522,7 @@ impl FrameData {
                     fg: color_to_u32(cell.fg),
                     bg: color_to_u32(cell.bg),
                     modifier: modifier_to_u16(cell.modifier),
-                    skip: cell.skip,
+                    skip: cell.diff_option == ratatui::buffer::CellDiffOption::Skip,
                     hyperlink,
                 });
             }
@@ -560,7 +560,11 @@ impl FrameData {
                 cell.fg = u32_to_color(cell_data.fg);
                 cell.bg = u32_to_color(cell_data.bg);
                 cell.modifier = u16_to_modifier(cell_data.modifier);
-                cell.skip = cell_data.skip;
+                cell.set_diff_option(if cell_data.skip {
+                    ratatui::buffer::CellDiffOption::Skip
+                } else {
+                    ratatui::buffer::CellDiffOption::None
+                });
             }
         }
 

--- a/tests/cli_wrapper.rs
+++ b/tests/cli_wrapper.rs
@@ -682,6 +682,96 @@ fn codex_hook_reports_session_id_from_stdin() {
     assert!(request["params"].get("state").is_none());
 }
 
+fn run_codebuddy_hook(action: &str, hook_input: &str) -> Option<serde_json::Value> {
+    run_shell_hook(
+        "src/integration/assets/codebuddy/herdr-agent-state.sh",
+        &[action],
+        hook_input,
+    )
+}
+
+#[test]
+fn codebuddy_hook_reports_session_id_from_stdin() {
+    let request = run_codebuddy_hook(
+        "session",
+        r#"{"hook_event_name":"SessionStart","session_id":"codebuddy-session"}"#,
+    )
+    .expect("codebuddy hook should report session identity");
+
+    assert_eq!(request["method"], "pane.report_agent_session");
+    assert_eq!(request["params"]["agent_session_id"], "codebuddy-session");
+    assert_eq!(request["params"]["agent"], "codebuddy");
+    assert!(request["params"].get("state").is_none());
+}
+
+#[test]
+fn codebuddy_hook_reports_working_state() {
+    let request = run_codebuddy_hook(
+        "working",
+        r#"{"hook_event_name":"UserPromptSubmit","session_id":"codebuddy-session","prompt":"hi"}"#,
+    )
+    .expect("codebuddy hook should report working state");
+
+    assert_eq!(request["method"], "pane.report_agent_session");
+    assert_eq!(request["params"]["state"], "working");
+    assert_eq!(request["params"]["agent"], "codebuddy");
+    assert_eq!(request["params"]["agent_session_id"], "codebuddy-session");
+}
+
+#[test]
+fn codebuddy_hook_reports_idle_state_on_stop() {
+    let request = run_codebuddy_hook(
+        "idle",
+        r#"{"hook_event_name":"Stop","session_id":"codebuddy-session","stop_hook_active":false}"#,
+    )
+    .expect("codebuddy hook should report idle state on Stop");
+
+    assert_eq!(request["method"], "pane.report_agent_session");
+    assert_eq!(request["params"]["state"], "idle");
+    assert_eq!(request["params"]["agent"], "codebuddy");
+}
+
+#[test]
+fn codebuddy_hook_reports_blocked_state_on_notification() {
+    let request = run_codebuddy_hook(
+        "blocked",
+        r#"{"hook_event_name":"Notification","session_id":"codebuddy-session"}"#,
+    )
+    .expect("codebuddy hook should report blocked state on Notification");
+
+    assert_eq!(request["method"], "pane.report_agent_session");
+    assert_eq!(request["params"]["state"], "blocked");
+    assert_eq!(request["params"]["agent"], "codebuddy");
+}
+
+#[test]
+fn codebuddy_hook_session_ignores_non_session_start_events() {
+    assert!(run_codebuddy_hook(
+        "session",
+        r#"{"hook_event_name":"UserPromptSubmit","session_id":"codebuddy-session"}"#
+    )
+    .is_none());
+    assert!(run_codebuddy_hook(
+        "session",
+        r#"{"hook_event_name":"Stop","session_id":"codebuddy-session"}"#
+    )
+    .is_none());
+}
+
+#[test]
+fn codebuddy_hook_ignores_unknown_actions() {
+    assert!(run_codebuddy_hook(
+        "release",
+        r#"{"hook_event_name":"SessionEnd","session_id":"codebuddy-session"}"#
+    )
+    .is_none());
+    assert!(run_codebuddy_hook(
+        "unknown",
+        r#"{"hook_event_name":"Foo","session_id":"codebuddy-session"}"#
+    )
+    .is_none());
+}
+
 #[test]
 fn copilot_hook_reports_session_id_from_stdin() {
     let request = run_copilot_hook(

--- a/website/agent-detection/codebuddy.toml
+++ b/website/agent-detection/codebuddy.toml
@@ -1,0 +1,31 @@
+id = "codebuddy"
+version = "2026.07.06.5"
+min_engine_version = 1
+updated_at = "2026-07-06T00:00:00Z"
+
+[[rules]]
+id = "confirmation_blocked"
+state = "blocked"
+priority = 300
+region = "whole_recent"
+visible_blocker = true
+all = [
+  { contains = ["Enter to select"] },
+  { any = [{ contains = ["↑/↓ to navigate"] }, { contains = ["Esc to cancel"] }] },
+]
+
+[[rules]]
+id = "prompt_idle"
+state = "idle"
+priority = 200
+region = "whole_recent"
+visible_idle = true
+line_regex = ['^\s*> .+↵ send$']
+
+[[rules]]
+id = "working_catchall"
+state = "working"
+priority = 50
+region = "whole_recent"
+visible_working = true
+regex = ['(?s).+']

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -13,6 +13,10 @@ id = "claude"
 path = "claude.toml"
 
 [[agents]]
+id = "codebuddy"
+path = "codebuddy.toml"
+
+[[agents]]
 id = "cline"
 path = "cline.toml"
 


### PR DESCRIPTION
## Description

Adds CodeBuddy as a first-class agent integration target alongside existing agents (Claude Code, Codex, Grok, etc.).

## Motivation

CodeBuddy is a coding agent that lacked Herdr integration. Users running CodeBuddy inside Herdr panes had no detection, status reporting, or integration plumbing. This adds the same level of support that other agents already have.

## Changes

- **Detection manifest** (`src/detect/manifests/codebuddy.toml`): encodes CodeBuddy screen states for agent detection
- **Integration target** (`src/integration/`): wires CodeBuddy into the integration registry, env construction, actions, and target types
- **Agent-state helper scripts**: `src/integration/assets/codebuddy/herdr-agent-state.sh` (POSIX) and `herdr-agent-state.ps1` (PowerShell) for reporting agent state back to Herdr
- **CLI integration plumbing** (`src/cli/integration.rs`): registers CodeBuddy in the CLI integration surface
- **Schema** (`src/api/schema/integrations.rs`, `docs/next/api/herdr-api.schema.json`): adds the `codebuddy` integration field
- **Docs** (`docs/next/website/src/content/docs/agents.mdx`, `integrations.mdx`, `docs/next/README.md`): lists CodeBuddy in the agents and integrations pages
- **Website agent-detection** (`website/agent-detection/codebuddy.toml`, `index.toml`): publishes the CodeBuddy detection manifest
- **Tests** (`src/integration/tests.rs`, `tests/cli_wrapper.rs`): unit and CLI wrapper tests for the new integration

Also includes a prerequisite build fix:
- `fix: migrate cell skip field to celloption` — ratatui 0.30.1 deprecated `Cell::skip` in favor of `CellDiffOption`; migrated the wire-protocol encode/decode so `cargo install` against latest 0.30.x stays warning-free.

## Testing

- [x] `cargo fmt --check` passes
- [x] `cargo nextest run` passes (2448 tests, 0 failed)
- [x] New integration tests pass locally
- [x] `cargo build` clean with no deprecation warnings

## Notes

- This is a first-time contribution from this account. I read CONTRIBUTING.md and AGENTS.md; I understand the approval gate. If a maintainer prefers I move this to a Discussion first, happy to do that instead.
- Docs updates are scoped to `docs/next/` per CONTRIBUTING.md (root README/CHANGELOG/website stable docs untouched).
- No new dependencies added; CodeBuddy integration reuses existing integration infrastructure.