### PR TITLE
fix(ui): drop unconditional Modifier::DIM from sidebar separators

### DIFF
--- a/src/ui/mobile.rs
+++ b/src/ui/mobile.rs
@@ -529,7 +529,7 @@ fn render_mobile_switcher_content(
                 ratatui::style::Color::Reset,
                 Line::from(Span::styled(
                     "  no matching agents",
-                    Style::default().fg(p.overlay0).add_modifier(Modifier::DIM),
+                    Style::default().fg(p.overlay0),
                 )),
             );
             doc_y += 1;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1024,7 +1024,7 @@ fn resolved_token_spans(
             let previous = &resolved[visible_indices[position - 1]];
             spans.push(Span::styled(
                 tokens::separator(previous, token),
-                Style::default().fg(p.overlay0).add_modifier(Modifier::DIM),
+                Style::default().fg(p.overlay0),
             ));
         }
         match &token.kind {
@@ -1361,7 +1361,7 @@ fn render_agent_detail(
     if details.is_empty() && app.agent_view_override.is_some() {
         frame.render_widget(
             Paragraph::new(" no matching agents")
-                .style(Style::default().fg(p.overlay0).add_modifier(Modifier::DIM)),
+                .style(Style::default().fg(p.overlay0)),
             Rect::new(body.x, body.y, body.width, 1),
         );
         return;
@@ -1650,7 +1650,7 @@ rows = [[{ token = "$hype", fg = "#abcdef", bold = true, dim = false }, "workspa
             assert_eq!(style.bg, Some(app.palette.surface_dim));
         }
         assert_eq!(separator.fg, Some(app.palette.overlay0));
-        assert!(separator.add_modifier.contains(Modifier::DIM));
+        assert!(!separator.add_modifier.contains(Modifier::DIM));
         assert!(!separator.add_modifier.contains(Modifier::BOLD));
         assert_eq!(separator.bg, Some(app.palette.surface_dim));
     }

--- a/src/ui/tab_surface.rs
+++ b/src/ui/tab_surface.rs
@@ -302,9 +302,12 @@ mod tests {
         assert!(!app.view.split_borders.is_empty());
         assert!(frame.cursor.is_some());
         assert_eq!(frame.hyperlinks, vec![uri.to_owned()]);
+        // Digest updated: sidebar token separators no longer carry Modifier::DIM
+        // (see the `terminal` theme contrast fix), which changes this frame's
+        // rendered style fingerprint.
         assert_eq!(
             frame_digest(&frame),
-            "ce383feeaac30922502b7c4f8af53b5ca30e816ec4503ca6d015738b584da487"
+            "9e157f411d3334ce365650e6a465aa3b68efe5a2761c7b8035e4d9d843ce15c8"
         );
     }
 


### PR DESCRIPTION
## What I ran into

Using `theme = "terminal"` with a light, high-contrast host palette (Ghostty's bundled "GitHub Light HC"), the sidebar's token separators (the `·` between e.g. `workspace · tab`) and the agent-panel's "no matching agents" placeholder read as washed-out/faint, even though the color they use (`overlay0`, ANSI "white"/index 7) has fine contrast on its own.

## Root cause

Both spans hardcode `Modifier::DIM` unconditionally:

```rust
// src/ui/sidebar.rs — token separator
spans.push(Span::styled(
    tokens::separator(previous, token),
    Style::default().fg(p.overlay0).add_modifier(Modifier::DIM),
));

// src/ui/sidebar.rs — agent-panel empty state
Paragraph::new(" no matching agents")
    .style(Style::default().fg(p.overlay0).add_modifier(Modifier::DIM)),

// src/ui/mobile.rs — same empty state, mobile layout
```

Terminals conventionally render SGR "faint" (what `Modifier::DIM` maps to) by blending the foreground toward the background. Ghostty does exactly this via `faint-opacity` (default `0.5`, confirmed against a real Ghostty install). On GitHub Light HC (`overlay0` = `#66707b`, background `#ffffff`), that blend takes contrast from **5.04:1 (passes WCAG AA) down to exactly 2.0:1** — below AA for any text size.

I checked whether this is already configurable before touching anything: other DIM'd sidebar tokens (`tab`, `agent`) go through the row-token pipeline, so a user *can* strip DIM from those via an inline `{ token = "tab", dim = false }` in `ui.sidebar.agents.rows`. These two spans don't — the separator isn't a token at all, and the empty-state message is a hardcoded `Paragraph`, so there's no config path to opt out today.

## The change

Drop `Modifier::DIM` from both call sites (3 lines across `sidebar.rs`/`mobile.rs`). This brings them in line with how nearby similarly-muted styling (e.g. `branch`/`mauve`) already renders — plain `overlay0`, no DIM. Everything else (colors, other DIM usages that *are* configurable) is untouched.

Updated one golden-hash snapshot assertion (`ui::tab_surface::tests::desktop_full_app_semantic_frame_is_characterized`) whose rendered-frame fingerprint legitimately changes because of this — confirmed the new hash is deterministic and that the old one still passes on unpatched `master`.

## Build & test

No local Rust toolchain, so I built/tested against the project's own pinned versions (`rust-toolchain.toml` → 1.96.1, `vendor/libghostty-vt/build.zig.zon` → Zig 0.15.2) inside `rust:1.96.1` + a matching Zig 0.15.2 download, single-threaded to avoid unrelated parallel-test flakiness:

```
$ cargo build
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 16s

$ cargo test -- --test-threads=1
test result: ok. 2779 passed; 0 failed   (unittests)
test result: ok. 23 passed; 0 failed
test result: ok. 14 passed; 0 failed
test result: ok. 95 passed; 3 failed     (tests/cli.rs)
test result: ok. 12 passed; 0 failed
test result: ok. 9 passed; 0 failed
test result: ok. 11 passed; 0 failed
test result: ok. 19 passed; 1 failed     (tests/live_handoff.rs)
test result: ok. 11 passed; 0 failed
test result: ok. 15 passed; 0 failed
```

The 4 failures (process-termination-timing assertions in `tests/cli.rs` and a PTY-fd-count check in `tests/live_handoff.rs`) reproduce identically on unpatched `master` in the same container, unrelated to this change — likely container/PID-namespace timing. Everything sidebar/mobile/theme-related passes, including the updated snapshot test.

Happy to adjust scope or approach if you'd prefer a different fix (e.g. exposing DIM as a themeable/configurable attribute rather than removing it) — this seemed like the smallest change that matches the existing styling of nearby non-DIM'd muted text.

https://claude.ai/code/session_01682qqcEjBhgUyfJ12XotLn
