### PR TITLE
fix: stagger agent resume spawns after session restore

### DIFF
--- a/src/app/agent_resume.rs
+++ b/src/app/agent_resume.rs
@@ -41,8 +41,23 @@ impl App {
     }
 
     pub(crate) fn start_pending_agent_resumes(&mut self, allow_empty_theme: bool) -> bool {
+        // Stagger resume spawns. A crash-recovery restore can hold ~100 agent
+        // panes; spawning every `<agent> --resume` in one synchronous burst
+        // hammers the host and mass-resumes every agent CLI within the same
+        // second, which agent CLIs do not always tolerate (concurrent resume
+        // of many sessions right after their processes were killed). Spawn at
+        // most a small batch per call with a minimum gap between batches; the
+        // remaining candidates stay pending and are picked up on subsequent
+        // ticks (both the TUI and headless loops call this every iteration).
+        let now = Instant::now();
+        if let Some(last) = self.last_agent_resume_spawn_at {
+            if now.duration_since(last) < super::AGENT_RESUME_SPAWN_MIN_GAP {
+                return false;
+            }
+        }
         let pending = self.pending_agent_resume_candidates();
         let mut changed = false;
+        let mut spawned = 0usize;
         for PendingAgentResumeCandidate {
             pane_id,
             terminal_id,
@@ -52,10 +67,13 @@ impl App {
             cols,
         } in pending
         {
+            if spawned >= super::AGENT_RESUME_SPAWN_BATCH_LIMIT {
+                break;
+            }
             if self.terminal_runtimes.get(&terminal_id).is_some() {
                 continue;
             }
-            changed |= self.start_pending_agent_resume(
+            let started = self.start_pending_agent_resume(
                 pane_id,
                 terminal_id,
                 cwd,
@@ -64,6 +82,13 @@ impl App {
                 cols,
                 allow_empty_theme,
             );
+            if started {
+                spawned += 1;
+            }
+            changed |= started;
+        }
+        if spawned > 0 {
+            self.last_agent_resume_spawn_at = Some(now);
         }
 
         if changed {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -39,6 +39,12 @@ const RESIZE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const GIT_REMOTE_STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(1500);
 const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
 const PENDING_AGENT_RESUME_THEME_WAIT: Duration = Duration::from_millis(750);
+/// Cap on agent resume spawns per `start_pending_agent_resumes` call, so a
+/// crash-recovery restore of ~100 agent panes doesn't fire every
+/// `<agent> --resume` in a single synchronous burst.
+pub(crate) const AGENT_RESUME_SPAWN_BATCH_LIMIT: usize = 4;
+/// Minimum gap between agent resume spawn batches.
+pub(crate) const AGENT_RESUME_SPAWN_MIN_GAP: Duration = Duration::from_millis(500);
 const SESSION_SAVE_DEBOUNCE: Duration = Duration::from_secs(5);
 const SIDEBAR_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(350);
 const PANE_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(350);
@@ -127,6 +133,7 @@ pub struct App {
     pub(crate) loaded_host_cursor: crate::config::HostCursorModeConfig,
     pub(crate) agent_metadata_deadline: Option<Instant>,
     pub(crate) pending_agent_resume_deadline: Option<Instant>,
+    pub(crate) last_agent_resume_spawn_at: Option<Instant>,
     pub(crate) selection_autoscroll_deadline: Option<Instant>,
     pub(crate) selection_highlight_clear_deadline: Option<Instant>,
     pub(crate) session_save_deadline: Option<Instant>,
@@ -737,6 +744,7 @@ impl App {
             loaded_host_cursor: config.ui.host_cursor,
             agent_metadata_deadline: None,
             pending_agent_resume_deadline: None,
+            last_agent_resume_spawn_at: None,
             session_save_deadline: None,
             session_save_thread: None,
             detached_custom_command_children: Vec::new(),


### PR DESCRIPTION
## Summary

`start_pending_agent_resumes` spawns every pending agent resume in one synchronous loop with no cap or pacing. After a server crash, restoring a large session fires the whole burst at once. From a real crash recovery on 2026-07-17 (server log, ~44 workspaces):

- **111 panes spawned in 5.6 seconds** (~20 panes/sec)
- **43 concurrent `claude --resume` commands within a 15-second window** (the earlier restart the same day: 111 panes / 7.3s, 63 resumes / 25s)

Beyond hammering the host, mass-resuming agent CLIs at the same instant — immediately after their previous processes were killed by the crash — is exactly where agent-side session handling is most fragile. In the incident that motivated this PR, Claude Code session transcripts covering a ~28-hour window were found truncated after such a restore storm (mtimes stamped at the restore moment). The truncation bug itself is on the agent CLI side (being reported separately), but herdr's all-at-once restore is the amplifier that turned one crash into mass data loss.

## Fix

Batch the spawn loop: at most `AGENT_RESUME_SPAWN_BATCH_LIMIT` (4) resumes per call, with `AGENT_RESUME_SPAWN_MIN_GAP` (500ms) between batches, tracked via a new `last_agent_resume_spawn_at` on `App`. Remaining candidates simply stay pending and are retried on subsequent ticks — both the TUI loop and the headless server already call `start_pending_agent_resumes` every iteration, so no new scheduling is needed. The theme-wait deadline mechanism is untouched.

Effect: small sessions are unaffected (a handful of panes still resume instantly); a 100-pane restore ramps over ~15 seconds instead of one burst.

## Testing

- `cargo check` clean; `cargo test --bin herdr agent_resume` 23/23 pass.
- Full suite: 2676 passed, 10 failed — the same 10 fail identically on unmodified master in this environment, unrelated to this change.

Related: #1565 (the heap corruption behind the crashes that trigger these restores).