### PR TITLE
fix: preserve navigator search commands

### DIFF
--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -165,15 +165,7 @@ pub(crate) fn handle_navigator_key(
     if state.navigator.search_focused {
         match key.code {
             KeyCode::Esc => {
-                if state.navigator.query.is_empty() {
-                    state.navigator.search_focused = false;
-                    leave_modal(state);
-                } else {
-                    state.navigator.query.clear();
-                    state.navigator.state_filter = None;
-                    state.navigator.search_focused = false;
-                    state.clamp_navigator_selection_from(terminal_runtimes);
-                }
+                state.navigator.search_focused = false;
             }
             KeyCode::Enter => {
                 state.accept_navigator_selection_from(terminal_runtimes);
@@ -208,19 +200,12 @@ pub(crate) fn handle_navigator_key(
 
     match key.code {
         KeyCode::Esc => {
-            if state.navigator.query.is_empty() && state.navigator.state_filter.is_none() {
-                leave_modal(state);
-            } else {
-                state.navigator.query.clear();
-                state.navigator.state_filter = None;
-                state.clamp_navigator_selection_from(terminal_runtimes);
-            }
+            leave_modal(state);
         }
         KeyCode::Enter => {
             state.accept_navigator_selection_from(terminal_runtimes);
         }
         KeyCode::Char('/') => {
-            state.navigator.query.clear();
             state.navigator.state_filter = None;
             state.navigator.search_focused = true;
             state.clamp_navigator_selection_from(terminal_runtimes);
@@ -1641,6 +1626,107 @@ mod tests {
         insert_navigator_search_text(&mut state, &terminal_runtimes, "beta");
 
         assert!(state.navigator.query.is_empty());
+    }
+
+    #[test]
+    fn navigator_empty_search_escape_returns_to_commands() {
+        let mut state = state_with_workspaces(&["alpha", "beta"]);
+        let terminal_runtimes = crate::terminal::TerminalRuntimeRegistry::new();
+        state.mode = Mode::Navigator;
+        state.navigator.search_focused = true;
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.mode, Mode::Navigator);
+        assert!(!state.navigator.search_focused);
+        assert!(state.navigator.query.is_empty());
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::empty()),
+        );
+
+        assert_eq!(
+            state.navigator.state_filter,
+            Some(NavigatorStateFilter::Working)
+        );
+        assert!(state.navigator.query.is_empty());
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.mode, Mode::Terminal);
+    }
+
+    #[test]
+    fn navigator_search_escape_blurs_then_next_escape_closes() {
+        let mut state = state_with_workspaces(&["alpha", "beta"]);
+        let terminal_runtimes = crate::terminal::TerminalRuntimeRegistry::new();
+        state.mode = Mode::Navigator;
+        state.navigator.search_focused = true;
+        state.navigator.query = "a".into();
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.mode, Mode::Navigator);
+        assert!(!state.navigator.search_focused);
+        assert_eq!(state.navigator.query, "a");
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.navigator.selected, 1);
+        assert_eq!(state.navigator.query, "a");
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.mode, Mode::Navigator);
+        assert!(state.navigator.search_focused);
+        assert_eq!(state.navigator.query, "a");
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.navigator.query, "al");
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.mode, Mode::Navigator);
+        assert!(!state.navigator.search_focused);
+
+        handle_navigator_key(
+            &mut state,
+            &terminal_runtimes,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()),
+        );
+
+        assert_eq!(state.mode, Mode::Terminal);
     }
 
     #[test]

--- a/src/ui/navigator.rs
+++ b/src/ui/navigator.rs
@@ -479,17 +479,30 @@ fn render_footer(app: &AppState, frame: &mut Frame, area: Rect) {
     let p = &app.palette;
     let key = Style::default().fg(p.accent).add_modifier(Modifier::BOLD);
     let dim = Style::default().fg(p.overlay0);
-    let line = Line::from(vec![
-        Span::styled(" enter", key),
-        Span::styled(" switch  ", dim),
-        Span::styled("/", key),
-        Span::styled(" search  ", dim),
-        Span::styled("b/w/i/d/a", key),
-        Span::styled(" states  ", dim),
-        Span::styled("j/k/↑↓", key),
-        Span::styled(" move  ", dim),
-        Span::styled("esc", key),
-        Span::styled(" close", dim),
-    ]);
+    let line = if app.navigator.search_focused {
+        Line::from(vec![
+            Span::styled(" enter", key),
+            Span::styled(" switch  ", dim),
+            Span::styled("↑↓", key),
+            Span::styled(" move  ", dim),
+            Span::styled("ctrl+u", key),
+            Span::styled(" clear  ", dim),
+            Span::styled("esc", key),
+            Span::styled(" back", dim),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(" enter", key),
+            Span::styled(" switch  ", dim),
+            Span::styled("/", key),
+            Span::styled(" search  ", dim),
+            Span::styled("b/w/i/d/a", key),
+            Span::styled(" states  ", dim),
+            Span::styled("j/k/↑↓", key),
+            Span::styled(" move  ", dim),
+            Span::styled("esc", key),
+            Span::styled(" close", dim),
+        ])
+    };
     frame.render_widget(Paragraph::new(line), area);
 }


### PR DESCRIPTION
Refs #1115

## Behavior

- Esc while search is focused only unfocuses the search field; the query and active state filter are kept.
- Esc outside search focus closes the navigator without clearing the query/filter first.
- `/` re-enters search focus without clearing the current query (it still clears the state filter).
- Footer now shows shortcuts for the active mode: search focus shows `enter switch`, `↑↓ move`, `ctrl+u clear`, `esc back`; command mode keeps `enter switch`, `/ search`, `b/w/i/d/a states`, `j/k/↑↓ move`, `esc close`.

## Tests

- `navigator_empty_search_escape_returns_to_commands`
- `navigator_search_escape_blurs_then_next_escape_closes`