### PR TITLE
fix(nix) make rust-analyzer available in nix develop shell

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.96.1"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-src", "rust-analyzer"]


### PR DESCRIPTION
Now you get `rust-analyzer` defined in `rust-toolchain.toml` in your shell:

```
which rust-analyzer
/nix/store/5xki10g6c5nw8bb0w3q7m7sw804x4vk3-rust-default-1.96.1/bin/rust-analyzer
```

Needed for editors such as `Zed` to have `rust-analyzer` enabled by running it in a `nix develop shell`.

@ogulcancelik Any way to enable `rust-analyzer` for Zed again (you disabled it in https://github.com/ogulcancelik/herdr/commit/63adf7ef2f8f046d809738ba6ea5bc68db4879d3)? Please check discussion in https://github.com/ogulcancelik/herdr/discussions/1476 .