### PR TITLE
fix(hermes): persist session changes after TUI resume

### DIFF
--- a/src/integration/assets/hermes/__init__.py
+++ b/src/integration/assets/hermes/__init__.py
@@ -1,7 +1,7 @@
 """Hermes plugin installed by Herdr to report agent lifecycle state."""
 
 # HERDR_INTEGRATION_ID=hermes
-# HERDR_INTEGRATION_VERSION=3
+# HERDR_INTEGRATION_VERSION=4
 
 from __future__ import annotations
 
@@ -71,6 +71,19 @@ def _report(state: str, **kwargs) -> None:
     _send("pane.report_agent", params)
 
 
+def _report_session(session_start_source: str, **kwargs) -> None:
+    session_id = _session_id(kwargs)
+    if not session_id:
+        return
+    _send(
+        "pane.report_agent_session",
+        {
+            "agent_session_id": session_id,
+            "session_start_source": session_start_source,
+        },
+    )
+
+
 def _working(**kwargs) -> None:
     _report("working", **kwargs)
 
@@ -83,8 +96,13 @@ def _idle(**kwargs) -> None:
     _report("idle", **kwargs)
 
 
+def _session_reset(**kwargs) -> None:
+    _report_session("resume", **kwargs)
+
+
 def register(ctx):
     ctx.register_hook("on_session_start", _idle)
+    ctx.register_hook("on_session_reset", _session_reset)
     ctx.register_hook("pre_llm_call", _working)
     ctx.register_hook("pre_api_request", _working)
     ctx.register_hook("pre_tool_call", _working)

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -149,7 +149,7 @@ const HERMES_PLUGIN_MANIFEST_INSTALL_NAME: &str = "plugin.yaml";
 const HERMES_PLUGIN_INIT_INSTALL_NAME: &str = "__init__.py";
 const HERMES_PLUGIN_MANIFEST_ASSET: &str = include_str!("assets/hermes/plugin.yaml");
 const HERMES_PLUGIN_INIT_ASSET: &str = include_str!("assets/hermes/__init__.py");
-const HERMES_INTEGRATION_VERSION: u32 = 3;
+const HERMES_INTEGRATION_VERSION: u32 = 4;
 const QODERCLI_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -2673,6 +2673,8 @@ fn bundled_integration_assets_report_session_refs() {
     assert!(HERMES_PLUGIN_INIT_ASSET.contains("session_id = _session_id(kwargs)"));
     assert!(HERMES_PLUGIN_INIT_ASSET.contains("agent_session_id"));
     assert!(HERMES_PLUGIN_INIT_ASSET.contains("pane.report_agent\","));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("pane.report_agent_session"));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("on_session_reset"));
     assert!(HERMES_PLUGIN_INIT_ASSET.contains("on_session_end"));
     assert!(!HERMES_PLUGIN_INIT_ASSET.contains("on_session_finalize"));
     assert!(!HERMES_PLUGIN_INIT_ASSET.contains("pane.release_agent"));

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -946,7 +946,8 @@ impl TerminalState {
                 "herdr:codex",
                 "codex",
                 Some("startup" | "clear" | "resume" | "compact")
-            ) | ("herdr:opencode", "opencode", Some("new"))
+            ) | ("herdr:hermes", "hermes", Some("resume"))
+                | ("herdr:opencode", "opencode", Some("new"))
                 | ("herdr:pi", "pi", Some("new" | "resume" | "fork"))
                 | (
                     "herdr:omp",
@@ -3658,6 +3659,38 @@ mod tests {
                 "{session_start_source} should store the replacement session"
             );
         }
+    }
+
+    #[test]
+    fn hermes_resume_session_ref_replaces_existing_session_ref() {
+        let mut terminal = test_terminal();
+        terminal
+            .set_agent_session_ref(
+                "herdr:hermes".into(),
+                "hermes".into(),
+                crate::agent_resume::AgentSessionRef::id("hermes-old"),
+                Some(20),
+            )
+            .expect("initial session should be accepted");
+
+        let mutation = terminal
+            .set_agent_session_ref_for_session_start(
+                "herdr:hermes".into(),
+                "hermes".into(),
+                crate::agent_resume::AgentSessionRef::id("hermes-resumed"),
+                Some(21),
+                Some("resume".into()),
+            )
+            .expect("resume should replace the Hermes session");
+
+        assert!(mutation.session_ref_changed);
+        assert_eq!(
+            terminal
+                .persisted_agent_session
+                .as_ref()
+                .map(|session| session.session_ref.value.as_str()),
+            Some("hermes-resumed")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report the current Hermes session ID when the TUI emits `on_session_reset`
- allow that trusted Hermes lifecycle transition to replace Herdr's previously persisted session reference
- bump the bundled Hermes integration to version 4 and add regression coverage

## Problem

After an in-TUI `/resume`, Hermes changes session identity without restarting the process. The existing Herdr integration continued reporting lifecycle state but never replaced the persisted session reference, so a later Herdr restart could resume the old conversation.

Hermes's TUI reset hook exposes the new session ID but not the originating command. The integration uses Herdr's existing `resume` transition source as the replacement-authority signal.

## Verification

- `RUST_TEST_THREADS=1 ZIG=/opt/homebrew/opt/zig@0.15/bin/zig cargo test`
- `cargo fmt --check`
- `python3 -m py_compile src/integration/assets/hermes/__init__.py`
- focused plugin hook contract probe
- `git diff --check`
