### PR TITLE
feat: optional `homepage` manifest field, surfaced in `herdr plugin list`

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -6898,6 +6898,12 @@
               },
               "type": "array"
             },
+            "homepage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "link_handlers": {
               "items": {
                 "$ref": "#/schemas/success_response/$defs/PluginManifestLinkHandler"

--- a/docs/next/website/src/content/docs/plugins.mdx
+++ b/docs/next/website/src/content/docs/plugins.mdx
@@ -100,6 +100,8 @@ action = "apply"
 ```
 
 Top-level `id`, `name`, `version`, and `min_herdr_version` are required.
+`homepage` is optional: an absolute `http(s)` URL for the plugin's docs or
+website, shown in `herdr plugin list`.
 Set `min_herdr_version` to the oldest Herdr version that supports the plugin
 APIs, event names, and manifest fields your plugin uses. Herdr refuses to link
 or install a plugin when its minimum version is newer than the current binary.

--- a/src/api/schema/plugins.rs
+++ b/src/api/schema/plugins.rs
@@ -42,6 +42,8 @@ pub struct InstalledPluginInfo {
     pub min_herdr_version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
     pub manifest_path: String,
     pub plugin_root: String,
     pub enabled: bool,

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -891,6 +891,7 @@ fn plugin_link_list_unlink_round_trip() {
         version: "0.1.0".into(),
         min_herdr_version: crate::build_info::BASE_VERSION.into(),
         description: Some("Prepare new worktrees".into()),
+        homepage: None,
         manifest_path: "/plugins/worktree-bootstrap/herdr-plugin.toml".into(),
         plugin_root: "/plugins/worktree-bootstrap".into(),
         enabled: true,

--- a/src/app/api/plugins/manifest.rs
+++ b/src/app/api/plugins/manifest.rs
@@ -18,6 +18,8 @@ struct RawPluginManifest {
     #[serde(default)]
     description: Option<String>,
     #[serde(default)]
+    homepage: Option<String>,
+    #[serde(default)]
     platforms: Option<Vec<RawPlatform>>,
     #[serde(default)]
     build: Vec<RawPluginManifestBuild>,
@@ -154,6 +156,7 @@ pub(crate) fn load_plugin_manifest(
         .description
         .map(|description| description.trim().to_string())
         .filter(|description| !description.is_empty());
+    let homepage = validate_homepage(raw.homepage.as_deref())?;
     let platforms = normalize_platforms(raw.platforms)?;
     let build = raw
         .build
@@ -211,6 +214,7 @@ pub(crate) fn load_plugin_manifest(
         version,
         min_herdr_version,
         description,
+        homepage,
         manifest_path: manifest_path.display().to_string(),
         plugin_root: plugin_root.display().to_string(),
         enabled,
@@ -224,6 +228,30 @@ pub(crate) fn load_plugin_manifest(
         source: Default::default(),
         warnings,
     })
+}
+
+fn validate_homepage(value: Option<&str>) -> Result<Option<String>, (&'static str, String)> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    let rest = value
+        .strip_prefix("https://")
+        .or_else(|| value.strip_prefix("http://"));
+    let valid = matches!(rest, Some(rest) if !rest.is_empty())
+        && !value
+            .chars()
+            .any(|ch| ch.is_whitespace() || ch.is_control());
+    if !valid {
+        return Err((
+            "invalid_plugin_homepage",
+            format!("homepage must be an absolute http(s) URL, got '{value}'"),
+        ));
+    }
+    Ok(Some(value.to_string()))
 }
 
 fn validate_min_herdr_version(value: Option<&str>) -> Result<String, (&'static str, String)> {

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -967,6 +967,87 @@ platforms = ["linux", "macos", "windows"]
     }
 
     #[test]
+    fn plugin_manifest_accepts_and_trims_homepage() {
+        let root = unique_temp_path("plugin-homepage-valid");
+        write_manifest_content(
+            &root,
+            r#"
+id = "example.homepage-valid"
+name = "Homepage valid"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+platforms = ["linux", "macos"]
+homepage = "  https://example.com/docs  "
+"#,
+        );
+
+        let plugin = load_plugin_manifest(&root.display().to_string(), true)
+            .expect("valid homepage should load");
+        assert_eq!(plugin.homepage.as_deref(), Some("https://example.com/docs"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn plugin_manifest_homepage_defaults_to_none() {
+        for (name, line) in [("missing", ""), ("empty", "homepage = \"  \"")] {
+            let root = unique_temp_path(&format!("plugin-homepage-{name}"));
+            write_manifest_content(
+                &root,
+                &format!(
+                    r#"
+id = "example.homepage-{name}"
+name = "Homepage {name}"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+platforms = ["linux", "macos"]
+{line}
+"#
+                ),
+            );
+
+            let plugin = load_plugin_manifest(&root.display().to_string(), true)
+                .expect("manifest without homepage should load");
+            assert_eq!(plugin.homepage, None);
+
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn plugin_manifest_rejects_invalid_homepage() {
+        for (name, value) in [
+            ("scheme", "ftp://example.com"),
+            ("relative", "example.com/docs"),
+            ("bare", "https://"),
+            ("spaced", "https://example.com/a b"),
+        ] {
+            let root = unique_temp_path(&format!("plugin-homepage-bad-{name}"));
+            write_manifest_content(
+                &root,
+                &format!(
+                    r#"
+id = "example.homepage-bad-{name}"
+name = "Homepage bad {name}"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+platforms = ["linux", "macos"]
+homepage = "{value}"
+"#
+                ),
+            );
+
+            let result = load_plugin_manifest(&root.display().to_string(), true);
+            assert!(
+                matches!(result, Err(("invalid_plugin_homepage", _))),
+                "expected invalid_plugin_homepage for {name}"
+            );
+
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
     fn plugin_manifest_preserves_whitespace_only_command_arguments() {
         let root = unique_temp_path("plugin-whitespace-argv");
         write_manifest_content(

--- a/src/app/api/worktrees.rs
+++ b/src/app/api/worktrees.rs
@@ -823,6 +823,7 @@ mod tests {
                 version: "0.1.0".into(),
                 min_herdr_version: "0.7.0".into(),
                 description: None,
+                homepage: None,
                 manifest_path: manifest_path.display().to_string(),
                 plugin_root: plugin_root.display().to_string(),
                 enabled: true,

--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -494,6 +494,7 @@ mod tests {
                 version: "0.1.0".into(),
                 min_herdr_version: "0.6.10".into(),
                 description: None,
+                homepage: None,
                 manifest_path: plugin_root.join("herdr-plugin.toml").display().to_string(),
                 plugin_root: plugin_root.display().to_string(),
                 enabled: true,

--- a/src/app/worktrees.rs
+++ b/src/app/worktrees.rs
@@ -1748,6 +1748,7 @@ mod tests {
                 version: "0.1.0".into(),
                 min_herdr_version: "0.7.0".into(),
                 description: None,
+                homepage: None,
                 manifest_path: manifest_path.display().to_string(),
                 plugin_root: plugin_root.display().to_string(),
                 enabled: true,

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -1169,6 +1169,9 @@ fn print_plugin_list_human(response: &serde_json::Value) -> std::io::Result<i32>
             "  config: {}",
             crate::plugin_paths::plugin_config_dir(&plugin.plugin_id).display()
         );
+        if let Some(homepage) = &plugin.homepage {
+            println!("  homepage: {homepage}");
+        }
         for warning in plugin.warnings {
             println!("  warning: {warning}");
         }
@@ -1208,6 +1211,9 @@ fn print_install_preview(
     eprintln!("  id: {}", plugin.plugin_id);
     eprintln!("  name: {}", plugin.name);
     eprintln!("  version: {}", plugin.version);
+    if let Some(homepage) = &plugin.homepage {
+        eprintln!("  homepage: {homepage}");
+    }
     if let (Some(owner), Some(repo)) = (&source.owner, &source.repo) {
         let subdir = source
             .subdir
@@ -1688,6 +1694,7 @@ mod tests {
             version: "0.1.0".to_string(),
             min_herdr_version: crate::build_info::BASE_VERSION.to_string(),
             description: None,
+            homepage: None,
             manifest_path: format!("/tmp/{id}/herdr-plugin.toml"),
             plugin_root: format!("/tmp/{id}"),
             enabled: true,

--- a/src/persist/plugin_registry.rs
+++ b/src/persist/plugin_registry.rs
@@ -155,6 +155,7 @@ mod tests {
             version: "0.1.0".to_string(),
             min_herdr_version: crate::build_info::BASE_VERSION.to_string(),
             description: None,
+            homepage: None,
             manifest_path: format!("/tmp/{id}/herdr-plugin.toml"),
             plugin_root: format!("/tmp/{id}"),
             enabled: true,
@@ -242,6 +243,7 @@ mod tests {
                 version: "0.2.0".to_string(),
                 min_herdr_version: crate::build_info::BASE_VERSION.to_string(),
                 description: Some("refreshed".to_string()),
+                homepage: None,
                 manifest_path: "/tmp/example.reload/herdr-plugin.toml".to_string(),
                 plugin_root: "/tmp/example.reload".to_string(),
                 enabled: true, // caller would pass stored enabled; fresh parse returns true


### PR DESCRIPTION
Implements #1810: an optional top-level `homepage` field in `herdr-plugin.toml` so an installed plugin can point users (and agents) at its documentation from inside herdr.

```toml
id = "structupath.swarm"
name = "Swarm"
version = "0.1.0"
homepage = "https://herdr.structupath.ai/docs/swarm/"
```

## What changed

- **Manifest parsing** (`src/app/api/plugins/manifest.rs`): `RawPluginManifest.homepage`, validated by a new `validate_homepage` — trimmed; missing/empty treated as absent; otherwise must be an absolute `http(s)` URL with a non-empty remainder and no whitespace/control characters. Rejections use the existing error-key convention: `("invalid_plugin_homepage", …)`. No new dependencies.
- **Schema** (`src/api/schema/plugins.rs`): `InstalledPluginInfo.homepage: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — existing registries load unchanged, and the field rides along in `plugin.list` JSON and the api snapshot. Generated schema artifact regenerated via `HERDR_UPDATE_API_SCHEMA=1`.
- **CLI** (`src/cli/plugin.rs`): `herdr plugin list` human output prints `homepage: …` when present; `plugin install` preview shows it too.
- **Docs** (`docs/next/website/src/content/docs/plugins.mdx`): one-line manifest reference addition.

## Tests

Three new tests in `src/app/api/plugins/mod.rs` following the existing `write_manifest_content` pattern:

- accepts and trims a valid homepage
- missing or whitespace-only homepage → `None`
- rejects `ftp://`, scheme-less, bare `https://`, and URLs containing spaces with `invalid_plugin_homepage`

`cargo fmt`, `cargo clippy --bin herdr -- -D warnings`, and the test suite pass locally (a couple of pre-existing env-sensitive tests are flaky on my machine independent of this change — they also fail intermittently on a clean checkout).

## Notes

- Because `RawPluginManifest` ignores unknown fields, older herdr versions simply ignore `homepage` — plugins can adopt it without a compatibility break.
- Happy to adjust the shape (naming, stricter URL validation, surfacing elsewhere) however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugin manifests now support an optional homepage URL.
  - Valid homepage links must use absolute HTTP(S) URLs; invalid values are rejected.
  - Installed plugin listings and installation previews display the homepage when available.

- **Documentation**
  - Added guidance for configuring the optional `homepage` manifest field.

- **Bug Fixes**
  - Blank homepage values are ignored and stored as unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->