### PR TITLE
fix: encode Esc as CSI u when kitty disambiguate mode is active

### DIFF
--- a/src/input/encode.rs
+++ b/src/input/encode.rs
@@ -2,6 +2,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventK
 
 use super::{KeyboardProtocol, MouseProtocolEncoding, TerminalKey};
 
+const KITTY_FLAG_DISAMBIGUATE_ESCAPE_CODES: u16 = 0b0000_0001;
 const KITTY_FLAG_REPORT_EVENT_TYPES: u16 = 0b0000_0010;
 const KITTY_FLAG_REPORT_ALTERNATE_KEYS: u16 = 0b0000_0100;
 const KITTY_FLAG_REPORT_ALL_KEYS: u16 = 0b0000_1000;
@@ -170,7 +171,14 @@ fn try_encode_csi_u(key: &TerminalKey, flags: u16) -> Option<Vec<u8>> {
 
     // Unmodified keys use legacy encoding (more compatible)
     if mods.is_empty() && event_suffix.is_none() && !report_all_keys {
-        return None;
+        // Kitty progressive enhancement 0b1 (disambiguate escape codes): the
+        // Esc key must be reported as CSI u. A bare 0x1b is the escape
+        // introducer, so a child parsing in disambiguate mode treats it as the
+        // start of an unterminated sequence and the keypress is lost.
+        let disambiguate = flags & KITTY_FLAG_DISAMBIGUATE_ESCAPE_CODES != 0;
+        if !(disambiguate && matches!(key.code, KeyCode::Esc)) {
+            return None;
+        }
     }
 
     // Special keys (arrows, F-keys, etc.) have well-established legacy
@@ -650,6 +658,27 @@ mod tests {
         .expect("mouse release should encode");
 
         assert_eq!(encoded, b"\x1b[<0;12;10m");
+    }
+
+    #[test]
+    fn kitty_disambiguate_esc_uses_csi_u() {
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::empty());
+        assert_eq!(
+            encode_key(key, KeyboardProtocol::Kitty { flags: 1 }),
+            b"\x1b[27;1u"
+        );
+    }
+
+    #[test]
+    fn kitty_disambiguate_enter_stays_legacy() {
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::empty());
+        assert_eq!(encode_key(key, KeyboardProtocol::Kitty { flags: 1 }), b"\r");
+    }
+
+    #[test]
+    fn legacy_esc_stays_bare() {
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::empty());
+        assert_eq!(encode_key(key, KeyboardProtocol::Legacy), vec![0x1b]);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`src/input/encode.rs` defines and handles the kitty flags `REPORT_EVENT_TYPES` (0b10), `REPORT_ALTERNATE_KEYS` (0b100), and `REPORT_ALL_KEYS` (0b1000), but never `DISAMBIGUATE_ESCAPE_CODES` (0b1). When a child pushes the kitty enhancement with only flag 0b1 (which Claude Code does), an unmodified Esc key falls through `try_encode_csi_u`'s "unmodified keys use legacy" early return and is delivered as a bare `0x1b`.

Under disambiguate mode, a bare `0x1b` is the escape *introducer*: the child's parser treats it as the start of an unterminated sequence and the keypress is silently lost. Per the kitty spec, the Esc key must be reported as CSI u (`\x1b[27;1u`) when flag 0b1 is active.

## How we hit it

Driving Claude Code panes on herdr 0.7.0: `herdr pane send-keys <pane> Escape` (and Esc from a client) never reaches the app — no interrupt, no input-clear — while Enter works fine (unmodified Enter correctly stays legacy `\r` under flag 0b1, which made this fun to hunt).

## The fix

- Add `KITTY_FLAG_DISAMBIGUATE_ESCAPE_CODES` (0b1).
- In `try_encode_csi_u`, exempt `KeyCode::Esc` from the unmodified-legacy early return when the flag is set, so it flows to the existing CSI-u path and emits `\x1b[27;1u`.
- Enter/Tab/Backspace keep their legacy encodings under flag 0b1, matching the spec and existing behavior (the existing guard is untouched).

## Tests

Three added, mirroring the surrounding style: `kitty_disambiguate_esc_uses_csi_u` (`\x1b[27;1u`), `kitty_disambiguate_enter_stays_legacy` (`\r`), `legacy_esc_stays_bare` (`0x1b`). `cargo test --bin herdr input::encode`: 52 passed, 0 failed. `cargo fmt --check` clean.

Thanks for herdr — we drive a whole agent fleet through it daily.