### PR TITLE
fix(windows): static CRT linking for Win10 25H2 compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/herdr.bat
+++ b/herdr.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Find herdr.exe
+set "HERDR="
+for %%d in (
+    "%USERPROFILE%\.herdr\bin\herdr.exe"
+    "%USERPROFILE%\herdr.exe"
+    "%LOCALAPPDATA%\herdr\herdr.exe"
+    "%ProgramFiles%\herdr\herdr.exe"
+) do (
+    if exist %%d set "HERDR=%%d"
+)
+
+:: Fallback: check PATH
+if not defined HERDR (
+    for /f "delims=" %%a in ('where herdr.exe 2^>nul') do set "HERDR=%%a"
+)
+
+if not defined HERDR (
+    echo [Herdr] Binary not found. Install: irm https://herdr.dev/install.ps1 ^| iex
+    exit /b 1
+)
+
+if "%1"=="--version" (
+    "!HERDR!" --version
+    exit /b 0
+)
+if "%1"=="version" (
+    "!HERDR!" --version
+    exit /b 0
+)
+if "%1"=="update" (
+    "!HERDR!" update
+    exit /b 0
+)
+
+"!HERDR!" %*


### PR DESCRIPTION
## Problem

Windows 10 25H2 (build 26200+, Insider Preview) no longer ships \pi-ms-win-core-path-l1-1-0.dll\ as a physical file. Rust's MSVC toolchain (1.96.1) dynamically loads this DLL, causing \