### PR TITLE
feat: add opt-in repeat for prefix keybinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Prefix-mode bindings can now opt into repeat with `{ key = "prefix+p", repeat = true }`: after the action fires, tapping a prefix binding key again activates it without pressing the prefix again. Supported on `previous_tab`/`next_tab`, `previous_workspace`/`next_workspace`, `previous_agent`/`next_agent`, `cycle_pane_next`/`cycle_pane_previous`, and `swap_pane_left`/`down`/`up`/`right`. (discussions#599)
+
 ## [0.7.1] - 2026-06-24
 
 ### Added

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -41,6 +41,7 @@ impl App {
         self.state.update_dismissed = true;
 
         if self.state.is_prefix_key(raw_key) {
+            self.repeat_armed_until = None;
             if !self.pass_through_key_to_focused_pane(raw_key) {
                 leave_command_mode(&mut self.state);
             }
@@ -48,13 +49,20 @@ impl App {
         }
 
         if key.code == KeyCode::Esc {
+            self.repeat_armed_until = None;
             leave_command_mode(&mut self.state);
             return;
         }
 
         if let Some(action) = action_for_key(&self.state, raw_key, BindingDispatch::Prefix) {
+            if self.repeat_armed_until.is_some() && !action_repeat_enabled(&self.state, action) {
+                self.repeat_armed_until = None;
+                leave_command_mode(&mut self.state);
+                return;
+            }
             if action == NavigateAction::EditScrollback {
                 let previous_mode = self.state.mode;
+                self.repeat_armed_until = None;
                 self.launch_focused_scrollback_editor();
                 finish_action_context(&mut self.state, ActionContext::Prefix, previous_mode);
             } else {
@@ -65,10 +73,16 @@ impl App {
         }
 
         if let Some(binding) = command_for_key(&self.state, raw_key, BindingDispatch::Prefix) {
+            if self.repeat_armed_until.is_some() {
+                self.repeat_armed_until = None;
+                leave_command_mode(&mut self.state);
+                return;
+            }
             self.launch_custom_command(binding, ActionContext::Prefix);
             return;
         }
 
+        self.repeat_armed_until = None;
         leave_command_mode(&mut self.state);
     }
 
@@ -107,6 +121,8 @@ impl App {
         context: ActionContext,
     ) {
         let previous_mode = self.state.mode;
+        let repeat_enabled =
+            context == ActionContext::Prefix && action_repeat_enabled(&self.state, action);
         match action {
             NavigateAction::NewWorkspace => {
                 self.runtime_workspace_create(
@@ -344,7 +360,14 @@ impl App {
             }
         }
 
-        finish_action_context(&mut self.state, context, previous_mode);
+        if repeat_enabled && self.state.active.is_some() {
+            self.state.mode = Mode::Prefix;
+            self.repeat_armed_until =
+                Some(std::time::Instant::now() + crate::app::PREFIX_REPEAT_TIMEOUT);
+        } else {
+            self.repeat_armed_until = None;
+            finish_action_context(&mut self.state, context, previous_mode);
+        }
     }
 
     pub(crate) fn focus_workspace_idx_via_api(&mut self, ws_idx: usize) {
@@ -1360,6 +1383,25 @@ fn action_for_key(
     None
 }
 
+fn action_repeat_enabled(state: &AppState, action: NavigateAction) -> bool {
+    let kb = &state.keybinds;
+    match action {
+        NavigateAction::PreviousTab => kb.previous_tab.repeat,
+        NavigateAction::NextTab => kb.next_tab.repeat,
+        NavigateAction::PreviousWorkspace => kb.previous_workspace.repeat,
+        NavigateAction::NextWorkspace => kb.next_workspace.repeat,
+        NavigateAction::PreviousAgent => kb.previous_agent.repeat,
+        NavigateAction::NextAgent => kb.next_agent.repeat,
+        NavigateAction::CyclePaneNext => kb.cycle_pane_next.repeat,
+        NavigateAction::CyclePanePrevious => kb.cycle_pane_previous.repeat,
+        NavigateAction::SwapPaneLeft => kb.swap_pane_left.repeat,
+        NavigateAction::SwapPaneDown => kb.swap_pane_down.repeat,
+        NavigateAction::SwapPaneUp => kb.swap_pane_up.repeat,
+        NavigateAction::SwapPaneRight => kb.swap_pane_right.repeat,
+        _ => false,
+    }
+}
+
 fn navigate_mode_action_for_key(state: &AppState, key: TerminalKey) -> Option<NavigateAction> {
     let action = action_for_key(state, key, BindingDispatch::Prefix)?;
     if matches!(
@@ -1393,6 +1435,7 @@ pub(super) fn execute_navigate_action_in_context(
     context: ActionContext,
 ) {
     let previous_mode = state.mode;
+    let repeat_enabled = context == ActionContext::Prefix && action_repeat_enabled(state, action);
     match action {
         NavigateAction::NewWorkspace => {
             state.request_new_workspace = true;
@@ -1585,7 +1628,11 @@ pub(super) fn execute_navigate_action_in_context(
         NavigateAction::OpenNavigator => state.open_navigator_from(terminal_runtimes),
     }
 
-    finish_action_context(state, context, previous_mode);
+    if repeat_enabled && state.active.is_some() {
+        state.mode = Mode::Prefix;
+    } else {
+        finish_action_context(state, context, previous_mode);
+    }
 }
 
 fn workspace_action_target(state: &AppState, context: ActionContext) -> Option<usize> {
@@ -1835,6 +1882,73 @@ mod tests {
         assert_eq!(state.workspaces.len(), 1);
         assert_eq!(state.workspaces[0].display_name(), "main");
         assert_eq!(state.mode, Mode::Terminal);
+    }
+
+    #[test]
+    fn repeat_enabled_prefix_action_stays_in_prefix_mode() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.workspaces[0].test_add_tab(Some("two"));
+        state.workspaces[0].test_add_tab(Some("three"));
+        let mut terminal_runtimes = TerminalRuntimeRegistry::new();
+        state.mode = Mode::Prefix;
+        state.keybinds.previous_tab = crate::config::ActionKeybinds::prefix("p").with_repeat(true);
+
+        assert_eq!(state.workspaces[0].active_tab, 0);
+        execute_navigate_action_in_context(
+            &mut state,
+            &mut terminal_runtimes,
+            NavigateAction::PreviousTab,
+            ActionContext::Prefix,
+        );
+        assert_eq!(state.mode, Mode::Prefix);
+        assert_eq!(state.workspaces[0].active_tab, 2);
+
+        execute_navigate_action_in_context(
+            &mut state,
+            &mut terminal_runtimes,
+            NavigateAction::PreviousTab,
+            ActionContext::Prefix,
+        );
+        assert_eq!(state.mode, Mode::Prefix);
+        assert_eq!(state.workspaces[0].active_tab, 1);
+    }
+
+    #[test]
+    fn repeat_disabled_prefix_action_exits_prefix_mode_as_before() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.workspaces[0].test_add_tab(Some("two"));
+        state.workspaces[0].test_add_tab(Some("three"));
+        let mut terminal_runtimes = TerminalRuntimeRegistry::new();
+        state.mode = Mode::Prefix;
+        state.keybinds.previous_tab = crate::config::ActionKeybinds::prefix("p");
+
+        execute_navigate_action_in_context(
+            &mut state,
+            &mut terminal_runtimes,
+            NavigateAction::PreviousTab,
+            ActionContext::Prefix,
+        );
+
+        assert_eq!(state.mode, Mode::Terminal);
+        assert_eq!(state.workspaces[0].active_tab, 2);
+    }
+
+    #[test]
+    fn repeat_enabled_action_in_direct_context_does_not_arm_prefix() {
+        let mut state = state_with_workspaces(&["test"]);
+        state.workspaces[0].test_add_tab(Some("two"));
+        let mut terminal_runtimes = TerminalRuntimeRegistry::new();
+        state.mode = Mode::Terminal;
+        state.keybinds.previous_tab = crate::config::ActionKeybinds::prefix("p").with_repeat(true);
+
+        execute_navigate_action_in_context(
+            &mut state,
+            &mut terminal_runtimes,
+            NavigateAction::PreviousTab,
+            ActionContext::Direct,
+        );
+
+        assert_ne!(state.mode, Mode::Prefix);
     }
 
     #[test]
@@ -2315,6 +2429,96 @@ last_pane = "prefix+tab"
         );
 
         assert_eq!(action, Some(NavigateAction::SwitchTab(2)));
+    }
+
+    #[tokio::test]
+    async fn handle_prefix_key_repeats_previous_tab_on_bare_key_without_prefix() {
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            &Config::default(),
+            true,
+            None,
+            api_rx,
+            crate::api::EventHub::default(),
+        );
+        app.state.workspaces = vec![Workspace::test_new("test")];
+        app.state.workspaces[0].test_add_tab(Some("two"));
+        app.state.workspaces[0].test_add_tab(Some("three"));
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Prefix;
+        app.state.keybinds.previous_tab =
+            crate::config::ActionKeybinds::prefix("p").with_repeat(true);
+
+        app.handle_prefix_key(TerminalKey::new(KeyCode::Char('p'), KeyModifiers::empty()));
+        assert_eq!(app.state.mode, Mode::Prefix);
+        assert_eq!(app.state.workspaces[0].active_tab, 2);
+        assert!(app.repeat_armed_until.is_some());
+
+        app.handle_prefix_key(TerminalKey::new(KeyCode::Char('p'), KeyModifiers::empty()));
+        assert_eq!(app.state.mode, Mode::Prefix);
+        assert_eq!(app.state.workspaces[0].active_tab, 1);
+        assert!(app.repeat_armed_until.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_prefix_key_unbound_key_exits_armed_prefix_mode_and_clears_deadline() {
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            &Config::default(),
+            true,
+            None,
+            api_rx,
+            crate::api::EventHub::default(),
+        );
+        app.state.workspaces = vec![Workspace::test_new("test")];
+        app.state.workspaces[0].test_add_tab(Some("two"));
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Prefix;
+        app.state.keybinds.previous_tab =
+            crate::config::ActionKeybinds::prefix("p").with_repeat(true);
+
+        app.handle_prefix_key(TerminalKey::new(KeyCode::Char('p'), KeyModifiers::empty()));
+        assert_eq!(app.state.mode, Mode::Prefix);
+        assert!(app.repeat_armed_until.is_some());
+
+        app.handle_prefix_key(TerminalKey::new(KeyCode::Char('z'), KeyModifiers::empty()));
+        assert_ne!(app.state.mode, Mode::Prefix);
+        assert!(app.repeat_armed_until.is_none());
+    }
+
+    #[tokio::test]
+    async fn handle_prefix_key_non_repeat_binding_during_repeat_window_exits_without_firing() {
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(
+            &Config::default(),
+            true,
+            None,
+            api_rx,
+            crate::api::EventHub::default(),
+        );
+        app.state.workspaces = vec![Workspace::test_new("test")];
+        app.state.workspaces[0].test_add_tab(Some("two"));
+        app.state.workspaces[0].test_add_tab(Some("three"));
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Prefix;
+        app.state.keybinds.previous_tab =
+            crate::config::ActionKeybinds::prefix("p").with_repeat(true);
+        app.state.keybinds.next_tab = crate::config::ActionKeybinds::prefix("n");
+
+        // Arm repeat window via repeat-enabled binding.
+        app.handle_prefix_key(TerminalKey::new(KeyCode::Char('p'), KeyModifiers::empty()));
+        assert_eq!(app.state.mode, Mode::Prefix);
+        assert_eq!(app.state.workspaces[0].active_tab, 2);
+        assert!(app.repeat_armed_until.is_some());
+
+        // Press a non-repeat binding during the window — should not fire, should exit.
+        app.handle_prefix_key(TerminalKey::new(KeyCode::Char('n'), KeyModifiers::empty()));
+        assert_ne!(app.state.mode, Mode::Prefix);
+        assert!(app.repeat_armed_until.is_none());
+        assert_eq!(app.state.workspaces[0].active_tab, 2); // unchanged
     }
 
     #[tokio::test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,6 +33,7 @@ pub(crate) const ANIMATION_INTERVAL: Duration = Duration::from_millis(16);
 pub(crate) const HEADLESS_ANIMATION_INTERVAL: Duration = Duration::from_millis(128);
 pub(crate) const HEADLESS_ANIMATION_TICK_STEP: u32 = 8;
 pub(crate) const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(30);
+pub(crate) const PREFIX_REPEAT_TIMEOUT: Duration = Duration::from_millis(500);
 const RESIZE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const GIT_REMOTE_STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(1500);
 const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
@@ -127,6 +128,7 @@ pub struct App {
     pub(crate) pending_agent_resume_deadline: Option<Instant>,
     pub(crate) selection_autoscroll_deadline: Option<Instant>,
     pub(crate) selection_highlight_clear_deadline: Option<Instant>,
+    pub(crate) repeat_armed_until: Option<Instant>,
     pub(crate) session_save_deadline: Option<Instant>,
     pub(crate) persist_pane_history: bool,
     pub(crate) last_render_at: Option<Instant>,
@@ -721,6 +723,7 @@ impl App {
             session_save_deadline: None,
             selection_autoscroll_deadline: None,
             selection_highlight_clear_deadline: None,
+            repeat_armed_until: None,
             persist_pane_history: config.experimental.pane_history,
             last_render_at: None,
             suppressed_repeat_keys: HashSet::new(),

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -265,6 +265,8 @@ impl App {
 
         changed |= self.clear_due_selection_highlight(now);
 
+        changed |= self.clear_due_repeat_armed(now);
+
         self.start_git_status_refresh_if_due(now);
 
         if self
@@ -328,6 +330,26 @@ impl App {
             .is_some_and(|selection| !selection.is_in_progress())
         {
             self.state.clear_selection();
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn clear_due_repeat_armed(&mut self, now: Instant) -> bool {
+        if self
+            .repeat_armed_until
+            .is_none_or(|deadline| now < deadline)
+        {
+            return false;
+        }
+
+        self.repeat_armed_until = None;
+        if self.state.mode == Mode::Prefix {
+            self.state.mode = if self.state.active.is_some() {
+                Mode::Terminal
+            } else {
+                Mode::Navigate
+            };
             return true;
         }
         false
@@ -566,6 +588,7 @@ impl App {
             self.session_save_deadline,
             self.selection_autoscroll_deadline,
             self.selection_highlight_clear_deadline,
+            self.repeat_armed_until,
             render_deadline,
         ]
         .into_iter()
@@ -1067,5 +1090,46 @@ mod tests {
             .pending_agent_resume_plan
             .is_some());
         assert!(app.pending_agent_resume_deadline.is_none());
+    }
+
+    #[test]
+    fn next_loop_deadline_includes_repeat_armed_deadline() {
+        let (mut app, _pane_id) = test_app_with_pane();
+        // Neutralize the git-refresh timer, which `App::new` starts already
+        // overdue once a workspace exists, so it can't race our deadline.
+        app.git_refresh_in_flight = true;
+        let now = Instant::now();
+        app.repeat_armed_until = Some(now + Duration::from_millis(5));
+
+        let deadline = app
+            .next_loop_deadline(now, false)
+            .expect("repeat_armed_until should surface a deadline");
+
+        assert_eq!(deadline, now + Duration::from_millis(5));
+    }
+
+    #[test]
+    fn due_repeat_armed_deadline_exits_prefix_mode() {
+        let (mut app, _pane_id) = test_app_with_pane();
+        app.state.mode = Mode::Prefix;
+        app.repeat_armed_until = Some(Instant::now() - Duration::from_secs(1));
+
+        app.handle_scheduled_tasks(Instant::now(), false);
+
+        assert!(app.repeat_armed_until.is_none());
+        assert_eq!(app.state.mode, Mode::Terminal);
+    }
+
+    #[test]
+    fn repeat_armed_deadline_not_yet_due_leaves_prefix_mode_untouched() {
+        let (mut app, _pane_id) = test_app_with_pane();
+        app.state.mode = Mode::Prefix;
+        let deadline = Instant::now() + Duration::from_secs(60);
+        app.repeat_armed_until = Some(deadline);
+
+        app.handle_scheduled_tasks(Instant::now(), false);
+
+        assert_eq!(app.repeat_armed_until, Some(deadline));
+        assert_eq!(app.state.mode, Mode::Prefix);
     }
 }

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -15,11 +15,19 @@ pub struct LiveKeybindConfig {
     pub keybinds: Keybinds,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct BindingTableConfig {
+    pub key: Box<BindingConfig>,
+    pub repeat: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum BindingConfig {
     One(String),
     Many(Vec<String>),
+    Table(BindingTableConfig),
 }
 
 impl Default for BindingConfig {
@@ -41,7 +49,12 @@ impl BindingConfig {
         match self {
             Self::One(value) => vec![value.as_str()],
             Self::Many(values) => values.iter().map(String::as_str).collect(),
+            Self::Table(table) => table.key.values(),
         }
+    }
+
+    pub(crate) fn repeat(&self) -> bool {
+        matches!(self, Self::Table(table) if table.repeat)
     }
 
     pub(crate) fn has_values(&self) -> bool {
@@ -157,6 +170,7 @@ impl ResolvedBinding {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ActionKeybinds {
     pub bindings: Vec<ResolvedBinding>,
+    pub repeat: bool,
 }
 
 impl ActionKeybinds {
@@ -175,6 +189,7 @@ impl ActionKeybinds {
             .expect("prefix binding should parse");
         Self {
             bindings: vec![trigger],
+            repeat: false,
         }
     }
 
@@ -188,7 +203,14 @@ impl ActionKeybinds {
             .expect("direct binding should parse");
         Self {
             bindings: vec![trigger],
+            repeat: false,
         }
+    }
+
+    #[cfg(test)]
+    pub fn with_repeat(mut self, repeat: bool) -> Self {
+        self.repeat = repeat;
+        self
     }
 
     #[cfg(test)]
@@ -719,6 +741,7 @@ fn append_custom_command_bindings(
             continue;
         }
 
+        diagnose_unsupported_repeat(&key_field, &command.key, diagnostics);
         let bindings = parse_action_bindings(
             &key_field,
             &command.key,
@@ -779,7 +802,18 @@ fn parse_action_bindings(
             }
         }
     }
-    ActionKeybinds { bindings }
+    ActionKeybinds {
+        bindings,
+        repeat: config.repeat(),
+    }
+}
+
+fn diagnose_unsupported_repeat(field: &str, config: &BindingConfig, diagnostics: &mut Vec<String>) {
+    if config.repeat() {
+        let diag = format!("repeat is not supported for {field}; ignoring");
+        warn!(message = %diag, "config diagnostic");
+        diagnostics.push(diag);
+    }
 }
 
 fn parse_navigate_bindings(
@@ -789,6 +823,7 @@ fn parse_navigate_bindings(
     diagnostics: &mut Vec<String>,
     source: BindingSource,
 ) -> ActionKeybinds {
+    diagnose_unsupported_repeat(field, config, diagnostics);
     let mut bindings = Vec::new();
     for raw in config.values() {
         let raw = raw.trim();
@@ -815,7 +850,10 @@ fn parse_navigate_bindings(
             }
         }
     }
-    ActionKeybinds { bindings }
+    ActionKeybinds {
+        bindings,
+        repeat: false,
+    }
 }
 
 fn parse_indexed_bindings(
@@ -825,6 +863,7 @@ fn parse_indexed_bindings(
     diagnostics: &mut Vec<String>,
     source: BindingSource,
 ) -> Vec<IndexedKeybind> {
+    diagnose_unsupported_repeat(field, config, diagnostics);
     let mut bindings = Vec::new();
     for raw in config.values() {
         let raw = raw.trim();
@@ -1490,6 +1529,106 @@ next_tab = "prefix+n"
                 KeyModifiers::empty()
             ))]
         );
+    }
+
+    #[test]
+    fn binding_config_table_parses_repeat_flag() {
+        let config: Config = toml::from_str(
+            r#"
+[keys]
+previous_tab = { key = "prefix+p", repeat = true }
+"#,
+        )
+        .unwrap();
+        let kb = config.keybinds();
+        assert!(kb.previous_tab.repeat);
+        assert_eq!(
+            binding_triggers(&kb.previous_tab),
+            vec![BindingTrigger::Prefix((
+                KeyCode::Char('p'),
+                KeyModifiers::empty()
+            ))]
+        );
+        assert!(config.collect_diagnostics().is_empty());
+    }
+
+    #[test]
+    fn binding_config_table_with_many_keys_parses_repeat_flag() {
+        let config: Config = toml::from_str(
+            r#"
+[keys]
+previous_tab = { key = ["prefix+p", "ctrl+alt+p"], repeat = true }
+"#,
+        )
+        .unwrap();
+        let kb = config.keybinds();
+        assert!(kb.previous_tab.repeat);
+        assert_eq!(
+            binding_triggers(&kb.previous_tab),
+            vec![
+                BindingTrigger::Prefix((KeyCode::Char('p'), KeyModifiers::empty())),
+                BindingTrigger::Direct((
+                    KeyCode::Char('p'),
+                    KeyModifiers::CONTROL | KeyModifiers::ALT
+                )),
+            ]
+        );
+    }
+
+    #[test]
+    fn plain_string_and_array_bindings_default_repeat_false() {
+        let config: Config = toml::from_str(
+            r#"
+[keys]
+previous_tab = "prefix+p"
+next_tab = ["prefix+n", "ctrl+alt+n"]
+"#,
+        )
+        .unwrap();
+        let kb = config.keybinds();
+        assert!(!kb.previous_tab.repeat);
+        assert!(!kb.next_tab.repeat);
+    }
+
+    #[test]
+    fn repeat_flag_ignored_with_diagnostic_for_custom_command() {
+        let config: Config = toml::from_str(
+            r#"
+[[keys.command]]
+key = { key = "prefix+alt+g", repeat = true }
+command = "lazygit"
+"#,
+        )
+        .unwrap();
+        let diagnostics = config.collect_diagnostics();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.contains("repeat is not supported for keys.command[0].key")),
+            "expected a repeat diagnostic, got: {diagnostics:?}"
+        );
+        let kb = config.keybinds();
+        assert_eq!(kb.custom_commands.len(), 1);
+        assert_eq!(kb.custom_commands[0].command, "lazygit");
+    }
+
+    #[test]
+    fn repeat_flag_ignored_with_diagnostic_for_indexed_binding() {
+        let config: Config = toml::from_str(
+            r#"
+[keys]
+switch_tab = { key = "prefix+1..9", repeat = true }
+"#,
+        )
+        .unwrap();
+        let diagnostics = config.collect_diagnostics();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.contains("repeat is not supported for keys.switch_tab")),
+            "expected a repeat diagnostic, got: {diagnostics:?}"
+        );
+        assert_eq!(config.keybinds().switch_tab.len(), 9);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,12 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # rename_tab = "prefix+shift+t"
 # previous_tab = "prefix+p"
 # next_tab = "prefix+n"
+# Repeatable form: after the action fires, tapping the
+# same key again within ~500ms repeats it without pressing the prefix again.
+# Opt-in per binding, default off. Also supported on: previous_workspace,
+# next_workspace, previous_agent, next_agent, cycle_pane_next,
+# cycle_pane_previous, swap_pane_left/down/up/right.
+# previous_tab = { key = "prefix+p", repeat = true }
 # switch_tab = "prefix+1..9"
 # switch_workspace = ""   # optional indexed binding, e.g. "prefix+shift+1..9"
 # close_tab = "prefix+shift+x"

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -3680,6 +3680,8 @@ impl HeadlessServer {
 
         changed |= self.app.clear_due_selection_highlight(now);
 
+        changed |= self.app.clear_due_repeat_armed(now);
+
         if self.has_app_client() {
             self.app.start_git_status_refresh_if_due(now);
         }
@@ -5514,6 +5516,24 @@ next_tab = ""
 
         assert!(!server.handle_scheduled_tasks_headless(now, false));
         assert_eq!(server.app.next_agent_manifest_update_check, None);
+    }
+
+    #[test]
+    fn headless_due_repeat_armed_deadline_exits_prefix_mode() {
+        let mut server = test_headless_server();
+        server
+            .app
+            .state
+            .workspaces
+            .push(crate::workspace::Workspace::test_new("test"));
+        server.app.state.active = Some(0);
+        server.app.state.mode = app::Mode::Prefix;
+        server.app.repeat_armed_until = Some(Instant::now() - Duration::from_secs(1));
+
+        assert!(server.handle_scheduled_tasks_headless(Instant::now(), false));
+
+        assert!(server.app.repeat_armed_until.is_none());
+        assert_eq!(server.app.state.mode, app::Mode::Terminal);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds a `repeat = true` opt-in to prefix keybindings so that after a prefix action fires, tapping the same bare key again within ~500ms repeats it without requiring the prefix keystroke again
- Supported actions: `previous_tab`/`next_tab`, `previous_workspace`/`next_workspace`, `previous_agent`/`next_agent`, `cycle_pane_next`/`cycle_pane_previous`, `swap_pane_left`/`down`/`up`/`right`
- Repeat mode expires after 500ms, reverts to terminal mode; unsupported binding types (indexed, custom commands) emit a config diagnostic and ignore the flag

## Usage

```toml
[keys]
previous_tab = { key = "prefix+p", repeat = true }
```

## Test plan

- [x] Unit tests added for `execute_navigate_action_in_context` repeat/no-repeat behavior
- [x] Integration tests for `handle_prefix_key` repeat arming, timeout expiry, and non-repeat binding during window
- [x] Headless server repeat deadline test
- [x] `just check` passes

refs discussions#599