### PR TITLE
feat(sidebar): separator between agent groups in grouped mode

### DIFF
--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -460,7 +460,7 @@ impl AppState {
             }
             row_y = row_y
                 .saturating_add(height)
-                .saturating_add(crate::ui::agent_entry_gap(self, index, entries.len()))
+                .saturating_add(crate::ui::agent_entry_gap(self, &entries, index))
                 .min(body_bottom);
         }
         None

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -712,6 +712,9 @@ mod tests {
                 .unwrap()
                 .detected_agent = Some(agent);
         }
+        // Card-gap / mouse-target geometry only: use Priority so distinct-workspace group
+        // separators (covered in ui::sidebar tests) don't inject rows between the agents.
+        app.state.agent_panel_sort = AgentPanelSort::Priority;
         app.state.sidebar_agents.rows = vec![vec![crate::config::AgentSidebarToken::Agent]];
         app.state.sidebar_agents.rows_by_agent.insert(
             "claude".into(),

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -558,15 +558,17 @@ pub(crate) fn agent_entry_height_in_body(
         .min(body_height)
 }
 
-/// Group key of an agent panel entry for the grouped (Spaces) view. `Some(key)` is the
-/// worktree-space key; `None` means the workspace belongs to no space. All ungrouped
-/// workspaces share the `None` bucket, so loose agents are not individually fenced —
-/// separators appear only on real space boundaries (including space<->ungrouped).
+/// Group key of an agent panel entry for the grouped (Spaces) view. Identity of the
+/// workspace: the worktree-space key when the workspace is a space member, otherwise the
+/// `ws_idx` itself, so each ungrouped workspace is its own group. `None` only when
+/// `ws_idx` is out of range. Agents sharing a `ws_idx` (different tabs/panes of one
+/// workspace) stay together; distinct workspaces are fenced by a separator.
 fn agent_group_key(app: &AppState, entry: &AgentPanelEntry) -> Option<String> {
-    app.workspaces
-        .get(entry.ws_idx)
-        .and_then(|ws| ws.worktree_space())
-        .map(|space| space.key.clone())
+    app.workspaces.get(entry.ws_idx).map(|ws| {
+        ws.worktree_space()
+            .map(|space| space.key.clone())
+            .unwrap_or_else(|| entry.ws_idx.to_string())
+    })
 }
 
 fn agent_group_boundary(app: &AppState, entries: &[AgentPanelEntry], entry_idx: usize) -> bool {
@@ -1700,6 +1702,10 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         }
         app.sidebar_agents.rows = vec![vec![crate::config::AgentSidebarToken::Agent]];
         assert_eq!(app.sidebar_agents.row_gap, 0);
+        // Pure row_gap packing: use Priority so distinct-workspace group separators
+        // (covered by agent_group_separator_only_on_space_boundaries_in_grouped_mode)
+        // don't inject rows here.
+        app.agent_panel_sort = AgentPanelSort::Priority;
 
         let area = Rect::new(0, 0, 20, 5);
         let metrics = agent_panel_scroll_metrics(&app, area);
@@ -2693,25 +2699,31 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
             workspace_with_worktree_space("loose", None, "/repo/loose"),
         ];
         app.sidebar_agents.row_gap = 0;
+        // Layout: alpha/main, alpha/issue, beta/main, solo, solo (second pane), loose.
+        // The two `solo` entries share a ws_idx (different panes of one workspace).
+        let entry_ws_order = [0usize, 1, 2, 3, 3, 4];
         let entries: Vec<AgentPanelEntry> =
-            (0..app.workspaces.len()).map(|i| agent_entry_for_ws(&app, i)).collect();
+            entry_ws_order.iter().map(|&i| agent_entry_for_ws(&app, i)).collect();
 
-        // Grouped mode: boundary only where the space group changes.
+        // Grouped mode: boundary where the workspace identity changes. Different ungrouped
+        // workspaces are fenced too; only same-ws_idx neighbours share a group.
         app.agent_panel_sort = AgentPanelSort::Spaces;
         assert!(!agent_group_boundary(&app, &entries, 0)); // alpha -> alpha (same space)
         assert!(agent_group_boundary(&app, &entries, 1)); // alpha -> beta
-        assert!(agent_group_boundary(&app, &entries, 2)); // beta -> ungrouped
-        assert!(!agent_group_boundary(&app, &entries, 3)); // ungrouped -> ungrouped (shared bucket)
-        assert!(!agent_group_boundary(&app, &entries, 4)); // last entry
+        assert!(agent_group_boundary(&app, &entries, 2)); // beta -> solo (ungrouped)
+        assert!(!agent_group_boundary(&app, &entries, 3)); // solo -> solo (same ws_idx)
+        assert!(agent_group_boundary(&app, &entries, 4)); // solo -> loose (distinct ungrouped)
+        assert!(!agent_group_boundary(&app, &entries, 5)); // last entry
 
         // row_gap == 0, so the gap equals just the separator row on boundaries.
         assert_eq!(agent_entry_gap(&app, &entries, 0), 0);
         assert_eq!(agent_entry_gap(&app, &entries, 1), 1);
         assert_eq!(agent_entry_gap(&app, &entries, 2), 1);
         assert_eq!(agent_entry_gap(&app, &entries, 3), 0);
-        assert_eq!(agent_entry_gap(&app, &entries, 4), 0);
+        assert_eq!(agent_entry_gap(&app, &entries, 4), 1);
+        assert_eq!(agent_entry_gap(&app, &entries, 5), 0);
 
-        // Priority mode: no separators regardless of space keys.
+        // Priority mode: no separators regardless of workspace identity.
         app.agent_panel_sort = AgentPanelSort::Priority;
         for idx in 0..entries.len() {
             assert!(!agent_group_boundary(&app, &entries, idx));

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -558,9 +558,26 @@ pub(crate) fn agent_entry_height_in_body(
         .min(body_height)
 }
 
-pub(crate) fn agent_entry_gap(app: &AppState, entry_idx: usize, entry_count: usize) -> u16 {
-    if entry_idx + 1 < entry_count {
-        app.sidebar_agents.row_gap
+/// Group key of an agent panel entry for the grouped (Spaces) view. `Some(key)` is the
+/// worktree-space key; `None` means the workspace belongs to no space. All ungrouped
+/// workspaces share the `None` bucket, so loose agents are not individually fenced —
+/// separators appear only on real space boundaries (including space<->ungrouped).
+fn agent_group_key(app: &AppState, entry: &AgentPanelEntry) -> Option<String> {
+    app.workspaces
+        .get(entry.ws_idx)
+        .and_then(|ws| ws.worktree_space())
+        .map(|space| space.key.clone())
+}
+
+fn agent_group_boundary(app: &AppState, entries: &[AgentPanelEntry], entry_idx: usize) -> bool {
+    entry_idx + 1 < entries.len()
+        && matches!(app.agent_panel_sort, AgentPanelSort::Spaces)
+        && agent_group_key(app, &entries[entry_idx]) != agent_group_key(app, &entries[entry_idx + 1])
+}
+
+pub(crate) fn agent_entry_gap(app: &AppState, entries: &[AgentPanelEntry], entry_idx: usize) -> u16 {
+    if entry_idx + 1 < entries.len() {
+        app.sidebar_agents.row_gap + agent_group_boundary(app, entries, entry_idx) as u16
     } else {
         0
     }
@@ -583,7 +600,7 @@ fn agent_panel_visible_count_from(app: &AppState, area: Rect, scroll: usize) -> 
         used_rows = used_rows.saturating_add(height);
         visible += 1;
         used_rows = used_rows
-            .saturating_add(agent_entry_gap(app, index, entries.len()))
+            .saturating_add(agent_entry_gap(app, &entries, index))
             .min(body.height);
     }
     visible
@@ -595,7 +612,7 @@ fn agent_panel_bottom_start(app: &AppState, area: Rect) -> usize {
     let mut used_rows = 0u16;
     let mut start = entries.len();
     for (index, entry) in entries.iter().enumerate().rev() {
-        let gap = agent_entry_gap(app, index, entries.len());
+        let gap = agent_entry_gap(app, &entries, index);
         let needed = agent_entry_height_in_body(app, entry, body.height).saturating_add(gap);
         if used_rows.saturating_add(needed) > body.height {
             break;
@@ -1382,9 +1399,19 @@ fn render_agent_detail(
                 Rect::new(body.x, row_y + row_index as u16, body.width, 1),
             );
         }
+        if agent_group_boundary(app, &details, index) {
+            let sep_y = row_y + height + app.sidebar_agents.row_gap;
+            if sep_y < body_bottom {
+                let sep = "─".repeat(body.width as usize);
+                frame.render_widget(
+                    Paragraph::new(Span::styled(sep, Style::default().fg(p.surface_dim))),
+                    Rect::new(body.x, sep_y, body.width, 1),
+                );
+            }
+        }
         row_y = row_y
             .saturating_add(height)
-            .saturating_add(agent_entry_gap(app, index, details.len()))
+            .saturating_add(agent_entry_gap(app, &details, index))
             .min(body_bottom);
     }
 
@@ -2632,5 +2659,64 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
                 },
             ]
         );
+    }
+
+    fn agent_entry_for_ws(app: &AppState, ws_idx: usize) -> AgentPanelEntry {
+        let ws = &app.workspaces[ws_idx];
+        AgentPanelEntry {
+            ws_idx,
+            tab_idx: 0,
+            pane_id: ws.tabs[0].root_pane,
+            primary_label: String::new(),
+            primary_tab_label: None,
+            pane_label: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
+            agent_label: None,
+            agent: None,
+            state: AgentState::Unknown,
+            seen: true,
+            last_agent_state_change_seq: None,
+            state_labels: std::collections::HashMap::new(),
+            tokens: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn agent_group_separator_only_on_space_boundaries_in_grouped_mode() {
+        let mut app = AppState::test_new();
+        app.workspaces = vec![
+            workspace_with_worktree_space("main", Some("alpha"), "/repo/alpha"),
+            workspace_with_worktree_space("issue", Some("alpha"), "/repo/alpha-issue"),
+            workspace_with_worktree_space("main", Some("beta"), "/repo/beta"),
+            workspace_with_worktree_space("solo", None, "/repo/solo"),
+            workspace_with_worktree_space("loose", None, "/repo/loose"),
+        ];
+        app.sidebar_agents.row_gap = 0;
+        let entries: Vec<AgentPanelEntry> =
+            (0..app.workspaces.len()).map(|i| agent_entry_for_ws(&app, i)).collect();
+
+        // Grouped mode: boundary only where the space group changes.
+        app.agent_panel_sort = AgentPanelSort::Spaces;
+        assert!(!agent_group_boundary(&app, &entries, 0)); // alpha -> alpha (same space)
+        assert!(agent_group_boundary(&app, &entries, 1)); // alpha -> beta
+        assert!(agent_group_boundary(&app, &entries, 2)); // beta -> ungrouped
+        assert!(!agent_group_boundary(&app, &entries, 3)); // ungrouped -> ungrouped (shared bucket)
+        assert!(!agent_group_boundary(&app, &entries, 4)); // last entry
+
+        // row_gap == 0, so the gap equals just the separator row on boundaries.
+        assert_eq!(agent_entry_gap(&app, &entries, 0), 0);
+        assert_eq!(agent_entry_gap(&app, &entries, 1), 1);
+        assert_eq!(agent_entry_gap(&app, &entries, 2), 1);
+        assert_eq!(agent_entry_gap(&app, &entries, 3), 0);
+        assert_eq!(agent_entry_gap(&app, &entries, 4), 0);
+
+        // Priority mode: no separators regardless of space keys.
+        app.agent_panel_sort = AgentPanelSort::Priority;
+        for idx in 0..entries.len() {
+            assert!(!agent_group_boundary(&app, &entries, idx));
+        }
+        assert_eq!(agent_entry_gap(&app, &entries, 1), 0);
+        assert_eq!(agent_entry_gap(&app, &entries, 2), 0);
     }
 }


### PR DESCRIPTION
## What

Draws a thin horizontal rule between agent groups in the sidebar's agents panel, in grouped
mode (`AgentPanelSort::Spaces`).

## Why

With agents spread across several workspaces the panel is one flat list, and group
boundaries are invisible: every neighbour gets the same `row_gap`, so the last agent of one
workspace and the first agent of the next look exactly like two agents of the same
workspace.

## How

- `agent_group_key()` returns the group identity of an entry: the worktree-space key when
  the workspace belongs to one, otherwise its `ws_idx`. That way distinct ungrouped
  workspaces are fenced too, while tabs and panes of one workspace stay together.
- `agent_group_boundary()` is true where that key changes between neighbours, and is gated
  on `AgentPanelSort::Spaces`. Priority mode is untouched: groups interleave by attention
  there, so a boundary would mean nothing.
- `agent_entry_gap()` returns `row_gap + 1` at a boundary, and that extra row is where the
  rule is drawn. All panel geometry (visible count, scroll, hit-testing, render) already
  flows through this function, so scrolling and click targeting stay consistent with no
  extra bookkeeping.
- `render_agent_detail()` draws `─` across the body width, reusing the existing
  section-divider style (`p.surface_dim`).

## Notes

- No behaviour change outside grouped mode, and no new config.
- The signature of `agent_entry_gap` changed (it now takes the entry slice); all four call
  sites are updated.
- Unit test covers: a boundary exactly where groups change, none inside a group, none in
  priority mode.
