### PR TITLE
fix: out-of-bounds grid access in screen_text_rows_range (heap corruption / SIGABRT)

### DIFF
--- a/src/ghostty/mod.rs
+++ b/src/ghostty/mod.rs
@@ -852,14 +852,26 @@ impl Terminal {
             let Some(y) = u32::try_from(y).ok() else {
                 break;
             };
-            let mut grid_ref = self.grid_ref(ghostty_screen_point(0, y))?;
-            let (soft_wrapped, wrap_continuation) = grid_ref_wrap_state(&grid_ref)?;
+            let row_ref = self.grid_ref(ghostty_screen_point(0, y))?;
+            let (soft_wrapped, wrap_continuation) = grid_ref_wrap_state(&row_ref)?;
             let mut cells = Vec::with_capacity(usize::from(cols));
             for x in 0..cols {
-                grid_ref.x = x;
+                // Re-resolve the grid ref for every cell instead of mutating
+                // `x` on a cached snapshot: grid refs are only valid for the
+                // exact position they were resolved at, and libghostty reflows
+                // pages lazily, so a scrollback page's real column count can
+                // be smaller than the terminal's logical width. Writing `x`
+                // directly bypasses PageList.pin()'s page-width guard and
+                // reads out of bounds (heap corruption under ReleaseFast,
+                // where the C shim's bounds asserts are compiled out).
+                let cell_ref = match self.grid_ref(ghostty_screen_point(x, y)) {
+                    Ok(cell_ref) => cell_ref,
+                    // A narrower (not yet reflowed) page ends the row early.
+                    Err(_) => break,
+                };
                 cells.push(ScreenTextCell {
-                    wide: grid_ref_wide(&grid_ref)?,
-                    graphemes: grid_ref_graphemes(&grid_ref)?,
+                    wide: grid_ref_wide(&cell_ref)?,
+                    graphemes: grid_ref_graphemes(&cell_ref)?,
                 });
             }
             rows.push(ScreenTextRow {


### PR DESCRIPTION
## Summary

`Terminal::screen_text_rows_range` resolves a grid ref once per row at `x = 0` and then walks the row by assigning `grid_ref.x` directly. That bypasses `PageList.pin()`'s page-width guard (`if (x >= p.node.cols()) return null`): libghostty reflows pages lazily, so a scrollback page's real column count can be smaller than the terminal's logical width (`PageList.zig` documents this: *"pages may still be a different size and not yet reflowed"*). The hand-set `x` then indexes past the page's cell array.

The vendored libghostty is built `-Doptimize=ReleaseFast` (build.rs), which compiles out the bounds asserts in `page.zig getRowAndCell` — so instead of failing cleanly, the read yields a wild `*Cell` whose garbage grapheme/style metadata corrupts the heap. The corruption then detonates at unrelated later allocations/frees.

## Real-world impact

On a session with ~44 workspaces / ~111 panes running streaming coding agents (lots of scrollback, multibyte Turkish graphemes), herdr 0.7.x SIGABRTed four times in ~54 hours on macOS 15.7.3/arm64. Two distinct death sites, one cause:

- `nanov2_guard_corruption_detected` → abort, backtrace through `herdr::ghostty::grid_ref_graphemes` ← `Terminal::screen_cell` ← `detection_text` (crash report 2026-07-17)
- `___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED` while dropping `protocol::wire::FrameData` in `ClientRenderState::commit_sent_frame` (crash report 2026-07-18, main thread)

Both are downstream victims of the same smashed heap; the corruptor is the `grid_ref.x = x` walk (reached via `retained_text_buffer`/`search_text_matches` → `screen_text_rows()`, which scans the full scrollback and maximizes the odds of hitting an un-reflowed narrow page). Happy to attach the full `.ips` files.

## Fix

Resolve the ref per cell through `ghostty_terminal_grid_ref` — the same validated pattern `screen_cell` already uses — and end the row cleanly when a narrower (not-yet-reflowed) page rejects the position. Threading was audited: all reads/writes are serialized by the pane's `core` mutex, so this is a within-call contract violation, not a race; per-cell re-resolution fully closes it.

Trade-off: one extra pin resolution per cell on a non-hot path (detection/search text extraction).

## Testing

- `cargo check` clean; `cargo test --bin herdr ghostty` 62/62 pass.
- Full suite: 2676 passed, 10 failed — the same 10 fail identically on unmodified master in this environment (they touch live agent-detection state), so unrelated to this change.

*Optional upstream hardening (separate concern): the C shim's `ghostty_grid_ref_*` functions could validate `ref.x/ref.y` against the node's real page size and return `invalid_value` instead of relying on asserts that ReleaseFast strips — that would protect any consumer that hand-builds a grid ref.*