### PR TITLE
fix(ui): give the sidebar its own panel_bg surface

### DIFF
--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -730,6 +730,23 @@ pub(crate) fn collapsed_sidebar_sections(area: Rect) -> (Rect, Option<u16>, Rect
     (ws_area, Some(divider_y), detail_area)
 }
 
+/// Paint the sidebar's own surface so it reads as a panel rather than
+/// inheriting the outer terminal background. Content rendered afterwards
+/// patches fg/attrs per-cell, so the fill shows through as row background.
+fn fill_panel_bg(frame: &mut Frame, area: Rect, p: &Palette) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let style = Style::default().bg(p.panel_bg);
+    let buf = frame.buffer_mut();
+    for y in area.y..area.y + area.height {
+        for x in area.x..area.x + area.width {
+            buf[(x, y)].set_symbol(" ");
+            buf[(x, y)].set_style(style);
+        }
+    }
+}
+
 /// Collapsed sidebar: workspace glance on top, compact agent list below.
 pub(super) fn render_sidebar_collapsed(app: &AppState, frame: &mut Frame, area: Rect) {
     if area.width == 0 || area.height == 0 {
@@ -739,6 +756,7 @@ pub(super) fn render_sidebar_collapsed(app: &AppState, frame: &mut Frame, area: 
     let is_navigating = matches!(app.mode, Mode::Navigate);
 
     let p = &app.palette;
+    fill_panel_bg(frame, area, p);
     let sep_style = if is_navigating {
         Style::default().fg(p.accent)
     } else {
@@ -872,6 +890,7 @@ pub(super) fn render_sidebar(
     area: Rect,
 ) {
     let p = &app.palette;
+    fill_panel_bg(frame, area, p);
     let is_navigating = matches!(app.mode, Mode::Navigate);
     let sep_style = if is_navigating {
         Style::default().fg(p.accent)
@@ -1575,7 +1594,7 @@ rows = [[{ token = "workspace", bold = false }, { token = "agent", dim = false }
         assert!(!inactive
             .add_modifier
             .intersects(Modifier::BOLD | Modifier::DIM));
-        assert_eq!(inactive.bg, Some(ratatui::style::Color::Reset));
+        assert_eq!(inactive.bg, Some(app.palette.panel_bg));
     }
 
     #[test]

--- a/src/ui/tab_surface.rs
+++ b/src/ui/tab_surface.rs
@@ -304,7 +304,7 @@ mod tests {
         assert_eq!(frame.hyperlinks, vec![uri.to_owned()]);
         assert_eq!(
             frame_digest(&frame),
-            "ce383feeaac30922502b7c4f8af53b5ca30e816ec4503ca6d015738b584da487"
+            "8a0c17d04f8bce48619b5beac9d4c59a41039ce40ec648e58d034568559e1b78"
         );
     }
 


### PR DESCRIPTION
## What

The desktop sidebar (spaces + agents panels) never paints a background — it inherits whatever the outer terminal shows, so it blends into the panes as one continuous color. The `panel_bg` palette token already exists for exactly this kind of surface and is used by dialogs, menus, and the **mobile layout** (which fills its panels with it via `fill_rect`), but the desktop sidebar ignores it.

This PR fills the sidebar area with `panel_bg` at the top of both `render_sidebar` and `render_sidebar_collapsed`, mirroring the mobile layout's approach. Highlighted rows still paint `surface0`/`surface_dim` over it, and content rendering patches fg/attrs per cell so the fill shows through as the row background.

This also matches the hero mock on herdr.dev, where the sidebar sits on an elevated background (`--term-sidebar-bg`) distinct from the pane background.

## Before / after

Tokyo Night with `[theme.custom] panel_bg = "#202331"` (the herdr.dev hero values); terminal background `#1a1b26`:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/alexarthurs/herdr/assets-sidebar-panel-bg/before.png) | ![after](https://raw.githubusercontent.com/alexarthurs/herdr/assets-sidebar-panel-bg/after.png) |

## Notes

- For themes where `panel_bg` differs from the user's terminal background (e.g. catppuccin's `#181825` vs a typical `#1e1e2e` terminal), the sidebar now visibly reads as its own surface — that's the intent, and it's consistent with what the mobile layout already does. Anyone preferring the old transparent look can set `panel_bg = "reset"` in `[theme.custom]`.
- Two tests updated: the sidebar row-style assertion that expected `Color::Reset` backgrounds, and the `tab_surface` frame characterization digest.
- Test status on Windows: the full `ui::sidebar` and `ui::tab_surface` suites pass with this change (47/47). For transparency: ~100 unrelated tests (mostly `integration::tests::install_*`) fail on Windows both with and without this patch (identical failure sets, verified against clean master), and the `tests/` integration binaries don't compile on Windows (`Permissions::from_mode`) — pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)