### PR TITLE
fix: add omp screen detection manifest

### DIFF
--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -253,6 +253,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("kiro", include_str!("manifests/kiro.toml")),
     ("maki", include_str!("manifests/maki.toml")),
     ("opencode", include_str!("manifests/opencode.toml")),
+    ("omp", include_str!("manifests/omp.toml")),
     ("pi", include_str!("manifests/pi.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),
     ("copilot", include_str!("manifests/github-copilot.toml")),

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -879,3 +879,72 @@ fn codex_osc_working_beats_weak_blocker_screen() {
         Some("osc_title_working")
     );
 }
+
+// ---------------------------------------------------------------------------
+// omp manifest tests — omp shares the pi TUI codebase and renders a
+// braille-spinner Loader line while working plus HookSelector dialogs when
+// blocked.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn omp_manifest_detects_working_spinner() {
+    let working = explain(
+        Agent::Omp,
+ "Some assistant text here\n\n ⠋ Working… ⟦esc⟧\nmodel-name  Context: 10k / 200k tokens (5%)",
+    );
+    assert_eq!(working.state, AgentState::Working);
+    assert!(working.visible_working);
+    assert_eq!(
+        working.matched_rule.as_ref().map(|r| r.id.as_str()),
+        Some("working_spinner")
+    );
+}
+
+#[test]
+fn omp_manifest_detects_working_literal() {
+    let working = explain(
+        Agent::Omp,
+        " ⠼ Reading file… ⟦esc⟧\nWorking… on task\nmodel-name  Context: 10k / 200k",
+    );
+    assert_eq!(working.state, AgentState::Working);
+    assert!(working.visible_working);
+}
+
+#[test]
+fn omp_manifest_detects_blocked_permission_selector() {
+    let blocked = explain(
+        Agent::Omp,
+ "Allow command?\n  bash: rm -rf /tmp/test\n\n❯ 1 Yes, proceed\n  2 No\nup/down navigate  enter select  esc cancel",
+    );
+    assert_eq!(blocked.state, AgentState::Blocked);
+    assert!(blocked.visible_blocker);
+    assert_eq!(
+        blocked.matched_rule.as_ref().map(|r| r.id.as_str()),
+        Some("permission_selector")
+    );
+}
+
+#[test]
+fn omp_manifest_detects_blocked_weak_blocker() {
+    let blocked = explain(Agent::Omp, "Run this command? [y/n]");
+    assert_eq!(blocked.state, AgentState::Blocked);
+    assert!(blocked.visible_blocker);
+}
+
+#[test]
+fn omp_manifest_idle_when_no_working_or_blocked_pattern() {
+    let idle = explain(
+        Agent::Omp,
+        "Welcome to omp\n❯ Ask me anything\nmodel-name  Context: 0k / 200k tokens (0%)",
+    );
+    assert_eq!(idle.state, AgentState::Idle);
+}
+
+#[test]
+fn omp_manifest_weak_blocker_outranks_spinner() {
+    // A stale [y/n] on screen triggers weak_blocker (priority 600), which
+    // outranks the working spinner (priority 500). Blocked states must win
+    // over working for safety.
+    let result = explain(Agent::Omp, "old prompt [y/n]\n ⠋ Working… ⟦esc⟧");
+    assert_eq!(result.state, AgentState::Blocked);
+}

--- a/src/detect/manifests/omp.toml
+++ b/src/detect/manifests/omp.toml
@@ -1,0 +1,52 @@
+id = "omp"
+version = "2026.07.21.1"
+min_engine_version = 1
+updated_at = "2026-07-21T00:00:00Z"
+aliases = ["herdr:omp"]
+
+# omp (Oh My Pi) shares the pi TUI codebase (@oh-my-pi/pi-coding-agent).
+# While working, the status container renders a braille-spinner Loader line
+# above the input area: " <frame> <message>" where <frame> is one of
+# ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ and <message> defaults to "Working… ⟦esc⟧" (Unicode ellipsis,
+# bracket preset varies: ⟦⟧ / [] / ⟨⟩). Tool-specific intents replace the
+# message text, so the spinner is the most reliable working indicator.
+# Permission/ask dialogs render a HookSelector with the controls hint
+# "up/down navigate  enter select  esc cancel".
+
+[[rules]]
+id = "permission_selector"
+state = "blocked"
+priority = 980
+region = "whole_recent"
+visible_blocker = true
+contains = ["enter select", "esc cancel"]
+
+[[rules]]
+id = "weak_blocker"
+state = "blocked"
+priority = 600
+region = "whole_recent"
+visible_blocker = true
+any = [
+  { contains = ["[y/n]"] },
+  { contains = ["yes (y)"] },
+]
+
+[[rules]]
+id = "working_spinner"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(3)"
+visible_working = true
+line_regex = ['^ [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] ']
+
+[[rules]]
+id = "working_literal"
+state = "working"
+priority = 100
+region = "whole_recent"
+visible_working = true
+any = [
+  { contains = ["Working…"] },
+  { contains = ["Working..."] },
+]

--- a/src/detect/manifests/pi.toml
+++ b/src/detect/manifests/pi.toml
@@ -1,8 +1,23 @@
 id = "pi"
-version = "2026.06.10.1"
+version = "2026.07.21.1"
 min_engine_version = 1
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-07-21T00:00:00Z"
 aliases = ["herdr:pi"]
+
+# pi shares the same TUI codebase as omp (@oh-my-pi/pi-coding-agent).
+# While working, the status container renders a braille-spinner Loader line:
+# " <frame> <message>" where <frame> is one of ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ and <message>
+# defaults to "Working… ⟦esc⟧" (Unicode ellipsis U+2026, not three ASCII dots).
+# Tool-specific intents replace the message text, so the spinner is the most
+# reliable working indicator.
+
+[[rules]]
+id = "working_spinner"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(3)"
+visible_working = true
+line_regex = ['^ [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] ']
 
 [[rules]]
 id = "working_literal"
@@ -10,4 +25,7 @@ state = "working"
 priority = 100
 region = "whole_recent"
 visible_working = true
-contains = ["Working..."]
+any = [
+  { contains = ["Working…"] },
+  { contains = ["Working..."] },
+]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -89,8 +89,9 @@ impl Agent {
         Self::Maki,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
+        Self::Omp,
         Self::Claude,
         Self::Codex,
         Self::Gemini,
@@ -642,7 +643,7 @@ mod tests {
 
     #[test]
     fn moved_agent_detection_routes_through_production_dispatch() {
-        let detection = detect_agent(Some(Agent::Pi), "Working...");
+        let detection = detect_agent(Some(Agent::Pi), "Working…");
 
         assert_eq!(detection.state, AgentState::Working);
         assert!(detection.visible_working);


### PR DESCRIPTION
## Problem

Issue #1618: omp (Oh My Pi) always shows as idle in herdr, even when actively running. The agent's working/running status is never displayed.

## Root Cause

omp had **no screen-detection manifest** in `src/detect/manifests/` — unlike all other agents (claude, codex, grok, maki, etc.), omp had no fallback for detecting working/blocked state from the terminal screen. When the integration asset (`herdr-agent-state.ts`) failed to report status (not installed, outdated, socket issues), herdr defaulted to idle with no way to detect omp's working state.

Additionally, the **pi manifest was broken**: it matched `"Working..."` (three ASCII dots) but the pi/omp TUI (`@oh-my-pi/pi-coding-agent`) renders `"Working…"` (Unicode ellipsis U+2026). The `contains` matcher does a substring comparison, and `…` ≠ `...`, so the pi screen-detection fallback never matched either.

## Fix

### 1. Add omp detection manifest (`src/detect/manifests/omp.toml`)
- **Working — spinner** (priority 500): matches the braille spinner line `^ [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] ` in the bottom 3 non-empty lines. The spinner is always present while the agent is working, regardless of the message text (tool-specific intents replace the default message).
- **Working — literal** (priority 100): matches `"Working…"` (Unicode) or `"Working..."` (ASCII) as a secondary indicator.
- **Blocked — permission selector** (priority 980): matches the HookSelector controls hint `"enter select"` + `"esc cancel"`.
- **Blocked — weak blocker** (priority 600): matches `"[y/n]"` or `"yes (y)"` patterns.

### 2. Register Omp in `SCREEN_MANIFEST_AGENTS`
Add `Self::Omp` to the constant array in `src/detect/mod.rs` so the bundled manifest is loaded and the `all_bundled_manifests_parse_and_validate` test covers it.

### 3. Fix pi manifest (`src/detect/manifests/pi.toml`)
- Add the same braille-spinner working rule.
- Match both `"Working…"` (Unicode ellipsis, current TUI) and `"Working..."` (ASCII dots, older versions/test fixtures) via an `any` gate.

### 4. Tests
- 6 new omp manifest tests: working spinner, working literal, blocked permission selector, blocked weak blocker, idle fallback, weak blocker outranks spinner.
- Updated the existing pi test to use Unicode ellipsis.

## Verification

- All 97 detect module tests pass.
- All 11 `api_ping` integration tests pass (these use fake pi scripts printing `"Working..."`).
- All 9 `cross_area` integration tests pass.
- `cargo fmt --check` passes.
- `live_handoff_keeps_agent_started_pane_after_agent_exits` is a pre-existing flaky test (fails on both main and worktree, unrelated to these changes).

refs #1618