### PR TITLE
Auto-focus search in goto/navigator picker on open

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Copy mode now supports literal smart-case search with `/` and `?`, repeating with `n` and `N`, match highlighting, and tmux-style cross-line `w`/`b`/`e` word motions. (#1230)
 - Added maki detection with idle, working, and blocked screen states. (#1301, thanks @tontinton)
+- Added `ui.goto_search_autofocus` to focus the search box by default when the goto navigator opens, disabled by default.
 
 ### Fixed
 - Outer-terminal focus gained and lost reports now reach the focused pane when its application enables focus reporting, restoring Neovim file autoreload and other focus-aware terminal behavior. (#1337)

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -659,6 +659,12 @@
           "description": "Hide the tab row when the workspace has one tab."
         },
         {
+          "key": "ui.goto_search_autofocus",
+          "type": "boolean",
+          "default": "false",
+          "description": "Focus the search box by default when the goto navigator opens."
+        },
+        {
           "key": "ui.agent_panel_sort",
           "type": "enum",
           "default": "\"spaces\"",

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -350,7 +350,7 @@ impl AppState {
         terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
     ) {
         self.navigator.query.clear();
-        self.navigator.search_focused = false;
+        self.navigator.search_focused = self.goto_search_autofocus;
         self.navigator.state_filter = None;
         self.navigator.scroll = 0;
         self.navigator.expanded_workspaces.clear();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -615,6 +615,7 @@ impl App {
             pane_gaps: config.ui.pane_gaps,
             show_agent_labels_on_pane_borders: config.ui.show_agent_labels_on_pane_borders,
             hide_tab_bar_when_single_tab: config.ui.hide_tab_bar_when_single_tab,
+            goto_search_autofocus: config.ui.goto_search_autofocus,
             pane_history_persistence: config.experimental.pane_history,
             reveal_hidden_cursor_for_cjk_ime: config.experimental.reveal_hidden_cursor_for_cjk_ime,
             cjk_ime_agent_filter_configured: !config.experimental.cjk_ime_agents.is_empty(),
@@ -1401,6 +1402,7 @@ impl App {
                 self.state.show_agent_labels_on_pane_borders =
                     config.ui.show_agent_labels_on_pane_borders;
                 self.state.hide_tab_bar_when_single_tab = config.ui.hide_tab_bar_when_single_tab;
+                self.state.goto_search_autofocus = config.ui.goto_search_autofocus;
                 self.state.agent_panel_sort =
                     agent_panel_sort_from_config(config.ui.agent_panel_sort);
                 self.state.sidebar_agents = config.ui.sidebar.agents.clone();

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1420,6 +1420,7 @@ pub struct AppState {
     pub pane_gaps: bool,
     pub show_agent_labels_on_pane_borders: bool,
     pub hide_tab_bar_when_single_tab: bool,
+    pub goto_search_autofocus: bool,
     pub pane_history_persistence: bool,
     /// Expose the focused pane's cursor anchor to the outer terminal even when
     /// the pane requested `?25l`. See `[experimental] reveal_hidden_cursor_for_cjk_ime`.
@@ -1781,6 +1782,7 @@ impl AppState {
             pane_gaps: false,
             show_agent_labels_on_pane_borders: false,
             hide_tab_bar_when_single_tab: false,
+            goto_search_autofocus: false,
             pane_history_persistence: false,
             reveal_hidden_cursor_for_cjk_ime: false,
             cjk_ime_agent_filter_configured: false,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -808,6 +808,8 @@ pub struct UiConfig {
     pub show_agent_labels_on_pane_borders: bool,
     /// Hide the tab row when the workspace has one tab. Default: false.
     pub hide_tab_bar_when_single_tab: bool,
+    /// Focus the search box by default when the goto navigator opens. Default: false.
+    pub goto_search_autofocus: bool,
     /// Agent sidebar ordering. Saved values are "spaces" or "priority". Default: "spaces".
     pub agent_panel_sort: AgentPanelSortConfig,
     /// Expanded sidebar row composition.
@@ -1004,6 +1006,7 @@ impl Default for UiConfig {
             pane_gaps: true,
             show_agent_labels_on_pane_borders: false,
             hide_tab_bar_when_single_tab: false,
+            goto_search_autofocus: false,
             agent_panel_sort: AgentPanelSortConfig::Spaces,
             sidebar: SidebarConfig::default(),
             accent: "cyan".into(),
@@ -1248,6 +1251,19 @@ hide_tab_bar_when_single_tab = true
         assert!(config.ui.pane_gaps);
         assert!(config.ui.show_agent_labels_on_pane_borders);
         assert!(config.ui.hide_tab_bar_when_single_tab);
+    }
+
+    #[test]
+    fn goto_search_autofocus_defaults_off_and_parses() {
+        let default_config = Config::default();
+        assert!(!default_config.ui.goto_search_autofocus);
+
+        let toml = r#"
+[ui]
+goto_search_autofocus = true
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.ui.goto_search_autofocus);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,10 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # New tabs can still be created with the configured keybinding.
 # hide_tab_bar_when_single_tab = false
 
+# Focus the search box by default when the goto navigator opens.
+# Set true to start typing a filter immediately without pressing "/" first.
+# goto_search_autofocus = false
+
 # Agent panel ordering: "spaces" (grouped by space) or "priority" (attention queue).
 # "workspaces" is accepted as an alias for "spaces".
 # agent_panel_sort = "spaces"


### PR DESCRIPTION
Implements https://github.com/ogulcancelik/herdr/discussions/1288 

```
[ui]
goto_search_autofocus = true
```

by default it's disabled for backwards compatibility