### PR TITLE
fix(render): emit SGR 58 underline color to the host terminal

### DIFF
--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -2007,6 +2007,9 @@ fn cell_data_from_style(symbol: String, style: Style) -> CellData {
         },
         fg: crate::protocol::color_to_u32(style.fg.unwrap_or(Color::Reset)),
         bg: crate::protocol::color_to_u32(style.bg.unwrap_or(Color::Reset)),
+        underline: crate::protocol::color_to_u32(
+            style.underline_color.unwrap_or(Color::Reset),
+        ),
         modifier: crate::protocol::modifier_to_u16(style.add_modifier),
         skip: false,
         hyperlink: None,

--- a/src/protocol/render_ansi.rs
+++ b/src/protocol/render_ansi.rs
@@ -291,6 +291,30 @@ fn color_to_sgr_bg(val: u32) -> String {
     }
 }
 
+/// Converts a packed u32 color to an SGR 58 underline-color fragment.
+///
+/// Returns `None` for default/reset underline color (after a leading SGR `0`,
+/// underline color is already default — SGR 59 is only needed when changing
+/// away from a previous non-default color without a full reset).
+fn color_to_sgr_ul(val: u32) -> Option<String> {
+    match val >> 24 {
+        0x00 => match val & 0xFF {
+            0x00 => None, // Reset / default
+            // Map named colors onto the standard 16-color palette for 58;5;n.
+            n @ 0x01..=0x10 => Some(format!("58;5;{}", n - 1)),
+            _ => None,
+        },
+        0x01 => Some(format!("58;5;{}", val & 0xFF)),
+        0x02 => {
+            let r = (val >> 16) & 0xFF;
+            let g = (val >> 8) & 0xFF;
+            let b = val & 0xFF;
+            Some(format!("58;2;{r};{g};{b}"))
+        }
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Modifier → SGR
 // ---------------------------------------------------------------------------
@@ -349,7 +373,7 @@ fn modifier_to_sgr_parts(val: u16) -> Vec<&'static str> {
 }
 
 /// Builds a complete SGR escape sequence for a cell's style.
-fn build_sgr(fg: u32, bg: u32, modifier: u16) -> String {
+fn build_sgr(fg: u32, bg: u32, underline: u32, modifier: u16) -> String {
     let mut parts = vec!["0".to_owned()];
     parts.extend(
         modifier_to_sgr_parts(modifier)
@@ -358,6 +382,11 @@ fn build_sgr(fg: u32, bg: u32, modifier: u16) -> String {
     );
     parts.push(color_to_sgr_fg(fg));
     parts.push(color_to_sgr_bg(bg));
+    // SGR 58 underline color is independent of the text foreground (SGR 38).
+    // Host terminals (Ghostty, Kitty, …) need this for diagnostics/undercurl.
+    if let Some(ul) = color_to_sgr_ul(underline) {
+        parts.push(ul);
+    }
     format!("\x1b[{}m", parts.join(";"))
 }
 
@@ -371,6 +400,7 @@ fn cells_equal(a: &CellData, b: &CellData) -> bool {
     a.symbol == b.symbol
         && a.fg == b.fg
         && a.bg == b.bg
+        && a.underline == b.underline
         && a.modifier == b.modifier
         && a.hyperlink == b.hyperlink
     // Skip flag is only for ratatui internal use, not visual.
@@ -604,8 +634,8 @@ fn write_all_cells(writer: &mut impl Write, frame: &FrameData) {
             // Move cursor to position (1-based).
             let _ = write!(writer, "\x1b[{};{}H", row + 1, col + 1);
 
-            // Set style.
-            let sgr = build_sgr(cell.fg, cell.bg, cell.modifier);
+            // Set style (includes SGR 58 underline color when set).
+            let sgr = build_sgr(cell.fg, cell.bg, cell.underline, cell.modifier);
             let _ = writer.write_all(sgr.as_bytes());
 
             write_hyperlink_if_changed(
@@ -695,7 +725,7 @@ fn write_cell(
 
     let _ = write!(writer, "\x1b[{};{}H", row + 1, col + 1);
 
-    let sgr = build_sgr(cell.fg, cell.bg, cell.modifier);
+    let sgr = build_sgr(cell.fg, cell.bg, cell.underline, cell.modifier);
     if sgr != *last_sgr {
         let _ = writer.write_all(sgr.as_bytes());
         *last_sgr = sgr;
@@ -715,6 +745,7 @@ fn cells_visually_equal(
     cell.symbol == prev_cell.symbol
         && cell.fg == prev_cell.fg
         && cell.bg == prev_cell.bg
+        && cell.underline == prev_cell.underline
         && cell.modifier == prev_cell.modifier
         && sanitized_cell_hyperlink_uri(sanitized_hyperlinks, cell)
             == sanitized_cell_hyperlink_uri(prev_sanitized_hyperlinks, prev_cell)
@@ -786,6 +817,7 @@ mod tests {
             symbol: symbol.to_owned(),
             fg,
             bg,
+            underline: 0,
             modifier,
             skip: false,
             hyperlink: None,
@@ -859,7 +891,7 @@ mod tests {
 
     #[test]
     fn build_sgr_produces_valid_sequence() {
-        let sgr = build_sgr(0x00_00_00_02, 0x00_00_00_01, 1); // fg=Red, bg=Black, bold
+        let sgr = build_sgr(0x00_00_00_02, 0x00_00_00_01, 0, 1); // fg=Red, bg=Black, ul=default, bold
         assert!(sgr.starts_with("\x1b["));
         assert!(sgr.ends_with("m"));
         assert!(sgr.contains("0")); // reset existing style first
@@ -870,17 +902,32 @@ mod tests {
 
     #[test]
     fn build_sgr_resets_previous_modifiers_when_cell_is_plain() {
-        assert_eq!(build_sgr(0x00_00_00_00, 0x00_00_00_00, 0), "\x1b[0;39;49m");
+        assert_eq!(build_sgr(0x00_00_00_00, 0x00_00_00_00, 0, 0), "\x1b[0;39;49m");
     }
 
     #[test]
+    
+    #[test]
+    fn color_to_sgr_ul_rgb_and_indexed() {
+        assert_eq!(color_to_sgr_ul(0x00_00_00_00), None); // default
+        assert_eq!(color_to_sgr_ul(0x01_00_00_AB).as_deref(), Some("58;5;171"));
+        assert_eq!(color_to_sgr_ul(0x02_FF_5F_5F).as_deref(), Some("58;2;255;95;95"));
+    }
+
+    #[test]
+    fn build_sgr_includes_underline_color() {
+        let sgr = build_sgr(0x00_00_00_10, 0x00_00_00_00, 0x02_FF_5F_5F, 0x08); // white fg, red ul, underlined
+        assert!(sgr.contains("58;2;255;95;95"), "got {sgr}");
+        assert!(sgr.contains("4"), "underline style missing: {sgr}");
+    }
+
     fn build_sgr_preserves_curly_underline_style() {
         let modifier = crate::protocol::modifier_to_u16(
             crate::protocol::modifier_with_underline_style(ratatui::style::Modifier::UNDERLINED, 3),
         );
 
         assert_eq!(
-            build_sgr(0x00_00_00_00, 0x00_00_00_00, modifier),
+            build_sgr(0x00_00_00_00, 0x00_00_00_00, 0, modifier),
             "\x1b[0;4:3;39;49m"
         );
     }

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -426,6 +426,13 @@ pub struct CellData {
     pub fg: u32,
     /// Background color as a packed u32.
     pub bg: u32,
+    /// Underline color as a packed u32 (same encoding as `fg`/`bg`).
+    ///
+    /// Carries SGR 58/59 underline color independently of the text foreground.
+    /// `0` / `Color::Reset` means default underline color (after SGR 0 or 59).
+    /// Older peers that omit this field deserialize it as `0` via `serde(default)`.
+    #[serde(default)]
+    pub underline: u32,
     /// Bitmask of style modifiers (bold, italic, etc.) plus Herdr extension bits.
     pub modifier: u16,
     /// Whether this cell should be skipped during diff-based rendering.
@@ -521,6 +528,11 @@ impl FrameData {
                     symbol: cell.symbol().to_owned(),
                     fg: color_to_u32(cell.fg),
                     bg: color_to_u32(cell.bg),
+                    underline: color_to_u32(
+                        cell.style()
+                            .underline_color
+                            .unwrap_or(ratatui::style::Color::Reset),
+                    ),
                     modifier: modifier_to_u16(cell.modifier),
                     skip: cell.skip,
                     hyperlink,
@@ -559,6 +571,10 @@ impl FrameData {
                 cell.set_symbol(&cell_data.symbol);
                 cell.fg = u32_to_color(cell_data.fg);
                 cell.bg = u32_to_color(cell_data.bg);
+                let ul = u32_to_color(cell_data.underline);
+                if ul != ratatui::style::Color::Reset {
+                    cell.set_style(cell.style().underline_color(ul));
+                }
                 cell.modifier = u16_to_modifier(cell_data.modifier);
                 cell.skip = cell_data.skip;
             }
@@ -1246,6 +1262,7 @@ mod tests {
                     symbol: "H".into(),
                     fg: color_to_u32(Color::Red),
                     bg: color_to_u32(Color::Black),
+                    underline: 0,
                     modifier: Modifier::BOLD.bits(),
                     skip: false,
                     hyperlink: None,
@@ -1254,6 +1271,7 @@ mod tests {
                     symbol: "i".into(),
                     fg: color_to_u32(Color::Green),
                     bg: color_to_u32(Color::Reset),
+                    underline: 0,
                     modifier: Modifier::ITALIC.bits(),
                     skip: false,
                     hyperlink: None,
@@ -1262,6 +1280,7 @@ mod tests {
                     symbol: "!".into(),
                     fg: color_to_u32(Color::Rgb(255, 128, 0)),
                     bg: color_to_u32(Color::Indexed(220)),
+                    underline: 0,
                     modifier: (Modifier::BOLD | Modifier::UNDERLINED).bits(),
                     skip: false,
                     hyperlink: Some(0),
@@ -1270,6 +1289,7 @@ mod tests {
                     symbol: " ".into(),
                     fg: color_to_u32(Color::Reset),
                     bg: color_to_u32(Color::Reset),
+                    underline: 0,
                     modifier: Modifier::empty().bits(),
                     skip: true,
                     hyperlink: None,
@@ -1278,6 +1298,7 @@ mod tests {
                     symbol: "→".into(), // multi-byte grapheme
                     fg: color_to_u32(Color::Cyan),
                     bg: color_to_u32(Color::Blue),
+                    underline: 0,
                     modifier: Modifier::REVERSED.bits(),
                     skip: false,
                     hyperlink: None,
@@ -1286,6 +1307,7 @@ mod tests {
                     symbol: "🦀".into(), // emoji, wide grapheme cluster
                     fg: color_to_u32(Color::Yellow),
                     bg: color_to_u32(Color::Magenta),
+                    underline: 0,
                     modifier: Modifier::empty().bits(),
                     skip: false,
                     hyperlink: None,
@@ -1459,6 +1481,7 @@ mod tests {
                 },
                 fg: color_to_u32(Color::Rgb((i % 256) as u8, ((i / 256) % 256) as u8, 128)),
                 bg: color_to_u32(Color::Indexed((i % 256) as u8)),
+                underline: 0,
                 modifier: ((i % 16) as u16),
                 skip: i % 100 == 0,
                 hyperlink: None,
@@ -1809,6 +1832,7 @@ mod tests {
                     symbol: "X".into(),
                     fg: 0,
                     bg: 0,
+                    underline: 0,
                     modifier: 0,
                     skip: false,
                     hyperlink: None,


### PR DESCRIPTION
## Summary

Fixes #1252.

Inside a herdr pane, underline **styles** (including undercurl `4:3`) already rendered, but **SGR 58 underline colors** did not. Colored underlines always fell back to the text foreground / host default, so Neovim diagnostics and similar decorations lost semantic color. Ghostty outside herdr showed the colors correctly.

## Root cause

1. Internal VT (libghostty) + ratatui conversion already kept `underline_color` (covered by `render_preserves_underline_color`).
2. Wire `CellData` only carried `fg` / `bg` / `modifier` — **no underline color**.
3. Host ANSI blit (`build_sgr`) never emitted **SGR 58** (or 59), so even local host rendering lost the color when frames were re-emitted as escape sequences.

## Change

| Area | Change |
|------|--------|
| `CellData` | Add `underline: u32` (same packing as `fg`/`bg`), `#[serde(default)]` for older peers |
| Buffer → frame | Copy `Style.underline_color` into `CellData.underline` |
| Dirty patch / style | `cell_data_from_style` includes underline color |
| `build_sgr` | Emit `58;2;r;g;b` / `58;5;n` when set (SGR `0` already resets to default) |
| Diff equality | Treat underline color as a visual difference |

## Tests

- Existing: `render_preserves_underline_color` (buffer path)
- New: `color_to_sgr_ul_rgb_and_indexed`, `build_sgr_includes_underline_color`

## Manual verify

```sh
printf '\033[38;2;255;255;255;4:3;58;2;255;95;95mWHITE TEXT / RED UNDERCURL\033[0m\n'
printf '\033[38;2;255;255;255;4;58;2;95;255;135mGREEN UNDERLINE\033[59m DEFAULT UNDERLINE\033[0m\n'
```

Inside a herdr pane (host Ghostty/Kitty/etc. with underline color support): underline should be red / green independently of white text.

## Notes

- No protocol version bump: field is additive with serde default `0` (default underline color).
- Foreground-only underlines (no SGR 58) behave as before.
