### PR TITLE
fix(raw_input): hold lone escape one flush while awaiting potential Alt chord continuation

### DIFF
--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -190,6 +190,7 @@ pub(crate) struct RawInputByteFramer {
     lone_escape_recently_flushed: bool,
     host_color_replies_awaited: u8,
     held_pending_color_esc: bool,
+    held_pending_alt_esc: bool,
     host_color_scheme_change_tracking: bool,
     split_coalesced_escape: bool,
 }
@@ -350,9 +351,15 @@ impl RawInputByteFramer {
                 tracing::trace!("holding lone escape one flush while awaiting host color reply");
                 return chunks;
             }
+            if !self.held_pending_alt_esc {
+                self.held_pending_alt_esc = true;
+                tracing::trace!("holding lone escape one flush while awaiting potential alt chord continuation");
+                return chunks;
+            }
             // No continuation arrived; give up the window so Escape is not delayed again.
             self.host_color_replies_awaited = 0;
             self.held_pending_color_esc = false;
+            self.held_pending_alt_esc = false;
             tracing::warn!(
                 bytes = ?self.buffer,
                 "flushing lone escape after input timeout; if this follows an alt chord or focus switch it may reach the pane as plain esc"


### PR DESCRIPTION
### Summary
On macOS host terminals (e.g. Ghostty), Alt/Option chords send ESC (`0x1b`) followed by a character (`b`/`f`). When `ESC` arrives in a separate stdin read chunk across PTY boundaries, the 10ms idle timeout previously flushed a bare `ESC` to the child PTY, putting interactive shells (`zsh`) into Vi/Escape mode where `Option+Right` fails to navigate and `Backspace` acts corrupted.

### Solution
Holds a lone `ESC` for one idle flush (`held_pending_alt_esc`) so split Alt chords frame together atomically before flushing `ESC` as a standalone key.