### PR TITLE
feat: add Grok Build (grok) integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added Grok Build (`grok`) integration: `herdr integration install grok` installs a SessionStart hook that reports native session ids for resume with `grok --resume <id>`. State detection continues to use the bundled grok screen manifest. (#xxxx)
+
 ## [0.7.3] - 2026-07-08
 
 ### Fixed

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -186,6 +186,9 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
                 session_ref.value.clone(),
             ]
         }
+        ("herdr:grok", "grok", AgentSessionRefKind::Id) => {
+            vec!["grok".into(), "--resume".into(), session_ref.value.clone()]
+        }
         _ => return None,
     };
 
@@ -220,6 +223,7 @@ fn is_official_agent_source(source: &str, agent: &str) -> bool {
             | ("herdr:qodercli", "qodercli")
             | ("herdr:kilo", "kilo")
             | ("herdr:cursor", "cursor")
+            | ("herdr:grok", "grok")
     )
 }
 

--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -27,6 +27,7 @@ pub enum IntegrationTarget {
     Qodercli,
     Cursor,
     Mastracode,
+    Grok,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -103,13 +103,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok>"
         );
         return Ok(None);
     }
@@ -129,10 +129,11 @@ fn parse_integration_target(
         "qodercli" => IntegrationTarget::Qodercli,
         "cursor" => IntegrationTarget::Cursor,
         "mastracode" => IntegrationTarget::Mastracode,
+        "grok" => IntegrationTarget::Grok,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, mastracode"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, mastracode, grok"
             );
             return Ok(None);
         }
@@ -157,6 +158,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install qodercli");
     eprintln!("  herdr integration install cursor");
     eprintln!("  herdr integration install mastracode");
+    eprintln!("  herdr integration install grok");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -171,5 +173,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall qodercli");
     eprintln!("  herdr integration uninstall cursor");
     eprintln!("  herdr integration uninstall mastracode");
+    eprintln!("  herdr integration uninstall grok");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -3,9 +3,9 @@ use std::io;
 use super::registry::{integration_target_label, integration_target_supported};
 use super::targets::{
     install_claude, install_codex, install_copilot, install_cursor, install_devin, install_droid,
-    install_hermes, install_kilo, install_kimi, install_mastracode, install_omp, install_opencode,
+    install_grok, install_hermes, install_kilo, install_kimi, install_mastracode, install_omp, install_opencode,
     install_pi, install_qodercli, uninstall_claude, uninstall_codex, uninstall_copilot,
-    uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_hermes, uninstall_kilo,
+    uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_grok, uninstall_hermes, uninstall_kilo,
     uninstall_kimi, uninstall_mastracode, uninstall_omp, uninstall_opencode, uninstall_pi,
     uninstall_qodercli,
 };
@@ -201,6 +201,19 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                 format!(
                     "ensured mastracode hooks at {}",
                     installed.hooks_path.display()
+                ),
+            ]
+        }
+        crate::api::schema::IntegrationTarget::Grok => {
+            let installed = install_grok()?;
+            vec![
+                format!(
+                    "installed grok integration hook to {}",
+                    installed.hook_path.display()
+                ),
+                format!(
+                    "registered grok hooks at {}",
+                    installed.hooks_json_path.display()
                 ),
             ]
         }
@@ -554,6 +567,33 @@ pub(crate) fn uninstall_target(
                 messages.push(format!(
                     "no herdr mastracode hook entries found in {}",
                     result.hooks_path.display()
+                ));
+            }
+            messages
+        }
+        crate::api::schema::IntegrationTarget::Grok => {
+            let result = uninstall_grok()?;
+            let mut messages = Vec::new();
+            if result.removed_hook_file {
+                messages.push(format!(
+                    "removed grok hook at {}",
+                    result.hook_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no grok hook found at {}",
+                    result.hook_path.display()
+                ));
+            }
+            if result.removed_hooks_json {
+                messages.push(format!(
+                    "removed herdr grok hook registration at {}",
+                    result.hooks_json_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no herdr grok hook registration found at {}",
+                    result.hooks_json_path.display()
                 ));
             }
             messages

--- a/src/integration/assets/grok/herdr-agent-state.sh
+++ b/src/integration/assets/grok/herdr-agent-state.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=grok
+# HERDR_INTEGRATION_VERSION=1
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-grok-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:grok"
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+def first_text(*keys):
+    for key in keys:
+        value = hook_input.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+hook_event_name = first_text("hook_event_name", "hookEventName", "hookEvent")
+if hook_event_name not in (None, "SessionStart", "sessionStart"):
+    raise SystemExit(0)
+
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = first_text("session_id", "sessionId", "sessionID", "id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+if agent_session_id:
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": {
+            "pane_id": pane_id,
+            "source": source,
+            "agent": "grok",
+            "seq": report_seq,
+            "agent_session_id": agent_session_id,
+        },
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -16,6 +16,7 @@ pub(crate) const KIMI_CODE_HOME_ENV_VAR: &str = "KIMI_CODE_HOME";
 pub(crate) const COPILOT_HOME_ENV_VAR: &str = "COPILOT_HOME";
 pub(crate) const QODERCLI_CONFIG_DIR_ENV_VAR: &str = "QODER_CONFIG_DIR";
 pub(crate) const CURSOR_CONFIG_DIR_ENV_VAR: &str = "CURSOR_CONFIG_DIR";
+pub(crate) const GROK_CONFIG_DIR_ENV_VAR: &str = "GROK_CONFIG_DIR";
 
 pub(crate) fn apply_pane_base_env(cmd: &mut CommandBuilder) {
     cmd.env(crate::api::SOCKET_PATH_ENV_VAR, crate::api::socket_path());
@@ -126,6 +127,10 @@ pub(crate) fn cursor_dir() -> io::Result<PathBuf> {
 
 pub(crate) fn mastracode_dir() -> io::Result<PathBuf> {
     Ok(home_dir()?.join(".mastracode"))
+}
+
+pub(crate) fn grok_dir() -> io::Result<PathBuf> {
+    config_dir_from_env_or_home(GROK_CONFIG_DIR_ENV_VAR, &[".grok"])
 }
 
 pub(crate) fn home_dir() -> io::Result<PathBuf> {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -183,6 +183,10 @@ const MASTRACODE_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const MASTRACODE_HOOK_ASSET: &str = include_str!("assets/mastracode/herdr-agent-state.sh");
 const MASTRACODE_INTEGRATION_VERSION: u32 = 1;
 const MASTRACODE_HOOK_TIMEOUT_MS: u64 = 10_000;
+
+const GROK_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
+const GROK_HOOK_ASSET: &str = include_str!("assets/grok/herdr-agent-state.sh");
+const GROK_INTEGRATION_VERSION: u32 = 1;
 const MASTRACODE_HOOK_EVENTS: [(&str, &str); 12] = [
     ("SessionStart", "idle"),
     ("UserPromptSubmit", "working"),

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -22,6 +22,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Qodercli => "qodercli",
         crate::api::schema::IntegrationTarget::Cursor => "cursor",
         crate::api::schema::IntegrationTarget::Mastracode => "mastracode",
+        crate::api::schema::IntegrationTarget::Grok => "grok",
     }
 }
 
@@ -49,6 +50,7 @@ pub(crate) fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Qodercli => qodercli_command_names(),
         crate::api::schema::IntegrationTarget::Cursor => cursor_command_names(),
         crate::api::schema::IntegrationTarget::Mastracode => &["mastracode"],
+        crate::api::schema::IntegrationTarget::Grok => &["grok"],
     }
 }
 
@@ -253,7 +255,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 14] {
+); 15] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -327,6 +329,11 @@ fn integration_specs() -> [(
             crate::api::schema::IntegrationTarget::Mastracode,
             mastracode_dir().map(|dir| dir.join("hooks").join(super::MASTRACODE_HOOK_INSTALL_NAME)),
             super::MASTRACODE_INTEGRATION_VERSION,
+        ),
+        (
+            crate::api::schema::IntegrationTarget::Grok,
+            grok_dir().map(|dir| dir.join(super::GROK_HOOK_INSTALL_NAME)),
+            super::GROK_INTEGRATION_VERSION,
         ),
     ]
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -15,7 +15,7 @@ use super::config_edit::{
 use super::env::{
     claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir, hermes_dir,
     hermes_plugin_dir, kilo_dir, kimi_dir, mastracode_dir, omp_extension_dir, opencode_dir,
-    pi_extension_dir, qodercli_dir,
+    pi_extension_dir, qodercli_dir, grok_dir,
 };
 use super::file_ops::{
     make_executable, remove_dir_all_if_exists, remove_file_if_exists, remove_legacy_bash_hook_file,
@@ -27,7 +27,7 @@ use super::types::{
     HermesInstallPaths, HermesUninstallResult, KiloInstallPaths, KiloUninstallResult,
     KimiInstallPaths, KimiUninstallResult, MastracodeInstallPaths, MastracodeUninstallResult,
     OmpInstallPaths, OmpUninstallResult, OpenCodeInstallPaths, OpenCodeUninstallResult,
-    PiUninstallResult, QodercliInstallPaths, QodercliUninstallResult,
+    PiUninstallResult, QodercliInstallPaths, QodercliUninstallResult, GrokInstallPaths, GrokUninstallResult,
 };
 use super::{
     CLAUDE_HOOK_ASSET, CLAUDE_HOOK_INSTALL_NAME, CODEX_HOOK_ASSET, CODEX_HOOK_INSTALL_NAME,
@@ -43,6 +43,7 @@ use super::{
     OMP_EXTENSION_INSTALL_NAME, OPENCODE_PLUGIN_ASSET, OPENCODE_PLUGIN_INSTALL_NAME,
     PI_EXTENSION_ASSET, PI_EXTENSION_INSTALL_NAME, QODERCLI_HOOK_ASSET, QODERCLI_HOOK_EVENTS,
     QODERCLI_HOOK_INSTALL_NAME, QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS,
+    GROK_HOOK_ASSET, GROK_HOOK_INSTALL_NAME,
 };
 
 pub(crate) fn install_pi() -> io::Result<PathBuf> {
@@ -1016,6 +1017,48 @@ pub(crate) fn install_cursor() -> io::Result<CursorInstallPaths> {
     })
 }
 
+pub(crate) fn install_grok() -> io::Result<GrokInstallPaths> {
+    let dir = grok_dir()?;
+    if !dir.is_dir() {
+        // Create base dir so hooks subdir can be made.
+        fs::create_dir_all(&dir)?;
+    }
+
+    let hook_path = dir.join(GROK_HOOK_INSTALL_NAME);
+    fs::write(&hook_path, GROK_HOOK_ASSET)?;
+    make_executable(&hook_path)?;
+
+    let hooks_dir = dir.join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+
+    let hooks_json_path = hooks_dir.join("herdr-agent-state.json");
+    // Write a dedicated hooks registration file. Grok loads all *.json under ~/.grok/hooks/
+    // Use Grok's nested hooks format with SessionStart.
+    let quoted = shell_single_quote(&hook_path.display().to_string());
+    let command = format!("bash {} session", quoted);
+    let hooks_json = json!({
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": command,
+                            "timeout": 10
+                        }
+                    ]
+                }
+            ]
+        }
+    });
+    fs::write(&hooks_json_path, serde_json::to_string_pretty(&hooks_json)?)?;
+
+    Ok(GrokInstallPaths {
+        hook_path,
+        hooks_json_path,
+    })
+}
+
 pub(crate) fn uninstall_qodercli() -> io::Result<QodercliUninstallResult> {
     let hook_path = qodercli_dir()?
         .join("hooks")
@@ -1105,6 +1148,22 @@ pub(crate) fn uninstall_cursor() -> io::Result<CursorUninstallResult> {
         hooks_path,
         removed_hook_file,
         updated_hooks,
+    })
+}
+
+pub(crate) fn uninstall_grok() -> io::Result<GrokUninstallResult> {
+    let home = grok_dir()?;
+    let hook_path = home.join(GROK_HOOK_INSTALL_NAME);
+    let hooks_json_path = home.join("hooks").join("herdr-agent-state.json");
+
+    let removed_hook_file = remove_file_if_exists(&hook_path)?;
+    let removed_hooks_json = remove_file_if_exists(&hooks_json_path)?;
+
+    Ok(GrokUninstallResult {
+        hook_path,
+        hooks_json_path,
+        removed_hook_file,
+        removed_hooks_json,
     })
 }
 

--- a/src/integration/types.rs
+++ b/src/integration/types.rs
@@ -96,6 +96,20 @@ pub(crate) struct MastracodeUninstallResult {
 }
 
 #[derive(Debug)]
+pub(crate) struct GrokInstallPaths {
+    pub hook_path: PathBuf,
+    pub hooks_json_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct GrokUninstallResult {
+    pub hook_path: PathBuf,
+    pub hooks_json_path: PathBuf,
+    pub removed_hook_file: bool,
+    pub removed_hooks_json: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct QodercliUninstallResult {
     pub hook_path: PathBuf,
     pub settings_path: PathBuf,

--- a/website/src/content/docs/agents.mdx
+++ b/website/src/content/docs/agents.mdx
@@ -26,7 +26,7 @@ Automatic detection works out of the box for common coding agents. The important
 | Codex | screen manifest | session |
 | Cursor Agent CLI | screen manifest | session |
 | Amp | screen manifest | none |
-| Grok CLI | screen manifest | none |
+| Grok CLI | screen manifest | session |
 | Antigravity CLI | screen manifest | none |
 | Kiro CLI | screen manifest | none |
 
@@ -42,7 +42,7 @@ For agents without complete lifecycle hooks, Herdr identifies the foreground pro
 
 The screen snapshot comes from the recent bottom of the pane buffer, not the scrolled viewport. If you scroll back in Herdr, detection still follows the live agent UI at the bottom.
 
-Claude Code, Codex, GitHub Copilot CLI, Droid, Qoder CLI, and Cursor Agent CLI integrations are intentionally not lifecycle authorities. They provide native session identity for restore, but their hooks do not cover the whole lifecycle. They can miss permission approval results, escape interrupts, or other transitions. For those agents, Herdr still uses screen manifest detection.
+Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, and Grok Build integrations are intentionally not lifecycle authorities. They provide native session identity for restore, but their hooks do not cover the whole lifecycle. They can miss permission approval results, escape interrupts, or other transitions. For those agents, Herdr still uses screen manifest detection.
 
 ## VMs and sandbox wrappers
 

--- a/website/src/content/docs/integrations.mdx
+++ b/website/src/content/docs/integrations.mdx
@@ -26,6 +26,7 @@ herdr integration install hermes
 herdr integration install qodercli
 herdr integration install cursor
 herdr integration install mastracode
+herdr integration install grok
 ```
 
 ## Uninstall integrations
@@ -45,6 +46,7 @@ herdr integration uninstall hermes
 herdr integration uninstall qodercli
 herdr integration uninstall cursor
 herdr integration uninstall mastracode
+herdr integration uninstall grok
 ```
 
 ## How Herdr uses integrations
@@ -255,6 +257,20 @@ The hook reports MastraCode lifecycle state and thread identity to Herdr for aut
 Herdr uses `~/.mastracode`. Install writes `hooks/herdr-agent-state.sh` and adds Herdr command entries to `hooks.json`, creating the directory when missing. Uninstall removes the matching hook entries and deletes the hook script.
 
 Herdr resumes stored MastraCode threads with `mastracode --thread <id>`.
+
+## Grok Build (grok)
+
+Install the Grok Build integration:
+
+```
+herdr integration install grok
+```
+
+*Terminal window*
+
+The integration reports native Grok session identity for restore via `grok --resume <id>`. Lifecycle state still comes from Herdr’s screen manifest detection.
+
+Herdr uses `~/.grok` (override with `GROK_CONFIG_DIR`). Install writes `herdr-agent-state.sh` and a registration under `~/.grok/hooks/herdr-agent-state.json`. Uninstall removes the hook script and the registration file.
 
 ## Custom status labels
 


### PR DESCRIPTION
Adds native `grok` integration.

- `herdr integration install grok`
- Reports session id for resume via `grok --resume <id>`
- Follows the existing session-identity pattern (Codex, Cursor, etc.)
- State detection remains via screen manifest

Grok Build was already detected; this adds restore support.