### PR TITLE
fix: scope pi and omp releases to active sessions

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2691,6 +2691,18 @@
             "agent": {
               "type": "string"
             },
+            "agent_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_session_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "pane_id": {
               "type": "string"
             },

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -689,6 +689,23 @@ Session-only official integrations report native session references with `pane.r
 
 If no native session reference is stored, the field is omitted.
 
+Lifecycle integrations release agent authority with `pane.release_agent`. Integrations that know their current session should include the same `agent_session_id` or `agent_session_path` used in their state reports:
+
+```json
+{
+  "id": "req_3",
+  "method": "pane.release_agent",
+  "params": {
+    "pane_id": "w1:p1",
+    "source": "herdr:pi",
+    "agent": "pi",
+    "agent_session_path": "/path/to/pi-session.jsonl"
+  }
+}
+```
+
+When the current owner is session-bound, Herdr accepts the release only when its source, agent, and session reference all match. Mismatched or unscoped releases are ignored without consuming their sequence number. Sessionless integrations retain the existing immediate release behavior.
+
 `pane.get`, `pane.list`, `agent.get`, and `agent.list` also expose `foreground_cwd` when Herdr can resolve the cwd of the process currently controlling the pane PTY. The existing `cwd` field remains the pane/workspace cwd used for labels, follow-cwd behavior, and restored session state.
 
 `PaneInfo` and `AgentInfo` expose optional `terminal_title` and `terminal_title_stripped` fields. `terminal_title` is the latest OSC 0/2 title after safety normalization. `terminal_title_stripped` removes one recognized leading activity or spinner glyph and following whitespace. These server-owned values are ephemeral across a cold restart and are independent of the metadata `title` and semantic agent state.

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -389,6 +389,10 @@ pub struct PaneReleaseAgentParams {
     pub agent: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_session_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -339,6 +339,32 @@ fn agent_view_requests_round_trip() {
 }
 
 #[test]
+fn pane_release_agent_round_trips_optional_session_scope() {
+    let json = serde_json::json!({
+        "id": "release-session",
+        "method": "pane.release_agent",
+        "params": {
+            "pane_id": "w1:p1",
+            "source": "herdr:pi",
+            "agent": "pi",
+            "seq": 21,
+            "agent_session_path": "/tmp/pi-root.jsonl"
+        }
+    });
+
+    let request: Request = serde_json::from_value(json.clone()).expect("release request");
+    let Method::PaneReleaseAgent(params) = &request.method else {
+        panic!("expected pane.release_agent");
+    };
+    assert_eq!(
+        params.agent_session_path.as_deref(),
+        Some("/tmp/pi-root.jsonl")
+    );
+    assert!(params.agent_session_id.is_none());
+    assert_eq!(serde_json::to_value(request).unwrap(), json);
+}
+
+#[test]
 fn unknown_method_is_rejected() {
     let json = r#"{"id":"req_1","method":"nope","params":{}}"#;
     let err = serde_json::from_str::<Request>(json)

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2791,13 +2791,19 @@ impl AppState {
                 source,
                 agent_label,
                 seq,
+                session_ref,
                 ..
             } => {
                 if crate::agent_resume::is_reserved_native_state_source(&source, &agent_label) {
                     Vec::new()
                 } else {
                     self.update_terminal_state(pane_id, |terminal| {
-                        terminal.release_agent_with_mutation(&source, &agent_label, seq)
+                        terminal.release_agent_with_mutation(
+                            &source,
+                            &agent_label,
+                            session_ref.as_ref(),
+                            seq,
+                        )
                     })
                     .into_iter()
                     .collect()
@@ -5003,6 +5009,7 @@ mod tests {
             agent_label: "claude".into(),
             known_agent: Some(Agent::Claude),
             seq: Some(1),
+            session_ref: None,
         });
 
         let terminal = state.terminals.get(&terminal_id).unwrap();
@@ -5081,6 +5088,65 @@ mod tests {
     }
 
     #[test]
+    fn session_scoped_release_is_dispatched_to_terminal_ownership_checks() {
+        let mut state = app_with_workspaces(&["active"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0]
+            .pane_state(pane_id)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+        let root_session = crate::agent_resume::AgentSessionRef::path(
+            std::env::current_dir()
+                .unwrap()
+                .join("pi-root.jsonl")
+                .display()
+                .to_string(),
+        )
+        .expect("root session");
+        let nested_session = crate::agent_resume::AgentSessionRef::path(
+            std::env::current_dir()
+                .unwrap()
+                .join("pi-nested.jsonl")
+                .display()
+                .to_string(),
+        )
+        .expect("nested session");
+        let terminal = state.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_detected_state(Some(Agent::Pi), AgentState::Working);
+        terminal.set_hook_authority_with_session_ref(
+            "herdr:pi".into(),
+            "pi".into(),
+            AgentState::Working,
+            None,
+            Some(root_session.clone()),
+            Some(20),
+        );
+
+        let nested_updates = state.handle_app_event(AppEvent::HookAgentReleased {
+            pane_id,
+            source: "herdr:pi".into(),
+            agent_label: "pi".into(),
+            known_agent: Some(Agent::Pi),
+            seq: Some(1000),
+            session_ref: Some(nested_session),
+        });
+        let root_updates = state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "herdr:pi".into(),
+            agent_label: "pi".into(),
+            state: AgentState::Idle,
+            message: None,
+            seq: Some(21),
+            session_ref: Some(root_session),
+        });
+
+        assert!(nested_updates.is_empty());
+        assert_eq!(root_updates.len(), 1);
+        assert_eq!(state.terminals[&terminal_id].state, AgentState::Idle);
+    }
+
+    #[test]
     fn releasing_an_agent_alias_marks_the_session_dirty() {
         let mut state = app_with_workspaces(&["active"]);
         let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
@@ -5100,6 +5166,7 @@ mod tests {
             agent_label: "pi".into(),
             known_agent: Some(Agent::Pi),
             seq: Some(1),
+            session_ref: None,
         });
 
         assert!(state.terminals[&terminal_id].agent_name.is_none());

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1449,12 +1449,19 @@ impl App {
         let Some(agent_label) = normalize_reported_agent_label(&params.agent) else {
             return invalid_agent(id);
         };
+        let session_ref = crate::agent_resume::session_ref_from_report(
+            &params.source,
+            &agent_label,
+            params.agent_session_id,
+            params.agent_session_path,
+        );
         self.handle_internal_event(crate::events::AppEvent::HookAgentReleased {
             pane_id,
             source: params.source,
             known_agent: crate::detect::parse_agent_label(&agent_label),
             agent_label,
             seq: params.seq,
+            session_ref,
         });
 
         encode_success(id, ResponseResult::Ok {})

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1228,7 +1228,7 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
 
 fn pane_release_agent(args: &[String]) -> std::io::Result<i32> {
     let Some(raw_pane_id) = args.first() else {
-        eprintln!("usage: herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N]");
+        eprintln!("usage: herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
         return Ok(2);
     };
 
@@ -1236,6 +1236,8 @@ fn pane_release_agent(args: &[String]) -> std::io::Result<i32> {
     let mut source = None;
     let mut agent = None;
     let mut seq = None;
+    let mut agent_session_id = None;
+    let mut agent_session_path = None;
 
     let mut index = 1;
     while index < args.len() {
@@ -1264,6 +1266,22 @@ fn pane_release_agent(args: &[String]) -> std::io::Result<i32> {
                 seq = Some(super::parse_u64_flag("--seq", value)?);
                 index += 2;
             }
+            "--agent-session-id" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --agent-session-id");
+                    return Ok(2);
+                };
+                agent_session_id = Some(value.clone());
+                index += 2;
+            }
+            "--agent-session-path" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --agent-session-path");
+                    return Ok(2);
+                };
+                agent_session_path = Some(value.clone());
+                index += 2;
+            }
             other => {
                 eprintln!("unknown option: {other}");
                 return Ok(2);
@@ -1288,6 +1306,8 @@ fn pane_release_agent(args: &[String]) -> std::io::Result<i32> {
         source,
         agent,
         seq,
+        agent_session_id,
+        agent_session_path,
     }))
 }
 
@@ -1512,7 +1532,7 @@ fn print_pane_help() {
     eprintln!("  herdr pane wait-output <pane_id> (--match TEXT | --regex PATTERN) [--source visible|recent|recent-unwrapped] [--lines N] [--timeout MS] [--raw]");
     eprintln!("  herdr pane report-agent <pane_id> --source ID --agent LABEL --state idle|working|blocked|unknown [--message TEXT] [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
     eprintln!("  herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
-    eprintln!("  herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N]");
+    eprintln!("  herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
     eprintln!("  herdr pane report-metadata <pane_id> --source ID [--agent LABEL] [--applies-to-source ID] [--title TEXT|--clear-title] [--display-agent TEXT|--clear-display-agent] [--state-label STATUS=TEXT] [--clear-state-labels] [--token NAME=VALUE] [--clear-token NAME] [--seq N] [--ttl-ms N]");
     eprintln!("  herdr pane run <pane_id> <command>");
 }

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -650,6 +650,8 @@ fn release_agent_command() -> Command {
         .arg(option("source", "ID").required(true))
         .arg(option("agent", "LABEL").required(true))
         .arg(option("seq", "N"))
+        .arg(option("agent-session-id", "ID"))
+        .arg(path_option("agent-session-path", "PATH"))
 }
 
 fn report_metadata_command() -> Command {
@@ -1141,6 +1143,19 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn release_agent_exposes_optional_session_scope() {
+        let command = super::command();
+        let release = command_path(&command, &["pane", "release-agent"]);
+
+        assert!(release
+            .get_arguments()
+            .any(|arg| arg.get_id() == "agent-session-id"));
+        assert!(release
+            .get_arguments()
+            .any(|arg| arg.get_id() == "agent-session-path"));
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -113,6 +113,7 @@ pub enum AppEvent {
         agent_label: String,
         known_agent: Option<Agent>,
         seq: Option<u64>,
+        session_ref: Option<crate::agent_resume::AgentSessionRef>,
     },
     /// A new version is available through the active installation manager.
     UpdateReady {

--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -224,6 +224,38 @@ for (const integration of integrations) {
   });
 }
 
+for (const integration of integrations) {
+  test(`${integration.name} scopes quit releases to the current session`, async () => {
+    const requests = await startRecordingServer(
+      `${integration.name.toLowerCase().replaceAll(" ", "-")}-release-session`,
+    );
+    const { handlers, pi } = createExtensionHarness();
+    const sessionPath = `/tmp/${integration.name.toLowerCase().replaceAll(" ", "-")}-root.jsonl`;
+
+    const { default: install } = await importFresh(integration.modulePath);
+    install(pi);
+    await handlers.get("session_start")?.(
+      { reason: "startup" },
+      {
+        hasUI: true,
+        isIdle: () => true,
+        sessionManager: {
+          getSessionFile: () => sessionPath,
+          getSessionId: () => "root-session",
+        },
+      },
+    );
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, {});
+
+    const release = requests.find(
+      (request) => isRecord(request) && request.method === "pane.release_agent",
+    );
+    expect(release).toBeDefined();
+    expect(isRecord(release) && isRecord(release.params) ? release.params.agent_session_path : null)
+      .toBe(sessionPath);
+  });
+}
+
 test("Pi reports the session replacement source", async () => {
   const requests = await startRecordingServer("pi-session-source");
   const { handlers, pi } = createExtensionHarness();

--- a/src/integration/assets/mastracode/herdr-agent-state.sh
+++ b/src/integration/assets/mastracode/herdr-agent-state.sh
@@ -3,7 +3,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=mastracode
-# HERDR_INTEGRATION_VERSION=1
+# HERDR_INTEGRATION_VERSION=2
 
 set -eu
 
@@ -78,8 +78,8 @@ else:
             "seq": report_seq,
         },
     }
-    if agent_session_id:
-        request["params"]["agent_session_id"] = agent_session_id
+if agent_session_id:
+    request["params"]["agent_session_id"] = agent_session_id
 
 try:
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -169,6 +169,7 @@ function sendState(state: AgentState, message?: string, seq = nextReportSeq()): 
 }
 
 function releaseAgent(): Promise<void> {
+  const sessionRef = currentSessionRef();
   return sendRequest({
     id: `${source}:release:${Date.now()}:${Math.random().toString(36).slice(2)}`,
     method: "pane.release_agent",
@@ -177,6 +178,7 @@ function releaseAgent(): Promise<void> {
       source,
       agent: "omp",
       seq: nextReportSeq(),
+      ...sessionRef,
     },
   });
 }

--- a/src/integration/assets/pi/herdr-agent-state.ts
+++ b/src/integration/assets/pi/herdr-agent-state.ts
@@ -159,6 +159,7 @@ function sendState(state: AgentState, message?: string, seq = nextReportSeq()): 
 }
 
 function releaseAgent(): Promise<void> {
+  const sessionRef = currentSessionRef();
   return sendRequest({
     id: `${source}:release:${Date.now()}:${Math.random().toString(36).slice(2)}`,
     method: "pane.release_agent",
@@ -167,6 +168,7 @@ function releaseAgent(): Promise<void> {
       source,
       agent: "pi",
       seq: nextReportSeq(),
+      ...sessionRef,
     },
   });
 }

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -198,7 +198,7 @@ const CURSOR_HOOK_ASSET: &str = include_str!("assets/cursor/herdr-agent-state.sh
 const CURSOR_INTEGRATION_VERSION: u32 = 1;
 const MASTRACODE_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const MASTRACODE_HOOK_ASSET: &str = include_str!("assets/mastracode/herdr-agent-state.sh");
-const MASTRACODE_INTEGRATION_VERSION: u32 = 1;
+const MASTRACODE_INTEGRATION_VERSION: u32 = 2;
 const MASTRACODE_HOOK_TIMEOUT_MS: u64 = 10_000;
 const MASTRACODE_HOOK_EVENTS: [(&str, &str); 12] = [
     ("SessionStart", "idle"),

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -2741,12 +2741,43 @@ fn bundled_integration_assets_report_session_refs() {
     assert!(!CURSOR_HOOK_ASSET.contains("\"state\":"));
     assert!(!CURSOR_HOOK_ASSET.contains("pane.release_agent"));
     assert!(MASTRACODE_HOOK_ASSET.contains("HERDR_INTEGRATION_ID=mastracode"));
-    assert!(MASTRACODE_HOOK_ASSET.contains("HERDR_INTEGRATION_VERSION=1"));
+    assert!(MASTRACODE_HOOK_ASSET.contains("HERDR_INTEGRATION_VERSION=2"));
     assert!(MASTRACODE_HOOK_ASSET.contains("session_id"));
     assert!(!MASTRACODE_HOOK_ASSET.contains("run_id"));
     assert!(MASTRACODE_HOOK_ASSET.contains("agent_session_id"));
     assert!(MASTRACODE_HOOK_ASSET.contains("pane.report_agent"));
     assert!(MASTRACODE_HOOK_ASSET.contains("pane.release_agent"));
+}
+
+#[test]
+fn pi_and_omp_release_payloads_include_current_session_refs() {
+    for (name, asset) in [("pi", PI_EXTENSION_ASSET), ("omp", OMP_EXTENSION_ASSET)] {
+        let release_start = asset
+            .find("function releaseAgent()")
+            .unwrap_or_else(|| panic!("{name} release function"));
+        let release_end = asset[release_start..]
+            .find("function shouldReleaseOnSessionShutdown")
+            .map(|offset| release_start + offset)
+            .unwrap_or_else(|| panic!("{name} release function end"));
+        let release = &asset[release_start..release_end];
+
+        assert!(release.contains("const sessionRef = currentSessionRef()"));
+        assert!(release.contains("...sessionRef"));
+    }
+}
+
+#[test]
+fn mastracode_release_payload_includes_hook_session_id() {
+    let release_start = MASTRACODE_HOOK_ASSET
+        .find("if action == \"release\":")
+        .expect("mastracode release branch");
+    let release_end = MASTRACODE_HOOK_ASSET[release_start..]
+        .find("\ntry:")
+        .map(|offset| release_start + offset)
+        .expect("mastracode request construction end");
+    let release = &MASTRACODE_HOOK_ASSET[release_start..release_end];
+
+    assert!(release.contains("agent_session_id"));
 }
 
 #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -317,6 +317,22 @@ fn foreground_shell_agent_action(
     ForegroundShellAgentAction::ObserveProbe
 }
 
+fn foreground_agent_under_lifecycle_authority(
+    previous_agent: Option<Agent>,
+    observed_agent: Option<Agent>,
+    full_lifecycle_authority_active: bool,
+) -> Option<Agent> {
+    if full_lifecycle_authority_active
+        && previous_agent.is_some()
+        && observed_agent.is_some()
+        && previous_agent != observed_agent
+    {
+        previous_agent
+    } else {
+        observed_agent
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ProcessProbeInput {
     current_agent: Option<Agent>,
@@ -680,6 +696,11 @@ fn spawn_basic_detection_task(
                     }
                 }
                 let previous_agent = agent_presence.current_agent();
+                new_agent = foreground_agent_under_lifecycle_authority(
+                    previous_agent,
+                    new_agent,
+                    lifecycle_authority_active,
+                );
                 let changed = match foreground_shell_agent_action(
                     previous_agent,
                     new_agent,
@@ -2102,6 +2123,11 @@ impl PaneRuntime {
                             }
 
                             let previous_agent = agent_presence.current_agent();
+                            new_agent = foreground_agent_under_lifecycle_authority(
+                                previous_agent,
+                                new_agent,
+                                lifecycle_authority_active,
+                            );
                             let changed = match foreground_shell_agent_action(
                                 previous_agent,
                                 new_agent,
@@ -3351,6 +3377,23 @@ mod tests {
             tokio::time::timeout(std::time::Duration::from_millis(10), rx.recv())
                 .await
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn nested_foreground_agent_does_not_replace_authoritative_root() {
+        assert_eq!(
+            foreground_agent_under_lifecycle_authority(Some(Agent::Pi), Some(Agent::Claude), true,),
+            Some(Agent::Pi)
+        );
+        assert_eq!(
+            foreground_agent_under_lifecycle_authority(Some(Agent::Pi), Some(Agent::Claude), false,),
+            Some(Agent::Claude)
+        );
+        assert_eq!(
+            foreground_agent_under_lifecycle_authority(Some(Agent::Pi), None, true),
+            None,
+            "returning to the shell remains exit evidence"
         );
     }
 

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -988,11 +988,7 @@ impl TerminalState {
                 Some("startup" | "clear" | "resume" | "compact")
             ) | ("herdr:opencode", "opencode", Some("new"))
                 | ("herdr:pi", "pi", Some("new" | "resume" | "fork"))
-                | (
-                    "herdr:omp",
-                    "omp",
-                    Some("startup" | "new" | "resume" | "fork")
-                )
+                | ("herdr:omp", "omp", Some("new" | "resume" | "fork"))
         )
     }
 
@@ -1029,9 +1025,6 @@ impl TerminalState {
         session_start_source: Option<String>,
     ) -> Option<TerminalStateMutation> {
         let session_ref = session_ref?;
-        if !self.accept_hook_report(&source, seq) {
-            return None;
-        }
         if self.known_agent_label_conflicts_with_detected_agent(&agent_label) {
             return None;
         }
@@ -1068,6 +1061,9 @@ impl TerminalState {
             &session_ref,
         );
         if replaced_hook_session.is_some() && !session_replacement_allowed {
+            return None;
+        }
+        if !self.accept_hook_report(&source, seq) {
             return None;
         }
 
@@ -1237,7 +1233,18 @@ impl TerminalState {
         agent_label: &str,
         seq: Option<u64>,
     ) -> Option<EffectiveStateChange> {
-        self.release_agent_with_mutation(source, agent_label, seq)
+        let session_ref = self
+            .hook_authority
+            .as_ref()
+            .filter(|authority| authority.source == source && authority.agent_label == agent_label)
+            .and_then(|authority| authority.session_ref.clone())
+            .or_else(|| {
+                self.persisted_agent_session
+                    .as_ref()
+                    .filter(|session| session.source == source && session.agent == agent_label)
+                    .map(|session| session.session_ref.clone())
+            });
+        self.release_agent_with_mutation(source, agent_label, session_ref.as_ref(), seq)
             .and_then(|mutation| mutation.effective_state_change)
     }
 
@@ -1245,12 +1252,9 @@ impl TerminalState {
         &mut self,
         source: &str,
         agent_label: &str,
+        session_ref: Option<&crate::agent_resume::AgentSessionRef>,
         seq: Option<u64>,
     ) -> Option<TerminalStateMutation> {
-        if !self.accept_hook_report(source, seq) {
-            return None;
-        }
-
         if self.hook_authority.as_ref().is_some_and(|authority| {
             authority.agent_label != agent_label || authority.source != source
         }) {
@@ -1262,11 +1266,12 @@ impl TerminalState {
         if !matches_current_agent && !matches_persisted_session {
             return None;
         }
-        let preserve_foreign_persisted_session = self
-            .persisted_agent_session
-            .as_ref()
-            .is_some_and(|session| session.source != source || session.agent != agent_label);
-
+        if !self.release_session_matches_current_owner(source, agent_label, session_ref) {
+            return None;
+        }
+        if !self.accept_hook_report(source, seq) {
+            return None;
+        }
         let now = Instant::now();
         let previous_agent_label = self.effective_agent_label().map(str::to_string);
         let previous_known_agent = self.effective_known_agent();
@@ -1284,9 +1289,7 @@ impl TerminalState {
         self.fallback_observed_at = None;
         self.hook_authority = None;
         self.clear_agent_name();
-        if !preserve_foreign_persisted_session {
-            self.persisted_agent_session = None;
-        }
+        self.persisted_agent_session = None;
         let current_session = self.current_session_identity_for_persistence();
         Some(TerminalStateMutation {
             effective_state_change: self.recompute_effective_state(
@@ -1299,6 +1302,25 @@ impl TerminalState {
             session_ref_changed: previous_session != current_session,
             agent_released: true,
         })
+    }
+
+    fn release_session_matches_current_owner(
+        &self,
+        source: &str,
+        agent_label: &str,
+        session_ref: Option<&crate::agent_resume::AgentSessionRef>,
+    ) -> bool {
+        let Some((owner_source, owner_agent, owner_kind, owner_value)) =
+            self.current_session_identity_for_persistence()
+        else {
+            return true;
+        };
+
+        owner_source == source
+            && owner_agent == agent_label
+            && session_ref.is_some_and(|session_ref| {
+                session_ref.kind == owner_kind && session_ref.value == owner_value
+            })
     }
 
     pub fn effective_agent_label(&self) -> Option<&str> {
@@ -3701,19 +3723,108 @@ mod tests {
     }
 
     #[test]
-    fn release_agent_clears_identity_immediately() {
+    fn mismatched_session_scoped_release_does_not_clear_or_consume_sequence() {
+        for (source, agent_label, agent) in [
+            ("herdr:pi", "pi", Agent::Pi),
+            ("herdr:omp", "omp", Agent::Omp),
+        ] {
+            let mut terminal = test_terminal();
+            let root_session = crate::agent_resume::AgentSessionRef::path(test_session_path(
+                &format!("{agent_label}-root.jsonl"),
+            ))
+            .expect("root session path");
+            let nested_session = crate::agent_resume::AgentSessionRef::path(test_session_path(
+                &format!("{agent_label}-nested.jsonl"),
+            ))
+            .expect("nested session path");
+            terminal.set_detected_state(Some(agent), AgentState::Working);
+            terminal.set_hook_authority_with_session_ref(
+                source.into(),
+                agent_label.into(),
+                AgentState::Working,
+                None,
+                Some(root_session.clone()),
+                Some(20),
+            );
+
+            let release = terminal.release_agent_with_mutation(
+                source,
+                agent_label,
+                Some(&nested_session),
+                Some(1000),
+            );
+            let root_update = terminal.set_hook_authority_with_session_ref(
+                source.into(),
+                agent_label.into(),
+                AgentState::Idle,
+                None,
+                Some(root_session),
+                Some(21),
+            );
+
+            assert!(release.is_none());
+            assert!(
+                root_update.is_some(),
+                "rejected release must not consume seq"
+            );
+            assert!(terminal.hook_authority.is_some());
+            assert_eq!(terminal.state, AgentState::Idle);
+            assert_eq!(terminal.hook_report_sequences.get(source), Some(&21));
+        }
+    }
+
+    #[test]
+    fn unscoped_release_against_session_bound_owner_does_not_consume_sequence() {
+        let mut terminal = test_terminal();
+        let root_session = crate::agent_resume::AgentSessionRef::path(test_session_path(
+            "unscoped-release-root.jsonl",
+        ))
+        .expect("root session path");
+        terminal.set_detected_state(Some(Agent::Pi), AgentState::Working);
+        terminal.set_hook_authority_with_session_ref(
+            "herdr:pi".into(),
+            "pi".into(),
+            AgentState::Working,
+            None,
+            Some(root_session.clone()),
+            Some(20),
+        );
+
+        let release = terminal.release_agent_with_mutation("herdr:pi", "pi", None, Some(1000));
+        let root_update = terminal.set_hook_authority_with_session_ref(
+            "herdr:pi".into(),
+            "pi".into(),
+            AgentState::Idle,
+            None,
+            Some(root_session),
+            Some(21),
+        );
+
+        assert!(release.is_none());
+        assert!(
+            root_update.is_some(),
+            "rejected release must not consume seq"
+        );
+        assert!(terminal.hook_authority.is_some());
+        assert_eq!(terminal.state, AgentState::Idle);
+        assert_eq!(terminal.hook_report_sequences.get("herdr:pi"), Some(&21));
+    }
+
+    #[test]
+    fn custom_sessionless_release_clears_identity_immediately() {
         let mut terminal = test_terminal();
         terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
         terminal.set_hook_authority(
-            "herdr:pi".into(),
+            "custom:integration".into(),
             "pi".into(),
             AgentState::Working,
             None,
             None,
         );
 
-        terminal.release_agent("herdr:pi", "pi", None);
+        let release = terminal.release_agent_with_mutation("custom:integration", "pi", None, None);
 
+        assert!(release.is_some());
         assert!(terminal.hook_authority.is_none());
         assert_eq!(terminal.detected_agent, None);
         assert_eq!(terminal.fallback_state, AgentState::Unknown);
@@ -3869,7 +3980,7 @@ mod tests {
     }
 
     #[test]
-    fn different_same_agent_session_ref_is_ignored_until_current_session_clears() {
+    fn rejected_session_start_does_not_consume_root_sequence() {
         let mut terminal = test_terminal();
         terminal
             .set_agent_session_ref(
@@ -3884,10 +3995,17 @@ mod tests {
             "herdr:claude".into(),
             "claude".into(),
             crate::agent_resume::AgentSessionRef::id("nested-session"),
+            Some(1000),
+        );
+        let root_update = terminal.set_agent_session_ref(
+            "herdr:claude".into(),
+            "claude".into(),
+            crate::agent_resume::AgentSessionRef::id("claude-session"),
             Some(21),
         );
 
         assert!(mutation.is_none());
+        assert!(root_update.is_some());
         assert_eq!(
             terminal.hook_report_sequences.get("herdr:claude"),
             Some(&21)
@@ -4003,6 +4121,62 @@ mod tests {
                 Some(next_session.as_str())
             );
         }
+    }
+
+    #[test]
+    fn nested_omp_startup_does_not_replace_root_or_consume_sequence() {
+        let mut terminal = test_terminal();
+        let root_session =
+            crate::agent_resume::AgentSessionRef::path(test_session_path("omp-root.jsonl"))
+                .expect("root session");
+        let nested_session =
+            crate::agent_resume::AgentSessionRef::path(test_session_path("omp-nested.jsonl"))
+                .expect("nested session");
+        terminal.set_detected_state(Some(Agent::Omp), AgentState::Working);
+        terminal.set_hook_authority_with_session_ref(
+            "herdr:omp".into(),
+            "omp".into(),
+            AgentState::Working,
+            None,
+            Some(root_session.clone()),
+            Some(20),
+        );
+
+        let root_start = terminal.set_agent_session_ref_for_session_start(
+            "herdr:omp".into(),
+            "omp".into(),
+            Some(root_session.clone()),
+            Some(21),
+            Some("startup".into()),
+        );
+        let nested_start = terminal.set_agent_session_ref_for_session_start(
+            "herdr:omp".into(),
+            "omp".into(),
+            Some(nested_session),
+            Some(1000),
+            Some("startup".into()),
+        );
+        let root_update = terminal.set_hook_authority_with_session_ref(
+            "herdr:omp".into(),
+            "omp".into(),
+            AgentState::Idle,
+            None,
+            Some(root_session.clone()),
+            Some(22),
+        );
+
+        assert!(root_start.is_some());
+        assert!(nested_start.is_none());
+        assert!(root_update.is_some());
+        assert_eq!(terminal.state, AgentState::Idle);
+        assert_eq!(terminal.hook_report_sequences.get("herdr:omp"), Some(&22));
+        assert_eq!(
+            terminal
+                .hook_authority
+                .as_ref()
+                .and_then(|authority| authority.session_ref.as_ref()),
+            Some(&root_session)
+        );
     }
 
     #[test]
@@ -4516,20 +4690,21 @@ mod tests {
     }
 
     #[test]
-    fn release_agent_clears_session_ref() {
+    fn matching_session_scoped_release_clears_session_ref_immediately() {
         let mut terminal = test_terminal();
-        let session_path = test_session_path("pi.jsonl");
+        let session_ref = crate::agent_resume::AgentSessionRef::path(test_session_path("pi.jsonl"))
+            .expect("session path");
         terminal.set_hook_authority_with_session_ref(
             "herdr:pi".into(),
             "pi".into(),
             AgentState::Working,
             None,
-            crate::agent_resume::AgentSessionRef::path(session_path),
+            Some(session_ref.clone()),
             Some(20),
         );
 
         let mutation = terminal
-            .release_agent_with_mutation("herdr:pi", "pi", Some(21))
+            .release_agent_with_mutation("herdr:pi", "pi", Some(&session_ref), Some(21))
             .expect("accepted release");
 
         assert!(mutation.session_ref_changed);
@@ -4550,7 +4725,7 @@ mod tests {
 
         terminal.set_agent_name("replacement".into());
         terminal
-            .release_agent_with_mutation("herdr:codex", "codex", None)
+            .release_agent_with_mutation("herdr:codex", "codex", None, None)
             .expect("detected agent release should be accepted");
         assert!(terminal.agent_name.is_none());
     }
@@ -4651,14 +4826,15 @@ mod tests {
     #[test]
     fn release_agent_clears_matching_restored_session_ref_before_detection() {
         let mut terminal = test_terminal();
+        let session_ref = crate::agent_resume::AgentSessionRef::id("hermes-session").unwrap();
         terminal.set_persisted_agent_session(crate::agent_resume::PersistedAgentSession {
             source: "herdr:hermes".into(),
             agent: "hermes".into(),
-            session_ref: crate::agent_resume::AgentSessionRef::id("hermes-session").unwrap(),
+            session_ref: session_ref.clone(),
         });
 
         let mutation = terminal
-            .release_agent_with_mutation("herdr:hermes", "hermes", Some(21))
+            .release_agent_with_mutation("herdr:hermes", "hermes", Some(&session_ref), Some(21))
             .expect("accepted release");
 
         assert!(mutation.session_ref_changed);
@@ -4667,27 +4843,28 @@ mod tests {
     }
 
     #[test]
-    fn release_agent_preserves_foreign_persisted_session_ref() {
+    fn unscoped_release_is_ignored_for_persisted_session_owner() {
         let mut terminal = test_terminal();
         terminal.set_persisted_agent_session(crate::agent_resume::PersistedAgentSession {
-            source: "herdr:claude".into(),
-            agent: "claude".into(),
-            session_ref: crate::agent_resume::AgentSessionRef::id("claude-session").unwrap(),
+            source: "herdr:pi".into(),
+            agent: "pi".into(),
+            session_ref: crate::agent_resume::AgentSessionRef::path(test_session_path(
+                "persisted-pi.jsonl",
+            ))
+            .expect("persisted session"),
         });
         terminal.set_detected_state(Some(Agent::Pi), AgentState::Idle);
 
-        let mutation = terminal
-            .release_agent_with_mutation("herdr:pi", "pi", Some(21))
-            .expect("visible agent release should be accepted");
+        let mutation = terminal.release_agent_with_mutation("herdr:pi", "pi", None, Some(21));
 
-        assert!(!mutation.session_ref_changed);
+        assert!(mutation.is_none());
+        assert_eq!(terminal.detected_agent, Some(Agent::Pi));
         assert_eq!(
-            terminal.persisted_agent_session.as_ref().map(|session| (
-                session.source.as_str(),
-                session.agent.as_str(),
-                session.session_ref.value.as_str()
-            )),
-            Some(("herdr:claude", "claude", "claude-session"))
+            terminal
+                .persisted_agent_session
+                .as_ref()
+                .map(|session| session.session_ref.value.as_str()),
+            Some(test_session_path("persisted-pi.jsonl").as_str())
         );
     }
 

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -1914,7 +1914,7 @@ fn pane_report_agent_accepts_unknown_agent_labels() {
 
 #[cfg(not(target_os = "macos"))]
 #[test]
-fn pane_release_agent_suppresses_reacquire_during_graceful_exit() {
+fn matching_session_scoped_pane_release_clears_immediately() {
     let _lock = test_lock();
     let base = unique_test_dir();
     let config_home = base.join("config");
@@ -1999,11 +1999,13 @@ fn pane_release_agent_suppresses_reacquire_during_graceful_exit() {
         thread::sleep(Duration::from_millis(100));
     }
 
+    let session_path = base.join("pi-root.jsonl");
     let hook = send_request(
         &socket_path,
         &format!(
-            r#"{{"id":"req_release_4","method":"pane.report_agent","params":{{"pane_id":"{}","source":"herdr:pi","agent":"pi","state":"working"}}}}"#,
-            pane_id
+            r#"{{"id":"req_release_4","method":"pane.report_agent","params":{{"pane_id":"{}","source":"herdr:pi","agent":"pi","state":"working","seq":20,"agent_session_path":"{}"}}}}"#,
+            pane_id,
+            session_path.display()
         ),
     );
     assert_eq!(hook["result"]["type"], "ok");
@@ -2011,8 +2013,9 @@ fn pane_release_agent_suppresses_reacquire_during_graceful_exit() {
     let released = send_request(
         &socket_path,
         &format!(
-            r#"{{"id":"req_release_5","method":"pane.release_agent","params":{{"pane_id":"{}","source":"herdr:pi","agent":"pi"}}}}"#,
-            pane_id
+            r#"{{"id":"req_release_5","method":"pane.release_agent","params":{{"pane_id":"{}","source":"herdr:pi","agent":"pi","seq":21,"agent_session_path":"{}"}}}}"#,
+            pane_id,
+            session_path.display()
         ),
     );
     assert_eq!(released["result"]["type"], "ok");


### PR DESCRIPTION
## Summary

Fix nested Pi and OpenCode OMP runtimes incorrectly releasing or replacing the active root agent session by scoping lifecycle releases to the session that owns the pane.

A matching session-scoped release still clears immediately. This implementation does not add process-owner tracking, termination confirmation events, runtime claim mutexes, or handoff plumbing.

## What changed

- Add optional `agent_session_id` and `agent_session_path` fields to `pane.release_agent`, its CLI wrapper, and the unreleased API schema/docs.
- Validate release source, agent, and session ownership in `TerminalState` before accepting a sequence number.
- Ignore mismatched scoped releases and unscoped releases against session-bound ownership without consuming their sequence number.
- Preserve immediate release behavior for custom and other sessionless integrations.
- Include `currentSessionRef()` in Pi and OMP release requests.
- Include MastraCode's known `session_id` in release requests and bump its integration migration version from the latest released value.
- Validate session-start semantics before accepting sequence numbers, so rejected nested starts cannot block later root updates.
- Stop treating OMP `startup` as authorization to replace an existing session.
- Preserve an authoritative root when a different nested foreground agent is detected; a return to the pane shell remains exit evidence.

## Test coverage

Adds coverage for:

- Mismatched nested Pi and OMP releases.
- Matching root-session releases.
- Unscoped releases against hook-authority and persisted session owners.
- Custom/sessionless immediate releases.
- Rejected release and session-start sequence handling.
- Nested OMP startup behavior.
- Nested foreground agents under full-lifecycle authority.
- Pi, OMP, and MastraCode release payload session fields.
- API schema round-tripping and CLI surface coverage.

## Validation

- `just lint`
- `just integration-assets-test`
- Focused Rust test groups for terminal state, app actions, API schema, pane detection, integrations, and CLI specification.
- The full Cargo nextest phase completed with 2,854 passing tests. The broader maintenance-script stage was not rerun because it hangs in this environment.
