### PR TITLE
fix(terminal): honor in-pane cd when new_cwd=follow

### DIFF
--- a/src/app/api/layouts.rs
+++ b/src/app/api/layouts.rs
@@ -341,11 +341,12 @@ impl App {
         let follow_cwd = replace_target.and_then(|(_, tab_idx)| {
             let ws = self.state.workspaces.get(ws_idx)?;
             let tab = ws.tabs.get(tab_idx)?;
-            tab.cwd_for_pane(
-                tab.layout.focused(),
-                &self.state.terminals,
-                &self.terminal_runtimes,
-            )
+            let pane_id = tab.layout.focused();
+            // Prefer live foreground cwd (nested shell after `cd`) over OSC/cache (#1245).
+            tab.foreground_cwd_for_pane(pane_id, &self.terminal_runtimes)
+                .or_else(|| {
+                    tab.cwd_for_pane(pane_id, &self.state.terminals, &self.terminal_runtimes)
+                })
         });
         self.resolve_new_terminal_cwd(
             follow_cwd.or_else(|| self.focused_pane_cwd_in_workspace(ws_idx)),
@@ -399,7 +400,7 @@ impl App {
             .cwd
             .as_ref()
             .map(PathBuf::from)
-            .or_else(|| self.cwd_for_pane_in_workspace(ws_idx, target_pane_id));
+            .or_else(|| self.follow_cwd_for_pane_in_workspace(ws_idx, target_pane_id));
         let extra_env = super::env::normalize_launch_env(pane.env.clone())
             .map_err(|(_, message)| message.to_string())?;
         let direction = match direction {

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -53,7 +53,8 @@ impl App {
         };
         let (rows, cols) = self.state.estimate_pane_size();
         let split_cwd = params.cwd.map(std::path::PathBuf::from).or_else(|| {
-            let follow_cwd = self.cwd_for_pane_in_workspace(ws_idx, target_pane_id);
+            // Prefer live foreground cwd so in-pane `cd` is honored (#1245).
+            let follow_cwd = self.follow_cwd_for_pane_in_workspace(ws_idx, target_pane_id);
             Some(self.resolve_new_terminal_cwd(follow_cwd))
         });
         let default_shell = self.state.default_shell.clone();

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -50,9 +50,28 @@ impl App {
             .cwd_for_pane(pane_id, &self.state.terminals, &self.terminal_runtimes)
     }
 
+    /// CWD used when `terminal.new_cwd = "follow"`.
+    ///
+    /// Prefer the **foreground** process cwd (nested shell after `cd` inside the
+    /// pane) over OSC-7 / cached shell cwd. Without this, follow often anchors on
+    /// the pane launch directory and ignores in-pane `cd` (#1245, #912).
+    pub(super) fn follow_cwd_for_pane_in_workspace(
+        &self,
+        ws_idx: usize,
+        pane_id: crate::layout::PaneId,
+    ) -> Option<PathBuf> {
+        let ws = self.state.workspaces.get(ws_idx)?;
+        let tab_idx = ws.find_tab_index_for_pane(pane_id)?;
+        let tab = ws.tabs.get(tab_idx)?;
+        tab.foreground_cwd_for_pane(pane_id, &self.terminal_runtimes)
+            .or_else(|| {
+                tab.cwd_for_pane(pane_id, &self.state.terminals, &self.terminal_runtimes)
+            })
+    }
+
     pub(super) fn focused_pane_cwd_in_workspace(&self, ws_idx: usize) -> Option<PathBuf> {
         let pane_id = self.state.workspaces.get(ws_idx)?.focused_pane_id()?;
-        self.cwd_for_pane_in_workspace(ws_idx, pane_id)
+        self.follow_cwd_for_pane_in_workspace(ws_idx, pane_id)
     }
 
     pub(super) fn resolve_new_terminal_cwd(&self, follow_cwd: Option<PathBuf>) -> PathBuf {
@@ -77,9 +96,10 @@ impl App {
     /// Create a workspace with a real PTY (needs event_tx).
     #[cfg(test)]
     pub(crate) fn create_workspace(&mut self) {
-        let follow_cwd = self
-            .workspace_creation_source()
-            .and_then(|ws_idx| self.seed_cwd_from_workspace(ws_idx));
+        let follow_cwd = self.workspace_creation_source().and_then(|ws_idx| {
+            self.focused_pane_cwd_in_workspace(ws_idx)
+                .or_else(|| self.seed_cwd_from_workspace(ws_idx))
+        });
         let initial_cwd = self.resolve_new_terminal_cwd(follow_cwd);
         if let Err(e) = self.create_workspace_with_events(initial_cwd, true) {
             error!(err = %e, "failed to create workspace");
@@ -91,10 +111,10 @@ impl App {
     pub(crate) fn create_tab(&mut self) {
         let custom_name = self.state.requested_new_tab_name.take();
         let active_before = self.state.active;
-        let follow_cwd = self
-            .state
-            .active
-            .and_then(|ws_idx| self.seed_cwd_from_workspace(ws_idx));
+        let follow_cwd = self.state.active.and_then(|ws_idx| {
+            self.focused_pane_cwd_in_workspace(ws_idx)
+                .or_else(|| self.seed_cwd_from_workspace(ws_idx))
+        });
         let initial_cwd = self.resolve_new_terminal_cwd(follow_cwd);
         match self.create_tab_with_options(initial_cwd, true) {
             Ok(created_idx) => {

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -541,7 +541,12 @@ impl AppState {
             .and_then(|i| self.workspaces.get(i))
             .and_then(|ws| {
                 let tab = ws.active_tab()?;
-                tab.cwd_for_pane(tab.layout.focused(), &self.terminals, terminal_runtimes)
+                let pane_id = tab.layout.focused();
+                // Prefer live foreground cwd so in-pane `cd` is followed (#1245).
+                tab.foreground_cwd_for_pane(pane_id, terminal_runtimes)
+                    .or_else(|| {
+                        tab.cwd_for_pane(pane_id, &self.terminals, terminal_runtimes)
+                    })
             });
         let cwd = Some(super::creation::resolve_new_terminal_cwd(
             &self.new_terminal_cwd,


### PR DESCRIPTION
## Summary

Fixes #1245 (related: #912).

With `terminal.new_cwd = "follow"`, new panes/tabs often still opened at the **workspace / pane launch directory** after the user `cd`s inside the focused pane. That matches using OSC-7 / shell-leader cwd only, which frequently does **not** update for nested shells.

## Change

Prefer the **foreground process cwd** (`foreground_cwd_for_pane` / `process_cwd` of the controlling process group) when resolving follow sources, then fall back to the existing OSC/cached `cwd_for_pane` path.

Applied on:

- Focused-pane follow helper used by tab create / workspace create
- Pane split API
- Layout apply / layout split
- In-process `AppState::split_pane` (keybind path)

## Why this is correct

`cwd()` tracks reported/shell-leader directory. `foreground_cwd()` reads the live process group controlling the PTY — the path after `cd` in an interactive nested shell. Config docs already describe follow as inheriting the source pane’s current directory; this makes that true for real shell navigation.

## Test plan

- [ ] Config: `[terminal] new_cwd = "follow"`
- [ ] Open pane at workspace root → `cd path/to/subdir` → prefix+c / prefix+v → new tab/split starts in `subdir`
- [ ] With OSC-7 shells that already report cwd, behavior unchanged
- [ ] Existing unit tests for follow/cached cwd still pass (`cargo test new_terminal_cwd` / workspace_create_follows_…)

## Notes

- Foreground cwd is Unix-capable via platform `process_cwd`; on platforms where it is unavailable, behavior falls back to the previous cached path.
- No config schema change.
