### PR TITLE
fix(omp): retain working status while subagents run

### DIFF
--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -53,14 +53,17 @@ type Handler = (event: unknown, context: unknown) => unknown;
 
 function createExtensionHarness() {
   const handlers = new Map<string, Handler>();
+  const eventHandlers = new Map<string, (event: unknown) => unknown>();
   return {
     handlers,
+    eventHandlers,
     pi: {
       on(event: string, handler: Handler) {
         handlers.set(event, handler);
       },
       events: {
-        on() {
+        on(event: string, handler: (event: unknown) => unknown) {
+          eventHandlers.set(event, handler);
           return () => {};
         },
       },
@@ -147,6 +150,50 @@ for (const integration of integrations) {
     expect(reportedState()).toBe("working");
   });
 }
+
+test("Oh My Pi remains working while a subagent outlives its parent turn", async () => {
+  const requests = await startRecordingServer("omp-subagent");
+  const { handlers, eventHandlers, pi } = createExtensionHarness();
+  const { default: install } = await importFresh("./omp/herdr-agent-state.ts");
+  install(pi);
+
+  const context = {
+    hasUI: true,
+    isIdle: () => false,
+    sessionManager: {
+      getSessionFile: () => undefined,
+      getSessionId: () => undefined,
+    },
+  };
+  handlers.get("session_start")?.({ reason: "startup" }, context);
+  handlers.get("agent_start")?.({}, context);
+  eventHandlers.get("task:subagent:lifecycle")?.({ id: "child", status: "started" });
+  handlers.get("agent_end")?.({ messages: [] }, context);
+
+  const deadline = Date.now() + 1_000;
+  while (
+    Date.now() < deadline &&
+    requests.filter(
+      request =>
+        isRecord(request) &&
+        request.method === "pane.report_agent" &&
+        isRecord(request.params) &&
+        request.params.state === "working",
+    ).length < 2
+  ) {
+    await Bun.sleep(5);
+  }
+
+  expect(
+    requests.filter(
+      request =>
+        isRecord(request) &&
+        request.method === "pane.report_agent" &&
+        isRecord(request.params) &&
+        request.params.state === "working",
+    ).length,
+  ).toBeGreaterThanOrEqual(2);
+});
 
 test("Pi reports the session replacement source", async () => {
   const requests = await startRecordingServer("pi-session-source");

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -268,6 +268,8 @@ export default function (pi) {
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
   let rootSession = false;
+  const activeSubagentIds = new Set<string>();
+  let subagentHeartbeatTimer: NodeJS.Timeout | undefined;
 
   function clearTimer(timer: ReturnType<typeof setTimeout> | undefined) {
     if (timer) {
@@ -280,6 +282,27 @@ export default function (pi) {
     clearTimer(retryTimer);
     idleTimer = undefined;
     retryTimer = undefined;
+  }
+
+  function syncSubagentHeartbeat() {
+    if (!rootSession || activeSubagentIds.size === 0) {
+      if (subagentHeartbeatTimer) {
+        clearInterval(subagentHeartbeatTimer);
+        subagentHeartbeatTimer = undefined;
+      }
+      return;
+    }
+    if (subagentHeartbeatTimer) {
+      return;
+    }
+    subagentHeartbeatTimer = setInterval(() => {
+      if (!rootSession || activeSubagentIds.size === 0) {
+        syncSubagentHeartbeat();
+        return;
+      }
+      publishState(true);
+    }, 250);
+    subagentHeartbeatTimer.unref?.();
   }
 
   function clearFailureState() {
@@ -295,7 +318,7 @@ export default function (pi) {
     if (failureBlocked) {
       return { state: "blocked" as const, message: failureMessage };
     }
-    if (agentActive || retryHoldActive) {
+    if (activeSubagentIds.size > 0 || agentActive || retryHoldActive) {
       return { state: "working" as const, message: undefined };
     }
     return { state: "idle" as const, message: undefined };
@@ -351,6 +374,8 @@ export default function (pi) {
     clearPendingTimers();
     clearFailureState();
     agentActive = false;
+    activeSubagentIds.clear();
+    syncSubagentHeartbeat();
     blockedCount = 0;
     blockedMessage = undefined;
   }
@@ -380,6 +405,31 @@ export default function (pi) {
     }
 
     activateBlocked(data.label);
+  });
+
+  pi.events.on("task:subagent:lifecycle", (data) => {
+    if (!rootSession || typeof data?.id !== "string") {
+      return;
+    }
+
+    if (data.status === "started") {
+      clearPendingTimers();
+      activeSubagentIds.add(data.id);
+      syncSubagentHeartbeat();
+      publishState(true);
+      return;
+    }
+
+    if (
+      data.status === "completed" ||
+      data.status === "failed" ||
+      data.status === "aborted"
+    ) {
+      if (activeSubagentIds.delete(data.id)) {
+        syncSubagentHeartbeat();
+        scheduleIdle();
+      }
+    }
   });
 
   pi.on("session_start", (_event, ctx) => {
@@ -465,6 +515,11 @@ export default function (pi) {
       return;
     }
 
+    if (activeSubagentIds.size > 0) {
+      syncSubagentHeartbeat();
+      publishState(true);
+      return;
+    }
     scheduleIdle();
   });
 
@@ -473,6 +528,10 @@ export default function (pi) {
       return;
     }
     clearPendingTimers();
+    if (subagentHeartbeatTimer) {
+      clearInterval(subagentHeartbeatTimer);
+      subagentHeartbeatTimer = undefined;
+    }
     if (shouldReleaseOnSessionShutdown(event)) {
       await releaseAgent();
     }


### PR DESCRIPTION
Keep an OMP pane working when detached subagents outlive the root turn. Track task lifecycle events and reassert working until the final child settles. Includes a regression test.