### PR TITLE
feat(windows): optional SDDL for local named-pipe security (sandboxed-agent access)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
+ "widestring",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ schemars = { version = "1.2.1", features = ["derive"] }
 portable-pty = { path = "vendor/portable-pty" }
 
 [target.'cfg(windows)'.dependencies]
+widestring = "1.2.1"
 windows-sys = { version = "0.61.2", features = [
     "Wdk_System_Threading",
     "Win32_Foundation",

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -856,6 +856,12 @@ pub struct AdvancedConfig {
     /// Maximum scrollback buffer size in bytes retained per pane terminal. Default: 10000000.
     #[serde(alias = "scrollback_lines")]
     pub scrollback_limit_bytes: usize,
+    /// Windows only: an SDDL DACL applied to Herdr's local named pipes.
+    ///
+    /// Leave unset to use Windows' default named-pipe security. This is intended for
+    /// managed hosts that need to grant a restricted local identity access to an
+    /// otherwise user-owned Herdr server.
+    pub windows_named_pipe_sddl: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1097,6 +1103,7 @@ impl Default for AdvancedConfig {
     fn default() -> Self {
         Self {
             scrollback_limit_bytes: DEFAULT_SCROLLBACK_LIMIT_BYTES,
+            windows_named_pipe_sddl: None,
         }
     }
 }
@@ -1104,6 +1111,22 @@ impl Default for AdvancedConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn advanced_config_parses_windows_named_pipe_sddl() {
+        let config: Config = toml::from_str(
+            r#"
+[advanced]
+windows_named_pipe_sddl = "D:P(A;;GRGW;;;WD)"
+"#,
+        )
+        .expect("parse config");
+
+        assert_eq!(
+            config.advanced.windows_named_pipe_sddl.as_deref(),
+            Some("D:P(A;;GRGW;;;WD)")
+        );
+    }
 
     #[test]
     fn update_config_defaults_and_parses() {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -60,13 +60,16 @@ pub(crate) fn bind_local_listener(path: &Path) -> io::Result<LocalListener> {
     #[cfg(windows)]
     {
         use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
+        use interprocess::os::windows::local_socket::ListenerOptionsExt as _;
 
         let name = path.to_string_lossy().to_string();
         let name = name.to_ns_name::<GenericNamespaced>()?;
-        let listener = ListenerOptions::new()
-            .name(name)
-            .reclaim_name(false)
-            .create_sync()?;
+        let options = ListenerOptions::new().name(name).reclaim_name(false);
+        let options = match crate::platform::configured_named_pipe_security_descriptor()? {
+            Some(descriptor) => options.security_descriptor(descriptor),
+            None => options,
+        };
+        let listener = options.create_sync()?;
         fs::write(path, windows_socket_marker())?;
         Ok(listener)
     }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,10 +1,14 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     ffi::c_void,
+    io,
     mem::{size_of, MaybeUninit},
     path::PathBuf,
     ptr::{copy_nonoverlapping, null_mut},
 };
+
+use interprocess::os::windows::security_descriptor::SecurityDescriptor;
+use widestring::U16CString;
 
 use windows_sys::{
     Wdk::System::Threading::{NtQueryInformationProcess, ProcessBasicInformation},
@@ -39,6 +43,30 @@ use windows_sys::{
 use super::{ClipboardImage, ForegroundJob, Signal};
 
 const STILL_ACTIVE: u32 = 259;
+
+pub(crate) fn configured_named_pipe_security_descriptor() -> io::Result<Option<SecurityDescriptor>>
+{
+    let Some(sddl) = crate::config::Config::load()
+        .config
+        .advanced
+        .windows_named_pipe_sddl
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+
+    named_pipe_security_descriptor(&sddl).map(Some)
+}
+
+fn named_pipe_security_descriptor(sddl: &str) -> io::Result<SecurityDescriptor> {
+    let sddl = U16CString::from_str(sddl).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("advanced.windows_named_pipe_sddl contains an embedded NUL: {err}"),
+        )
+    })?;
+    SecurityDescriptor::deserialize(&sddl)
+}
 
 pub(crate) fn should_draw_host_cursor_by_default() -> bool {
     true
@@ -672,6 +700,14 @@ mod tests {
 
     const CONSOLE_TEST_CHILD_ENV: &str = "HERDR_TEST_CONSOLE_CHILD_MODE";
     const CONSOLE_TEST_PARENT_PID_ENV: &str = "HERDR_TEST_CONSOLE_PARENT_PID";
+
+    #[test]
+    fn named_pipe_security_descriptor_accepts_a_restricted_dacl() {
+        super::named_pipe_security_descriptor(
+            "D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;OW)(A;;GRGW;;;WD)",
+        )
+        .expect("parse named-pipe DACL");
+    }
 
     fn console_process_ids() -> Vec<u32> {
         let mut process_ids = vec![0; 8];


### PR DESCRIPTION
## What

Adds `advanced.windows_named_pipe_sddl` — an **opt-in, Windows-only** config setting that applies a caller-supplied SDDL security descriptor to Herdr's local named pipes at listener creation.

Unset (the default) leaves behavior exactly as today: Windows default named-pipe security. Set, it lets the pipe DACL be controlled explicitly, e.g.:

```toml
[advanced]
windows_named_pipe_sddl = "D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;OW)(A;;GRGW;;;<sandbox-group-SID>)"
```

## Why

Coding agents are increasingly run under **restricted local identities** (e.g. Codex's sandbox user on Windows) rather than the desktop user's identity. Today such an agent cannot reach the Herdr socket API at all — the pipe only accepts the owning user — so a sandboxed agent can't participate in Herdr-orchestrated multi-agent workflows without being run unsandboxed, which is exactly the wrong trade.

This setting lets a managed host grant a specific local group read/write on the pipe while keeping everything else (SYSTEM / Administrators / owner) at full access and denying the rest — a *tighter* posture than granting the agent broad host access.

## Implementation notes

- New optional field on `AdvancedConfig` (`src/config/model.rs`), default `None`.
- `src/platform/windows.rs`: parses the SDDL via `interprocess`'s `SecurityDescriptor::deserialize` (using `widestring` for the wide-string conversion); invalid SDDL **fails closed** with a clear error naming the setting.
- `src/ipc.rs`: applies the descriptor through `interprocess`'s existing `ListenerOptionsExt::security_descriptor` when configured; untouched path otherwise.
- Tests: config-parse round-trip and SDDL-parse acceptance.

## Testing

- `cargo test` for the two new tests plus the existing suite on Windows.
- Exercised on a live Windows host: with the DACL configured, a client running under a restricted sandbox identity (member of the granted group) can use the socket API (`agent list`, `pane send-text`, waits), while other non-privileged local identities remain denied; with the setting unset, behavior is unchanged.

---

The feature was developed on a Windows multi-agent host (human-supervised AI pair; the patch was authored by a GPT-5.6 Codex agent and independently reviewed by a Claude agent before submission). Happy to adjust naming, docs placement, or scope to fit the project's conventions.
