### PR TITLE
Default CLI spawn targets to the calling pane

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -45,13 +45,12 @@ important: ids can compact when tabs, panes, or workspaces are closed. do not tr
 
 ## discover yourself
 
-see what panes exist and which one is focused:
+your pane is the one running this command (`HERDR_PANE_ID`), not necessarily the UI-focused pane. if the operator clicked another tab while you work, `herdr pane list` may show a different pane as `focused`.
 
 ```bash
+herdr pane current
 herdr pane list
 ```
-
-the focused pane is yours. other panes are your neighbors.
 
 list workspaces:
 
@@ -116,7 +115,13 @@ herdr pane read 1-1 --source recent --lines 50
 split your pane to the right and keep focus on your current pane:
 
 ```bash
-herdr pane split 1-2 --direction right --no-focus
+herdr pane split --current --direction right --no-focus
+```
+
+or pass your pane id explicitly:
+
+```bash
+herdr pane split "$HERDR_PANE_ID" --direction right --no-focus
 ```
 
 that prints json with the new pane nested at `result.pane.pane_id`. parse that value, then run a command in that pane:

--- a/src/api/schema/agents.rs
+++ b/src/api/schema/agents.rs
@@ -39,6 +39,8 @@ pub struct AgentStartParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tab_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_pane_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub split: Option<SplitDirection>,
     #[serde(default)]
     pub focus: bool,

--- a/src/app/agents.rs
+++ b/src/app/agents.rs
@@ -150,6 +150,31 @@ impl App {
                 extra_env,
                 focus,
             )?
+        } else if let Some(caller_pane_id) = params.caller_pane_id {
+            let (ws_idx, target_pane) =
+                self.parse_pane_id(&caller_pane_id)
+                    .ok_or_else(|| AgentStartError::TargetNotFound {
+                        target: caller_pane_id.clone(),
+                    })?;
+            if let Some(workspace_id) = params.workspace_id.as_deref() {
+                let requested_ws_idx = self.parse_workspace_id(workspace_id).ok_or_else(|| {
+                    AgentStartError::TargetNotFound {
+                        target: workspace_id.to_string(),
+                    }
+                })?;
+                if requested_ws_idx != ws_idx {
+                    return Err(AgentStartError::PlacementConflict);
+                }
+            }
+            self.spawn_agent_split(
+                ws_idx,
+                target_pane,
+                params.split.unwrap_or(SplitDirection::Right),
+                cwd,
+                &argv,
+                extra_env,
+                focus,
+            )?
         } else if let Some(workspace_id) = params.workspace_id {
             let ws_idx = self.parse_workspace_id(&workspace_id).ok_or_else(|| {
                 AgentStartError::TargetNotFound {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3902,6 +3902,7 @@ mod tests {
                 cwd: None,
                 workspace_id: None,
                 tab_id: None,
+                caller_pane_id: None,
                 split: Some(crate::api::schema::SplitDirection::Right),
                 focus: true,
                 argv: vec![exiting_test_command().into()],
@@ -3917,6 +3918,49 @@ mod tests {
 
         assert_eq!(app.state.active, Some(0));
         assert_eq!(app.state.workspaces[0].focused_pane_id(), Some(root));
+
+        let runtimes: Vec<_> = app.terminal_runtimes.drain().collect();
+        for (_terminal_id, runtime) in runtimes {
+            runtime.shutdown();
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_start_splits_from_caller_pane_when_ui_focus_differs() {
+        let mut app = test_app();
+        let workspace = Workspace::test_new("agent-start-caller");
+        let root = workspace.tabs[0].root_pane;
+        let right = workspace.test_split(ratatui::layout::Direction::Horizontal);
+        app.state.workspaces = vec![workspace];
+        app.state.ensure_test_terminals();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.workspaces[0].tabs[0].layout.focus_pane(root);
+        let right_public = app.public_pane_id(0, right).unwrap();
+
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "req_agent_start_caller".into(),
+            method: crate::api::schema::Method::AgentStart(crate::api::schema::AgentStartParams {
+                name: "worker".into(),
+                cwd: None,
+                workspace_id: None,
+                tab_id: None,
+                caller_pane_id: Some(right_public.clone()),
+                split: Some(crate::api::schema::SplitDirection::Right),
+                focus: false,
+                argv: vec![exiting_test_command().into()],
+                env: Default::default(),
+            }),
+        });
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+
+        assert_eq!(response["result"]["type"], "agent_started");
+        let started_pane = response["result"]["agent"]["pane_id"].as_str().unwrap();
+        let root_public = app.public_pane_id(0, root).unwrap();
+        assert_ne!(started_pane, root_public);
+        assert_ne!(started_pane, right_public);
+        assert_eq!(app.state.workspaces[0].focused_pane_id(), Some(root));
+        assert_eq!(app.state.workspaces[0].tabs[0].layout.pane_count(), 3);
 
         let runtimes: Vec<_> = app.terminal_runtimes.drain().collect();
         for (_terminal_id, runtime) in runtimes {

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -282,6 +282,9 @@ fn agent_start(args: &[String]) -> std::io::Result<i32> {
         return Ok(2);
     }
 
+    let env_pane_id = std::env::var("HERDR_PANE_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
     let mut cwd = None;
     let mut workspace_id = None;
     let mut tab_id = None;
@@ -361,6 +364,11 @@ fn agent_start(args: &[String]) -> std::io::Result<i32> {
             cwd,
             workspace_id,
             tab_id,
+            caller_pane_id: if tab_id.is_none() {
+                env_pane_id.map(super::normalize_pane_id)
+            } else {
+                None
+            },
             split,
             focus,
             argv: args[separator + 1..].to_vec(),

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -618,6 +618,10 @@ fn parse_pane_split_args(
         );
     };
 
+    if pane_id.is_none() {
+        pane_id = env_pane_id.map(super::normalize_pane_id);
+    }
+
     Ok(PaneSplitParams {
         workspace_id: None,
         target_pane_id: pane_id,
@@ -1483,9 +1487,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_pane_split_args_omitted_target_keeps_focused_fallback() {
+    fn parse_pane_split_args_omitted_target_defaults_to_caller_pane() {
         let params =
             parse_pane_split_args(&args(&["--direction", "down"]), Some("issue-1")).unwrap();
+
+        assert_eq!(params.target_pane_id, Some("issue-1".into()));
+        assert_eq!(params.direction, crate::api::schema::SplitDirection::Down);
+    }
+
+    #[test]
+    fn parse_pane_split_args_omitted_target_without_env_keeps_focused_fallback() {
+        let params = parse_pane_split_args(&args(&["--direction", "down"]), None).unwrap();
 
         assert_eq!(params.target_pane_id, None);
         assert_eq!(params.direction, crate::api::schema::SplitDirection::Down);

--- a/src/cli/tab.rs
+++ b/src/cli/tab.rs
@@ -51,6 +51,9 @@ fn tab_list(args: &[String]) -> std::io::Result<i32> {
 }
 
 fn tab_create(args: &[String]) -> std::io::Result<i32> {
+    let env_workspace_id = std::env::var("HERDR_WORKSPACE_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
     let mut workspace_id = None;
     let mut cwd = None;
     let mut focus = false;
@@ -112,6 +115,10 @@ fn tab_create(args: &[String]) -> std::io::Result<i32> {
                 return Ok(2);
             }
         }
+    }
+
+    if workspace_id.is_none() {
+        workspace_id = env_workspace_id.map(super::normalize_workspace_id);
     }
 
     super::runtime::tab_create(TabCreateParams {

--- a/website/src/content/docs/cli-reference.mdx
+++ b/website/src/content/docs/cli-reference.mdx
@@ -179,7 +179,16 @@ herdr pane close <pane_id>
 For pane commands that accept `--current`, Herdr uses the calling pane's
 `HERDR_PANE_ID` when the command runs inside a Herdr pane. For `pane split`,
 an explicit pane id or `--pane ID` splits that pane, `--current` splits the
-calling pane, and an omitted target keeps using the UI-focused pane.
+calling pane, and an omitted target defaults to the calling pane when
+`HERDR_PANE_ID` is set. Outside a Herdr pane, an omitted target falls back to
+the UI-focused pane.
+
+`tab create` without `--workspace` defaults to `HERDR_WORKSPACE_ID` when the
+CLI runs inside a Herdr pane.
+
+`agent start` without `--tab` passes the calling pane through the socket API
+as `caller_pane_id`, so `--split` anchors to your pane instead of the
+UI-focused pane. `--tab` still targets the requested tab.
 
 Read output:
 


### PR DESCRIPTION
## Summary
- `herdr pane split` without an explicit target now defaults to `HERDR_PANE_ID` when the CLI runs inside a Herdr pane
- `herdr agent start` passes `caller_pane_id` through the socket API (unless `--tab` is set) so `--split` anchors to the invoking pane, not the UI-focused pane
- `herdr tab create` without `--workspace` defaults to `HERDR_WORKSPACE_ID` inside a Herdr pane
- Updates `SKILL.md` and CLI reference docs; adds regression test for caller-anchored agent start

## Problem
When an agent spawns a sibling pane while the operator has clicked another tab/workspace, Herdr used the UI-focused pane as the split target. That made spawns appear in random places relative to the calling agent.

## Test plan
- [ ] Agent in pane A, operator focuses pane B in another tab → `herdr pane split --direction right` creates a sibling of A
- [ ] Same setup → `herdr agent start worker --split right -- /bin/sh` creates the agent beside A
- [ ] `herdr tab create` without `--workspace` creates a tab in the caller workspace
- [ ] `herdr agent start worker --tab <newTab> -- ...` still targets the requested tab
- [ ] `cargo test agent_start_splits_from_caller_pane_when_ui_focus_differs`


Made with [Cursor](https://cursor.com)