### PR TITLE
fix: prefer manual_label in agents panel sidebar

### DIFF
--- a/src/workspace/aggregate.rs
+++ b/src/workspace/aggregate.rs
@@ -49,7 +49,9 @@ impl Tab {
                     .or_else(|| terminal.effective_agent_label())?
                     .to_string();
                 let agent_label = terminal
-                    .effective_display_agent()
+                    .manual_label
+                    .clone()
+                    .or_else(|| terminal.effective_display_agent())
                     .unwrap_or_else(|| fallback_agent_label.clone());
                 let presentation = terminal.effective_presentation();
                 Some(PaneDetail {


### PR DESCRIPTION
## Current behavior

Pane labels set via `herdr pane rename` are shown in pane borders and returned in `herdr pane list` JSON (as the `label` field), but NOT displayed in the Agents panel of the sidebar. The sidebar shows the workspace `display_name` (derived from cwd) for all panes, ignoring their custom labels.

## Expected behavior

The Agents panel should prefer the pane's `manual_label` (set via `herdr pane rename`) when displaying agent entries, matching the priority that `border_label()` already uses.

## Reproduction

```bash
herdr pane rename w1:p1 "My-Custom-Name"
# Observe: pane border shows "My-Custom-Name"
# Observe: sidebar agents panel still shows folder name (e.g. "data-projects")
herdr pane list | jq '.result.panes[] | select(.pane_id=="w1:p1") | .label'
# Returns: "My-Custom-Name"
```

## Impact

When running multiple agents in the same workspace/folder, the sidebar shows identical folder-derived names for all of them, making them indistinguishable. Pane labels exist specifically to solve this but aren't used in the one place they matter most.

## Fix

One-line change in `src/workspace/aggregate.rs`: when building `PaneDetail`, prefer `terminal.manual_label` over `effective_display_agent()`, matching the priority `border_label()` uses.

## Environment

- Herdr version: 0.7.1
- Update channel: stable
- Operating system: macOS 26.5.2
- Terminal: herdr (native)
- Shell: zsh