### PR TITLE
feat: native session restore for Ocean

### DIFF
--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -88,6 +88,7 @@ pub fn is_reserved_native_state_source(source: &str, agent: &str) -> bool {
             | ("herdr:droid", "droid")
             | ("herdr:qodercli", "qodercli")
             | ("herdr:cursor", "cursor")
+            | ("herdr:ocean", "ocean")
     )
 }
 
@@ -183,6 +184,13 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
             vec![
                 "cursor-agent".into(),
                 "--resume".into(),
+                session_ref.value.clone(),
+            ]
+        }
+        ("herdr:ocean", "ocean", AgentSessionRefKind::Id) => {
+            vec![
+                "ocean".into(),
+                "--session".into(),
                 session_ref.value.clone(),
             ]
         }
@@ -401,6 +409,16 @@ mod tests {
             .unwrap()
             .argv,
             vec!["cursor-agent", "--resume", "cursor-session"]
+        );
+        assert_eq!(
+            plan(
+                "herdr:ocean",
+                "ocean",
+                &AgentSessionRef::id("ocean-session").unwrap()
+            )
+            .unwrap()
+            .argv,
+            vec!["ocean", "--session", "ocean-session"]
         );
     }
 

--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -622,6 +622,7 @@ rows = [[{ token = "git_status", fg = "#ff00aa" }], [{ token = "$jj", bold = tru
             Agent::Kilo,
             Agent::Qodercli,
             Agent::Maki,
+            Agent::Ocean,
         ];
         let entries = agents
             .iter()

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -140,6 +140,7 @@ impl AgentSoundOverrides {
             Some(Agent::Kilo) => self.kilo,
             Some(Agent::Qodercli) => self.qodercli,
             Some(Agent::Maki) => self.maki,
+            Some(Agent::Ocean) => AgentSoundSetting::Default,
             None => AgentSoundSetting::Default,
         }
     }

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -62,6 +62,7 @@ pub enum Agent {
     Kilo,
     Qodercli,
     Maki,
+    Ocean,
 }
 
 impl Agent {
@@ -111,6 +112,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Ocean => "ocean",
     }
 }
 
@@ -147,6 +149,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "maki" => Some(Agent::Maki),
+        "ocean" | "ocean-tui" => Some(Agent::Ocean),
         _ => None,
     }
 }
@@ -632,6 +635,8 @@ mod tests {
         assert_eq!(identify_agent("kilo"), Some(Agent::Kilo));
         assert_eq!(identify_agent("kilo-code"), Some(Agent::Kilo));
         assert_eq!(identify_agent("maki"), Some(Agent::Maki));
+        assert_eq!(identify_agent("ocean"), Some(Agent::Ocean));
+        assert_eq!(identify_agent("ocean-tui"), Some(Agent::Ocean));
     }
 
     #[test]

--- a/website/src/content/docs/session-state.mdx
+++ b/website/src/content/docs/session-state.mdx
@@ -79,6 +79,7 @@ Native session restore requires these Herdr integration versions or newer:
 | OpenCode | `5` | `opencode --session <id>` |
 | Kilo Code CLI | `1` | `kilo --session <id>` |
 | Hermes Agent | `2` | `hermes --resume <id>` |
+| Ocean | n/a (TUI reports `herdr:ocean`) | `ocean --session <id>` |
 | MastraCode | `1` | `mastracode --thread <id>` |
 
 Run `herdr integration status` to check installed integration versions. Reinstall outdated integrations with `herdr integration install <agent>`.


### PR DESCRIPTION
Add official Ocean native session restore.

Summary
- Add herdr:ocean / ocean to the official agent resume planner as ocean --session <id>
- Detect ocean / ocean-tui process labels so restored panes keep agent identity
- Document Ocean in the session restore table

Ocean TUI reports lifecycle state and agent session ids. With this planner entry Herdr can relaunch Ocean panes into the prior conversation after a server restart.

Test plan
- cargo test agent_resume (or focused planner unit tests)
- Manual: run Ocean in a Herdr pane, confirm herdr agent get shows agent_session
- Restart Herdr with resume_agents_on_restore = true and confirm pane relaunches as ocean --session <id>