### PR TITLE
feat(api): add checked atomic agent input

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added atomic checked agent input APIs with stable terminal targeting, revision/agent/status/content preconditions, one-shot input enqueueing, and the `checked_input.v1` ping capability for safe orchestration clients.
+
 ## [0.7.3] - 2026-07-08
 
 ### Fixed

--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -1122,6 +1122,17 @@
     },
     "request": {
       "$defs": {
+        "AgentReadCheckedParams": {
+          "properties": {
+            "terminal_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "terminal_id"
+          ],
+          "type": "object"
+        },
         "AgentReadParams": {
           "properties": {
             "format": {
@@ -1167,6 +1178,49 @@
           },
           "required": [
             "target"
+          ],
+          "type": "object"
+        },
+        "AgentSendInputCheckedParams": {
+          "properties": {
+            "allowed_statuses": {
+              "items": {
+                "$ref": "#/schemas/request/$defs/PaneAgentState"
+              },
+              "type": "array"
+            },
+            "expected_agent": {
+              "type": "string"
+            },
+            "expected_content_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "expected_input_revision": {
+              "format": "uint64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "keys": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "terminal_id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "terminal_id",
+            "expected_input_revision",
+            "expected_agent",
+            "allowed_statuses"
           ],
           "type": "object"
         },
@@ -4230,6 +4284,22 @@
         {
           "properties": {
             "method": {
+              "const": "agent.read_checked",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentReadCheckedParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
               "const": "agent.explain",
               "type": "string"
             },
@@ -4251,6 +4321,22 @@
             },
             "params": {
               "$ref": "#/schemas/request/$defs/AgentSendParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.send_input_checked",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentSendInputCheckedParams"
             }
           },
           "required": [
@@ -5244,6 +5330,70 @@
     },
     "success_response": {
       "$defs": {
+        "AgentCheckedInputResult": {
+          "properties": {
+            "input_revision": {
+              "format": "uint64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "terminal_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "terminal_id",
+            "input_revision"
+          ],
+          "type": "object"
+        },
+        "AgentCheckedReadResult": {
+          "properties": {
+            "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content_hash": {
+              "type": "string"
+            },
+            "input_revision": {
+              "format": "uint64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/schemas/success_response/$defs/PaneAgentState"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "terminal_id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "terminal_id",
+            "workspace_id",
+            "tab_id",
+            "pane_id",
+            "status",
+            "input_revision",
+            "content_hash",
+            "text"
+          ],
+          "type": "object"
+        },
         "AgentInfo": {
           "properties": {
             "agent": {
@@ -6330,6 +6480,15 @@
             "rate_limited",
             "no_foreground_client",
             "busy"
+          ],
+          "type": "string"
+        },
+        "PaneAgentState": {
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "unknown"
           ],
           "type": "string"
         },
@@ -7901,6 +8060,38 @@
             },
             {
               "properties": {
+                "read": {
+                  "$ref": "#/schemas/success_response/$defs/AgentCheckedReadResult"
+                },
+                "type": {
+                  "const": "agent_checked_read",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "read"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "input": {
+                  "$ref": "#/schemas/success_response/$defs/AgentCheckedInputResult"
+                },
+                "type": {
+                  "const": "agent_checked_input",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "input"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
                 "pane": {
                   "$ref": "#/schemas/success_response/$defs/PaneInfo"
                 },
@@ -8600,6 +8791,10 @@
         },
         "ServerCapabilities": {
           "properties": {
+            "checked_input.v1": {
+              "default": false,
+              "type": "boolean"
+            },
             "detached_server_daemon": {
               "default": false,
               "type": "boolean"

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -105,7 +105,7 @@ Raw socket method names use dot notation:
 | Tab | `tab.create`, `tab.list`, `tab.get`, `tab.focus`, `tab.rename`, `tab.move`, `tab.close` |
 | Pane | `pane.split`, `pane.swap`, `pane.move`, `pane.zoom`, `pane.layout`, `pane.process_info`, `pane.neighbor`, `pane.edges`, `pane.focus_direction`, `pane.resize`, `pane.list`, `pane.current`, `pane.get`, `pane.rename`, `pane.send_text`, `pane.send_keys`, `pane.send_input`, `pane.read`, `pane.report_agent`, `pane.report_agent_session`, `pane.report_metadata`, `pane.clear_agent_authority`, `pane.release_agent`, `pane.close`, `pane.wait_for_output` |
 | Layout | `layout.export`, `layout.apply`, `layout.set_split_ratio` |
-| Agent | `agent.list`, `agent.get`, `agent.read`, `agent.explain`, `agent.send`, `agent.rename`, `agent.focus`, `agent.start` |
+| Agent | `agent.list`, `agent.get`, `agent.read`, `agent.read_checked`, `agent.explain`, `agent.send`, `agent.send_input_checked`, `agent.rename`, `agent.focus`, `agent.start` |
 | Events | `events.subscribe`, `events.wait` |
 | Integrations | `integration.install`, `integration.uninstall` |
 | Plugins | `plugin.link`, `plugin.list`, `plugin.unlink`, `plugin.enable`, `plugin.disable`, `plugin.action.list`, `plugin.action.invoke`, `plugin.log.list`, `plugin.pane.open`, `plugin.pane.focus`, `plugin.pane.close` |
@@ -668,6 +668,78 @@ herdr pane read w1:p1 --source detection
 
 `recent-unwrapped` is useful for logs because it ignores soft wrapping.
 `detection` returns the bottom-buffer snapshot used by agent screen detection.
+
+## Checked agent input
+
+Protocol clients that write prompts based on observed agent state should first
+check `ping.result.capabilities["checked_input.v1"]`. When it is `true`, use
+`agent.read_checked` and `agent.send_input_checked` instead of resolving a
+mutable pane or agent label and writing in separate requests.
+
+`agent.read_checked` accepts only a stable `terminal_id`. It returns the current
+terminal location, semantic agent label and status, normalized detection text,
+the lowercase SHA-256 `content_hash` of those exact text bytes, and a nonzero
+`input_revision`:
+
+```json
+{"id":"checked_read","method":"agent.read_checked","params":{"terminal_id":"term_abc123"}}
+```
+
+The input revision belongs to the live terminal, not its pane location. It
+increases when the semantic agent label or status changes and whenever the
+normalized detection text changes. Moving a live terminal between panes, tabs,
+or workspaces preserves its revision. A restored or handed-off terminal may
+have a new terminal identity and a fresh nonzero revision, so clients must read
+again after reconnecting.
+
+After deciding on input, send all text and keys in one checked request:
+
+```json
+{
+  "id": "checked_send",
+  "method": "agent.send_input_checked",
+  "params": {
+    "terminal_id": "term_abc123",
+    "expected_input_revision": 17,
+    "expected_agent": "codex",
+    "allowed_statuses": ["blocked"],
+    "expected_content_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "text": "Approve this command",
+    "keys": ["enter"]
+  }
+}
+```
+
+`allowed_statuses` uses semantic values: `idle`, `working`, `blocked`, and
+`unknown`. `expected_content_hash` is optional, but recommended when the exact
+prompt text influenced the decision. Herdr validates the terminal identity,
+revision, agent label, status, and optional hash before writing. It validates
+and encodes every key, then enqueues the complete text-and-keys byte sequence
+once. At least one nonempty `text` value or key is required. Key-only requests
+do not emit an empty bracketed-paste sequence. An invalid key or failed
+precondition enqueues nothing and leaves the revision unchanged.
+
+A queue attempt consumes the expected revision exactly once. A successful
+response returns the new revision and means that one complete input sequence
+was queued; it does not mean the agent accepted, processed, or completed the
+request. Legacy or direct terminal input also advances the revision before it
+is queued, so it invalidates any interleaved checked request. If the queue
+rejects a checked send with `checked_input_send_failed`, no bytes from that
+request were queued, but its revision remains consumed. Read a fresh snapshot
+before deciding whether to retry.
+
+Checked-input precondition failures use stable error codes:
+
+| Code | Meaning |
+| --- | --- |
+| `stale_input_revision` | The live terminal revision no longer matches. |
+| `stale_agent` | The semantic agent label no longer matches. |
+| `stale_status` | The semantic status is not in `allowed_statuses`. |
+| `stale_content` | The normalized detection content hash no longer matches. |
+| `unsupported_target` | The supplied id is not a currently live stable terminal id. |
+
+These are raw socket methods in this release; there is no CLI wrapper for the
+read-check-write transaction.
 
 ## Waiting for state
 

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -105,10 +105,14 @@ pub enum Method {
     AgentGet(AgentTarget),
     #[serde(rename = "agent.read")]
     AgentRead(AgentReadParams),
+    #[serde(rename = "agent.read_checked")]
+    AgentReadChecked(AgentReadCheckedParams),
     #[serde(rename = "agent.explain")]
     AgentExplain(AgentTarget),
     #[serde(rename = "agent.send")]
     AgentSend(AgentSendParams),
+    #[serde(rename = "agent.send_input_checked")]
+    AgentSendInputChecked(AgentSendInputCheckedParams),
     #[serde(rename = "agent.rename")]
     AgentRename(AgentRenameParams),
     #[serde(rename = "agent.focus")]

--- a/src/api/schema/agents.rs
+++ b/src/api/schema/agents.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::common::{AgentStatus, ReadFormat, ReadSource, SplitDirection};
+use super::common::{AgentStatus, PaneAgentState, ReadFormat, ReadSource, SplitDirection};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentReadParams {
@@ -20,6 +20,48 @@ pub struct AgentReadParams {
 pub struct AgentSendParams {
     pub target: String,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentReadCheckedParams {
+    pub terminal_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentSendInputCheckedParams {
+    pub terminal_id: String,
+    #[schemars(range(min = 1))]
+    pub expected_input_revision: u64,
+    pub expected_agent: String,
+    pub allowed_statuses: Vec<PaneAgentState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_content_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentCheckedReadResult {
+    pub terminal_id: String,
+    pub workspace_id: String,
+    pub tab_id: String,
+    pub pane_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    pub status: PaneAgentState,
+    #[schemars(range(min = 1))]
+    pub input_revision: u64,
+    pub content_hash: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentCheckedInputResult {
+    pub terminal_id: String,
+    #[schemars(range(min = 1))]
+    pub input_revision: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/api/schema/response.rs
+++ b/src/api/schema/response.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::agents::AgentInfo;
+use super::agents::{AgentCheckedInputResult, AgentCheckedReadResult, AgentInfo};
 use super::common::{ClientWindowTitleReason, NotificationShowReason};
 use super::events::EventEnvelope;
 use super::integrations::{
@@ -103,6 +103,12 @@ pub enum ResponseResult {
     },
     AgentList {
         agents: Vec<AgentInfo>,
+    },
+    AgentCheckedRead {
+        read: AgentCheckedReadResult,
+    },
+    AgentCheckedInput {
+        input: AgentCheckedInputResult,
     },
     PaneInfo {
         pane: PaneInfo,

--- a/src/api/schema/server.rs
+++ b/src/api/schema/server.rs
@@ -18,4 +18,6 @@ pub struct ServerCapabilities {
     pub live_handoff: bool,
     #[serde(default)]
     pub detached_server_daemon: bool,
+    #[serde(rename = "checked_input.v1", default)]
+    pub checked_input_v1: bool,
 }

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -117,6 +117,18 @@ fn generated_protocol_schema_artifact_is_current() {
 }
 
 #[test]
+fn checked_input_revisions_have_schema_minimum_one() {
+    let schema = protocol_schema_document();
+    for pointer in [
+        "/schemas/request/$defs/AgentSendInputCheckedParams/properties/expected_input_revision/minimum",
+        "/schemas/success_response/$defs/AgentCheckedReadResult/properties/input_revision/minimum",
+        "/schemas/success_response/$defs/AgentCheckedInputResult/properties/input_revision/minimum",
+    ] {
+        assert_eq!(schema.pointer(pointer), Some(&serde_json::json!(1)), "{pointer}");
+    }
+}
+
+#[test]
 fn request_round_trips_for_server_stop() {
     let request = Request {
         id: "req_stop".into(),
@@ -181,6 +193,35 @@ fn request_round_trips_for_agent_explain() {
     assert_eq!(json["method"], "agent.explain");
     let restored: Request = serde_json::from_value(json).unwrap();
     assert_eq!(restored, request);
+}
+
+#[test]
+fn checked_agent_requests_round_trip() {
+    let read = Request {
+        id: "req_checked_read".into(),
+        method: Method::AgentReadChecked(AgentReadCheckedParams {
+            terminal_id: "term_1".into(),
+        }),
+    };
+    let json = serde_json::to_value(&read).unwrap();
+    assert_eq!(json["method"], "agent.read_checked");
+    assert_eq!(serde_json::from_value::<Request>(json).unwrap(), read);
+
+    let send = Request {
+        id: "req_checked_send".into(),
+        method: Method::AgentSendInputChecked(AgentSendInputCheckedParams {
+            terminal_id: "term_1".into(),
+            expected_input_revision: 7,
+            expected_agent: "codex".into(),
+            allowed_statuses: vec![PaneAgentState::Blocked],
+            expected_content_hash: Some("abc".into()),
+            text: "yes".into(),
+            keys: vec!["enter".into()],
+        }),
+    };
+    let json = serde_json::to_value(&send).unwrap();
+    assert_eq!(json["method"], "agent.send_input_checked");
+    assert_eq!(serde_json::from_value::<Request>(json).unwrap(), send);
 }
 
 #[test]
@@ -525,11 +566,14 @@ fn success_response_round_trips() {
             capabilities: Some(ServerCapabilities {
                 live_handoff: true,
                 detached_server_daemon: true,
+                checked_input_v1: true,
             }),
         },
     };
 
     let json = serde_json::to_string(&response).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(value["result"]["capabilities"]["checked_input.v1"], true);
     let restored: SuccessResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(restored, response);
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -63,6 +63,7 @@ pub fn start_server(
         Some(ServerCapabilities {
             live_handoff: crate::platform::capabilities().live_handoff,
             detached_server_daemon: crate::platform::current_process_is_detached_server_daemon(),
+            checked_input_v1: true,
         }),
     )
 }
@@ -336,8 +337,10 @@ fn api_method_name(method: &Method) -> &'static str {
         Method::AgentList(_) => "agent.list",
         Method::AgentGet(_) => "agent.get",
         Method::AgentRead(_) => "agent.read",
+        Method::AgentReadChecked(_) => "agent.read_checked",
         Method::AgentExplain(_) => "agent.explain",
         Method::AgentSend(_) => "agent.send",
+        Method::AgentSendInputChecked(_) => "agent.send_input_checked",
         Method::AgentRename(_) => "agent.rename",
         Method::AgentFocus(_) => "agent.focus",
         Method::AgentStart(_) => "agent.start",
@@ -806,6 +809,7 @@ mod tests {
             Some(ServerCapabilities {
                 live_handoff: true,
                 detached_server_daemon: true,
+                checked_input_v1: true,
             }),
         );
 

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -152,6 +152,7 @@ impl App {
         if let AppEvent::PaneDied { pane_id } = &ev {
             let previous_toast = self.state.toast.clone();
             if let Some(update) = self.state.publish_pane_process_exit_if_agent(*pane_id) {
+                self.bump_checked_input_revision_for_update(&update);
                 self.sync_full_lifecycle_authority_detection_pauses();
                 self.refresh_new_herdr_toast_context_for_update(&update, &previous_toast);
                 self.emit_pane_state_update(&update);
@@ -264,6 +265,7 @@ impl App {
             self.render_notify.notify_one();
         }
         for update in &pane_updates {
+            self.bump_checked_input_revision_for_update(update);
             self.refresh_new_herdr_toast_context_for_update(update, &previous_toast);
             self.emit_pane_state_update(update);
         }
@@ -308,6 +310,24 @@ impl App {
 
         self.sync_toast_deadline(previous_toast);
         self.shutdown_detached_terminal_runtimes();
+    }
+
+    fn bump_checked_input_revision_for_update(
+        &self,
+        update: &crate::app::actions::PaneStateUpdate,
+    ) {
+        if update.previous_agent_label == update.agent_label
+            && update.previous_state == update.state
+        {
+            return;
+        }
+        if let Some(runtime) = self.state.runtime_for_pane_in_workspace(
+            &self.terminal_runtimes,
+            update.ws_idx,
+            update.pane_id,
+        ) {
+            runtime.bump_checked_input_revision();
+        }
     }
 
     fn reset_agent_detection_for_agents(&self, agents: &[crate::detect::Agent]) {
@@ -498,6 +518,12 @@ impl App {
         };
 
         let cwd = terminal.cwd.clone();
+        let previous_input_revision = self
+            .terminal_runtimes
+            .get(&terminal_id)
+            .and_then(|runtime| runtime.checked_input_snapshot())
+            .map(|snapshot| snapshot.input_revision)
+            .unwrap_or(1);
         let (rows, cols) = self
             .terminal_runtimes
             .get(&terminal_id)
@@ -530,6 +556,8 @@ impl App {
                 return false;
             }
         };
+
+        runtime.advance_checked_input_revision_to(previous_input_revision.saturating_add(1));
 
         self.terminal_runtimes.insert(terminal_id.clone(), runtime);
         if let Some(terminal) = self.state.terminals.get_mut(&terminal_id) {
@@ -942,8 +970,14 @@ impl App {
             Method::AgentRename(params) => return self.handle_agent_rename(request.id, params),
             Method::AgentStart(params) => return self.handle_agent_start(request.id, params),
             Method::AgentRead(params) => return self.handle_agent_read(request.id, params),
+            Method::AgentReadChecked(params) => {
+                return self.handle_agent_read_checked(request.id, params)
+            }
             Method::AgentExplain(target) => return self.handle_agent_explain(request.id, target),
             Method::AgentSend(params) => return self.handle_agent_send(request.id, params),
+            Method::AgentSendInputChecked(params) => {
+                return self.handle_agent_send_input_checked(request.id, params)
+            }
             Method::PaneSplit(params) => return self.handle_pane_split(request.id, params),
             Method::PaneSwap(params) => return self.handle_pane_swap(request.id, params),
             Method::PaneMove(params) => return self.handle_pane_move(request.id, params),

--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -1,12 +1,15 @@
 use bytes::Bytes;
 
 use crate::api::schema::{
-    AgentRenameParams, AgentSendParams, AgentStartParams, AgentTarget, PaneReadResult, ReadFormat,
-    ReadSource, ResponseResult,
+    AgentCheckedInputResult, AgentCheckedReadResult, AgentReadCheckedParams, AgentRenameParams,
+    AgentSendInputCheckedParams, AgentSendParams, AgentStartParams, AgentTarget, PaneAgentState,
+    PaneReadResult, ReadFormat, ReadSource, ResponseResult,
 };
 use crate::app::App;
 
 use super::responses::{encode_error, encode_error_body, encode_success};
+
+use super::super::api_helpers::{encode_api_text_for_mode, parse_api_keys};
 
 impl App {
     pub(super) fn handle_agent_list(&mut self, id: String) -> String {
@@ -108,6 +111,50 @@ impl App {
         )
     }
 
+    pub(super) fn handle_agent_read_checked(
+        &mut self,
+        id: String,
+        params: AgentReadCheckedParams,
+    ) -> String {
+        let Some(target) = self.checked_terminal_target(&params.terminal_id) else {
+            return checked_input_unsupported_target(id, &params.terminal_id);
+        };
+        let Some(runtime) = self.state.runtime_for_pane_in_workspace(
+            &self.terminal_runtimes,
+            target.ws_idx,
+            target.pane_id,
+        ) else {
+            return checked_input_unsupported_target(id, &params.terminal_id);
+        };
+        let Some(snapshot) = runtime.checked_input_snapshot() else {
+            return encode_error(
+                id,
+                "checked_input_unavailable",
+                "terminal detection snapshot is unavailable",
+            );
+        };
+        let Some(terminal) = self.state.terminals.get(&target.terminal_id) else {
+            return checked_input_unsupported_target(id, &params.terminal_id);
+        };
+
+        encode_success(
+            id,
+            ResponseResult::AgentCheckedRead {
+                read: AgentCheckedReadResult {
+                    terminal_id: terminal.id.to_string(),
+                    workspace_id: target.workspace_id,
+                    tab_id: target.tab_id,
+                    pane_id: target.pane_id_public,
+                    agent: terminal.effective_agent_label().map(str::to_string),
+                    status: semantic_agent_status(terminal.state),
+                    input_revision: snapshot.input_revision,
+                    content_hash: snapshot.content_hash,
+                    text: snapshot.text,
+                },
+            },
+        )
+    }
+
     pub(super) fn handle_agent_explain(&mut self, id: String, target: AgentTarget) -> String {
         let resolved = match self.resolve_terminal_target(&target.target) {
             Ok(resolved) => resolved,
@@ -193,6 +240,163 @@ impl App {
 
         encode_success(id, ResponseResult::Ok {})
     }
+
+    pub(super) fn handle_agent_send_input_checked(
+        &mut self,
+        id: String,
+        params: AgentSendInputCheckedParams,
+    ) -> String {
+        let Some(target) = self.checked_terminal_target(&params.terminal_id) else {
+            return checked_input_unsupported_target(id, &params.terminal_id);
+        };
+        if params.text.is_empty() && params.keys.is_empty() {
+            return encode_error(
+                id,
+                "invalid_params",
+                "checked input requires non-empty text or at least one key",
+            );
+        }
+        let parsed_keys = match parse_api_keys(&params.keys) {
+            Ok(keys) => keys,
+            Err(key) => return encode_error(id, "invalid_key", format!("unsupported key {key}")),
+        };
+        let Some(terminal) = self.state.terminals.get(&target.terminal_id) else {
+            return checked_input_unsupported_target(id, &params.terminal_id);
+        };
+        let actual_agent = terminal.effective_agent_label().map(str::to_string);
+        let actual_status = semantic_agent_status(terminal.state);
+        let Some(runtime) = self.state.runtime_for_pane_in_workspace(
+            &self.terminal_runtimes,
+            target.ws_idx,
+            target.pane_id,
+        ) else {
+            return checked_input_unsupported_target(id, &params.terminal_id);
+        };
+
+        let outcome =
+            runtime.with_checked_input(|snapshot, bracketed_paste, protocol, consume_revision| {
+                if snapshot.input_revision != params.expected_input_revision {
+                    return Err((
+                        "stale_input_revision",
+                        format!(
+                            "expected input revision {}, got {}",
+                            params.expected_input_revision, snapshot.input_revision
+                        ),
+                    ));
+                }
+                if actual_agent.as_deref() != Some(params.expected_agent.as_str()) {
+                    return Err((
+                        "stale_agent",
+                        format!(
+                            "expected agent {}, got {}",
+                            params.expected_agent,
+                            actual_agent.as_deref().unwrap_or("none")
+                        ),
+                    ));
+                }
+                if !params.allowed_statuses.contains(&actual_status) {
+                    return Err((
+                        "stale_status",
+                        format!("agent status {actual_status:?} is not allowed")
+                            .to_ascii_lowercase(),
+                    ));
+                }
+                if params
+                    .expected_content_hash
+                    .as_ref()
+                    .is_some_and(|expected| expected != &snapshot.content_hash)
+                {
+                    return Err((
+                        "stale_content",
+                        "detection content hash no longer matches".to_string(),
+                    ));
+                }
+
+                let mut bytes = if params.text.is_empty() {
+                    Vec::new()
+                } else {
+                    encode_api_text_for_mode(&params.text, bracketed_paste)
+                };
+                for key in &parsed_keys {
+                    bytes.extend(runtime.encode_terminal_key_with_protocol(*key, protocol));
+                }
+                let consumed_revision = consume_revision();
+                runtime
+                    .try_send_bytes_untracked(Bytes::from(bytes))
+                    .map_err(|err| ("checked_input_send_failed", err.to_string()))?;
+                Ok(consumed_revision)
+            });
+
+        match outcome {
+            Some(Ok(input_revision)) => encode_success(
+                id,
+                ResponseResult::AgentCheckedInput {
+                    input: AgentCheckedInputResult {
+                        terminal_id: params.terminal_id,
+                        input_revision,
+                    },
+                },
+            ),
+            Some(Err((code, message))) => encode_error(id, code, message),
+            None => encode_error(
+                id,
+                "checked_input_unavailable",
+                "terminal input lock is unavailable",
+            ),
+        }
+    }
+
+    fn checked_terminal_target(&self, terminal_id: &str) -> Option<CheckedTerminalTarget> {
+        for (ws_idx, workspace) in self.state.workspaces.iter().enumerate() {
+            for (tab_idx, tab) in workspace.tabs.iter().enumerate() {
+                for (pane_id, pane) in &tab.panes {
+                    let Some(terminal) = self.state.terminals.get(&pane.attached_terminal_id)
+                    else {
+                        continue;
+                    };
+                    if terminal.id.to_string() == terminal_id {
+                        let tab_id_public = self.public_tab_id(ws_idx, tab_idx)?;
+                        let pane_id_public = self.public_pane_id(ws_idx, *pane_id)?;
+                        return Some(CheckedTerminalTarget {
+                            ws_idx,
+                            pane_id: *pane_id,
+                            terminal_id: pane.attached_terminal_id.clone(),
+                            workspace_id: self.public_workspace_id(ws_idx),
+                            tab_id: tab_id_public,
+                            pane_id_public,
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+struct CheckedTerminalTarget {
+    ws_idx: usize,
+    pane_id: crate::layout::PaneId,
+    terminal_id: crate::terminal::TerminalId,
+    workspace_id: String,
+    tab_id: String,
+    pane_id_public: String,
+}
+
+fn semantic_agent_status(state: crate::detect::AgentState) -> PaneAgentState {
+    match state {
+        crate::detect::AgentState::Idle => PaneAgentState::Idle,
+        crate::detect::AgentState::Working => PaneAgentState::Working,
+        crate::detect::AgentState::Blocked => PaneAgentState::Blocked,
+        crate::detect::AgentState::Unknown => PaneAgentState::Unknown,
+    }
+}
+
+fn checked_input_unsupported_target(id: String, terminal_id: &str) -> String {
+    encode_error(
+        id,
+        "unsupported_target",
+        format!("live terminal {terminal_id} not found"),
+    )
 }
 
 fn agent_not_found(id: String, target: &str) -> String {
@@ -207,7 +411,7 @@ fn agent_not_found(id: String, target: &str) -> String {
 mod tests {
     use super::*;
     use crate::{
-        api::schema::{AgentStatus, SuccessResponse},
+        api::schema::{AgentStatus, ErrorResponse, SuccessResponse},
         app::Mode,
         config::Config,
         detect::{Agent, AgentState},
@@ -229,6 +433,87 @@ mod tests {
         app.state.selected = 0;
         app.state.mode = Mode::Terminal;
         app
+    }
+
+    fn app_with_checked_agent(
+        channel_capacity: usize,
+        screen: &[u8],
+    ) -> (App, String, tokio::sync::mpsc::Receiver<bytes::Bytes>) {
+        let mut app = app_with_agent();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0].tabs[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        let (runtime, rx) =
+            crate::terminal::TerminalRuntime::test_with_channel_and_scrollback_bytes(
+                80,
+                24,
+                1000,
+                screen,
+                channel_capacity,
+            );
+        app.state.insert_test_runtime(pane_id, runtime);
+        app.handle_internal_event(crate::events::AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:checked-test".into(),
+            agent_label: "codex".into(),
+            state: AgentState::Blocked,
+            message: None,
+            custom_status: None,
+            seq: Some(1),
+            session_ref: None,
+        });
+        (app, terminal_id.to_string(), rx)
+    }
+
+    fn checked_read(app: &mut App, terminal_id: &str) -> AgentCheckedReadResult {
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "read".into(),
+            method: crate::api::schema::Method::AgentReadChecked(AgentReadCheckedParams {
+                terminal_id: terminal_id.into(),
+            }),
+        });
+        let success: SuccessResponse = serde_json::from_str(&response)
+            .unwrap_or_else(|err| panic!("invalid checked read response {response}: {err}"));
+        let ResponseResult::AgentCheckedRead { read } = success.result else {
+            panic!("expected checked read response");
+        };
+        read
+    }
+
+    fn checked_send_params(read: &AgentCheckedReadResult) -> AgentSendInputCheckedParams {
+        AgentSendInputCheckedParams {
+            terminal_id: read.terminal_id.clone(),
+            expected_input_revision: read.input_revision,
+            expected_agent: read.agent.clone().expect("agent label"),
+            allowed_statuses: vec![read.status],
+            expected_content_hash: Some(read.content_hash.clone()),
+            text: "answer".into(),
+            keys: vec!["enter".into()],
+        }
+    }
+
+    fn error_code(response: &str) -> String {
+        serde_json::from_str::<ErrorResponse>(response)
+            .unwrap()
+            .error
+            .code
+    }
+
+    fn checked_send_revision(response: &str) -> u64 {
+        let success: SuccessResponse = serde_json::from_str(response).unwrap();
+        let ResponseResult::AgentCheckedInput { input } = success.result else {
+            panic!("expected checked input response");
+        };
+        input.input_revision
+    }
+
+    fn sha256(value: &str) -> String {
+        use sha2::{Digest, Sha256};
+        Sha256::digest(value.as_bytes())
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
     }
 
     #[test]
@@ -264,5 +549,368 @@ mod tests {
             panic!("expected agent info response");
         };
         assert_eq!(agent.agent_status, AgentStatus::Idle);
+    }
+
+    #[tokio::test]
+    async fn checked_read_returns_one_bound_detection_snapshot() {
+        let (mut app, terminal_id, _rx) = app_with_checked_agent(4, b"blocked prompt");
+
+        let read = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(read.terminal_id, terminal_id);
+        assert_eq!(read.agent.as_deref(), Some("codex"));
+        assert_eq!(read.status, PaneAgentState::Blocked);
+        assert!(read.input_revision > 0);
+        assert_eq!(read.content_hash, sha256(&read.text));
+        assert!(read.text.contains("blocked prompt"));
+    }
+
+    #[tokio::test]
+    async fn detection_content_change_advances_revision_without_status_change() {
+        let (mut app, terminal_id, _rx) = app_with_checked_agent(4, b"first prompt");
+        let first = checked_read(&mut app, &terminal_id);
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+
+        app.state
+            .runtime_for_pane_in_workspace(&app.terminal_runtimes, 0, pane_id)
+            .unwrap()
+            .test_process_pty_bytes(b"\rsecond prompt");
+        let second = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(first.status, second.status);
+        assert!(second.input_revision > first.input_revision);
+        assert_ne!(second.content_hash, first.content_hash);
+    }
+
+    #[tokio::test]
+    async fn raw_output_without_normalized_detection_change_keeps_revision() {
+        let (mut app, terminal_id, _rx) = app_with_checked_agent(4, b"prompt");
+        let first = checked_read(&mut app, &terminal_id);
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+
+        app.state
+            .runtime_for_pane_in_workspace(&app.terminal_runtimes, 0, pane_id)
+            .unwrap()
+            .test_process_pty_bytes(b"\x1b[?2026h");
+        let second = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(second.text, first.text);
+        assert_eq!(second.content_hash, first.content_hash);
+        assert_eq!(second.input_revision, first.input_revision);
+    }
+
+    #[tokio::test]
+    async fn semantic_status_transitions_each_advance_revision() {
+        let (mut app, terminal_id, _rx) = app_with_checked_agent(4, b"prompt");
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let blocked = checked_read(&mut app, &terminal_id);
+
+        app.handle_internal_event(crate::events::AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:checked-test".into(),
+            agent_label: "codex".into(),
+            state: AgentState::Working,
+            message: None,
+            custom_status: None,
+            seq: Some(2),
+            session_ref: None,
+        });
+        let working = checked_read(&mut app, &terminal_id);
+        app.handle_internal_event(crate::events::AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:checked-test".into(),
+            agent_label: "codex".into(),
+            state: AgentState::Blocked,
+            message: None,
+            custom_status: None,
+            seq: Some(3),
+            session_ref: None,
+        });
+        let blocked_again = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(working.status, PaneAgentState::Working);
+        assert_eq!(blocked_again.status, PaneAgentState::Blocked);
+        assert!(working.input_revision > blocked.input_revision);
+        assert!(blocked_again.input_revision > working.input_revision);
+    }
+
+    #[tokio::test]
+    async fn semantic_agent_identity_change_advances_revision() {
+        let (mut app, terminal_id, _rx) = app_with_checked_agent(4, b"prompt");
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let codex = checked_read(&mut app, &terminal_id);
+
+        app.handle_internal_event(crate::events::AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:checked-test".into(),
+            agent_label: "claude".into(),
+            state: AgentState::Blocked,
+            message: None,
+            custom_status: None,
+            seq: Some(2),
+            session_ref: None,
+        });
+        let claude = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(claude.agent.as_deref(), Some("claude"));
+        assert_eq!(claude.status, codex.status);
+        assert!(claude.input_revision > codex.input_revision);
+    }
+
+    #[tokio::test]
+    async fn checked_send_enqueues_text_and_keys_once() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(1, b"prompt");
+        let read = checked_read(&mut app, &terminal_id);
+
+        let response = app.handle_api_request(crate::api::schema::Request {
+            id: "send".into(),
+            method: crate::api::schema::Method::AgentSendInputChecked(checked_send_params(&read)),
+        });
+
+        assert_eq!(checked_send_revision(&response), read.input_revision + 1);
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            bytes::Bytes::from_static(b"answer\r")
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_send_consumes_revision_and_rejects_reuse() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(2, b"prompt");
+        let read = checked_read(&mut app, &terminal_id);
+        let params = checked_send_params(&read);
+
+        let first = app.handle_agent_send_input_checked("first".into(), params.clone());
+        let consumed_revision = checked_send_revision(&first);
+        let reused = app.handle_agent_send_input_checked("reused".into(), params);
+
+        assert_eq!(consumed_revision, read.input_revision + 1);
+        assert_eq!(error_code(&reused), "stale_input_revision");
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            bytes::Bytes::from_static(b"answer\r")
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn two_checked_senders_cannot_use_the_same_revision() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(2, b"prompt");
+        let read = checked_read(&mut app, &terminal_id);
+        let client_a = checked_send_params(&read);
+        let client_b = checked_send_params(&read);
+
+        let first = app.handle_agent_send_input_checked("client-a".into(), client_a);
+        let second = app.handle_agent_send_input_checked("client-b".into(), client_b);
+
+        assert_eq!(checked_send_revision(&first), read.input_revision + 1);
+        assert_eq!(error_code(&second), "stale_input_revision");
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            bytes::Bytes::from_static(b"answer\r")
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn legacy_input_invalidates_an_interleaved_checked_send() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(2, b"prompt");
+        let read = checked_read(&mut app, &terminal_id);
+
+        let legacy = app.handle_agent_send(
+            "legacy".into(),
+            AgentSendParams {
+                target: terminal_id,
+                text: "legacy".into(),
+            },
+        );
+        let checked =
+            app.handle_agent_send_input_checked("checked".into(), checked_send_params(&read));
+
+        let success: SuccessResponse = serde_json::from_str(&legacy).unwrap();
+        assert_eq!(success.result, ResponseResult::Ok {});
+        assert_eq!(error_code(&checked), "stale_input_revision");
+        assert_eq!(rx.try_recv().unwrap(), bytes::Bytes::from_static(b"legacy"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_enqueue_failure_still_consumes_revision() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(1, b"prompt");
+        let fill = app.handle_agent_send(
+            "fill".into(),
+            AgentSendParams {
+                target: terminal_id.clone(),
+                text: "queued".into(),
+            },
+        );
+        let success: SuccessResponse = serde_json::from_str(&fill).unwrap();
+        assert_eq!(success.result, ResponseResult::Ok {});
+        let read = checked_read(&mut app, &terminal_id);
+        let params = checked_send_params(&read);
+
+        let failed = app.handle_agent_send_input_checked("failed".into(), params.clone());
+        let after_failure = checked_read(&mut app, &terminal_id);
+        let reused = app.handle_agent_send_input_checked("reused".into(), params);
+
+        assert_eq!(error_code(&failed), "checked_input_send_failed");
+        assert_eq!(after_failure.input_revision, read.input_revision + 1);
+        assert_eq!(error_code(&reused), "stale_input_revision");
+        assert_eq!(rx.try_recv().unwrap(), bytes::Bytes::from_static(b"queued"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_key_only_send_does_not_emit_empty_bracketed_paste() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(1, b"\x1b[?2004hprompt");
+        let read = checked_read(&mut app, &terminal_id);
+        let mut params = checked_send_params(&read);
+        params.text.clear();
+
+        let response = app.handle_agent_send_input_checked("key-only".into(), params);
+
+        assert_eq!(checked_send_revision(&response), read.input_revision + 1);
+        assert_eq!(rx.try_recv().unwrap(), bytes::Bytes::from_static(b"\r"));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_send_rejects_completely_empty_input_without_consuming_revision() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(1, b"prompt");
+        let read = checked_read(&mut app, &terminal_id);
+        let mut params = checked_send_params(&read);
+        params.text.clear();
+        params.keys.clear();
+
+        let response = app.handle_agent_send_input_checked("empty".into(), params);
+        let after = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(error_code(&response), "invalid_params");
+        assert_eq!(after.input_revision, read.input_revision);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_send_rejects_invalid_key_without_partial_enqueue() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(4, b"prompt");
+        let read = checked_read(&mut app, &terminal_id);
+        let mut params = checked_send_params(&read);
+        params.keys = vec!["enter".into(), "not-a-key".into()];
+
+        let response = app.handle_agent_send_input_checked("send".into(), params);
+
+        assert_eq!(error_code(&response), "invalid_key");
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_send_rejects_stale_revision_hash_agent_and_status() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(8, b"first");
+        let first = checked_read(&mut app, &terminal_id);
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        app.state
+            .runtime_for_pane_in_workspace(&app.terminal_runtimes, 0, pane_id)
+            .unwrap()
+            .test_process_pty_bytes(b"\rsecond");
+        let current = checked_read(&mut app, &terminal_id);
+
+        let stale_revision =
+            app.handle_agent_send_input_checked("revision".into(), checked_send_params(&first));
+        assert_eq!(error_code(&stale_revision), "stale_input_revision");
+
+        let mut stale_hash = checked_send_params(&current);
+        stale_hash.expected_content_hash = Some(first.content_hash.clone());
+        let stale_hash = app.handle_agent_send_input_checked("hash".into(), stale_hash);
+        assert_eq!(error_code(&stale_hash), "stale_content");
+
+        let mut wrong_agent = checked_send_params(&current);
+        wrong_agent.expected_agent = "claude".into();
+        let wrong_agent = app.handle_agent_send_input_checked("agent".into(), wrong_agent);
+        assert_eq!(error_code(&wrong_agent), "stale_agent");
+
+        let mut wrong_status = checked_send_params(&current);
+        wrong_status.allowed_statuses = vec![PaneAgentState::Working];
+        let wrong_status = app.handle_agent_send_input_checked("status".into(), wrong_status);
+        assert_eq!(error_code(&wrong_status), "stale_status");
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn checked_methods_require_stable_terminal_id() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(4, b"prompt");
+        let pane_id = app
+            .public_pane_id(0, app.state.workspaces[0].tabs[0].root_pane)
+            .unwrap();
+
+        let read = app.handle_agent_read_checked(
+            "read".into(),
+            AgentReadCheckedParams {
+                terminal_id: pane_id.clone(),
+            },
+        );
+        assert_eq!(error_code(&read), "unsupported_target");
+
+        let current = checked_read(&mut app, &terminal_id);
+        let mut send = checked_send_params(&current);
+        send.terminal_id = pane_id;
+        let send = app.handle_agent_send_input_checked("send".into(), send);
+        assert_eq!(error_code(&send), "unsupported_target");
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn pane_move_preserves_checked_terminal_identity_and_revision() {
+        let (mut app, terminal_id, _rx) = app_with_checked_agent(4, b"prompt");
+        let before = checked_read(&mut app, &terminal_id);
+
+        let response = app.handle_pane_move(
+            "move".into(),
+            crate::api::schema::PaneMoveParams {
+                pane_id: before.pane_id.clone(),
+                destination: crate::api::schema::PaneMoveDestination::NewTab {
+                    workspace_id: None,
+                    label: Some("moved".into()),
+                },
+                focus: true,
+            },
+        );
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert!(matches!(success.result, ResponseResult::PaneMove { .. }));
+        let after = checked_read(&mut app, &terminal_id);
+
+        assert_eq!(after.terminal_id, before.terminal_id);
+        assert_eq!(after.input_revision, before.input_revision);
+        assert_eq!(after.pane_id, before.pane_id);
+        assert_ne!(after.tab_id, before.tab_id);
+    }
+
+    #[tokio::test]
+    async fn legacy_agent_read_and_send_remain_compatible() {
+        let (mut app, terminal_id, mut rx) = app_with_checked_agent(2, b"legacy prompt");
+
+        let read = app.handle_agent_read(
+            "read".into(),
+            crate::api::schema::AgentReadParams {
+                target: terminal_id.clone(),
+                source: ReadSource::Detection,
+                lines: None,
+                format: ReadFormat::Text,
+                strip_ansi: true,
+            },
+        );
+        let success: SuccessResponse = serde_json::from_str(&read).unwrap();
+        assert!(matches!(success.result, ResponseResult::PaneRead { .. }));
+
+        let send = app.handle_agent_send(
+            "send".into(),
+            AgentSendParams {
+                target: terminal_id,
+                text: "legacy".into(),
+            },
+        );
+        let success: SuccessResponse = serde_json::from_str(&send).unwrap();
+        assert_eq!(success.result, ResponseResult::Ok {});
+        assert_eq!(rx.try_recv().unwrap(), bytes::Bytes::from_static(b"legacy"));
     }
 }

--- a/src/app/api_helpers.rs
+++ b/src/app/api_helpers.rs
@@ -14,6 +14,24 @@ fn parse_api_key(key: &str) -> Option<crossterm::event::KeyEvent> {
     Some(crossterm::event::KeyEvent::new(code, modifiers))
 }
 
+pub(super) fn parse_api_keys(keys: &[String]) -> Result<Vec<crate::input::TerminalKey>, String> {
+    keys.iter()
+        .map(|key| {
+            parse_api_key(key)
+                .map(Into::into)
+                .ok_or_else(|| key.clone())
+        })
+        .collect()
+}
+
+pub(super) fn encode_api_text_for_mode(text: &str, bracketed_paste: bool) -> Vec<u8> {
+    if bracketed_paste {
+        format!("\x1b[200~{text}\x1b[201~").into_bytes()
+    } else {
+        text.as_bytes().to_vec()
+    }
+}
+
 fn normalize_api_key_alias(key: &str) -> &str {
     match key {
         "C-c" | "c-c" => "ctrl+c",
@@ -27,25 +45,18 @@ pub(super) fn encode_api_text(runtime: &crate::terminal::TerminalRuntime, text: 
         .input_state()
         .map(|state| state.bracketed_paste)
         .unwrap_or(false);
-    if bracketed {
-        format!("\x1b[200~{text}\x1b[201~").into_bytes()
-    } else {
-        text.as_bytes().to_vec()
-    }
+    encode_api_text_for_mode(text, bracketed)
 }
 
 pub(super) fn encode_api_keys(
     runtime: &crate::terminal::TerminalRuntime,
     keys: &[String],
 ) -> Result<Vec<Vec<u8>>, String> {
-    let mut encoded_keys = Vec::with_capacity(keys.len());
-    for key in keys {
-        let Some(key_event) = parse_api_key(key) else {
-            return Err(key.clone());
-        };
-        encoded_keys.push(runtime.encode_terminal_key(key_event.into()));
-    }
-    Ok(encoded_keys)
+    parse_api_keys(keys).map(|keys| {
+        keys.into_iter()
+            .map(|key| runtime.encode_terminal_key(key))
+            .collect()
+    })
 }
 
 pub(super) fn detect_state_from_api(

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,7 +692,15 @@ fn main() -> io::Result<()> {
 
     let (api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
     let event_hub = api::EventHub::default();
-    let _api_server = match api::start_server_with_capabilities(api_tx, event_hub.clone(), None) {
+    let _api_server = match api::start_server_with_capabilities(
+        api_tx,
+        event_hub.clone(),
+        Some(api::schema::ServerCapabilities {
+            live_handoff: false,
+            detached_server_daemon: false,
+            checked_input_v1: true,
+        }),
+    ) {
         Ok(server) => server,
         Err(err) if err.kind() == io::ErrorKind::AddrInUse => {
             eprintln!("error: herdr is already running");

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -39,8 +39,10 @@ use self::agent_detection::{
     DetectionScreenReadInput, PendingIdleConfirmation, ScreenDetectionPublishInput,
     AGENT_PENDING_IDLE_RECHECK, AGENT_STARTUP_GRACE_WINDOW,
 };
+pub(crate) use self::terminal::{
+    CheckedInputSnapshot, TerminalDirtyPatch, TerminalDirtyPatchOutcome,
+};
 use self::terminal::{GhosttyPaneTerminal, PaneTerminal};
-pub(crate) use self::terminal::{TerminalDirtyPatch, TerminalDirtyPatchOutcome};
 pub use self::{
     state::PaneState,
     terminal::{InputState, ScrollMetrics, TerminalCursorState},
@@ -2419,6 +2421,41 @@ impl PaneRuntime {
         self.terminal.detection_text()
     }
 
+    pub(crate) fn checked_input_snapshot(&self) -> Option<CheckedInputSnapshot> {
+        self.terminal.checked_input_snapshot()
+    }
+
+    pub(crate) fn bump_checked_input_revision(&self) {
+        self.terminal.bump_checked_input_revision();
+    }
+
+    pub(crate) fn advance_checked_input_revision_to(&self, revision: u64) {
+        self.terminal.advance_checked_input_revision_to(revision);
+    }
+
+    pub(crate) fn with_checked_input<R>(
+        &self,
+        f: impl FnOnce(
+            CheckedInputSnapshot,
+            bool,
+            crate::input::KeyboardProtocol,
+            &mut dyn FnMut() -> u64,
+        ) -> R,
+    ) -> Option<R> {
+        let fallback = crate::input::KeyboardProtocol::from_kitty_flags(
+            self.kitty_keyboard_flags.load(Ordering::Relaxed),
+        );
+        self.terminal.with_checked_input(fallback, f)
+    }
+
+    pub(crate) fn encode_terminal_key_with_protocol(
+        &self,
+        key: crate::input::TerminalKey,
+        protocol: crate::input::KeyboardProtocol,
+    ) -> Vec<u8> {
+        self.terminal.encode_terminal_key(key, protocol)
+    }
+
     pub fn agent_osc_title(&self) -> String {
         self.terminal.agent_osc_title()
     }
@@ -2492,10 +2529,19 @@ impl PaneRuntime {
     }
 
     pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::SendError<Bytes>> {
+        self.bump_checked_input_revision();
         self.io.send_bytes(bytes).await
     }
 
     pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        self.bump_checked_input_revision();
+        self.io.try_send_bytes(bytes)
+    }
+
+    pub(crate) fn try_send_bytes_untracked(
+        &self,
+        bytes: Bytes,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
         self.io.try_send_bytes(bytes)
     }
 

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::{layout::Rect, Frame};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 use unicode_width::UnicodeWidthStr;
@@ -68,6 +69,13 @@ pub(crate) enum TerminalDirtyPatchOutcome {
     Clean,
     Patch(TerminalDirtyPatch),
     Fallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CheckedInputSnapshot {
+    pub(crate) text: String,
+    pub(crate) content_hash: String,
+    pub(crate) input_revision: u64,
 }
 
 fn decscusr_cursor_shape(style: crate::ghostty::CursorVisualStyle, blinking: bool) -> u8 {
@@ -143,6 +151,10 @@ pub(crate) struct GhosttyPaneCore {
     decscusr_tracker: DecscusrTracker,
     cursor_settle_state: CursorPositionSettleState,
     windows_powershell_prompt_cwd_reporting: bool,
+    // Kept under the parser lock so normalized output snapshots and checked
+    // input validation cannot race PTY output processing.
+    checked_input_revision: u64,
+    checked_detection_content_hash: String,
 }
 
 pub(crate) struct PaneTerminal {
@@ -222,6 +234,31 @@ impl PaneTerminal {
 
     pub fn detection_text(&self) -> String {
         self.ghostty.detection_text()
+    }
+
+    pub(crate) fn checked_input_snapshot(&self) -> Option<CheckedInputSnapshot> {
+        self.ghostty.checked_input_snapshot()
+    }
+
+    pub(crate) fn bump_checked_input_revision(&self) {
+        self.ghostty.bump_checked_input_revision();
+    }
+
+    pub(crate) fn advance_checked_input_revision_to(&self, revision: u64) {
+        self.ghostty.advance_checked_input_revision_to(revision);
+    }
+
+    pub(crate) fn with_checked_input<R>(
+        &self,
+        fallback_protocol: crate::input::KeyboardProtocol,
+        f: impl FnOnce(
+            CheckedInputSnapshot,
+            bool,
+            crate::input::KeyboardProtocol,
+            &mut dyn FnMut() -> u64,
+        ) -> R,
+    ) -> Option<R> {
+        self.ghostty.with_checked_input(fallback_protocol, f)
     }
 
     pub fn recent_text(&self, lines: usize) -> String {
@@ -404,6 +441,8 @@ impl GhosttyPaneTerminal {
                 decscusr_tracker: DecscusrTracker::default(),
                 cursor_settle_state: CursorPositionSettleState::default(),
                 windows_powershell_prompt_cwd_reporting: false,
+                checked_input_revision: 1,
+                checked_detection_content_hash: detection_content_hash(""),
             }),
             key_encoder: Mutex::new(key_encoder),
             pending_pty_responses,
@@ -495,6 +534,62 @@ impl GhosttyPaneTerminal {
         if let Ok(mut core) = self.core.lock() {
             core.agent_osc_state.clear_retained();
         }
+    }
+
+    pub(crate) fn checked_input_snapshot(&self) -> Option<CheckedInputSnapshot> {
+        self.core
+            .lock()
+            .map(|mut core| refresh_checked_detection_input(&mut core))
+            .ok()
+    }
+
+    pub(crate) fn bump_checked_input_revision(&self) {
+        if let Ok(mut core) = self.core.lock() {
+            bump_checked_input_revision(&mut core);
+        }
+    }
+
+    pub(crate) fn advance_checked_input_revision_to(&self, revision: u64) {
+        if let Ok(mut core) = self.core.lock() {
+            core.checked_input_revision = core.checked_input_revision.max(revision.max(1));
+        }
+    }
+
+    pub(crate) fn with_checked_input<R>(
+        &self,
+        fallback_protocol: crate::input::KeyboardProtocol,
+        f: impl FnOnce(
+            CheckedInputSnapshot,
+            bool,
+            crate::input::KeyboardProtocol,
+            &mut dyn FnMut() -> u64,
+        ) -> R,
+    ) -> Option<R> {
+        // The caller validates and enqueues inside this closure. Holding the
+        // terminal core lock throughout prevents detection content changes
+        // between the checked snapshot and the single queue operation.
+        let mut core = self.core.lock().ok()?;
+        let snapshot = refresh_checked_detection_input(&mut core);
+        let bracketed_paste = core
+            .terminal
+            .mode_get(crate::ghostty::MODE_BRACKETED_PASTE)
+            .unwrap_or(false);
+        let protocol = core
+            .terminal
+            .kitty_keyboard_flags()
+            .ok()
+            .map(|flags| crate::input::KeyboardProtocol::from_kitty_flags(flags as u16))
+            .unwrap_or(fallback_protocol);
+        let mut consume_revision = || {
+            bump_checked_input_revision(&mut core);
+            core.checked_input_revision
+        };
+        Some(f(
+            snapshot,
+            bracketed_paste,
+            protocol,
+            &mut consume_revision,
+        ))
     }
 
     pub fn process_pty_bytes(
@@ -595,6 +690,8 @@ impl GhosttyPaneTerminal {
         if let Ok(mut key_encoder) = self.key_encoder.lock() {
             key_encoder.set_from_terminal(&core.terminal);
         }
+        // Compare the fully normalized detection buffer, not the raw PTY chunk.
+        refresh_checked_detection_input(&mut core);
         let synchronized_output = core
             .terminal
             .mode_get(crate::ghostty::MODE_SYNCHRONIZED_OUTPUT)
@@ -707,6 +804,7 @@ impl GhosttyPaneTerminal {
         if let Ok(mut key_encoder) = self.key_encoder.lock() {
             key_encoder.set_from_terminal(&core.terminal);
         }
+        refresh_checked_detection_input(&mut core);
     }
 
     #[cfg(unix)]
@@ -865,6 +963,7 @@ impl GhosttyPaneTerminal {
                     remaining -= 1;
                 }
             }
+            refresh_checked_detection_input(&mut core);
             terminal_responses
         } else {
             Vec::new()
@@ -1652,6 +1751,35 @@ fn ghostty_detection_text(core: &GhosttyPaneCore) -> Result<String, crate::ghost
         .map(|rows| usize::from(rows).max(1))
         .unwrap_or(DEFAULT_DETECTION_ROWS);
     ghostty_recent_text(core, lines)
+}
+
+fn detection_content_hash(text: &str) -> String {
+    let digest = Sha256::digest(text.as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn bump_checked_input_revision(core: &mut GhosttyPaneCore) {
+    core.checked_input_revision = core.checked_input_revision.saturating_add(1);
+}
+
+fn refresh_checked_detection_input(core: &mut GhosttyPaneCore) -> CheckedInputSnapshot {
+    let text = ghostty_detection_text(core).unwrap_or_default();
+    let content_hash = detection_content_hash(&text);
+    if content_hash != core.checked_detection_content_hash {
+        core.checked_detection_content_hash
+            .clone_from(&content_hash);
+        bump_checked_input_revision(core);
+    }
+    CheckedInputSnapshot {
+        text,
+        content_hash,
+        input_revision: core.checked_input_revision,
+    }
 }
 
 #[cfg(windows)]

--- a/src/terminal/runtime.rs
+++ b/src/terminal/runtime.rs
@@ -279,6 +279,38 @@ impl TerminalRuntime {
         self.0.detection_text()
     }
 
+    pub(crate) fn checked_input_snapshot(&self) -> Option<crate::pane::CheckedInputSnapshot> {
+        self.0.checked_input_snapshot()
+    }
+
+    pub(crate) fn bump_checked_input_revision(&self) {
+        self.0.bump_checked_input_revision();
+    }
+
+    pub(crate) fn advance_checked_input_revision_to(&self, revision: u64) {
+        self.0.advance_checked_input_revision_to(revision);
+    }
+
+    pub(crate) fn with_checked_input<R>(
+        &self,
+        f: impl FnOnce(
+            crate::pane::CheckedInputSnapshot,
+            bool,
+            crate::input::KeyboardProtocol,
+            &mut dyn FnMut() -> u64,
+        ) -> R,
+    ) -> Option<R> {
+        self.0.with_checked_input(f)
+    }
+
+    pub(crate) fn encode_terminal_key_with_protocol(
+        &self,
+        key: crate::input::TerminalKey,
+        protocol: crate::input::KeyboardProtocol,
+    ) -> Vec<u8> {
+        self.0.encode_terminal_key_with_protocol(key, protocol)
+    }
+
     pub fn agent_osc_title(&self) -> String {
         self.0.agent_osc_title()
     }
@@ -351,6 +383,13 @@ impl TerminalRuntime {
 
     pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
         self.0.try_send_bytes(bytes)
+    }
+
+    pub(crate) fn try_send_bytes_untracked(
+        &self,
+        bytes: Bytes,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        self.0.try_send_bytes_untracked(bytes)
     }
 
     pub async fn send_paste(&self, text: String) -> Result<(), mpsc::error::SendError<Bytes>> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -2735,6 +2735,7 @@ mod tests {
                 capabilities: Some(crate::api::schema::ServerCapabilities {
                     live_handoff: true,
                     detached_server_daemon: true,
+                    checked_input_v1: false,
                 }),
             },
         };

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -305,6 +305,7 @@ fn ping_over_socket_returns_version() {
     // Intentionally hardcoded so wire protocol bumps require updating this test.
     // Changing this value means old clients/servers are no longer compatible.
     assert_eq!(value["result"]["protocol"], 16);
+    assert_eq!(value["result"]["capabilities"]["checked_input.v1"], true);
 
     cleanup_spawned_herdr(child, base);
 }
@@ -531,6 +532,77 @@ fn workspace_list_and_create_round_trip() {
         .as_str()
         .unwrap()
         .contains("delta"));
+
+    let report_checked_agent = send_request(
+        &socket_path,
+        &serde_json::json!({
+            "id": "req_checked_report",
+            "method": "pane.report_agent",
+            "params": {
+                "pane_id": pane_id,
+                "source": "custom:socket-test",
+                "agent": "socket-test",
+                "state": "blocked",
+                "seq": 1
+            }
+        })
+        .to_string(),
+    );
+    assert_eq!(report_checked_agent["result"]["type"], "ok");
+    let checked_read = send_request(
+        &socket_path,
+        &serde_json::json!({
+            "id": "req_checked_read",
+            "method": "agent.read_checked",
+            "params": { "terminal_id": root_terminal_id }
+        })
+        .to_string(),
+    );
+    let checked = &checked_read["result"]["read"];
+    assert_eq!(checked["terminal_id"], root_terminal_id);
+    assert_eq!(checked["pane_id"], pane_id);
+    assert_eq!(checked["agent"], "socket-test");
+    assert_eq!(checked["status"], "blocked");
+    assert!(checked["input_revision"].as_u64().unwrap() > 0);
+    assert_eq!(checked["content_hash"].as_str().unwrap().len(), 64);
+
+    let checked_send = send_request(
+        &socket_path,
+        &serde_json::json!({
+            "id": "req_checked_send",
+            "method": "agent.send_input_checked",
+            "params": {
+                "terminal_id": root_terminal_id,
+                "expected_input_revision": checked["input_revision"],
+                "expected_agent": "socket-test",
+                "allowed_statuses": ["blocked"],
+                "expected_content_hash": checked["content_hash"],
+                "text": "echo checked_input_v1",
+                "keys": ["enter"]
+            }
+        })
+        .to_string(),
+    );
+    assert_eq!(checked_send["result"]["type"], "agent_checked_input");
+    assert_eq!(
+        checked_send["result"]["input"]["terminal_id"],
+        root_terminal_id
+    );
+    assert!(
+        checked_send["result"]["input"]["input_revision"]
+            .as_u64()
+            .unwrap()
+            > checked["input_revision"].as_u64().unwrap()
+    );
+
+    let waited_checked = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_checked_wait","method":"pane.wait_for_output","params":{{"pane_id":"{}","source":"recent","lines":40,"match":{{"type":"substring","value":"checked_input_v1"}},"timeout_ms":2000}}}}"#,
+            pane_id
+        ),
+    );
+    assert_eq!(waited_checked["result"]["type"], "output_matched");
 
     let waited_regex = send_request(
         &socket_path,


### PR DESCRIPTION
## Summary

- expose monotonic terminal input revisions through the socket API
- add atomic checked read/send operations that reject stale content, generation, and revision preconditions
- publish checked-input capability metadata and generated schema documentation
- consume revisions exactly once, including queue failures and legacy input interleaving

## Motivation

Remote controllers need a fail-closed way to answer an agent prompt without racing terminal changes. These additions remain additive: existing input methods continue to work and invalidate outstanding checked revisions.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- 16 targeted checked-input tests
- generated schema freshness test
- socket API integration test
- build and 60 Python maintenance tests

The full suite is environment-limited in this Nix shell by existing tests that hardcode `/bin/bash`, `/usr/bin/true`, and `/bin/cat`; 2,421 tests passed before those failures and poison cascades.
