### PR TITLE
fix: resume a lone Claude pane with --continue so a fork isn't lost

### DIFF
--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -196,6 +196,35 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
     })
 }
 
+/// Build a plan that resumes the agent's most-recent session in the pane's
+/// working directory instead of a pinned session id.
+///
+/// Herdr normally resumes Claude with `claude --resume <id>`. A fork (`/branch`,
+/// `--fork-session`) starts a NEW session id but reports it only as
+/// `SessionStart{source:"startup"}`, which herdr must refuse: the hook carries no
+/// pid and a fork is indistinguishable from a second/nested `claude` in the pane,
+/// so adopting startup ids would let a throwaway session hijack the pane's pinned
+/// id. The pinned id therefore stays on the pre-fork trunk and a later restore
+/// resumes the abandoned trunk, silently dropping the fork's history.
+///
+/// `claude --continue` sidesteps this by resuming whichever session is most recent
+/// in the cwd — which is the fork. It is only safe when the pane is the sole Claude
+/// session for its cwd (otherwise `--continue` could resume a different pane's
+/// session); the caller enforces that. The `dedupe_key` is keyed on the cwd (there
+/// is no id to key on) so it is unique per pane — though continue plans are built at
+/// launch, after restore-time dedup, so the key is defensive rather than consumed.
+pub fn continue_plan(source: &str, agent: &str, cwd: &Path) -> Option<AgentResumePlan> {
+    let argv = match (source, agent) {
+        ("herdr:claude", "claude") => vec!["claude".into(), "--continue".into()],
+        _ => return None,
+    };
+    Some(AgentResumePlan {
+        agent: agent.to_string(),
+        argv,
+        dedupe_key: format!("{source}\u{0}{agent}\u{0}__continue__\u{0}{}", cwd.display()),
+    })
+}
+
 pub fn dedupe_key(source: &str, agent: &str, session_ref: &AgentSessionRef) -> String {
     format!(
         "{source}\u{0}{agent}\u{0}{:?}\u{0}{}",
@@ -256,6 +285,35 @@ mod tests {
             "herdr:opencode",
             "opencode"
         ));
+    }
+
+    #[test]
+    fn continue_plan_targets_claude_continue_and_keys_on_cwd() {
+        let cwd_a = std::path::Path::new("/tmp/project-a");
+        let cwd_b = std::path::Path::new("/tmp/project-b");
+
+        let plan_a = continue_plan("herdr:claude", "claude", cwd_a).unwrap();
+        assert_eq!(plan_a.argv, vec!["claude", "--continue"]);
+        assert_eq!(plan_a.agent, "claude");
+
+        // A --continue plan has no session id, so its dedupe key is per-cwd:
+        // two lone-Claude panes in different dirs must not collide (which would
+        // drop one from the resume batch), but the same cwd is stable.
+        let plan_b = continue_plan("herdr:claude", "claude", cwd_b).unwrap();
+        assert_ne!(plan_a.dedupe_key, plan_b.dedupe_key);
+        assert_eq!(
+            continue_plan("herdr:claude", "claude", cwd_a)
+                .unwrap()
+                .dedupe_key,
+            plan_a.dedupe_key,
+        );
+
+        // continue_plan is Claude-only: `--continue` is a Claude flag, and Claude
+        // is the agent whose fork rotates the id while reporting only `startup`.
+        // Other agents either self-heal (codex/omp accept startup/fork) or have no
+        // known fork feature, so none fall back to --continue.
+        assert!(continue_plan("herdr:codex", "codex", cwd_a).is_none());
+        assert!(continue_plan("herdr:omp", "omp", cwd_a).is_none());
     }
 
     #[test]

--- a/src/app/agent_resume.rs
+++ b/src/app/agent_resume.rs
@@ -118,6 +118,72 @@ impl App {
         pending
     }
 
+    /// Choose the resume plan for `terminal`, preferring `claude --continue` over
+    /// the pinned `claude --resume <id>` when the pane is the SOLE Claude session
+    /// in its cwd.
+    ///
+    /// herdr pins a Claude session by id, but a fork (`/branch`, `--fork-session`)
+    /// rotates that id and reports it only as `SessionStart{source:"startup"}`,
+    /// which herdr must refuse (it cannot tell a fork from a nested claude), so the
+    /// pinned id goes stale and restore resumes the abandoned trunk, dropping the
+    /// fork's history. `claude --continue` resumes whichever session is most recent
+    /// in the cwd — the fork.
+    ///
+    /// Used only when no OTHER herdr pane holds a Claude session for the same cwd,
+    /// so `--continue` (which is cwd-global) can't resume a different pane's
+    /// session. Two limits herdr cannot close here, because `--continue` trusts the
+    /// cwd's newest session: a `claude` the user ran in the same dir OUTSIDE herdr,
+    /// or a cwd that has drifted from the session's dir, mis-resumes — but both
+    /// leave the original session intact on disk (recoverable), unlike the silent
+    /// history loss this fixes. Applied at the single launch point
+    /// (`start_pending_agent_resume`) that both resume entry points funnel through,
+    /// so it never runs on the per-render candidate build.
+    fn agent_resume_plan_for_terminal(
+        &self,
+        terminal: &crate::terminal::TerminalState,
+        plan: crate::agent_resume::AgentResumePlan,
+    ) -> crate::agent_resume::AgentResumePlan {
+        let is_claude = terminal
+            .persisted_agent_session
+            .as_ref()
+            .is_some_and(|session| {
+                session.source == "herdr:claude" && session.agent == "claude"
+            });
+        if is_claude {
+            let cwd = crate::worktree::canonical_or_original(&terminal.cwd);
+            if self.claude_sessions_in_cwd(&cwd) <= 1 {
+                if let Some(continue_plan) =
+                    crate::agent_resume::continue_plan("herdr:claude", "claude", &cwd)
+                {
+                    return continue_plan;
+                }
+            }
+        }
+        plan
+    }
+
+    /// Count terminals whose persisted session is a Claude session rooted at the
+    /// (already-canonicalized) `cwd`. Both sides are canonicalized so panes that
+    /// reach the same physical directory via different paths (e.g. `/tmp` vs
+    /// `/private/tmp`, or a symlinked worktree) count as the same cwd — otherwise
+    /// each would see only itself and both would take `--continue` into the same
+    /// directory, the cross-pane collision the sole-session guard exists to prevent.
+    fn claude_sessions_in_cwd(&self, cwd: &std::path::Path) -> usize {
+        self.state
+            .terminals
+            .values()
+            .filter(|terminal| {
+                crate::worktree::canonical_or_original(&terminal.cwd).as_path() == cwd
+                    && terminal
+                        .persisted_agent_session
+                        .as_ref()
+                        .is_some_and(|session| {
+                            session.source == "herdr:claude" && session.agent == "claude"
+                        })
+            })
+            .count()
+    }
+
     fn pending_agent_resume_pane_infos(
         &self,
         ws_idx: usize,
@@ -215,6 +281,17 @@ impl App {
         if host_terminal_theme.is_empty() && !allow_empty_theme {
             return false;
         }
+
+        // Both resume entry points funnel through here, so resolve the pinned
+        // `claude --resume <id>` to `claude --continue` for a lone Claude pane at
+        // this single launch point (see `agent_resume_plan_for_terminal`). Doing it
+        // here rather than in the per-render candidate build keeps the
+        // filesystem-touching sole-session check off the render loop — it runs once
+        // per actual launch, not on every tick during the theme wait.
+        let plan = match self.state.terminals.get(&terminal_id) {
+            Some(terminal) => self.agent_resume_plan_for_terminal(terminal, plan),
+            None => plan,
+        };
 
         let Some(resume_command) = shell_command_from_argv(&plan.argv) else {
             tracing::warn!(
@@ -368,6 +445,130 @@ mod tests {
             "-c".into(),
             "printf '%s' 'restored agent: shell quoted | marker'; sleep 5".into(),
         ]
+    }
+
+    /// Build an app with a single terminal holding `agent`'s persisted session
+    /// `session_id` and its pinned resume plan, rooted at `cwd`.
+    #[cfg(unix)]
+    fn app_with_agent_terminal(
+        source: &str,
+        agent: &str,
+        cwd: &std::path::Path,
+        session_id: &str,
+    ) -> (App, crate::terminal::TerminalId) {
+        let mut app = test_app();
+        let id = crate::terminal::TerminalId::alloc();
+        let session_ref = crate::agent_resume::AgentSessionRef::id(session_id).unwrap();
+        let mut terminal = crate::terminal::TerminalState::new(id.clone(), cwd.to_path_buf());
+        terminal.persisted_agent_session = Some(crate::agent_resume::PersistedAgentSession {
+            source: source.into(),
+            agent: agent.into(),
+            session_ref: session_ref.clone(),
+        });
+        terminal.pending_agent_resume_plan = crate::agent_resume::plan(source, agent, &session_ref);
+        app.state.terminals.insert(id.clone(), terminal);
+        (app, id)
+    }
+
+    /// Insert a second, pane-less Claude terminal rooted at `cwd` — enough to make
+    /// `claude_sessions_in_cwd` see more than one Claude session in that directory.
+    #[cfg(unix)]
+    fn insert_paneless_claude_terminal(app: &mut App, cwd: &std::path::Path, session_id: &str) {
+        let other_id = crate::terminal::TerminalId::alloc();
+        let mut other = crate::terminal::TerminalState::new(other_id.clone(), cwd.to_path_buf());
+        other.persisted_agent_session = Some(crate::agent_resume::PersistedAgentSession {
+            source: "herdr:claude".into(),
+            agent: "claude".into(),
+            session_ref: crate::agent_resume::AgentSessionRef::id(session_id).unwrap(),
+        });
+        app.state.terminals.insert(other_id, other);
+    }
+
+    /// The launch argv herdr would actually use for terminal `id` — the pinned plan
+    /// after `agent_resume_plan_for_terminal` resolves it, which is exactly what
+    /// `start_pending_agent_resume` (the single launch point) runs.
+    #[cfg(unix)]
+    fn resolved_resume_argv(app: &App, id: &crate::terminal::TerminalId) -> Vec<String> {
+        let terminal = app.state.terminals.get(id).expect("terminal exists");
+        let plan = terminal
+            .pending_agent_resume_plan
+            .clone()
+            .expect("terminal has a pending resume plan");
+        app.agent_resume_plan_for_terminal(terminal, plan).argv
+    }
+
+    /// Removes a temp directory tree on drop so a panicking test can't leak it.
+    #[cfg(unix)]
+    struct TempDirGuard(std::path::PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).ok();
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn lone_claude_terminal_resolves_to_continue_but_shared_cwd_keeps_pinned_id() {
+        let cwd = std::path::PathBuf::from("/tmp/lone-claude-cwd");
+        let (mut app, id) = app_with_agent_terminal("herdr:claude", "claude", &cwd, "trunk-session");
+
+        // Sole Claude session in its cwd: resume with `--continue` so a fork (whose
+        // rotated id herdr cannot safely adopt at report time) is followed instead
+        // of the stale pinned trunk.
+        assert_eq!(resolved_resume_argv(&app, &id), vec!["claude", "--continue"]);
+
+        // A second Claude session in the same cwd: `--continue` could resume the
+        // other pane's session, so herdr must keep the pinned `--resume <id>`.
+        insert_paneless_claude_terminal(&mut app, &cwd, "other-session");
+        assert_eq!(
+            resolved_resume_argv(&app, &id),
+            vec!["claude", "--resume", "trunk-session"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn claude_continue_guard_canonicalizes_cwd_across_symlinks() {
+        // Two Claude terminals reaching the SAME physical dir via different path
+        // strings (a symlink) must count as one cwd — otherwise each sees only
+        // itself and both take `--continue` into the same dir, the collision the
+        // sole-session guard prevents.
+        let base = std::env::temp_dir().join(format!("herdr-canon-cwd-{}", std::process::id()));
+        let _guard = TempDirGuard(base.clone());
+        std::fs::remove_dir_all(&base).ok();
+        let real = base.join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = base.join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let (mut app, id) = app_with_agent_terminal("herdr:claude", "claude", &real, "trunk-session");
+
+        // Sole Claude session in `real` -> `--continue`.
+        assert_eq!(resolved_resume_argv(&app, &id), vec!["claude", "--continue"]);
+
+        // A second Claude whose cwd is the SYMLINK to `real`. Canonicalized they are
+        // the same directory, so the terminal reverts to the pinned `--resume`.
+        insert_paneless_claude_terminal(&mut app, &link, "other-session");
+        assert_eq!(
+            resolved_resume_argv(&app, &id),
+            vec!["claude", "--resume", "trunk-session"],
+            "a symlinked cwd must be recognized as the same directory"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn lone_non_claude_terminal_keeps_pinned_resume() {
+        // The `--continue` swap is Claude-only; a lone Codex terminal keeps its
+        // pinned `resume <id>` (Codex self-heals forks via its own startup allowlist).
+        let cwd = std::path::PathBuf::from("/tmp/lone-codex-cwd");
+        let (app, id) = app_with_agent_terminal("herdr:codex", "codex", &cwd, "codex-session");
+        assert_eq!(
+            resolved_resume_argv(&app, &id),
+            vec!["codex", "resume", "codex-session"]
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Problem

Restoring a herdr session relaunches each Claude pane with its pinned session id:
`claude --resume <id>`. After a **fork** (`/branch`, `--fork-session`) that id is **stale**, so
the resumed pane silently loses recent history even though the full transcript is on disk.

## Why herdr can't fix this at report time

A fork starts a NEW session id and reports it as `SessionStart{source:"startup"}`. herdr
deliberately refuses to adopt a same-owner `startup` id, because the hook payload carries no
pid and a fork is **indistinguishable** from a second/nested `claude` in the same pane —
adopting startup ids would let a throwaway session hijack the pane's pinned id (the guard added
in #712 / `92a10fc`). Claude Code exposes no `fork` hook source and no parent-session pointer,
and its transcript format is explicitly internal/unstable, so herdr has no reliable report-time
signal to tell a fork from a nested session. (herdr also only receives `SessionStart` for
Claude — no per-turn events — so it may not even observe the fork before a restart.)

So the pinned id stays on the pre-fork trunk, and restore resumes the abandoned trunk.

## Fix (resume-time)

`claude --continue` resumes whichever session is most recent in the cwd — which is the fork. At
restore, when a pane is the **sole Claude session in its cwd**, resume with `--continue` instead
of `--resume <id>`. When another pane holds a Claude session in the same cwd, keep the pinned
`--resume <id>` so `--continue` can't resume a different pane's session.

The decision uses only herdr's own pane registry (`claude_sessions_in_cwd`) — no parsing of
Claude's internal transcript format. It runs at the single launch point
(`start_pending_agent_resume`) that both restore paths (batch restore and direct terminal-attach)
funnel through, so its filesystem check never touches the per-render candidate build. The
report-time guard is left untouched, so the #712 hijack stays closed.

## Scope / limits

- Claude-specific: `continue_plan` is Claude-only (`--continue` is a Claude flag), and Claude is
  the agent whose fork rotates the id while reporting only `startup`. Other native agents either
  accept their own `startup`/`fork` source and self-heal (codex, omp) or have no known fork
  feature, so they keep pinned `--resume`.
- Two Claude sessions in one cwd keep pinned ids (no `--continue`), so a fork in that rarer case
  is not auto-followed — a deliberate trade so a pane never resumes another pane's session.
- `--continue` trusts the cwd's most-recent session. Two cases where it can mis-resume — both
  leave the original session intact on disk (recoverable), unlike the silent history loss this
  fixes: a `claude` run in the same directory *outside* herdr, and a pane whose cwd has drifted
  away from the session's directory (`--continue` there finds nothing and starts fresh).
- cwds are canonicalized (`worktree::canonical_or_original`) before comparison so panes reaching
  one directory via different path strings (e.g. `/tmp` vs `/private/tmp`, a symlinked worktree)
  count as the same cwd.

## Tests

- `continue_plan` unit test: argv, per-cwd dedupe key, Claude-only scoping.
- Decision tests for `agent_resume_plan_for_terminal`: lone Claude → `--continue`; a second
  Claude in the same cwd → pinned `--resume`; a symlinked-cwd second terminal still counts as one
  directory (canonicalization); a non-Claude (Codex) terminal keeps pinned `resume`.

Full suite green (2446).
