### PR TITLE
fix: clear lifecycle hook authority when agent process exits undetected

### DIFF
--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -262,7 +262,7 @@ impl TerminalState {
         if process_exited
             && self.hook_authority_not_newer_than(now)
             && self.hook_authority.as_ref().is_some_and(|authority| {
-                crate::detect::parse_agent_label(&authority.agent_label) == agent
+                agent.is_none() || crate::detect::parse_agent_label(&authority.agent_label) == agent
             })
         {
             let cleared_source = self


### PR DESCRIPTION
When a full-lifecycle hook authority (e.g. opencode plugin) is active, herdr skips process probing and screen content detection. If the agent then exits without firing a final idle/deleted event through the plugin (e.g. abrupt termination), the process-exit handler calls `set_detected_state_with_screen_signals_at` with `agent=None` because process detection was never performed.

The clearance condition parsed the hook authoritys agent label and compared it against the detected agent — but with `agent=None` the comparison always failed (`Some(OpenCode) == None → false`), leaving the hook authority stuck in its last reported state ("working").

**Fix:** treat `agent=None` as a match during process-exit clearance — the process is dead, the plugin socket is gone, so the lifecycle authority should always be released regardless of whether the agent process was being detected.

**Reproduction:**
- Run opencode under herdr (herdr plugin installed)
- Wait for opencode to finish working and exit
- `herdr agent list` still shows `agent_status: "working"` with `screen_detection_skipped: true`

Fixes the agent-status-stuck-on-working bug when agents managed via lifecycle hooks exit without sending a final idle/released event.