### PR TITLE
fix: detect claude/codex working turns from screen content, not only OSC title

### DIFF
--- a/src/detect/manifests/claude.toml
+++ b/src/detect/manifests/claude.toml
@@ -1,7 +1,7 @@
 id = "claude"
-version = "2026.06.10.3"
+version = "2026.07.10.1"
 min_engine_version = 2
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-07-10T00:00:00Z"
 aliases = ["claude-code"]
 
 [[rules]]
@@ -145,3 +145,23 @@ state = "idle"
 priority = 250
 region = "osc_progress"
 regex = ['^4;0']
+
+[[rules]]
+# Claude Code 2.1.x working status line: "✢ Imagining… (33m 56s · ↓ 105.4k tokens)"
+# (random verb; "esc to interrupt" is no longer always printed, and the legacy
+# variant "✻ Deliberating… (esc to interrupt)" still exists). Two reasons the
+# stock rules miss it: (1) osc_title_working needs a braille spinner in the OSC
+# title, which never appears when the host owns the pane title; (2) the prompt
+# box stays visible while working, so live_prompt_box (950) reports idle. The
+# agents panel can push the status line 20+ rows above the bottom, hence
+# whole_recent rather than a bottom window. Blocked forms (980) still outrank.
+id = "screen_working_spinner"
+state = "working"
+priority = 960
+region = "whole_recent"
+visible_working = true
+line_regex = ['^\s*[·✢✳✶✻✽*+]\s\S.{0,40}…\s*\((\d+[hms]|esc to interrupt)']
+not = [
+  { contains = ["do you want to proceed?"] },
+  { contains = ["enter to select"] },
+]

--- a/src/detect/manifests/codex.toml
+++ b/src/detect/manifests/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.06.10.3"
+version = "2026.07.10.1"
 min_engine_version = 2
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-07-10T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -67,3 +67,18 @@ not = [
   { regex = ['^[\x{2800}-\x{28FF}]'] },
   { contains = ["Action Required"] },
 ]
+
+[[rules]]
+# Codex >= ~0.144 active turns show "• Working (33m 09s • esc to interrupt)" in the
+# transcript footer, but the OSC title carries no spinner when the host (herdr
+# itself, or the user's shell) owns the pane title — so osc_title_working never
+# fires and active turns fall through to osc_title_idle (#1281). Detect the
+# working footer from screen content instead. Priority sits below the strong
+# blocker rules (900); Codex replaces this footer with the prompt while
+# blocked, so they never appear together.
+id = "screen_working_footer"
+state = "working"
+priority = 700
+region = "bottom_non_empty_lines(10)"
+visible_working = true
+contains = ["esc to interrupt"]


### PR DESCRIPTION
Fixes #1281 (codex active turns reported as idle), and the claude-flavored sibling of the same failure.

## Diagnosis

Both stock manifests decide `working` solely via `osc_title_working` — a braille-spinner (`^[\x{2800}-\x{28FF}] `) pane title. Two independent things break that:

1. **The pane title often isn't the agent's.** When herdr names the pane itself (agent titles like `<project> · <task> · codex-<id>`), or a shell precmd hook rewrites the title, the agent's spinner never reaches the title register. `herdr agent explain` on a codex pane that visibly showed `• Working (33m 09s • esc to interrupt)` reported:

   ```
   state: idle
   rule: osc_title_idle (region=osc_title priority=100)
   evidence: "cl-backend-monorepo · follow  docs/plans/architectur · codex-019f4c95-4"
   ```

2. **Claude Code 2.1.x keeps the prompt box (`❯`) visible while working**, so even without the title problem, `live_prompt_box` (priority 950, state idle) matches during active turns. Its status line also no longer reliably prints "esc to interrupt" — current format is a random verb, e.g. `✢ Imagining… (33m 56s · ↓ 105.4k tokens)` or `· Choreographing… (3m 19s · ↓ 8.3k tokens · thinking with xhigh effort)`.

## Fix (data-only, both manifests bumped to 2026.07.10.1)

- **codex**: `esc to interrupt` within `bottom_non_empty_lines(10)` ⇒ `working`, priority 700 — below the strong blockers (900); codex replaces this footer with the prompt while blocked, so they never co-occur.
- **claude**: status-line structure `^\s*[·✢✳✶✻✽*+]\s\S.{0,40}…\s*\((\d+[hms]|esc to interrupt)` as a `line_regex` over `whole_recent` ⇒ `working`, priority 960 — above `live_prompt_box` (950), below the blocked forms (980), with `not`-guards on `do you want to proceed?` / `enter to select`. `whole_recent` because the in-pane agents panel can push the status line 20+ rows above the bottom window. Matches both the current verb/stats format and the legacy `✻ Deliberating… (esc to interrupt)`.

The `osc_title_working` rules keep their higher priority, so environments where the spinner title does come through are unchanged.

## Validation

Couldn't build locally (no zig for vendored libghostty-vt), so validated the identical rules on **released herdr 0.7.3** (macOS + Linux, 4 hosts) as local overrides in `~/.config/herdr/agent-detection/`:

- three genuinely-working panes (codex 0.144.1 ×2, claude 2.1.206 ×1) flipped idle→working, `herdr agent explain` showing the new rule + live screen evidence
- claude working/idle/blocked screen fixtures via `herdr agent explain --file` all classify correctly (blocked still wins via `bash_permission_prompt`; idle still lands on `live_prompt_box`)
- both TOMLs parse (python tomllib); `all_bundled_manifests_parse_and_validate` should confirm in CI

## Note on the deeper issue

The manifest fix is the low-risk mitigation, but the root cause in setups like ours is that title-based detection reads back titles herdr itself wrote. A follow-up engine-level fix could exclude herdr-authored title writes from the `osc_title` detection region.

Environment: herdr 0.7.3 stable · codex CLI 0.144.1 · Claude Code 2.1.205/2.1.206 · macOS 15 + Ubuntu 24.04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)