### PR TITLE
feat(ui): opt-in confirm_close_pane

### DIFF
--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -310,6 +310,7 @@ right_click_passthrough_modifier = ""
 redraw_on_focus_gained = true
 mouse_scroll_lines = 3
 confirm_close = true
+confirm_close_pane = false
 prompt_new_tab_name = true
 pane_borders = true
 pane_gaps = true
@@ -327,7 +328,7 @@ accent = "cyan"
 
 The agent panel shows all agents across all spaces. `agent_panel_sort` can be `spaces` or `priority`; `workspaces` is accepted as an alias for `spaces`. `spaces` is the default and keeps agents grouped by space order. `priority` sorts by attention priority: blocked, done, working, idle, then unknown. Within the same status, agents that most recently changed state appear first.
 
-`confirm_close` controls whether closing a workspace asks for confirmation. `prompt_new_tab_name` controls whether new tabs ask for a label first.
+`confirm_close` controls whether closing a workspace asks for confirmation. `confirm_close_pane` is opt-in and defaults to false; when enabled, it asks for confirmation before closing a pane, mirroring `confirm_close` for workspaces. `prompt_new_tab_name` controls whether new tabs ask for a label first.
 
 Set `mouse_capture = false` if you want your terminal to handle normal clicks, such as command-clicking URLs. With mouse capture enabled, Ctrl-click opens pane links when your terminal sends that modified click to Herdr. This includes macOS; Cmd-click is not reported separately from plain click while Herdr captures mouse input. Use Shift-Ctrl-click on Linux or Shift-Cmd-click on macOS for the terminal-native bypass path.
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1875,10 +1875,6 @@ impl AppState {
         else {
             return;
         };
-        if self.close_pane_would_close_workspace(ws_idx, pane_id) {
-            return;
-        }
-
         self.selection = None;
         self.selection_autoscroll = None;
         self.mark_session_dirty();

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -15,8 +15,8 @@ use unicode_width::UnicodeWidthChar;
 
 use super::state::{
     text_matches_query, AgentNotificationDelivery, AppState, Mode, NavigatorRow,
-    NavigatorStateFilter, NavigatorTarget, PaneFocusTarget, PendingAgentNotification, ToastKind,
-    ToastNotification, ToastTarget, ViewLayout,
+    NavigatorStateFilter, NavigatorTarget, PaneFocusTarget, PendingAgentNotification, PendingClose,
+    ToastKind, ToastNotification, ToastTarget, ViewLayout,
 };
 
 fn is_background_completion_transition(prev_state: AgentState, new_state: AgentState) -> bool {
@@ -1776,6 +1776,7 @@ impl AppState {
     pub(crate) fn confirm_implicit_worktree_group_close(&mut self, ws_idx: usize) -> bool {
         if self.confirm_close && self.workspace_close_would_close_worktree_group(ws_idx) {
             self.selected = ws_idx;
+            self.pending_close = PendingClose::Workspace;
             self.mode = Mode::ConfirmClose;
             true
         } else {
@@ -1817,6 +1818,23 @@ impl AppState {
             }
         }
 
+        if let Some(ws_idx) = active {
+            if let Some(pane_id) = self
+                .workspaces
+                .get(ws_idx)
+                .and_then(crate::workspace::Workspace::focused_pane_id)
+            {
+                if self.confirm_close_pane
+                    && !self.close_pane_would_close_workspace(ws_idx, pane_id)
+                {
+                    self.pending_close = PendingClose::Pane(pane_id);
+                    self.selected = ws_idx;
+                    self.mode = Mode::ConfirmClose;
+                    return true;
+                }
+            }
+        }
+
         self.selection = None;
         self.selection_autoscroll = None;
         self.mark_session_dirty();
@@ -1846,6 +1864,39 @@ impl AppState {
             self.remove_unattached_terminal_ids(terminal_ids);
         }
         false
+    }
+
+    #[cfg(test)]
+    pub(crate) fn close_pane_confirmed(&mut self, pane_id: PaneId) {
+        let Some(ws_idx) = self
+            .workspaces
+            .iter()
+            .position(|ws| ws.find_tab_index_for_pane(pane_id).is_some())
+        else {
+            return;
+        };
+        if self.close_pane_would_close_workspace(ws_idx, pane_id) {
+            return;
+        }
+
+        self.selection = None;
+        self.selection_autoscroll = None;
+        self.mark_session_dirty();
+        let terminal_ids = self
+            .terminal_id_for_pane(ws_idx, pane_id)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let should_close_workspace = self
+            .workspaces
+            .get_mut(ws_idx)
+            .is_some_and(|ws| ws.close_pane(pane_id));
+        self.remove_plugin_pane_records([pane_id]);
+        if should_close_workspace {
+            self.selected = ws_idx;
+            self.close_selected_workspace();
+        } else {
+            self.remove_unattached_terminal_ids(terminal_ids);
+        }
     }
 
     #[cfg(test)]
@@ -3073,6 +3124,7 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::input::{confirm_close_accept, confirm_close_cancel};
     use crate::detect::{Agent, AgentState};
     use crate::workspace::Workspace;
     use ratatui::layout::Direction;
@@ -5189,6 +5241,77 @@ mod tests {
     }
 
     #[test]
+    fn close_pane_closes_immediately_when_pane_confirmation_disabled() {
+        let mut state = app_with_workspaces(&["test"]);
+        let closed = state.workspaces[0].test_split(Direction::Horizontal);
+        state.ensure_test_terminals();
+        let mode = state.mode;
+
+        let deferred = state.close_pane();
+
+        assert!(!deferred);
+        assert_eq!(state.mode, mode);
+        assert!(state.workspaces[0]
+            .find_tab_index_for_pane(closed)
+            .is_none());
+        state.assert_invariants_for_test();
+    }
+
+    #[test]
+    fn close_pane_prompts_with_pane_scope_when_enabled() {
+        let mut state = app_with_workspaces(&["test"]);
+        state.confirm_close_pane = true;
+        let pane_id = state.workspaces[0].test_split(Direction::Horizontal);
+        state.ensure_test_terminals();
+
+        let deferred = state.close_pane();
+
+        assert!(deferred);
+        assert_eq!(state.mode, Mode::ConfirmClose);
+        assert_eq!(state.pending_close, PendingClose::Pane(pane_id));
+        assert!(state.workspaces[0]
+            .find_tab_index_for_pane(pane_id)
+            .is_some());
+        state.assert_invariants_for_test();
+    }
+
+    #[test]
+    fn confirm_close_accept_removes_pending_pane_and_resets_scope() {
+        let mut state = app_with_workspaces(&["test"]);
+        state.confirm_close_pane = true;
+        let pane_id = state.workspaces[0].test_split(Direction::Horizontal);
+        state.ensure_test_terminals();
+
+        assert!(state.close_pane());
+        confirm_close_accept(&mut state);
+
+        assert_eq!(state.mode, Mode::Terminal);
+        assert_eq!(state.pending_close, PendingClose::Workspace);
+        assert!(state.workspaces[0]
+            .find_tab_index_for_pane(pane_id)
+            .is_none());
+        state.assert_invariants_for_test();
+    }
+
+    #[test]
+    fn confirm_close_cancel_keeps_pending_pane_and_resets_scope() {
+        let mut state = app_with_workspaces(&["test"]);
+        state.confirm_close_pane = true;
+        let pane_id = state.workspaces[0].test_split(Direction::Horizontal);
+        state.ensure_test_terminals();
+
+        assert!(state.close_pane());
+        confirm_close_cancel(&mut state);
+
+        assert_eq!(state.mode, Mode::Navigate);
+        assert_eq!(state.pending_close, PendingClose::Workspace);
+        assert!(state.workspaces[0]
+            .find_tab_index_for_pane(pane_id)
+            .is_some());
+        state.assert_invariants_for_test();
+    }
+
+    #[test]
     fn pane_process_exit_publish_marks_agent_idle_before_pane_removal() {
         let mut state = app_with_workspaces(&["active", "background"]);
         state.toast_config.delivery = crate::config::ToastDelivery::Herdr;
@@ -5323,8 +5446,32 @@ mod tests {
 
         assert!(deferred);
         assert_eq!(state.mode, Mode::ConfirmClose);
+        assert_eq!(state.pending_close, PendingClose::Workspace);
         assert_eq!(state.selected, 0);
         assert_eq!(state.workspaces.len(), 2);
+    }
+
+    #[test]
+    fn close_pane_last_pane_with_pane_confirmation_uses_workspace_confirm() {
+        let mut state = app_with_workspaces(&["parent", "child"]);
+        mark_parent_worktree(&mut state, 0);
+        mark_linked_worktree(&mut state, 1);
+        state.confirm_close_pane = true;
+        state.active = Some(0);
+        state.selected = 1;
+
+        let deferred = state.close_pane();
+
+        assert!(deferred);
+        assert_eq!(state.mode, Mode::ConfirmClose);
+        assert_eq!(state.pending_close, PendingClose::Workspace);
+        assert_eq!(state.selected, 0);
+
+        confirm_close_accept(&mut state);
+
+        assert!(state.workspaces.is_empty());
+        assert_eq!(state.pending_close, PendingClose::Workspace);
+        state.assert_invariants_for_test();
     }
 
     #[test]

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -14,9 +14,7 @@ use crate::api::schema::{
     PaneZoomResult, ReadFormat, ReadSource, ResponseResult,
 };
 use crate::app::actions::{PaneZoomCommand, PaneZoomNoopReason};
-use crate::app::App;
-#[cfg(test)]
-use crate::app::Mode;
+use crate::app::{App, Mode, PendingClose};
 use crate::layout::{find_in_direction, NavDirection, PaneId};
 
 use super::super::api_helpers::{
@@ -1465,11 +1463,6 @@ impl App {
         let Some((ws_idx, pane_id)) = self.parse_pane_id(&target.pane_id) else {
             return Err(pane_not_found(id, &target.pane_id));
         };
-        let Some(public_pane_id) = self.public_pane_id(ws_idx, pane_id) else {
-            return Err(pane_not_found(id, &target.pane_id));
-        };
-        let workspace_id = self.public_workspace_id(ws_idx);
-        let layout_update_target = self.layout_update_target_after_pane_removal(ws_idx, pane_id);
         if self.state.close_pane_would_close_workspace(ws_idx, pane_id)
             && self.state.confirm_implicit_worktree_group_close(ws_idx)
         {
@@ -1479,11 +1472,39 @@ impl App {
                 "closing this pane would close a worktree group",
             ));
         }
+        if self.state.confirm_close_pane
+            && !self.state.close_pane_would_close_workspace(ws_idx, pane_id)
+        {
+            self.state.pending_close = PendingClose::Pane(pane_id);
+            self.state.selected = ws_idx;
+            self.state.mode = Mode::ConfirmClose;
+            return Err(encode_error(
+                id,
+                "confirmation_required",
+                "closing this pane requires confirmation",
+            ));
+        }
+
+        self.close_pane_confirmed(id, ws_idx, pane_id)
+    }
+
+    pub(crate) fn close_pane_confirmed(
+        &mut self,
+        id: String,
+        ws_idx: usize,
+        pane_id: PaneId,
+    ) -> Result<(), String> {
+        let target_pane_id = self.public_pane_id(ws_idx, pane_id);
+        let Some(public_pane_id) = target_pane_id else {
+            return Err(pane_not_found(id, &pane_id.raw().to_string()));
+        };
+        let workspace_id = self.public_workspace_id(ws_idx);
+        let layout_update_target = self.layout_update_target_after_pane_removal(ws_idx, pane_id);
         let workspace_snapshot = self.workspace_info(ws_idx);
         let terminal_id = self.state.terminal_id_for_pane(ws_idx, pane_id);
         let should_close_workspace = {
             let Some(ws) = self.state.workspaces.get_mut(ws_idx) else {
-                return Err(pane_not_found(id, &target.pane_id));
+                return Err(pane_not_found(id, &pane_id.raw().to_string()));
             };
             ws.close_pane(pane_id)
         };

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1872,6 +1872,7 @@ mod tests {
         config::Config,
         workspace::Workspace,
     };
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     fn app_with_test_workspace() -> (App, String) {
         let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -3625,5 +3626,149 @@ mod tests {
 
             assert_eq!(metadata_error_code(&response), "invalid_metadata_ttl");
         }
+    }
+
+    #[test]
+    fn api_pane_close_defers_non_last_pane_when_pane_confirmation_enabled() {
+        let mut app = app_with_linked_worktree();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.confirm_close_pane = true;
+        let root = app.state.workspaces[0].tabs[0].root_pane;
+        let right = app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let right_public = app.public_pane_id(0, right).unwrap();
+
+        let response = app.handle_pane_close(
+            "req".into(),
+            PaneTarget {
+                pane_id: right_public,
+            },
+        );
+
+        let error: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(error.error.code, "confirmation_required");
+        assert_eq!(app.state.mode, Mode::ConfirmClose);
+        assert_eq!(app.state.pending_close, PendingClose::Pane(right));
+        assert_eq!(app.state.selected, 0);
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(right)
+            .is_some());
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(root)
+            .is_some());
+    }
+
+    #[test]
+    fn api_confirm_close_accept_removes_deferred_pane_and_emits_pane_closed() {
+        let mut app = app_with_linked_worktree();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.confirm_close_pane = true;
+        let root = app.state.workspaces[0].tabs[0].root_pane;
+        let right = app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let right_public = app.public_pane_id(0, right).unwrap();
+        let _ = app.handle_pane_close(
+            "req".into(),
+            PaneTarget {
+                pane_id: right_public.clone(),
+            },
+        );
+        assert_eq!(app.state.pending_close, PendingClose::Pane(right));
+
+        app.handle_confirm_close_key_via_api(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+
+        assert_eq!(app.state.mode, Mode::Terminal);
+        assert_eq!(app.state.pending_close, PendingClose::Workspace);
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(right)
+            .is_none());
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(root)
+            .is_some());
+        let envelopes = app.event_hub.events_after(0);
+        assert!(envelopes.iter().any(|(_, envelope)| matches!(
+            &envelope.data,
+            EventData::PaneClosed { pane_id, .. } if pane_id == &right_public
+        )));
+        assert!(!envelopes
+            .iter()
+            .any(|(_, envelope)| matches!(envelope.event, EventKind::WorkspaceClosed)));
+    }
+
+    #[test]
+    fn api_confirm_close_accept_defers_to_workspace_when_pane_became_last() {
+        let mut app = app_with_linked_worktree();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.confirm_close_pane = true;
+        let root = app.state.workspaces[0].tabs[0].root_pane;
+        let right = app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let right_public = app.public_pane_id(0, right).unwrap();
+        let _ = app.handle_pane_close(
+            "req".into(),
+            PaneTarget {
+                pane_id: right_public,
+            },
+        );
+        assert_eq!(app.state.pending_close, PendingClose::Pane(right));
+
+        // Sibling auto-exits while the confirm modal is open: the captured pane
+        // becomes the last pane in the workspace.
+        app.state.workspaces[0].close_pane(root);
+        assert!(app.state.close_pane_would_close_workspace(0, right));
+
+        app.handle_confirm_close_key_via_api(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+
+        // Must NOT silently bypass the workspace guard: it routes to workspace
+        // confirmation instead of closing outright.
+        assert_eq!(app.state.mode, Mode::ConfirmClose);
+        assert_eq!(app.state.pending_close, PendingClose::Workspace);
+        assert_eq!(app.state.selected, 0);
+        assert_eq!(app.state.workspaces.len(), 1);
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(right)
+            .is_some());
+
+        // A second confirmation now closes the workspace.
+        app.handle_confirm_close_key_via_api(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+        assert!(app.state.workspaces.is_empty());
+    }
+
+    #[test]
+    fn api_confirm_close_accept_ignores_vanished_pane_without_closing_workspace() {
+        let mut app = app_with_linked_worktree();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.confirm_close_pane = true;
+        let root = app.state.workspaces[0].tabs[0].root_pane;
+        let right = app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let right_public = app.public_pane_id(0, right).unwrap();
+        let _ = app.handle_pane_close(
+            "req".into(),
+            PaneTarget {
+                pane_id: right_public,
+            },
+        );
+        assert_eq!(app.state.pending_close, PendingClose::Pane(right));
+
+        // The captured pane vanishes entirely before the user confirms.
+        app.state.workspaces[0].close_pane(right);
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(right)
+            .is_none());
+
+        app.handle_confirm_close_key_via_api(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+
+        // Graceful no-op: the surviving pane and workspace remain, scope reset.
+        assert_eq!(app.state.workspaces.len(), 1);
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(root)
+            .is_some());
+        assert_eq!(app.state.pending_close, PendingClose::Workspace);
+        assert_eq!(app.state.mode, Mode::Terminal);
     }
 }

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -44,6 +44,8 @@ mod settings;
 mod sidebar;
 mod terminal;
 
+#[cfg(test)]
+pub(crate) use self::modal::{confirm_close_accept, confirm_close_cancel};
 pub(crate) use self::{
     modal::{
         handle_global_menu_key, handle_keybind_help_key, handle_navigator_key,

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -659,6 +659,24 @@ pub(super) fn open_confirm_close(state: &mut AppState) {
 
 #[cfg(test)]
 pub(crate) fn confirm_close_accept(state: &mut AppState) {
+    // If the pending pane became the last pane (e.g. a sibling exited while the
+    // modal was open), closing it would close the workspace. When workspace
+    // confirmation is enabled, route back to the workspace confirmation instead
+    // of silently closing outright — keeping the confirm modal open.
+    if let PendingClose::Pane(pane_id) = state.pending_close {
+        if let Some(ws_idx) = state
+            .workspaces
+            .iter()
+            .position(|ws| ws.find_tab_index_for_pane(pane_id).is_some())
+        {
+            if state.confirm_close && state.close_pane_would_close_workspace(ws_idx, pane_id) {
+                state.selected = ws_idx;
+                state.pending_close = PendingClose::Workspace;
+                state.mode = Mode::ConfirmClose;
+                return;
+            }
+        }
+    }
     match state.pending_close {
         PendingClose::Workspace => state.close_selected_workspace(),
         PendingClose::Pane(pane_id) => state.close_pane_confirmed(pane_id),
@@ -1025,6 +1043,28 @@ impl App {
     }
 
     pub(super) fn confirm_close_accept_via_api(&mut self) {
+        // If the pending pane became the last pane (e.g. a sibling exited while
+        // the modal was open), closing it would close the workspace. When
+        // workspace confirmation is enabled, route back to the workspace
+        // confirmation instead of silently closing outright — keeping the
+        // confirm modal open.
+        if let PendingClose::Pane(pane_id) = self.state.pending_close {
+            if let Some(ws_idx) = self
+                .state
+                .workspaces
+                .iter()
+                .position(|ws| ws.find_tab_index_for_pane(pane_id).is_some())
+            {
+                if self.state.confirm_close
+                    && self.state.close_pane_would_close_workspace(ws_idx, pane_id)
+                {
+                    self.state.selected = ws_idx;
+                    self.state.pending_close = PendingClose::Workspace;
+                    self.state.mode = Mode::ConfirmClose;
+                    return;
+                }
+            }
+        }
         match self.state.pending_close {
             PendingClose::Workspace => {
                 let ws_idx = self.state.selected;

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -7,6 +7,7 @@ use crate::{
     app::{
         state::{
             AppState, ContextMenuKind, ContextMenuState, MenuListState, Mode, NavigatorStateFilter,
+            PendingClose,
         },
         App,
     },
@@ -652,12 +653,17 @@ pub(crate) fn handle_resize_key(state: &mut AppState, raw_key: TerminalKey) {
 }
 
 pub(super) fn open_confirm_close(state: &mut AppState) {
+    state.pending_close = PendingClose::Workspace;
     state.mode = Mode::ConfirmClose;
 }
 
 #[cfg(test)]
-pub(super) fn confirm_close_accept(state: &mut AppState) {
-    state.close_selected_workspace();
+pub(crate) fn confirm_close_accept(state: &mut AppState) {
+    match state.pending_close {
+        PendingClose::Workspace => state.close_selected_workspace(),
+        PendingClose::Pane(pane_id) => state.close_pane_confirmed(pane_id),
+    }
+    state.pending_close = PendingClose::Workspace;
     if state.workspaces.is_empty() {
         state.mode = Mode::Navigate;
     } else {
@@ -665,7 +671,8 @@ pub(super) fn confirm_close_accept(state: &mut AppState) {
     }
 }
 
-pub(super) fn confirm_close_cancel(state: &mut AppState) {
+pub(crate) fn confirm_close_cancel(state: &mut AppState) {
+    state.pending_close = PendingClose::Workspace;
     state.mode = Mode::Navigate;
 }
 
@@ -1018,10 +1025,29 @@ impl App {
     }
 
     pub(super) fn confirm_close_accept_via_api(&mut self) {
-        let ws_idx = self.state.selected;
-        if ws_idx < self.state.workspaces.len() {
-            self.close_workspace_idx_via_api(ws_idx);
+        match self.state.pending_close {
+            PendingClose::Workspace => {
+                let ws_idx = self.state.selected;
+                if ws_idx < self.state.workspaces.len() {
+                    self.close_workspace_idx_via_api(ws_idx);
+                }
+            }
+            PendingClose::Pane(pane_id) => {
+                if let Some(ws_idx) = self
+                    .state
+                    .workspaces
+                    .iter()
+                    .position(|ws| ws.find_tab_index_for_pane(pane_id).is_some())
+                {
+                    let _ = self.close_pane_confirmed(
+                        "tui.confirm_close_pane".to_string(),
+                        ws_idx,
+                        pane_id,
+                    );
+                }
+            }
         }
+        self.state.pending_close = PendingClose::Workspace;
         self.state.mode = if self.state.active.is_some() {
             Mode::Terminal
         } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -55,7 +55,7 @@ use tracing::info;
 use crate::config::Config;
 use crate::events::AppEvent;
 
-pub use state::{AppState, Mode, ToastKind, ViewState};
+pub use state::{AppState, Mode, PendingClose, ToastKind, ViewState};
 
 pub(crate) fn load_plugin_manifest(
     path: &str,
@@ -605,6 +605,8 @@ impl App {
             redraw_on_focus_gained: config.ui.redraw_on_focus_gained,
             mouse_scroll_lines: config.ui.mouse_scroll_lines(),
             confirm_close: config.ui.confirm_close,
+            confirm_close_pane: config.ui.confirm_close_pane,
+            pending_close: PendingClose::Workspace,
             prompt_new_tab_name: config.ui.prompt_new_tab_name,
             pane_borders: config.ui.pane_borders,
             pane_gaps: config.ui.pane_gaps,
@@ -1378,6 +1380,7 @@ impl App {
                 self.state.right_click_passthrough_modifiers =
                     config.ui.right_click_passthrough_modifiers();
                 self.state.confirm_close = config.ui.confirm_close;
+                self.state.confirm_close_pane = config.ui.confirm_close_pane;
                 self.state.prompt_new_tab_name = config.ui.prompt_new_tab_name;
                 self.state.pane_borders = config.ui.pane_borders;
                 self.state.pane_gaps = config.ui.pane_gaps;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1288,6 +1288,18 @@ pub(crate) struct PaneFocusTarget {
     pub pane_id: PaneId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingClose {
+    Workspace,
+    Pane(PaneId),
+}
+
+impl Default for PendingClose {
+    fn default() -> Self {
+        Self::Workspace
+    }
+}
+
 /// All application state — pure data, no channels or async runtime.
 /// Testable without PTYs or a tokio runtime.
 pub struct AppState {
@@ -1389,6 +1401,8 @@ pub struct AppState {
     pub redraw_on_focus_gained: bool,
     pub mouse_scroll_lines: usize,
     pub confirm_close: bool,
+    pub confirm_close_pane: bool,
+    pub pending_close: PendingClose,
     pub prompt_new_tab_name: bool,
     pub pane_borders: bool,
     pub pane_gaps: bool,
@@ -1747,6 +1761,8 @@ impl AppState {
             redraw_on_focus_gained: true,
             mouse_scroll_lines: crate::config::DEFAULT_MOUSE_SCROLL_LINES,
             confirm_close: true,
+            confirm_close_pane: false,
+            pending_close: PendingClose::Workspace,
             prompt_new_tab_name: true,
             pane_borders: true,
             pane_gaps: false,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1288,16 +1288,11 @@ pub(crate) struct PaneFocusTarget {
     pub pane_id: PaneId,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PendingClose {
+    #[default]
     Workspace,
     Pane(PaneId),
-}
-
-impl Default for PendingClose {
-    fn default() -> Self {
-        Self::Workspace
-    }
 }
 
 /// All application state — pure data, no channels or async runtime.

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -796,6 +796,8 @@ pub struct UiConfig {
     pub mouse_scroll_lines: Option<NonZeroUsize>,
     /// Ask for confirmation before closing a workspace. Default: true.
     pub confirm_close: bool,
+    /// Ask for confirmation before closing a pane. Default: false.
+    pub confirm_close_pane: bool,
     /// Ask for a tab name before creating a new tab. Default: true.
     pub prompt_new_tab_name: bool,
     /// Draw borders around split panes. Default: true.
@@ -994,6 +996,7 @@ impl Default for UiConfig {
             redraw_on_focus_gained: true,
             mouse_scroll_lines: None,
             confirm_close: true,
+            confirm_close_pane: false,
             prompt_new_tab_name: true,
             pane_borders: true,
             pane_gaps: true,
@@ -1250,6 +1253,30 @@ prompt_new_tab_name = false
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert!(!config.ui.prompt_new_tab_name);
+    }
+
+    #[test]
+    fn confirm_close_pane_defaults_off_and_parses() {
+        let default_config = Config::default();
+        assert!(!default_config.ui.confirm_close_pane);
+
+        let config: Config = toml::from_str(
+            r#"
+[ui]
+confirm_close = true
+"#,
+        )
+        .unwrap();
+        assert!(!config.ui.confirm_close_pane);
+
+        let config: Config = toml::from_str(
+            r#"
+[ui]
+confirm_close_pane = true
+"#,
+        )
+        .unwrap();
+        assert!(config.ui.confirm_close_pane);
     }
 
     #[test]

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -11,7 +11,7 @@ use super::widgets::{
     action_button_row_rects, centered_popup_rect, panel_contrast_fg, render_action_button,
     render_modal_header, render_modal_shell, render_panel_shell, ActionButtonSpec,
 };
-use crate::app::{state::WorktreeOpenState, AppState, Mode};
+use crate::app::{state::WorktreeOpenState, AppState, Mode, PendingClose};
 
 const NEW_LINKED_WORKTREE_POPUP_WIDTH: u16 = 68;
 const NEW_LINKED_WORKTREE_POPUP_HEIGHT: u16 = 12;
@@ -596,6 +596,13 @@ fn render_open_worktree_search(
 }
 
 fn confirm_close_overlay_text(app: &AppState) -> (String, String) {
+    if matches!(app.pending_close, PendingClose::Pane(_)) {
+        return (
+            "Close pane?".to_string(),
+            "Pane — terminates the running process".to_string(),
+        );
+    }
+
     let ws_name = app
         .workspaces
         .get(app.selected)
@@ -757,7 +764,7 @@ pub(crate) fn confirm_close_button_rects(inner: Rect) -> (Rect, Rect) {
 #[cfg(test)]
 mod tests {
     use crate::{
-        app::{state::WorktreeCreateState, AppState},
+        app::{state::WorktreeCreateState, AppState, PendingClose},
         workspace::Workspace,
     };
     use ratatui::{backend::TestBackend, layout::Rect, Terminal};
@@ -790,6 +797,17 @@ mod tests {
 
         assert_eq!(title, "Close worktree group?");
         assert_eq!(detail, "main — 2 workspaces, 2 panes");
+    }
+
+    #[test]
+    fn confirm_close_text_reports_pane_scope() {
+        let mut app = AppState::test_new();
+        app.pending_close = PendingClose::Pane(crate::layout::PaneId::alloc());
+
+        let (title, detail) = confirm_close_overlay_text(&app);
+
+        assert_eq!(title, "Close pane?");
+        assert_eq!(detail, "Pane — terminates the running process");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an opt-in `[ui] confirm_close_pane` (default `false`). When enabled, `close_pane`
shows the existing close-confirmation modal before closing a pane, instead of closing it
immediately. Default-off means no behavior change unless you turn it on.

It reuses the existing `Mode::ConfirmClose` modal and mirrors the `confirm_close`
(workspace) guard — no new screen or interaction pattern.

Implements the idea from discussion #884 (also raised earlier in #173). I know per
CONTRIBUTING a feature normally wants a maintainer nod first — opening this since it's
small, opt-in, and follows an existing pattern, but happy to move it back to the discussion
or adjust the approach if you'd rather align there first.

## Behavior

- `confirm_close_pane = false` (default): panes close immediately, exactly as today.
- `confirm_close_pane = true`: closing a pane that would **not** close its workspace defers
  to the confirm modal — confirm closes the pane, cancel keeps it.
- Last-pane closes still defer to the existing workspace `confirm_close`: no double prompt,
  and (importantly) no silent workspace close if a sibling pane exits while the modal is
  open — that path re-routes to the workspace confirmation.

## Design

- Adds a `PendingClose { Workspace, Pane(PaneId) }` scope so the shared `Mode::ConfirmClose`
  modal resolves to either a workspace or a pane close. This is TUI/client presentation
  state only — no new server/runtime API, event, or socket surface (per AGENTS.md's
  runtime/client boundary rule).
- The target `PaneId` is captured at defer time, so it's race-safe if focus changes or the
  pane vanishes while the modal is open (vanished pane = graceful no-op).
- The re-defer-to-workspace-confirm decision lives in the confirm-modal accept path, so the
  direct programmatic `pane.close` API contract is unchanged.

## Tests

- Config default + round-trip.
- TUI-state defer / accept / cancel, scope reset, last-pane routing.
- Production API-path tests: defer → `confirmation_required` + `PendingClose::Pane`;
  accept → pane removed + `PaneClosed` emitted (no `WorkspaceClosed`); now-last-pane →
  routes to workspace confirmation; vanished captured pane → graceful no-op.

## Docs

- Adds a `confirm_close_pane` entry alongside `confirm_close` in
  `docs/next/website/src/content/docs/configuration.mdx`. Root `README.md`,
  `CHANGELOG.md`, and `website/` left untouched per CONTRIBUTING.

## Checks

`just ci` is green locally on macOS (zig@0.15): `cargo fmt --check`, `cargo clippy
--all-targets -D warnings` (clean), `cargo nextest run` (2531 passed, 0 failed),
plus the integration-assets and plugin-marketplace suites.

refs #884
