### PR TITLE
feat: push OSC 10/11 theme notifications to child process stdin

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1501,6 +1501,28 @@ impl PaneRuntime {
 
     pub fn apply_host_terminal_theme(&self, theme: crate::terminal_theme::TerminalTheme) {
         self.terminal.apply_host_terminal_theme(theme);
+
+        // Push OSC 10/11 color notifications to the child process stdin so
+        // apps like Claude Code can react to host theme changes dynamically
+        // without needing to re-query the terminal themselves.
+        let mut notification = String::new();
+        if let Some(fg) = theme.foreground {
+            notification.push_str(&crate::terminal_theme::osc_set_default_color_sequence(
+                crate::terminal_theme::DefaultColorKind::Foreground,
+                fg,
+            ));
+        }
+        if let Some(bg) = theme.background {
+            notification.push_str(&crate::terminal_theme::osc_set_default_color_sequence(
+                crate::terminal_theme::DefaultColorKind::Background,
+                bg,
+            ));
+        }
+        if !notification.is_empty() {
+            if let Err(err) = self.try_send_bytes(Bytes::from(notification)) {
+                warn!(err = %err, "failed to push host terminal theme notification to child process");
+            }
+        }
     }
 
     pub fn spawn(


### PR DESCRIPTION
## Problem

When the host terminal's color scheme changes, Herdr calls `apply_host_terminal_theme_to_panes()`, which updates Ghostty's internal stored colors for each pane. This means future OSC 10/11 queries from child processes (e.g. `\x1b]11;?\x07`) get the correct answer — but apps that don't re-query never see the change.

Claude Code is one such app: it queries the terminal background color at startup (or when `/theme` is run) but doesn't poll continuously. So when the outer terminal switches from dark to light, Claude Code stays on its original theme.

## Fix

In `PaneRuntime::apply_host_terminal_theme`, after updating Ghostty's state, also write the OSC 10/11 sequences directly to the child process stdin via `try_send_bytes`. This pushes the notification so apps can react immediately.

```
host terminal changes color
  → viktorterm sends \x1b]11;rgb:...\x1b\\ to outer PTY
    → Herdr receives it, updates stored theme
      → apply_host_terminal_theme_to_panes()
        → Ghostty state updated (existing)
        → OSC 10/11 written to child stdin (new)
          → Claude Code reads it from stdin, switches theme ✓
```

The write is `try_send_bytes` (non-blocking, fire-and-forget). If the channel is full the notification is dropped silently — the child can still query at any time and will get the correct answer from Ghostty's updated state.

## Testing

With a terminal that pushes OSC 10/11 on theme change (e.g. viktorterm with this support):
1. Open Claude Code inside a Herdr pane with `/theme auto`
2. Switch the outer terminal's color scheme
3. Claude Code should switch themes immediately without running `/theme` again