### PR TITLE
docs: clarify pane send-text and send-keys usage and add --help

### DIFF
--- a/docs/next/website/src/content/docs/cli-reference.mdx
+++ b/docs/next/website/src/content/docs/cli-reference.mdx
@@ -197,14 +197,41 @@ herdr pane send-keys <pane_id> <key> [key ...]
 herdr pane run <pane_id> <command>
 ```
 
-`<key>` uses Herdr key-combo syntax: plain printable keys such as `a`,
-special keys such as `enter`, `tab`, `esc`, `backspace`, `left`, `right`,
-`up`, and `down`, modifier chords such as `ctrl+h`, `control+j`, `alt+x`,
-and `shift+tab`, function keys such as `f1`, and named punctuation such as
-`minus`, `plus`, and `backtick`. Legacy `C-c` and `c-c` are accepted as
-aliases for `ctrl+c`.
+`send-text` types text into the pane exactly as if the bytes were entered at
+the keyboard. Arguments after `<pane_id>` are joined with single spaces and
+sent verbatim: escape sequences such as `\n` are **not** interpreted, and no
+Enter/newline is appended, so the text is typed but not submitted. To submit a
+command, use `pane run` (which appends Enter), follow the `send-text` with
+`send-keys <pane_id> enter`, or embed a real newline in the argument (for
+example bash/zsh `$'ls -la\n'`).
+
+`send-keys` presses one or more keys. Each argument is a single key chord and
+the chords are sent in order. A chord is zero or more modifiers plus one key
+joined with `+`, and names are case-insensitive:
+
+- **modifiers:** `ctrl` (`control`), `shift`, `alt` (`option`, `meta`),
+  `cmd` (`command`, `super`), `hyper`.
+- **keys:** any single character (`a`, `7`, `/`; an uppercase letter implies
+  `shift`); named keys `enter`/`return`, `esc`/`escape`, `tab` (`shift+tab`
+  sends back-tab), `backspace`/`bs`, `space`, `up`, `down`, `left`, `right`;
+  punctuation words `minus`, `comma`, `period`, `slash`, `backslash`, `quote`,
+  `double_quote`, `semicolon`, `colon`, `percent`, `ampersand`, `backtick`,
+  `plus`; and function keys `f1`–`f12`.
+
+Legacy `C-c` and `c-c` are accepted as aliases for `ctrl+c`, and a bare `+`
+means the `plus` key. If any argument is not a valid key, no keys are sent and
+the command reports `unsupported key <key>`.
 
 `pane run` submits text plus Enter atomically. Prefer it over `send-text` plus `send-keys Enter` for commands.
+
+Examples:
+
+```bash
+herdr pane send-text <pane_id> 'git commit -m '   # type without submitting
+herdr pane run <pane_id> 'ls -la'                 # type a command and run it
+herdr pane send-keys <pane_id> ctrl+c             # interrupt the foreground process
+herdr pane send-keys <pane_id> up up enter        # recall a previous command and run it
+```
 
 Report agent state from custom hooks:
 

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -905,8 +905,12 @@ fn pane_close(args: &[String]) -> std::io::Result<i32> {
 }
 
 fn pane_send_text(args: &[String]) -> std::io::Result<i32> {
+    if wants_help(args.first()) {
+        print_send_text_help();
+        return Ok(0);
+    }
     if args.len() < 2 {
-        eprintln!("usage: herdr pane send-text <pane_id> <text>");
+        print_send_text_help();
         return Ok(2);
     }
 
@@ -916,14 +920,79 @@ fn pane_send_text(args: &[String]) -> std::io::Result<i32> {
 }
 
 fn pane_send_keys(args: &[String]) -> std::io::Result<i32> {
+    if wants_help(args.first()) {
+        print_send_keys_help();
+        return Ok(0);
+    }
     if args.len() < 2 {
-        eprintln!("usage: herdr pane send-keys <pane_id> <key> [key ...]");
+        print_send_keys_help();
         return Ok(2);
     }
 
     let pane_id = super::normalize_pane_id(&args[0]);
     let keys = args[1..].to_vec();
     super::send_ok_request(Method::PaneSendKeys(PaneSendKeysParams { pane_id, keys }))
+}
+
+/// True when the first argument is a help flag (`-h`, `--help`, or `help`).
+fn wants_help(first: Option<&String>) -> bool {
+    matches!(first.map(String::as_str), Some("-h" | "--help" | "help"))
+}
+
+fn print_send_text_help() {
+    eprintln!("usage: herdr pane send-text <pane_id> <text>...");
+    eprintln!();
+    eprintln!("Type text into a pane, exactly as if the bytes were entered at the keyboard.");
+    eprintln!("Every argument after <pane_id> is joined with single spaces and sent verbatim.");
+    eprintln!();
+    eprintln!("The text is sent literally:");
+    eprintln!("  - escape sequences such as \\n or \\t are NOT interpreted (a literal '\\' 'n');");
+    eprintln!("  - no Enter/newline is appended, so the text is typed but not submitted.");
+    eprintln!();
+    eprintln!("To submit a command (press Enter), use one of:");
+    eprintln!("  herdr pane run <pane_id> <command>       # types the text and presses Enter");
+    eprintln!("  herdr pane send-keys <pane_id> enter      # press Enter after a send-text");
+    eprintln!("  herdr pane send-text <pane_id> $'cmd\\n'   # bash/zsh: embed a real newline");
+    eprintln!();
+    eprintln!("examples:");
+    eprintln!("  herdr pane send-text <pane_id> 'hello world'");
+    eprintln!("  herdr pane send-text <pane_id> 'git commit -m '   # leaves the cursor mid-line");
+    eprintln!("  herdr pane run <pane_id> 'ls -la'                 # type and run in one step");
+    eprintln!();
+    eprintln!("<pane_id> is a pane id (see `herdr pane list`).");
+}
+
+fn print_send_keys_help() {
+    eprintln!("usage: herdr pane send-keys <pane_id> <key> [key ...]");
+    eprintln!();
+    eprintln!("Press one or more keys in a pane. Each argument is a single key chord, and the");
+    eprintln!("chords are sent in order. A chord is zero or more modifiers and one key joined");
+    eprintln!("with '+', for example `ctrl+c`, `alt+shift+f`, or just `enter`. Names are");
+    eprintln!("case-insensitive.");
+    eprintln!();
+    eprintln!("modifiers:");
+    eprintln!("  ctrl (control), shift, alt (option, meta), cmd (command, super), hyper");
+    eprintln!();
+    eprintln!("keys:");
+    eprintln!("  - any single character: a b 7 / ? (an uppercase letter implies shift)");
+    eprintln!("  - named: enter (return), esc (escape), tab, backspace (bs), space,");
+    eprintln!("           up, down, left, right");
+    eprintln!("  - punctuation words: minus comma period slash backslash quote double_quote");
+    eprintln!("           semicolon colon percent ampersand backtick plus");
+    eprintln!("  - function keys: f1, f2, ... f12");
+    eprintln!();
+    eprintln!("aliases: `C-c` (and `c-c`) mean `ctrl+c`; a bare `+` means the plus key.");
+    eprintln!();
+    eprintln!("If any argument is not a valid key, no keys are sent and the command reports");
+    eprintln!("`unsupported key <key>`.");
+    eprintln!();
+    eprintln!("examples:");
+    eprintln!("  herdr pane send-keys <pane_id> enter          # press Enter");
+    eprintln!("  herdr pane send-keys <pane_id> ctrl+c         # interrupt (Ctrl-C)");
+    eprintln!("  herdr pane send-keys <pane_id> up up enter    # recall a command and run it");
+    eprintln!("  herdr pane send-keys <pane_id> escape : w q enter   # vim :wq");
+    eprintln!();
+    eprintln!("<pane_id> is a pane id (see `herdr pane list`).");
 }
 
 fn pane_run(args: &[String]) -> std::io::Result<i32> {
@@ -1431,8 +1500,10 @@ fn print_pane_help() {
     eprintln!("  herdr pane move <pane_id> --new-tab [--workspace ID] [--label TEXT] [--focus|--no-focus]");
     eprintln!("  herdr pane move <pane_id> --new-workspace [--label TEXT] [--tab-label TEXT] [--focus|--no-focus]");
     eprintln!("  herdr pane close <pane_id>");
-    eprintln!("  herdr pane send-text <pane_id> <text>");
-    eprintln!("  herdr pane send-keys <pane_id> <key> [key ...]");
+    eprintln!(
+        "  herdr pane send-text <pane_id> <text>  (types verbatim, no Enter; see send-text --help)"
+    );
+    eprintln!("  herdr pane send-keys <pane_id> <key> [key ...]  (key chords e.g. enter, ctrl+c; see send-keys --help)");
     eprintln!("  herdr pane report-agent <pane_id> --source ID --agent LABEL --state idle|working|blocked|unknown [--message TEXT] [--custom-status TEXT] [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
     eprintln!("  herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
     eprintln!("  herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N]");
@@ -1446,6 +1517,31 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn wants_help_detects_help_flags() {
+        assert!(wants_help(Some(&"--help".to_string())));
+        assert!(wants_help(Some(&"-h".to_string())));
+        assert!(wants_help(Some(&"help".to_string())));
+        assert!(!wants_help(Some(&"%1".to_string())));
+        assert!(!wants_help(None));
+    }
+
+    #[test]
+    fn send_text_and_keys_help_flag_exit_zero_without_contacting_server() {
+        // The help path must return before any request is sent, so these are safe
+        // to call with no server running.
+        assert_eq!(pane_send_text(&args(&["--help"])).unwrap(), 0);
+        assert_eq!(pane_send_text(&args(&["-h"])).unwrap(), 0);
+        assert_eq!(pane_send_keys(&args(&["help"])).unwrap(), 0);
+    }
+
+    #[test]
+    fn send_text_and_keys_missing_operands_return_usage_code() {
+        // Only a pane id, no text/keys: prints usage and exits 2 without a request.
+        assert_eq!(pane_send_text(&args(&["%1"])).unwrap(), 2);
+        assert_eq!(pane_send_keys(&args(&["%1"])).unwrap(), 2);
     }
 
     #[test]


### PR DESCRIPTION
The `send-text` and `send-keys` usage strings only printed a bare synopsis and, because the hand-rolled CLI never handled `--help` for them, `send-text <pane_id> --help` sent "--help" as literal text and `send-keys <pane_id> --help` errored with "unsupported key". This left the input format, the key grammar, and the no-Enter behavior of send-text undocumented at the CLI.

- cli/pane: handle `--help`/`-h`/`help` for both commands and print detailed help. send-text help explains that text is sent verbatim (no escape interpretation, no trailing Enter) and how to submit a command. send-keys help documents the chord grammar: modifiers (ctrl/shift/alt/cmd/hyper and aliases), key names, function keys, the C-c/`+` aliases, and that an invalid key sends nothing. Both include examples. Enrich the `pane` command index lines and add unit tests for the help/usage exit codes.
- docs: expand the CLI reference send-input section with send-text semantics, the full send-keys grammar, and worked examples.