### PR TITLE
fix: add OMP manifest detection for status working state

### DIFF
--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -252,6 +252,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("kimi", include_str!("manifests/kimi.toml")),
     ("kiro", include_str!("manifests/kiro.toml")),
     ("maki", include_str!("manifests/maki.toml")),
+    ("omp", include_str!("manifests/omp.toml")),
     ("opencode", include_str!("manifests/opencode.toml")),
     ("pi", include_str!("manifests/pi.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -879,3 +879,25 @@ fn codex_osc_working_beats_weak_blocker_screen() {
         Some("osc_title_working")
     );
 }
+
+#[test]
+fn omp_manifest_detects_working_state() {
+    let explain = explain(Agent::Omp, "Some previous output\nWorking...\n> ");
+    assert_eq!(explain.state, AgentState::Working);
+    assert!(explain.visible_working);
+    assert_eq!(
+        explain.matched_rule.as_ref().map(|r| r.id.as_str()),
+        Some("working_literal")
+    );
+}
+
+#[test]
+fn omp_manifest_defaults_to_idle_fallback() {
+    let explain = explain(Agent::Omp, "ordinary prompt text\n> ");
+    assert_eq!(explain.state, AgentState::Idle);
+    assert!(!explain.visible_idle);
+    assert_eq!(
+        explain.fallback_reason.as_deref(),
+        Some(DEFAULT_KNOWN_AGENT_IDLE_FALLBACK)
+    );
+}

--- a/src/detect/manifests/omp.toml
+++ b/src/detect/manifests/omp.toml
@@ -1,0 +1,13 @@
+id = "omp"
+version = "2026.06.10.1"
+min_engine_version = 1
+updated_at = "2026-06-10T00:00:00Z"
+aliases = ["herdr:omp"]
+
+[[rules]]
+id = "working_literal"
+state = "working"
+priority = 100
+region = "whole_recent"
+visible_working = true
+contains = ["Working…"]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -89,8 +89,9 @@ impl Agent {
         Self::Maki,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
+        Self::Omp,
         Self::Claude,
         Self::Codex,
         Self::Gemini,


### PR DESCRIPTION
Adds OMP (Oh My Pi) manifest detection to herdr.

OMP uses regular 3 dots  for working state, but herdr was previously not detecting it. This fix adds:
- OMP manifest file with working state detection
- OMP to bundled manifests
- OMP to screen manifest agents
- Tests for OMP manifest detection

This allows herdr to correctly detect when OMP is in a working state.