### PR TITLE
fix: make OMP integration reliable on Windows

### DIFF
--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,11 +8,18 @@ const originalEnvironment = {
   HERDR_ENV: process.env.HERDR_ENV,
   HERDR_PANE_ID: process.env.HERDR_PANE_ID,
   HERDR_SOCKET_PATH: process.env.HERDR_SOCKET_PATH,
+  HERDR_BIN_PATH: process.env.HERDR_BIN_PATH,
+  HERDR_OMP_REPORTER_SCRIPT: process.env.HERDR_OMP_REPORTER_SCRIPT,
+  HERDR_OMP_TEST_REPORTS: process.env.HERDR_OMP_TEST_REPORTS,
+  HERDR_OMP_TEST_DELAY_METHOD: process.env.HERDR_OMP_TEST_DELAY_METHOD,
+  HERDR_OMP_TEST_DELAY_MS: process.env.HERDR_OMP_TEST_DELAY_MS,
+  HERDR_OMP_TEST_FAIL_METHOD: process.env.HERDR_OMP_TEST_FAIL_METHOD,
 };
 
 let server: Server | undefined;
 let socketPath: string | undefined;
 let importCounter = 0;
+let reporterPath: string | undefined;
 
 afterEach(async () => {
   await new Promise<void>((resolve, reject) => {
@@ -29,6 +36,11 @@ afterEach(async () => {
     socketPath = undefined;
   }
 
+  if (reporterPath) {
+    await rm(reporterPath, { force: true });
+    reporterPath = undefined;
+  }
+
   for (const [name, value] of Object.entries(originalEnvironment)) {
     if (value === undefined) {
       delete process.env[name];
@@ -38,10 +50,7 @@ afterEach(async () => {
   }
 });
 
-const integrations = [
-  { name: "Pi", modulePath: "./pi/herdr-agent-state.ts" },
-  { name: "Oh My Pi", modulePath: "./omp/herdr-agent-state.ts" },
-] as const;
+const socketIntegrations = [{ name: "Pi", modulePath: "./pi/herdr-agent-state.ts" }] as const;
 
 function importFresh(modulePath: string) {
   importCounter += 1;
@@ -73,6 +82,35 @@ function configureIntegrationEnvironment(recordingSocketPath: string) {
   process.env.HERDR_PANE_ID = "test:p1";
 }
 
+async function configureOmpReporter(name: string): Promise<void> {
+  reporterPath = join(tmpdir(), `herdr-omp-${name}-${process.pid}.jsonl`);
+  await rm(reporterPath, { force: true });
+  process.env.HERDR_ENV = "1";
+  process.env.HERDR_SOCKET_PATH = "test-only";
+  process.env.HERDR_PANE_ID = "test:p1";
+  process.env.HERDR_BIN_PATH = process.execPath;
+  process.env.HERDR_OMP_REPORTER_SCRIPT = join(import.meta.dir, "omp", "reporter-fixture.ts");
+  process.env.HERDR_OMP_TEST_REPORTS = reporterPath;
+}
+
+async function readOmpReports(): Promise<string[][]> {
+  if (!reporterPath) {
+    return [];
+  }
+  try {
+    const content = await readFile(reporterPath, "utf8");
+    return content
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line));
+  } catch (error) {
+    if (isRecord(error) && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
 async function startRecordingServer(name: string): Promise<unknown[]> {
   const recordingSocketPath = join(tmpdir(), `herdr-${name}-${process.pid}.sock`);
   socketPath = recordingSocketPath;
@@ -101,7 +139,7 @@ async function startRecordingServer(name: string): Promise<unknown[]> {
   return requests;
 }
 
-for (const integration of integrations) {
+for (const integration of socketIntegrations) {
   test(`${integration.name} reload preserves working state when the agent is active`, async () => {
     const requests = await startRecordingServer(
       integration.name.toLowerCase().replaceAll(" ", "-"),
@@ -330,6 +368,175 @@ test("Pi retries working state after an unanswered socket attempt", async () => 
   expect(reportedWorking()).toBe(true);
 });
 
+
+test("OMP accepts a root context without hasUI and preserves a Windows session path", async () => {
+  await configureOmpReporter("missing-has-ui");
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  const windowsSessionPath = String.raw`C:\Users\tester\.omp\sessions\session.jsonl`;
+  const beforeAgentStart = handlers.get("before_agent_start");
+  expect(beforeAgentStart).toBeDefined();
+  await beforeAgentStart?.(
+    { prompt: "test" },
+    {
+      isIdle: () => false,
+      sessionManager: {
+        getSessionFile: () => windowsSessionPath,
+        getSessionId: () => "session-id",
+      },
+    },
+  );
+
+  const deadline = Date.now() + 1_000;
+  let reports = await readOmpReports();
+  while (Date.now() < deadline && reports.length < 2) {
+    await Bun.sleep(5);
+    reports = await readOmpReports();
+  }
+  expect(reports.map((args) => args.slice(0, 2))).toEqual([
+    ["pane", "report-agent-session"],
+    ["pane", "report-agent"],
+  ]);
+  expect(reports[0]).toContain(windowsSessionPath);
+  expect(reports[1]).toContain("working");
+});
+
+test("OMP rejects an explicitly non-UI context", async () => {
+  await configureOmpReporter("explicit-no-ui");
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  await handlers.get("before_agent_start")?.(
+    { prompt: "test" },
+    {
+      hasUI: false,
+      sessionManager: {
+        getSessionFile: () => undefined,
+        getSessionId: () => "ignored",
+      },
+    },
+  );
+  await Bun.sleep(50);
+  expect(await readOmpReports()).toEqual([]);
+});
+
+test("OMP reports a replacement session before its state", async () => {
+  await configureOmpReporter("session-order");
+  process.env.HERDR_OMP_TEST_DELAY_METHOD = "pane report-agent-session";
+  process.env.HERDR_OMP_TEST_DELAY_MS = "150";
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  const sessionStart = handlers.get("session_start");
+  expect(sessionStart).toBeDefined();
+  const result = sessionStart?.(
+    { reason: "new" },
+    {
+      hasUI: true,
+      isIdle: () => false,
+      sessionManager: {
+        getSessionFile: () => String.raw`C:\sessions\new.jsonl`,
+        getSessionId: () => "new-session",
+      },
+    },
+  );
+  await Bun.sleep(50);
+  expect(await readOmpReports()).toEqual([]);
+  await result;
+
+  const deadline = Date.now() + 1_000;
+  let reports = await readOmpReports();
+  while (Date.now() < deadline && reports.length < 2) {
+    await Bun.sleep(5);
+    reports = await readOmpReports();
+  }
+  expect(reports.map((args) => args.slice(0, 2))).toEqual([
+    ["pane", "report-agent-session"],
+    ["pane", "report-agent"],
+  ]);
+});
+
+test("OMP preserves working to idle edges while a report is slow", async () => {
+  await configureOmpReporter("state-fifo");
+  process.env.HERDR_OMP_TEST_DELAY_METHOD = "pane report-agent";
+  process.env.HERDR_OMP_TEST_DELAY_MS = "500";
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  const context = {
+    hasUI: true,
+    isIdle: () => false,
+    sessionManager: {
+      getSessionFile: () => "/tmp/session.jsonl",
+      getSessionId: () => "session-id",
+    },
+  };
+  await handlers.get("before_agent_start")?.({ prompt: "test" }, context);
+  handlers.get("agent_end")?.({ messages: [] }, context);
+
+  const deadline = Date.now() + 2_000;
+  let stateReports: string[][] = [];
+  while (Date.now() < deadline && stateReports.length < 2) {
+    await Bun.sleep(10);
+    stateReports = (await readOmpReports()).filter(
+      (args) => args[0] === "pane" && args[1] === "report-agent",
+    );
+  }
+  expect(stateReports.map((args) => args[args.indexOf("--state") + 1])).toEqual([
+    "working",
+    "idle",
+  ]);
+});
+
+test("OMP retries failed state reports and deduplicates only after acknowledgment", async () => {
+  await configureOmpReporter("state-retry");
+  process.env.HERDR_OMP_TEST_FAIL_METHOD = "pane report-agent";
+  const { handlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  const context = {
+    hasUI: true,
+    isIdle: () => false,
+    sessionManager: {
+      getSessionFile: () => "/tmp/retry-session.jsonl",
+      getSessionId: () => "retry-session",
+    },
+  };
+  await handlers.get("before_agent_start")?.({ prompt: "test" }, context);
+
+  const failedDeadline = Date.now() + 1_500;
+  let stateReports: string[][] = [];
+  while (Date.now() < failedDeadline && stateReports.length < 3) {
+    await Bun.sleep(10);
+    stateReports = (await readOmpReports()).filter(
+      (args) => args[0] === "pane" && args[1] === "report-agent",
+    );
+  }
+  expect(stateReports).toHaveLength(3);
+
+  delete process.env.HERDR_OMP_TEST_FAIL_METHOD;
+  const recoveredDeadline = Date.now() + 1_000;
+  while (Date.now() < recoveredDeadline && stateReports.length < 4) {
+    await Bun.sleep(10);
+    stateReports = (await readOmpReports()).filter(
+      (args) => args[0] === "pane" && args[1] === "report-agent",
+    );
+  }
+  expect(stateReports).toHaveLength(4);
+
+  await handlers.get("agent_start")?.({}, context);
+  await Bun.sleep(100);
+  stateReports = (await readOmpReports()).filter(
+    (args) => args[0] === "pane" && args[1] === "report-agent",
+  );
+  expect(stateReports).toHaveLength(4);
+});
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,10 +2,11 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=4
+// HERDR_INTEGRATION_VERSION=9
 // @ts-nocheck
 
-import { createConnection } from "node:net";
+import { spawn } from "node:child_process";
+import { posix, win32 } from "node:path";
 
 const HERDR_ENV = process.env.HERDR_ENV;
 const socketPath = process.env.HERDR_SOCKET_PATH;
@@ -16,38 +17,103 @@ function enabled() {
   return HERDR_ENV === "1" && !!socketPath && !!paneId;
 }
 
-let requestQueue = Promise.resolve();
+let requestQueue = Promise.resolve(true);
 
-function sendRequestNow(request: unknown): Promise<void> {
-  if (!enabled()) {
-    return Promise.resolve();
-  }
-
-  return new Promise((resolve) => {
-    let done = false;
-    const finish = () => {
-      if (done) return;
-      done = true;
-      socket.destroy();
-      resolve();
-    };
-
-    const socket = createConnection(socketPath!);
-    socket.on("error", finish);
-    socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
-    socket.on("data", finish);
-    socket.on("end", finish);
-    const timeout = setTimeout(finish, 500);
-    timeout.unref?.();
-  });
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
-function sendRequest(request: unknown): Promise<void> {
-  requestQueue = requestQueue.then(
+function appendCliFlag(args: string[], flag: string, value: unknown): void {
+  if (typeof value === "string" && value.length > 0) {
+    args.push(flag, value);
+  } else if (typeof value === "number") {
+    args.push(flag, String(value));
+  }
+}
+
+function requestCliArgs(request: unknown): string[] | undefined {
+  if (!isRecord(request) || !isRecord(request.params)) {
+    return undefined;
+  }
+  const params = request.params;
+  if (typeof params.pane_id !== "string") {
+    return undefined;
+  }
+
+  if (request.method === "pane.report_agent") {
+    const args = ["pane", "report-agent", params.pane_id];
+    appendCliFlag(args, "--source", params.source);
+    appendCliFlag(args, "--agent", params.agent);
+    appendCliFlag(args, "--state", params.state);
+    appendCliFlag(args, "--message", params.message);
+    appendCliFlag(args, "--seq", params.seq);
+    appendCliFlag(args, "--agent-session-id", params.agent_session_id);
+    appendCliFlag(args, "--agent-session-path", params.agent_session_path);
+    return args;
+  }
+  if (request.method === "pane.report_agent_session") {
+    const args = ["pane", "report-agent-session", params.pane_id];
+    appendCliFlag(args, "--source", params.source);
+    appendCliFlag(args, "--agent", params.agent);
+    appendCliFlag(args, "--seq", params.seq);
+    appendCliFlag(args, "--agent-session-id", params.agent_session_id);
+    appendCliFlag(args, "--agent-session-path", params.agent_session_path);
+    appendCliFlag(args, "--session-start-source", params.session_start_source);
+    return args;
+  }
+  if (request.method === "pane.release_agent") {
+    const args = ["pane", "release-agent", params.pane_id];
+    appendCliFlag(args, "--source", params.source);
+    appendCliFlag(args, "--agent", params.agent);
+    appendCliFlag(args, "--seq", params.seq);
+    return args;
+  }
+  return undefined;
+}
+
+function sendRequestNow(request: unknown): Promise<boolean> {
+  if (!enabled()) {
+    return Promise.resolve(true);
+  }
+  const args = requestCliArgs(request);
+  if (!args) {
+    return Promise.resolve(false);
+  }
+
+  const { promise, resolve } = Promise.withResolvers<boolean>();
+  const reporterScript = process.env.HERDR_OMP_REPORTER_SCRIPT;
+  const reporterArgs = reporterScript ? [reporterScript, ...args] : args;
+  const child = spawn(process.env.HERDR_BIN_PATH || "herdr", reporterArgs, {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  let settled = false;
+  let timeout: NodeJS.Timeout | undefined;
+  const finish = (delivered: boolean) => {
+    if (settled) return;
+    settled = true;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    resolve(delivered);
+  };
+  child.on("error", () => finish(false));
+  child.on("exit", (code) => finish(code === 0));
+  timeout = setTimeout(() => {
+    child.kill();
+    finish(false);
+  }, 2_000);
+  timeout.unref?.();
+  return promise;
+}
+
+function sendRequest(request: unknown): Promise<boolean> {
+  const queued = requestQueue.then(
     () => sendRequestNow(request),
     () => sendRequestNow(request),
   );
-  return requestQueue;
+  requestQueue = queued;
+  return queued;
 }
 
 type AgentState = "working" | "blocked" | "idle";
@@ -56,6 +122,7 @@ type QueuedState = {
   state: AgentState;
   message?: string;
   seq: number;
+  attempts: number;
 };
 
 const idleDebounceMs = parseDurationEnv("HERDR_OMP_IDLE_DEBOUNCE_MS", 250);
@@ -71,17 +138,26 @@ function nextReportSeq(): number {
   return reportSeq;
 }
 
-function updateSessionRef(ctx: any): void {
+function updateSessionRef(ctx: unknown): void {
+  const sessionManager = isRecord(ctx) && isRecord(ctx.sessionManager) ? ctx.sessionManager : undefined;
   try {
-    const file = ctx?.sessionManager?.getSessionFile?.();
+    const file =
+      sessionManager && typeof sessionManager.getSessionFile === "function"
+        ? sessionManager.getSessionFile()
+        : undefined;
     currentAgentSessionPath =
-      typeof file === "string" && file.startsWith("/") ? file : undefined;
+      typeof file === "string" && (posix.isAbsolute(file) || win32.isAbsolute(file))
+        ? file
+        : undefined;
   } catch {
     currentAgentSessionPath = undefined;
   }
 
   try {
-    const id = ctx?.sessionManager?.getSessionId?.();
+    const id =
+      sessionManager && typeof sessionManager.getSessionId === "function"
+        ? sessionManager.getSessionId()
+        : undefined;
     currentAgentSessionId = typeof id === "string" && id.length > 0 ? id : undefined;
   } catch {
     currentAgentSessionId = undefined;
@@ -120,10 +196,10 @@ function currentSessionRef(): Record<string, unknown> | undefined {
   return undefined;
 }
 
-function reportSession(sessionStartSource = "startup"): Promise<void> {
+function reportSession(sessionStartSource = "startup"): Promise<boolean> {
   const sessionRef = currentSessionRef();
   if (!sessionRef) {
-    return Promise.resolve();
+    return Promise.resolve(true);
   }
 
   return sendRequest({
@@ -140,7 +216,7 @@ function reportSession(sessionStartSource = "startup"): Promise<void> {
   });
 }
 
-function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<void> {
+function sendState(state: AgentState, message?: string, seq = nextReportSeq()): Promise<boolean> {
   return sendRequest({
     id: `${source}:${Date.now()}:${Math.random().toString(36).slice(2)}`,
     method: "pane.report_agent",
@@ -155,7 +231,7 @@ function sendState(state: AgentState, message?: string, seq = nextReportSeq()): 
   });
 }
 
-function releaseAgent(): Promise<void> {
+function releaseAgent(): Promise<boolean> {
   return sendRequest({
     id: `${source}:release:${Date.now()}:${Math.random().toString(36).slice(2)}`,
     method: "pane.release_agent",
@@ -168,21 +244,30 @@ function releaseAgent(): Promise<void> {
   });
 }
 
-function shouldReleaseOnSessionShutdown(event: any): boolean {
+function shouldReleaseOnSessionShutdown(event: unknown): boolean {
   // OMP tears down and rebinds extension runtimes for internal lifecycle actions
   // such as /reload, /new, /resume, and /fork. Those do not mean the pane's
   // agent process has exited, and releasing hook authority there can suppress
   // legitimate reports from the replacement runtime. Only a user/process quit
   // should release Herdr's full-lifecycle authority.
-  const reason = event?.reason;
-  return reason === "quit";
+  return isRecord(event) && event.reason === "quit";
 }
 
 let sendInFlight = false;
-let queuedState: QueuedState | undefined;
+const queuedStates: QueuedState[] = [];
+let acknowledgedState: AgentState | undefined;
+let acknowledgedMessage: string | undefined;
 
-function queueState(state: AgentState, message?: string): void {
-  queuedState = { state, message, seq: nextReportSeq() };
+function queueState(state: AgentState, message?: string, force = false): void {
+  const pending = queuedStates.at(-1);
+  if (
+    !force &&
+    ((pending && pending.state === state && pending.message === message) ||
+      (!pending && acknowledgedState === state && acknowledgedMessage === message))
+  ) {
+    return;
+  }
+  queuedStates.push({ state, message, seq: nextReportSeq(), attempts: 0 });
   if (!sendInFlight) {
     void drainStateQueue();
   }
@@ -195,33 +280,44 @@ async function drainStateQueue(): Promise<void> {
 
   sendInFlight = true;
   try {
-    while (queuedState) {
-      const next = queuedState;
-      queuedState = undefined;
-      await sendState(next.state, next.message, next.seq);
+    while (queuedStates.length > 0) {
+      const next = queuedStates[0];
+      if (await sendState(next.state, next.message, next.seq)) {
+        queuedStates.shift();
+        acknowledgedState = next.state;
+        acknowledgedMessage = next.message;
+        continue;
+      }
+
+      next.attempts += 1;
+      const retryDelay = Promise.withResolvers<void>();
+      const backoffMs = Math.min(5_000, 100 * 2 ** Math.min(next.attempts - 1, 6));
+      const timeout = setTimeout(retryDelay.resolve, backoffMs);
+      timeout.unref?.();
+      await retryDelay.promise;
     }
   } finally {
     sendInFlight = false;
-    if (queuedState) {
+    if (queuedStates.length > 0) {
       void drainStateQueue();
     }
   }
 }
 
-function lastAssistantMessage(messages: unknown[]): any | undefined {
+function lastAssistantMessage(messages: unknown[]): Record<string, unknown> | undefined {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const message = messages[i] as any;
-    if (message?.role === "assistant") {
+    const message = messages[i];
+    if (isRecord(message) && message.role === "assistant") {
       return message;
     }
   }
   return undefined;
 }
 
-function retryableErrorMessage(event: any): string | undefined {
-  const messages = Array.isArray(event?.messages) ? event.messages : [];
+function retryableErrorMessage(event: unknown): string | undefined {
+  const messages = isRecord(event) && Array.isArray(event.messages) ? event.messages : [];
   const assistant = lastAssistantMessage(messages);
-  if (assistant?.stopReason !== "error") {
+  if (!assistant || assistant.stopReason !== "error") {
     return undefined;
   }
 
@@ -232,13 +328,14 @@ function retryableErrorMessage(event: any): string | undefined {
   return errorMessage || "retryable provider error";
 }
 
-function askBlockedMessage(args: any): string {
-  const questions = Array.isArray(args?.questions) ? args.questions : [];
-  const firstQuestion = questions.find((question: any) => typeof question?.question === "string");
-  if (firstQuestion?.question) {
-    return firstQuestion.question;
-  }
-  return "waiting for user input";
+function askBlockedMessage(args: unknown): string {
+  const questions = isRecord(args) && Array.isArray(args.questions) ? args.questions : [];
+  const firstQuestion = questions.find(
+    (question: unknown) => isRecord(question) && typeof question.question === "string",
+  );
+  return isRecord(firstQuestion) && typeof firstQuestion.question === "string"
+    ? firstQuestion.question
+    : "waiting for user input";
 }
 
 export default function (pi) {
@@ -252,13 +349,12 @@ export default function (pi) {
   let failureMessage: string | undefined;
   let blockedCount = 0;
   let blockedMessage: string | undefined;
-  let lastState: AgentState | undefined;
-  let lastMessage: string | undefined;
-  let idleTimer: ReturnType<typeof setTimeout> | undefined;
-  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  // Delivery deduplication is based on acknowledged state at module scope.
+  let idleTimer: NodeJS.Timeout | undefined;
+  let retryTimer: NodeJS.Timeout | undefined;
   let rootSession = false;
 
-  function clearTimer(timer: ReturnType<typeof setTimeout> | undefined) {
+  function clearTimer(timer: NodeJS.Timeout | undefined) {
     if (timer) {
       clearTimeout(timer);
     }
@@ -292,12 +388,7 @@ export default function (pi) {
 
   function publishState(force = false) {
     const next = desiredState();
-    if (!force && next.state === lastState && next.message === lastMessage) {
-      return;
-    }
-    lastState = next.state;
-    lastMessage = next.message;
-    queueState(next.state, next.message);
+    queueState(next.state, next.message, force);
   }
 
   function scheduleIdle() {
@@ -326,13 +417,12 @@ export default function (pi) {
     retryTimer.unref?.();
   }
 
-  function activateRootSession(ctx: any, sessionStartSource = "startup"): boolean {
-    if (ctx?.hasUI !== true) {
+  function activateRootSession(ctx: unknown): boolean {
+    if (!isRecord(ctx) || ctx.hasUI === false || !isRecord(ctx.sessionManager)) {
       return false;
     }
     rootSession = true;
     updateSessionRef(ctx);
-    void reportSession(sessionStartSource);
     return true;
   }
 
@@ -371,29 +461,55 @@ export default function (pi) {
     activateBlocked(data.label);
   });
 
-  pi.on("session_start", (_event, ctx) => {
-    if (!activateRootSession(ctx)) {
-      return;
-    }
-    // A reload can replace this extension mid-run without emitting another agent_start.
-    agentActive = ctx?.isIdle?.() === false;
-    publishState(true);
-  });
-
-  pi.on("session_switch", (event, ctx) => {
-    if (!activateRootSession(ctx, event?.reason || "resume")) {
-      return;
-    }
-    resetSessionState();
-    publishState(true);
-  });
-
-  pi.on("agent_start", (_event, ctx) => {
+  pi.on("before_agent_start", async (_event, ctx) => {
     if (!rootSession && !activateRootSession(ctx)) {
       return;
     }
     updateSessionRef(ctx);
-    void reportSession();
+    if (!(await reportSession())) {
+      return;
+    }
+    clearPendingTimers();
+    clearFailureState();
+    agentActive = true;
+    publishState();
+  });
+
+  pi.on("session_start", async (event, ctx) => {
+    if (!activateRootSession(ctx)) {
+      return;
+    }
+    const sessionStartSource = isRecord(event) && typeof event.reason === "string" ? event.reason : "startup";
+    if (!(await reportSession(sessionStartSource))) {
+      return;
+    }
+    const contextIsIdle =
+      isRecord(ctx) && typeof ctx.isIdle === "function" ? ctx.isIdle() : undefined;
+    // A pre-start hook can arrive before a late session_start with stale idle context.
+    agentActive = agentActive || contextIsIdle === false;
+    publishState(true);
+  });
+
+  pi.on("session_switch", async (event, ctx) => {
+    if (!activateRootSession(ctx)) {
+      return;
+    }
+    resetSessionState();
+    const sessionStartSource = isRecord(event) && typeof event.reason === "string" ? event.reason : "resume";
+    if (!(await reportSession(sessionStartSource))) {
+      return;
+    }
+    publishState(true);
+  });
+
+  pi.on("agent_start", async (_event, ctx) => {
+    if (!rootSession && !activateRootSession(ctx)) {
+      return;
+    }
+    updateSessionRef(ctx);
+    if (!(await reportSession())) {
+      return;
+    }
     clearPendingTimers();
     clearFailureState();
     agentActive = true;

--- a/src/integration/assets/omp/reporter-fixture.ts
+++ b/src/integration/assets/omp/reporter-fixture.ts
@@ -1,0 +1,18 @@
+import { appendFileSync } from "node:fs";
+
+const outputPath = process.env.HERDR_OMP_TEST_REPORTS;
+if (!outputPath) {
+  process.exit(2);
+}
+
+const args = process.argv.slice(2);
+const method = args.slice(0, 2).join(" ");
+const delayMethod = process.env.HERDR_OMP_TEST_DELAY_METHOD;
+const delayMs = Number.parseInt(process.env.HERDR_OMP_TEST_DELAY_MS || "0", 10);
+if (delayMethod === method && Number.isFinite(delayMs) && delayMs > 0) {
+  await Bun.sleep(delayMs);
+}
+
+appendFileSync(outputPath, `${JSON.stringify(args)}\n`, "utf8");
+const failMethod = process.env.HERDR_OMP_TEST_FAIL_METHOD;
+process.exit(failMethod === method ? 1 : 0);

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -25,7 +25,7 @@ const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
 const PI_INTEGRATION_VERSION: u32 = 5;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 4;
+const OMP_INTEGRATION_VERSION: u32 = 9;
 const CLAUDE_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -67,6 +67,7 @@ pub(crate) fn integration_target_supported(target: crate::api::schema::Integrati
                 | crate::api::schema::IntegrationTarget::Droid
                 | crate::api::schema::IntegrationTarget::Kimi
                 | crate::api::schema::IntegrationTarget::Qodercli
+                | crate::api::schema::IntegrationTarget::Omp
         )
     }
 

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -169,7 +169,6 @@ fn windows_supports_only_cli_hook_integrations() {
     use crate::api::schema::IntegrationTarget;
 
     assert!(!integration_target_supported(IntegrationTarget::Pi));
-    assert!(!integration_target_supported(IntegrationTarget::Omp));
     assert!(!integration_target_supported(IntegrationTarget::Opencode));
     assert!(!integration_target_supported(IntegrationTarget::Kilo));
     assert!(!integration_target_supported(IntegrationTarget::Hermes));
@@ -177,6 +176,7 @@ fn windows_supports_only_cli_hook_integrations() {
     assert!(!integration_target_supported(IntegrationTarget::Devin));
     assert!(!integration_target_supported(IntegrationTarget::Mastracode));
 
+    assert!(integration_target_supported(IntegrationTarget::Omp));
     assert!(integration_target_supported(IntegrationTarget::Claude));
     assert!(integration_target_supported(IntegrationTarget::Codex));
     assert!(integration_target_supported(IntegrationTarget::Copilot));
@@ -2567,7 +2567,7 @@ fn bundled_integration_assets_report_session_refs() {
     assert!(PI_EXTENSION_ASSET.contains("pi.on(\"session_shutdown\""));
     assert!(OMP_EXTENSION_ASSET.contains("agent_session_path"));
     assert!(OMP_EXTENSION_ASSET.contains("agent_session_id"));
-    assert!(OMP_EXTENSION_ASSET.contains("ctx?.hasUI !== true"));
+    assert!(OMP_EXTENSION_ASSET.contains("ctx.hasUI === false"));
     assert!(OMP_EXTENSION_ASSET.contains("pane.report_agent_session"));
     assert!(OMP_EXTENSION_ASSET.contains("pane.report_agent\""));
     assert!(OMP_EXTENSION_ASSET.contains("pi.on(\"agent_start\""));
@@ -2736,15 +2736,15 @@ fn omp_extension_releases_only_for_quit_session_shutdown() {
 #[test]
 fn omp_extension_refreshes_session_ref_before_agent_start_state() {
     let agent_start = OMP_EXTENSION_ASSET
-        .find("pi.on(\"agent_start\", (_event, ctx)")
+        .find("pi.on(\"agent_start\", async (_event, ctx)")
         .expect("omp extension should receive agent_start context");
     let handler = &OMP_EXTENSION_ASSET[agent_start..];
     let update_session = handler
         .find("updateSessionRef(ctx);")
         .expect("omp extension should refresh the active session on agent_start");
     let report_session = handler
-        .find("void reportSession();")
-        .expect("omp extension should report the refreshed session before state");
+        .find("await reportSession()")
+        .expect("omp extension should await the refreshed session before state");
     let publish_state = handler
         .find("publishState();")
         .expect("omp extension should publish working state after refreshing session");
@@ -2766,29 +2766,29 @@ fn omp_handler(event: &str) -> &'static str {
 }
 
 #[test]
-fn omp_root_activation_requires_ui_context() {
+fn omp_root_activation_accepts_missing_ui_but_rejects_explicit_non_ui_context() {
     let activator = OMP_EXTENSION_ASSET
-        .find("function activateRootSession(ctx: any, sessionStartSource = \"startup\"): boolean")
+        .find("function activateRootSession(ctx: unknown): boolean")
         .expect("omp extension should centralize root session activation");
     let helper = &OMP_EXTENSION_ASSET[activator..];
-    let non_ui_guard = helper
-        .find("ctx?.hasUI !== true")
-        .expect("omp extension checks UI context before activating");
+    let explicit_non_ui_guard = helper
+        .find("ctx.hasUI === false")
+        .expect("omp extension should reject an explicitly non-UI context");
+    let session_manager_guard = helper
+        .find("!isRecord(ctx.sessionManager)")
+        .expect("omp extension should require a session manager");
     let root_session = helper
         .find("rootSession = true;")
-        .expect("omp extension activates root session after UI guard");
-    let session_report = helper
-        .find("void reportSession(sessionStartSource);")
-        .expect("omp extension reports root session");
+        .expect("omp extension activates a valid root session");
 
-    assert!(non_ui_guard < root_session);
-    assert!(root_session < session_report);
+    assert!(explicit_non_ui_guard < root_session);
+    assert!(session_manager_guard < root_session);
 }
 
 #[test]
 fn omp_session_start_and_switch_use_root_activation() {
     let session_start = OMP_EXTENSION_ASSET
-        .find("pi.on(\"session_start\", (_event, ctx)")
+        .find("pi.on(\"session_start\", async (event, ctx)")
         .expect("omp extension registers session_start handler");
     let session_start_handler = &OMP_EXTENSION_ASSET[session_start..];
     session_start_handler
@@ -2796,18 +2796,21 @@ fn omp_session_start_and_switch_use_root_activation() {
         .expect("omp session_start handler should activate root session");
 
     let session_switch = OMP_EXTENSION_ASSET
-        .find("pi.on(\"session_switch\", (event, ctx)")
+        .find("pi.on(\"session_switch\", async (event, ctx)")
         .expect("omp extension registers session_switch handler");
     let session_switch_handler = &OMP_EXTENSION_ASSET[session_switch..];
     session_switch_handler
-        .find("if (!activateRootSession(ctx, event?.reason || \"resume\"))")
-        .expect("omp session_switch handler should activate root session with switch reason");
+        .find("if (!activateRootSession(ctx))")
+        .expect("omp session_switch handler should activate root session");
+    session_switch_handler
+        .find("await reportSession(sessionStartSource)")
+        .expect("omp session_switch should await the replacement session report");
 }
 
 #[test]
 fn omp_session_reports_include_start_source() {
     let report_session = OMP_EXTENSION_ASSET
-        .find("function reportSession(sessionStartSource = \"startup\"): Promise<void>")
+        .find("function reportSession(sessionStartSource = \"startup\"): Promise<boolean>")
         .expect("omp extension should label session reports with a lifecycle source");
     let helper = &OMP_EXTENSION_ASSET[report_session..];
     let session_source = helper
@@ -2821,19 +2824,19 @@ fn omp_session_reports_include_start_source() {
 }
 
 #[test]
-fn omp_socket_requests_are_serialized() {
+fn omp_cli_requests_are_serialized() {
     let queue = OMP_EXTENSION_ASSET
-        .find("let requestQueue = Promise.resolve();")
-        .expect("omp extension should keep socket reports ordered");
+        .find("let requestQueue = Promise.resolve(true);")
+        .expect("omp extension should keep CLI reports ordered");
     let send_request = OMP_EXTENSION_ASSET[queue..]
-        .find("function sendRequest(request: unknown): Promise<void>")
-        .expect("omp extension should wrap socket sends in an ordered queue");
+        .find("function sendRequest(request: unknown): Promise<boolean>")
+        .expect("omp extension should wrap CLI reports in an ordered queue");
     let queued_send = OMP_EXTENSION_ASSET[queue + send_request..]
-        .find("requestQueue = requestQueue.then(")
-        .expect("omp extension should serialize socket requests through the queue");
+        .find("const queued = requestQueue.then(")
+        .expect("omp extension should serialize CLI reports through the queue");
     let raw_send = OMP_EXTENSION_ASSET[queue + send_request..]
         .find("sendRequestNow(request)")
-        .expect("omp extension should enqueue the raw socket send");
+        .expect("omp extension should enqueue the raw CLI report");
 
     assert!(queued_send < raw_send);
 }


### PR DESCRIPTION
## Summary

- replace OMP's raw Node local-socket transport with Herdr's injected CLI reporter
- hide Windows reporter processes and bound each invocation with a timeout
- preserve Windows absolute session paths
- replace the single pending-state slot with an acknowledgement-aware FIFO and capped retry backoff
- handle `before_agent_start`, missing `hasUI`, and transactional session-before-state ordering
- enable the OMP integration target on Windows and bump the bundled integration to v9
- add behavioral coverage for Windows paths, lifecycle ordering, slow transitions, retries, and acknowledged-state deduplication

## Verification

- `bun test src/integration/assets/herdr-agent-state.test.ts` — 9 passed
- `cargo test --bin herdr omp_` — 20 passed
- `cargo check --bin herdr` — passed
- installed extension and repository asset verified byte-identical locally

## Live smoke-test gate

This is intentionally a draft until one real Windows OMP pane completes several `idle → working → idle` rounds, including an `ask`/blocked transition and a session replacement (`/new`, `/resume`, or `/fork`). Existing running OMP processes must reload `herdr-omp-agent-state.ts` or restart after installation.

## Notes

The broad integration test command currently attempts to compile Unix-only integration targets on Windows and fails on existing `std::os::unix`/`libc` usage; the focused OMP and asset suites above pass.