### PR TITLE
fix: return pane_not_found when wait agent-status target closes

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1125,6 +1125,57 @@ mod tests {
     }
 
     #[test]
+    fn events_wait_agent_status_returns_pane_not_found_when_pane_disappears() {
+        let (api_tx, mut api_rx) = mpsc::unbounded_channel::<ApiRequestMessage>();
+        let responder = std::thread::spawn(move || {
+            let first = api_rx.blocking_recv().expect("initial pane probe");
+            assert!(matches!(first.request.method, Method::PaneGet(_)));
+            first
+                .respond_to
+                .send(
+                    serde_json::to_string(&SuccessResponse {
+                        id: first.request.id,
+                        result: ResponseResult::PaneInfo {
+                            pane: pane_info("pane_1", crate::api::schema::AgentStatus::Unknown),
+                        },
+                    })
+                    .unwrap(),
+                )
+                .unwrap();
+
+            let second = api_rx.blocking_recv().expect("poll-time pane probe");
+            assert!(matches!(second.request.method, Method::PaneGet(_)));
+            second
+                .respond_to
+                .send(error_response_json(
+                    second.request.id,
+                    "pane_not_found",
+                    "pane pane_1 not found".into(),
+                ))
+                .unwrap();
+        });
+
+        let (mut client, server, _path) = local_stream_pair("api-wait-missing");
+        client
+            .write_all(br#"{"id":"wait_missing","method":"events.wait","params":{"match_event":{"event":"pane_agent_status_changed","pane_id":"pane_1","agent_status":"blocked"},"timeout_ms":1000}}"#)
+            .unwrap();
+        client.write_all(b"\n").unwrap();
+        client.flush().unwrap();
+
+        let running = Arc::new(AtomicBool::new(true));
+        let event_hub = EventHub::default();
+        handle_connection(server, &api_tx, &event_hub, &running, None).unwrap();
+
+        let response: serde_json::Value = serde_json::from_str(&read_line(&mut client)).unwrap();
+        assert_eq!(response["id"], "wait_missing");
+        assert_eq!(response["error"]["code"], "pane_not_found");
+        assert_eq!(response["error"]["message"], "pane pane_1 not found");
+
+        drop(api_tx);
+        responder.join().unwrap();
+    }
+
+    #[test]
     fn wait_for_output_stops_when_client_disconnects() {
         let (api_tx, mut api_rx) = mpsc::unbounded_channel::<ApiRequestMessage>();
         let (first_read_tx, first_read_rx) = std::sync::mpsc::channel();

--- a/src/api/subscriptions.rs
+++ b/src/api/subscriptions.rs
@@ -297,17 +297,25 @@ impl ActiveSubscription {
         api_tx: &ApiRequestSender,
         event_hub: &EventHub,
     ) -> Option<serde_json::Value> {
+        self.poll_result(api_tx, event_hub).ok().flatten()
+    }
+
+    pub(super) fn poll_result(
+        &mut self,
+        api_tx: &ApiRequestSender,
+        event_hub: &EventHub,
+    ) -> Result<Option<serde_json::Value>, ErrorResponse> {
         match self {
-            Self::Event(subscription) => subscription.poll(event_hub),
-            Self::OutputMatched(subscription) => {
-                serde_json::to_value(subscription.poll(api_tx)?).ok()
-            }
-            Self::AgentStatusChanged(subscription) => {
-                serde_json::to_value(subscription.poll(api_tx, event_hub)?).ok()
-            }
-            Self::ScrollChanged(subscription) => {
-                serde_json::to_value(subscription.poll(api_tx)?).ok()
-            }
+            Self::Event(subscription) => Ok(subscription.poll(event_hub)),
+            Self::OutputMatched(subscription) => Ok(subscription
+                .poll(api_tx)?
+                .and_then(|event| serde_json::to_value(event).ok())),
+            Self::AgentStatusChanged(subscription) => Ok(subscription
+                .poll_result(api_tx, event_hub)?
+                .and_then(|event| serde_json::to_value(event).ok())),
+            Self::ScrollChanged(subscription) => Ok(subscription
+                .poll_result(api_tx)?
+                .and_then(|event| serde_json::to_value(event).ok())),
         }
     }
 }
@@ -325,7 +333,10 @@ impl ActiveEventSubscription {
 }
 
 impl ActiveOutputMatchedSubscription {
-    fn poll(&mut self, api_tx: &ApiRequestSender) -> Option<SubscriptionEventEnvelope> {
+    fn poll(
+        &mut self,
+        api_tx: &ApiRequestSender,
+    ) -> Result<Option<SubscriptionEventEnvelope>, ErrorResponse> {
         let read = pane_read(
             format!("{}:read", self.request_prefix),
             &self.pane_id,
@@ -334,13 +345,13 @@ impl ActiveOutputMatchedSubscription {
             self.strip_ansi,
             api_tx,
         )
-        .ok()?;
+        ?;
 
         let matched_line = match_output(&read.text, &self.matcher, self.regex.as_ref());
-        match matched_line {
+        Ok(match matched_line {
             Some(matched_line) => {
                 if self.currently_matching {
-                    return None;
+                    return Ok(None);
                 }
                 self.currently_matching = true;
                 Some(SubscriptionEventEnvelope {
@@ -356,16 +367,16 @@ impl ActiveOutputMatchedSubscription {
                 self.currently_matching = false;
                 None
             }
-        }
+        })
     }
 }
 
 impl ActiveAgentStatusChangedSubscription {
-    fn poll(
+    fn poll_result(
         &mut self,
         api_tx: &ApiRequestSender,
         event_hub: &EventHub,
-    ) -> Option<SubscriptionEventEnvelope> {
+    ) -> Result<Option<SubscriptionEventEnvelope>, ErrorResponse> {
         let mut saw_status_event = false;
         for (sequence, event) in event_hub.events_after(self.last_sequence) {
             self.last_sequence = sequence;
@@ -401,7 +412,7 @@ impl ActiveAgentStatusChangedSubscription {
             }
 
             self.initial_event = None;
-            return Some(SubscriptionEventEnvelope {
+            return Ok(Some(SubscriptionEventEnvelope {
                 event: SubscriptionEventKind::PaneAgentStatusChanged,
                 data: SubscriptionEventData::PaneAgentStatusChanged(PaneAgentStatusChangedEvent {
                     pane_id,
@@ -412,18 +423,18 @@ impl ActiveAgentStatusChangedSubscription {
                     display_agent,
                     state_labels,
                 }),
-            });
+            }));
         }
 
         if saw_status_event {
             self.initial_event = None;
         } else if event_hub.current_sequence() != self.last_sequence {
-            return None;
+            return Ok(None);
         } else if let Some(event) = self.initial_event.take() {
-            return Some(SubscriptionEventEnvelope {
+            return Ok(Some(SubscriptionEventEnvelope {
                 event: SubscriptionEventKind::PaneAgentStatusChanged,
                 data: SubscriptionEventData::PaneAgentStatusChanged(event),
-            });
+            }));
         }
 
         let before_snapshot_sequence = self.last_sequence;
@@ -432,17 +443,17 @@ impl ActiveAgentStatusChangedSubscription {
             &self.pane_id,
             api_tx,
         )
-        .ok()?;
+        ?;
         let after_snapshot_sequence = event_hub.current_sequence();
         if after_snapshot_sequence != before_snapshot_sequence {
-            return None;
+            return Ok(None);
         }
 
         let event = self.event_from_snapshot(pane);
         if event.is_some() {
             self.last_sequence = after_snapshot_sequence;
         }
-        event
+        Ok(event)
     }
 
     fn event_from_snapshot(
@@ -483,14 +494,17 @@ impl ActiveAgentStatusChangedSubscription {
 }
 
 impl ActiveScrollChangedSubscription {
-    fn poll(&mut self, api_tx: &ApiRequestSender) -> Option<SubscriptionEventEnvelope> {
+    fn poll_result(
+        &mut self,
+        api_tx: &ApiRequestSender,
+    ) -> Result<Option<SubscriptionEventEnvelope>, ErrorResponse> {
         let pane = pane_get(
             format!("{}:pane", self.request_prefix),
             &self.pane_id,
             api_tx,
         )
-        .ok()?;
-        self.event_from_snapshot(pane)
+        ?;
+        Ok(self.event_from_snapshot(pane))
     }
 
     fn event_from_snapshot(
@@ -545,13 +559,14 @@ fn pane_read(
         },
     })?;
     if value.get("error").is_some() {
-        return serde_json::from_value(value).map_err(|_| ErrorResponse {
+        let error = serde_json::from_value(value).map_err(|_| ErrorResponse {
             id: request_id,
             error: ErrorBody {
                 code: "internal_error".into(),
                 message: "failed to decode pane read error".into(),
             },
-        });
+        })?;
+        return Err(error);
     }
     serde_json::from_value(value["result"]["read"].clone()).map_err(|_| ErrorResponse {
         id: request_id,
@@ -585,13 +600,14 @@ fn pane_get(
         },
     })?;
     if value.get("error").is_some() {
-        return serde_json::from_value(value).map_err(|_| ErrorResponse {
+        let error = serde_json::from_value(value).map_err(|_| ErrorResponse {
             id: request_id,
             error: ErrorBody {
                 code: "internal_error".into(),
                 message: "failed to decode pane get error".into(),
             },
-        });
+        })?;
+        return Err(error);
     }
     serde_json::from_value(value["result"]["pane"].clone()).map_err(|_| ErrorResponse {
         id: request_id,
@@ -725,7 +741,8 @@ mod tests {
         event_hub.push(presentation_event(None));
 
         let set_event = subscription
-            .poll(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .poll_result(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .expect("set event request")
             .expect("set event");
         let SubscriptionEventData::PaneAgentStatusChanged(set_data) = set_event.data else {
             panic!("wrong event data");
@@ -733,7 +750,8 @@ mod tests {
         assert_eq!(set_data.title.as_deref(), Some("short lived"));
 
         let expiry_event = subscription
-            .poll(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .poll_result(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .expect("expiry event request")
             .expect("expiry event");
         let SubscriptionEventData::PaneAgentStatusChanged(expiry_data) = expiry_event.data else {
             panic!("wrong event data");
@@ -770,7 +788,8 @@ mod tests {
         event_hub.push(presentation_event(None));
 
         let set_event = subscription
-            .poll(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .poll_result(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .expect("set event request")
             .expect("set event");
         let SubscriptionEventData::PaneAgentStatusChanged(set_data) = set_event.data else {
             panic!("wrong event data");
@@ -778,7 +797,8 @@ mod tests {
         assert_eq!(set_data.title.as_deref(), Some("short lived"));
 
         let expiry_event = subscription
-            .poll(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .poll_result(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .expect("expiry event request")
             .expect("expiry event");
         let SubscriptionEventData::PaneAgentStatusChanged(expiry_data) = expiry_event.data else {
             panic!("wrong event data");
@@ -814,7 +834,8 @@ mod tests {
         event_hub.push(presentation_event(Some("short lived")));
 
         let event = subscription
-            .poll(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .poll_result(&tokio::sync::mpsc::unbounded_channel().0, &event_hub)
+            .expect("setup-window event request")
             .expect("setup-window event");
         let SubscriptionEventData::PaneAgentStatusChanged(data) = event.data else {
             panic!("wrong event data");

--- a/src/api/wait.rs
+++ b/src/api/wait.rs
@@ -153,8 +153,13 @@ pub(super) fn wait_for_event(
             return Ok(None);
         }
 
-        if let Some(event) = active.poll(api_tx, event_hub) {
-            return Ok(Some(wait_matched_response(&request_id, event)));
+        match active.poll_result(api_tx, event_hub) {
+            Ok(Some(event)) => return Ok(Some(wait_matched_response(&request_id, event))),
+            Ok(None) => {}
+            Err(mut response) => {
+                response.id = request_id.clone();
+                return Ok(Some(serde_json::to_string(&response).unwrap()));
+            }
         }
 
         if deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline) {

--- a/tests/cli_wrapper.rs
+++ b/tests/cli_wrapper.rs
@@ -4458,6 +4458,61 @@ fn wait_agent_status_times_out_when_status_does_not_match() {
 }
 
 #[test]
+fn wait_agent_status_returns_pane_not_found_when_pane_closes_mid_wait() {
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let socket_path = runtime_dir.join("herdr.sock");
+
+    let herdr = spawn_herdr(&config_home, &runtime_dir, &socket_path);
+    wait_for_socket(&socket_path, Duration::from_secs(5));
+
+    let created = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"req_cli_close_wait_1","method":"workspace.create","params":{{"cwd":"{}","focus":true}}}}"#,
+            base.display()
+        ),
+    );
+    let root_pane_id = created["result"]["root_pane"]["pane_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut wait_child = Command::new(env!("CARGO_BIN_EXE_herdr"))
+        .args([
+            "wait",
+            "agent-status",
+            "1-1",
+            "--status",
+            "blocked",
+            "--timeout",
+            "5000",
+        ])
+        .env("HERDR_SOCKET_PATH", &socket_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    thread::sleep(Duration::from_millis(150));
+
+    let closed = run_cli(&socket_path, &["pane", "close", &root_pane_id]);
+    assert!(closed.status.success());
+
+    let waited = wait_child.wait_with_output().unwrap();
+    assert_eq!(waited.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&waited.stderr);
+    assert!(stderr.contains(r#""code":"pane_not_found""#), "{stderr}");
+    assert!(
+        !stderr.contains("timed out waiting for agent status change"),
+        "{stderr}"
+    );
+
+    cleanup_spawned_herdr(herdr, base);
+}
+
+#[test]
 fn wait_agent_status_exits_when_done_status_matches() {
     let base = unique_test_dir();
     let config_home = base.join("config");


### PR DESCRIPTION
refs #1439
## Summary

Return `pane_not_found` immediately when `wait agent-status` is waiting on a pane that gets closed mid-wait.

## Changes

- propagate subscription polling errors instead of dropping them
- preserve the top-level wait request id in the returned error response
- fix pane read/get error decoding so real API errors are not collapsed into `internal_error`
- add regression coverage for the pane-disappears-mid-wait case

## Validation

- `cargo test --locked events_wait_agent_status_returns_pane_not_found_when_pane_disappears -- --nocapture`