### PR TITLE
fix(input source): when second_field ommited, parse third one

### DIFF
--- a/src/input/encode.rs
+++ b/src/input/encode.rs
@@ -454,6 +454,7 @@ fn kitty_event_suffix(key: &TerminalKey, flags: u16) -> Option<u8> {
 fn encode_legacy_inner(key: TerminalKey) -> Vec<u8> {
     match key.code {
         KeyCode::Char(ch) => {
+            let ch = key.shifted_codepoint.and_then(char::from_u32).unwrap_or(ch);
             if key.modifiers.contains(KeyModifiers::CONTROL) {
                 let upper = ch.to_ascii_uppercase();
                 match upper {
@@ -1057,5 +1058,16 @@ mod tests {
         let encoded = encode_terminal_key(key, KeyboardProtocol::Kitty { flags: 7 });
         assert!(!encoded.is_empty());
         assert_ne!(encoded, "测".as_bytes());
+    }
+
+    #[test]
+    fn legacy_ctrl_cyrillic_uses_alternate_shifted_codepoint() {
+        let key = TerminalKey::new(KeyCode::Char('ц'), KeyModifiers::CONTROL)
+            .with_shifted_codepoint('w' as u32);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), vec![23]);
+
+        let key = TerminalKey::new(KeyCode::Char('г'), KeyModifiers::CONTROL)
+            .with_shifted_codepoint('u' as u32);
+        assert_eq!(encode_terminal_key(key, KeyboardProtocol::Legacy), vec![21]);
     }
 }

--- a/src/input/parse.rs
+++ b/src/input/parse.rs
@@ -25,10 +25,15 @@ fn parse_kitty_key_sequence(data: &str) -> Option<TerminalKey> {
 
     let mut key_fields = key_part.split(':');
     let codepoint = key_fields.next()?.parse::<u32>().ok()?;
-    let shifted_codepoint = key_fields
+    let second_field = key_fields
         .next()
         .filter(|field| !field.is_empty())
         .and_then(|field| field.parse::<u32>().ok());
+    let third_field = key_fields
+        .next()
+        .filter(|field| !field.is_empty())
+        .and_then(|field| field.parse::<u32>().ok());
+    let shifted_codepoint = second_field.or(third_field);
 
     let code = kitty_codepoint_to_keycode(codepoint)?;
     let kind = parse_kitty_event_type(event_type)?;


### PR DESCRIPTION
Fixes the problem with input modifier keys on other input sources. Even added a test function for it