### PR TITLE
feat: add OSC 9 progress rules to jcode detection manifest

### DIFF
--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -899,7 +899,7 @@ pub struct ExperimentalConfig {
     /// if the list contains no valid names, the reveal does not apply.
     /// Accepted names: pi, claude, codex, gemini, cursor, devin, cline,
     /// opencode, copilot, kimi, kiro, droid, amp, grok, hermes, kilo,
-    /// qodercli, qoder, maki.
+    /// qodercli, qoder, maki, jcode.
     /// Default: empty.
     pub cjk_ime_agents: Vec<String>,
     /// Cursor shape rendered for the IME anchor when

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -41,6 +41,7 @@ pub struct AgentSoundOverrides {
     pub amp: AgentSoundSetting,
     pub grok: AgentSoundSetting,
     pub hermes: AgentSoundSetting,
+    pub jcode: AgentSoundSetting,
     pub kilo: AgentSoundSetting,
     pub qodercli: AgentSoundSetting,
     pub maki: AgentSoundSetting,
@@ -137,6 +138,7 @@ impl AgentSoundOverrides {
             Some(Agent::Amp) => self.amp,
             Some(Agent::Grok) => self.grok,
             Some(Agent::Hermes) => self.hermes,
+            Some(Agent::Jcode) => self.jcode,
             Some(Agent::Kilo) => self.kilo,
             Some(Agent::Qodercli) => self.qodercli,
             Some(Agent::Maki) => self.maki,
@@ -176,6 +178,7 @@ impl Default for AgentSoundOverrides {
             amp: AgentSoundSetting::Default,
             grok: AgentSoundSetting::Default,
             hermes: AgentSoundSetting::Default,
+            jcode: AgentSoundSetting::Default,
             kilo: AgentSoundSetting::Default,
             qodercli: AgentSoundSetting::Default,
             maki: AgentSoundSetting::Default,
@@ -202,6 +205,7 @@ request_path = "/tmp/request.mp3"
 [ui.sound.agents]
 droid = "off"
 claude = "on"
+jcode = "off"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert!(config.ui.sound.enabled);
@@ -216,6 +220,7 @@ claude = "on"
         );
         assert_eq!(config.ui.sound.agents.droid, AgentSoundSetting::Off);
         assert_eq!(config.ui.sound.agents.claude, AgentSoundSetting::On);
+        assert_eq!(config.ui.sound.agents.jcode, AgentSoundSetting::Off);
         assert_eq!(config.ui.sound.agents.pi, AgentSoundSetting::Default);
     }
 

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -248,6 +248,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("gemini", include_str!("manifests/gemini.toml")),
     ("grok", include_str!("manifests/grok.toml")),
     ("hermes", include_str!("manifests/hermes.toml")),
+    ("jcode", include_str!("manifests/jcode.toml")),
     ("kilo", include_str!("manifests/kilo.toml")),
     ("kimi", include_str!("manifests/kimi.toml")),
     ("kiro", include_str!("manifests/kiro.toml")),

--- a/src/detect/manifests/jcode.toml
+++ b/src/detect/manifests/jcode.toml
@@ -1,7 +1,7 @@
 id = "jcode"
-version = "2026.07.03.1"
+version = "2026.07.23.1"
 min_engine_version = 1
-updated_at = "2026-07-03T00:00:00Z"
+updated_at = "2026-07-23T00:00:00Z"
 
 [[rules]]
 id = "permission_choice_blocker"
@@ -11,6 +11,7 @@ region = "bottom_non_empty_lines(8)"
 visible_blocker = true
 any = [
   { contains = ["permission"], all = [{ any = [{ contains = ["allow once"] }, { contains = ["always allow"] }, { contains = ["allow"] }] }, { any = [{ contains = ["deny"] }, { contains = ["reject"] }, { contains = ["cancel"] }] }] },
+  { contains = ["permissions"], all = [{ any = [{ contains = ["approve"] }, { contains = ["allow"] }] }, { any = [{ contains = ["deny"] }, { contains = ["reject"] }] }] },
   { contains = ["approve?"], all = [{ any = [{ contains = ["allow"] }, { contains = ["yes"] }] }, { any = [{ contains = ["reject"] }, { contains = ["no"] }, { contains = ["cancel"] }] }] },
   { contains = ["confirm action"], all = [{ any = [{ contains = ["allow"] }, { contains = ["yes"] }, { contains = ["proceed"] }] }, { any = [{ contains = ["reject"] }, { contains = ["no"] }, { contains = ["cancel"] }] }] },
 ]

--- a/src/detect/manifests/jcode.toml
+++ b/src/detect/manifests/jcode.toml
@@ -1,7 +1,39 @@
 id = "jcode"
-version = "2026.07.23.1"
+version = "2026.07.24.1"
 min_engine_version = 1
-updated_at = "2026-07-23T00:00:00Z"
+updated_at = "2026-07-24T00:00:00Z"
+
+# --- OSC 9 progress rules (primary detection path, version-stable) ---
+# jcode emits `OSC 9 ;jcode:<state> BEL` on every full redraw when the
+# processing status changes. These rules win over all screen-scrape rules
+# because they carry a structured payload that cannot appear in conversation
+# text, eliminating false positives and stale-text issues.
+
+[[rules]]
+id = "osc_progress_working"
+state = "working"
+priority = 1100
+region = "osc_progress"
+visible_working = true
+contains = ["jcode:working"]
+
+[[rules]]
+id = "osc_progress_blocked"
+state = "blocked"
+priority = 1100
+region = "osc_progress"
+visible_blocker = true
+contains = ["jcode:blocked"]
+
+[[rules]]
+id = "osc_progress_idle"
+state = "idle"
+priority = 1100
+region = "osc_progress"
+visible_idle = true
+contains = ["jcode:idle"]
+
+# --- Screen-scrape fallback rules (lower priority, for terminals that strip OSC) ---
 
 [[rules]]
 id = "permission_choice_blocker"

--- a/src/detect/manifests/jcode.toml
+++ b/src/detect/manifests/jcode.toml
@@ -1,0 +1,76 @@
+id = "jcode"
+version = "2026.07.03.1"
+min_engine_version = 1
+updated_at = "2026-07-03T00:00:00Z"
+
+[[rules]]
+id = "permission_choice_blocker"
+state = "blocked"
+priority = 300
+region = "bottom_non_empty_lines(8)"
+visible_blocker = true
+any = [
+  { contains = ["permission"], all = [{ any = [{ contains = ["allow once"] }, { contains = ["always allow"] }, { contains = ["allow"] }] }, { any = [{ contains = ["deny"] }, { contains = ["reject"] }, { contains = ["cancel"] }] }] },
+  { contains = ["approve?"], all = [{ any = [{ contains = ["allow"] }, { contains = ["yes"] }] }, { any = [{ contains = ["reject"] }, { contains = ["no"] }, { contains = ["cancel"] }] }] },
+  { contains = ["confirm action"], all = [{ any = [{ contains = ["allow"] }, { contains = ["yes"] }, { contains = ["proceed"] }] }, { any = [{ contains = ["reject"] }, { contains = ["no"] }, { contains = ["cancel"] }] }] },
+]
+
+[[rules]]
+id = "question_input_blocker"
+state = "blocked"
+priority = 290
+region = "bottom_non_empty_lines(6)"
+visible_blocker = true
+any = [
+  { contains = ["enter your response"], any = [{ contains = ["continue"] }, { contains = ["submit"] }, { contains = ["cancel"] }] },
+  { contains = ["asking user"], any = [{ contains = ["enter your response"] }, { contains = ["awaiting input"] }, { contains = ["waiting for user"] }] },
+  { contains = ["awaiting input"], any = [{ contains = ["enter"] }, { contains = ["type"] }, { contains = ["respond"] }] },
+]
+
+[[rules]]
+id = "spinner_working"
+state = "working"
+priority = 100
+region = "bottom_non_empty_lines(3)"
+visible_working = true
+line_regex = ['^\s*[\u2800-\u28FF]\s+.*\p{Alphabetic}']
+
+[[rules]]
+id = "tool_bar_working"
+state = "working"
+priority = 95
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = [
+  '^\s*[·●]{3}\s+\S+\s+[·●]{3}(?:\s+·\s+.*)?$',
+]
+
+[[rules]]
+id = "tool_status_working"
+state = "working"
+priority = 90
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+any = [
+  { contains = ["running tool"] },
+  { contains = ["executing tool"] },
+  { contains = ["network disconnected, waiting to retry"] },
+]
+
+[[rules]]
+id = "ready_prompt_idle"
+state = "idle"
+priority = 80
+region = "bottom_non_empty_lines(3)"
+visible_idle = true
+any = [
+  { contains = ["session ready"] },
+  { contains = ["ready for input"] },
+  { line_regex = ['^\s*❯\s*$'] },
+]
+not = [
+  { contains = ["processing"] },
+  { contains = ["embedding"] },
+  { contains = ["running tool"] },
+  { contains = ["executing"] },
+]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -62,10 +62,11 @@ pub enum Agent {
     Kilo,
     Qodercli,
     Maki,
+    Jcode,
 }
 
 impl Agent {
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -85,6 +86,7 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Jcode,
     ];
 }
 
@@ -111,6 +113,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Jcode => "jcode",
     }
 }
 
@@ -147,6 +150,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "maki" => Some(Agent::Maki),
+        "jcode" => Some(Agent::Jcode),
         _ => None,
     }
 }
@@ -632,6 +636,7 @@ mod tests {
         assert_eq!(identify_agent("kilo"), Some(Agent::Kilo));
         assert_eq!(identify_agent("kilo-code"), Some(Agent::Kilo));
         assert_eq!(identify_agent("maki"), Some(Agent::Maki));
+        assert_eq!(identify_agent("jcode"), Some(Agent::Jcode));
     }
 
     #[test]
@@ -658,6 +663,7 @@ mod tests {
         assert_eq!(parse_agent_label("hermes-agent"), Some(Agent::Hermes));
         assert_eq!(parse_agent_label("maki"), Some(Agent::Maki));
         assert_eq!(parse_agent_label("kilo-code"), Some(Agent::Kilo));
+        assert_eq!(parse_agent_label("jcode"), Some(Agent::Jcode));
     }
 
     #[test]
@@ -684,6 +690,7 @@ mod tests {
             Agent::Kilo,
             Agent::Qodercli,
             Agent::Maki,
+            Agent::Jcode,
         ];
 
         for agent in agents {
@@ -699,6 +706,96 @@ mod tests {
         assert_eq!(parse_canonical_agent_label("Pi"), None);
         assert_eq!(parse_canonical_agent_label(" pi "), None);
         assert_eq!(parse_canonical_agent_label("opencode.exe"), None);
+    }
+
+    #[test]
+    fn jcode_screen_manifest_detects_visible_states() {
+        let blocked = detect_agent(
+            Some(Agent::Jcode),
+            "Approve?\n❯ Allow\n  Reject\nEsc to cancel",
+        );
+        assert_eq!(blocked.state, AgentState::Blocked);
+        assert!(blocked.visible_blocker);
+
+        let permission_blocked = detect_agent(
+            Some(Agent::Jcode),
+            "Permission request\nRun shell command?\n❯ Allow once\n  Deny",
+        );
+        assert_eq!(permission_blocked.state, AgentState::Blocked);
+        assert!(permission_blocked.visible_blocker);
+
+        let question_blocked = detect_agent(
+            Some(Agent::Jcode),
+            "Asking user\nEnter your response to continue",
+        );
+        assert_eq!(question_blocked.state, AgentState::Blocked);
+        assert!(question_blocked.visible_blocker);
+
+        let working = detect_agent(Some(Agent::Jcode), "⠋ Processing request");
+        assert_eq!(working.state, AgentState::Working);
+        assert!(working.visible_working);
+
+        let tool_working = detect_agent(Some(Agent::Jcode), "Running tool bash");
+        assert_eq!(tool_working.state, AgentState::Working);
+        assert!(tool_working.visible_working);
+
+        let tool_bar_working = detect_agent(Some(Agent::Jcode), "··● bash ●·· · 12s");
+        assert_eq!(tool_bar_working.state, AgentState::Working);
+        assert!(tool_bar_working.visible_working);
+
+        let clipped_bash_tool_bar = detect_agent(Some(Agent::Jcode), "··● bash ●··");
+        assert_eq!(clipped_bash_tool_bar.state, AgentState::Working);
+        assert!(clipped_bash_tool_bar.visible_working);
+
+        let batch_tool_working = detect_agent(
+            Some(Agent::Jcode),
+            "●·· batch ··● · 2/5 done · last done: read · 1m 3s",
+        );
+        assert_eq!(batch_tool_working.state, AgentState::Working);
+        assert!(batch_tool_working.visible_working);
+
+        let clipped_batch_tool_bar = detect_agent(Some(Agent::Jcode), "●·· batch ··● · 2/5 done");
+        assert_eq!(clipped_batch_tool_bar.state, AgentState::Working);
+        assert!(clipped_batch_tool_bar.visible_working);
+
+        let network_waiting = detect_agent(
+            Some(Agent::Jcode),
+            "↻ network disconnected, waiting to retry · websocket · 8s",
+        );
+        assert_eq!(network_waiting.state, AgentState::Working);
+        assert!(network_waiting.visible_working);
+
+        let idle = detect_agent(Some(Agent::Jcode), "jcode\n❯ ");
+        assert_eq!(idle.state, AgentState::Idle);
+        assert!(idle.visible_idle);
+
+        let deny_transcript = detect_agent(
+            Some(Agent::Jcode),
+            "We should deny this assumption in the explanation.\n❯ ",
+        );
+        assert_eq!(deny_transcript.state, AgentState::Idle);
+        assert!(!deny_transcript.visible_blocker);
+
+        let stale_permission_text = detect_agent(
+            Some(Agent::Jcode),
+            "Permission request\n❯ Allow once\n  Deny\nold response line 1\nold response line 2\nold response line 3\nold response line 4\nold response line 5\nold response line 6\nold response line 7\nold response line 8\n❯ ",
+        );
+        assert_eq!(stale_permission_text.state, AgentState::Idle);
+        assert!(!stale_permission_text.visible_blocker);
+
+        let stale_processing_text = detect_agent(
+            Some(Agent::Jcode),
+            "Processing request\nold response line 1\nold response line 2\nold response line 3\nold response line 4\n❯ ",
+        );
+        assert_eq!(stale_processing_text.state, AgentState::Idle);
+        assert!(!stale_processing_text.visible_working);
+
+        let stale_tool_bar = detect_agent(
+            Some(Agent::Jcode),
+            "··● bash ●·· · 12s\nold response line 1\nold response line 2\nold response line 3\nold response line 4\n❯ ",
+        );
+        assert_eq!(stale_tool_bar.state, AgentState::Idle);
+        assert!(!stale_tool_bar.visible_working);
     }
 
     #[test]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -844,6 +844,49 @@ mod tests {
     }
 
     #[test]
+    fn jcode_osc_progress_rules_detect_working_and_idle() {
+        // OSC 9 progress payload "jcode:working" → working state at highest priority.
+        let working = detect_agent_with_osc(
+            Some(Agent::Jcode),
+            "❯ ",
+            "jcode:working",
+            "",
+        );
+        assert_eq!(working.state, AgentState::Working);
+        assert!(working.visible_working);
+
+        // OSC 9 progress payload "jcode:idle" → idle state at highest priority.
+        let idle = detect_agent_with_osc(
+            Some(Agent::Jcode),
+            "⠋ sending… 0.3s",
+            "jcode:idle",
+            "",
+        );
+        assert_eq!(idle.state, AgentState::Idle);
+        assert!(idle.visible_idle);
+
+        // OSC 9 progress payload "jcode:blocked" → blocked state at highest priority.
+        let blocked = detect_agent_with_osc(
+            Some(Agent::Jcode),
+            "❯ ",
+            "jcode:blocked",
+            "",
+        );
+        assert_eq!(blocked.state, AgentState::Blocked);
+        assert!(blocked.visible_blocker);
+
+        // No OSC progress payload → falls back to screen-scrape rules.
+        let no_osc = detect_agent_with_osc(
+            Some(Agent::Jcode),
+            "⠋ sending… 0.3s",
+            "",
+            "",
+        );
+        assert_eq!(no_osc.state, AgentState::Working);
+        assert!(no_osc.visible_working);
+    }
+
+    #[test]
     fn mastracode_is_hook_authority_without_screen_manifest() {
         assert!(full_lifecycle_hook_authority(
             "herdr:mastracode",

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -731,9 +731,47 @@ mod tests {
         assert_eq!(question_blocked.state, AgentState::Blocked);
         assert!(question_blocked.visible_blocker);
 
+        // The jcode permissions viewer shows "Permissions" + "approve" + "deny"
+        // (not "allow"/"reject" like the inline prompt).
+        let permissions_viewer = detect_agent(
+            Some(Agent::Jcode),
+            " Permissions (2 pending) \n❯ ● [normal] Run shell command\n   rm -rf /tmp/test\n  ○ [low] Read file\n a  approve   d  deny   A  approve all   D  deny all",
+        );
+        assert_eq!(permissions_viewer.state, AgentState::Blocked);
+        assert!(permissions_viewer.visible_blocker);
+
         let working = detect_agent(Some(Agent::Jcode), "⠋ Processing request");
         assert_eq!(working.state, AgentState::Working);
         assert!(working.visible_working);
+
+        // jcode TUI renders spinner labels: "sending…", "thinking…", "connecting…", etc.
+        let sending_spinner = detect_agent(Some(Agent::Jcode), "⠋ sending… 0.3s");
+        assert_eq!(sending_spinner.state, AgentState::Working);
+        assert!(sending_spinner.visible_working);
+
+        let thinking_spinner = detect_agent(Some(Agent::Jcode), "⠙ thinking… 1.2s");
+        assert_eq!(thinking_spinner.state, AgentState::Working);
+        assert!(thinking_spinner.visible_working);
+
+        let connecting_spinner = detect_agent(Some(Agent::Jcode), "⠹ connecting… 0.5s");
+        assert_eq!(connecting_spinner.state, AgentState::Working);
+        assert!(connecting_spinner.visible_working);
+
+        let streaming_spinner = detect_agent(Some(Agent::Jcode), "⠸ 0.3s · ↑1.2k ↓500");
+        assert_eq!(streaming_spinner.state, AgentState::Working);
+        assert!(streaming_spinner.visible_working);
+
+        let streaming_stalled = detect_agent(Some(Agent::Jcode), "⠼ (stalled 15s) · 2.3s");
+        assert_eq!(streaming_stalled.state, AgentState::Working);
+        assert!(streaming_stalled.visible_working);
+
+        let refreshing_auth = detect_agent(Some(Agent::Jcode), "⠹ refreshing auth… 3s");
+        assert_eq!(refreshing_auth.state, AgentState::Working);
+        assert!(refreshing_auth.visible_working);
+
+        let retrying = detect_agent(Some(Agent::Jcode), "⠹ retrying 2/3… 5s");
+        assert_eq!(retrying.state, AgentState::Working);
+        assert!(retrying.visible_working);
 
         let tool_working = detect_agent(Some(Agent::Jcode), "Running tool bash");
         assert_eq!(tool_working.state, AgentState::Working);
@@ -782,6 +820,13 @@ mod tests {
         );
         assert_eq!(stale_permission_text.state, AgentState::Idle);
         assert!(!stale_permission_text.visible_blocker);
+
+        let stale_permissions_viewer = detect_agent(
+            Some(Agent::Jcode),
+            "Permissions (2 pending)\n❯ ● [normal] Run shell command\n a  approve   d  deny\nold response line 1\nold response line 2\nold response line 3\nold response line 4\nold response line 5\nold response line 6\nold response line 7\nold response line 8\n❯ ",
+        );
+        assert_eq!(stale_permissions_viewer.state, AgentState::Idle);
+        assert!(!stale_permissions_viewer.visible_blocker);
 
         let stale_processing_text = detect_agent(
             Some(Agent::Jcode),

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,7 @@ pane_history = false
 # matches one of these names. Empty means apply to any focused pane.
 # If the list contains no valid names, the reveal does not apply.
 # Accepted: pi, claude, codex, gemini, cursor, devin, cline, opencode,
-# copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder.
+# copilot, kimi, kiro, droid, amp, grok, hermes, jcode, kilo, qodercli, qoder.
 # cjk_ime_agents = []
 # Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.
 # Values: block, steady_block (default), underline, steady_underline, bar, steady_bar.

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -49,6 +49,10 @@ id = "kilo"
 path = "kilo.toml"
 
 [[agents]]
+id = "jcode"
+path = "jcode.toml"
+
+[[agents]]
 id = "kimi"
 path = "kimi.toml"
 

--- a/website/agent-detection/jcode.toml
+++ b/website/agent-detection/jcode.toml
@@ -1,7 +1,39 @@
 id = "jcode"
-version = "2026.07.03.1"
+version = "2026.07.24.1"
 min_engine_version = 1
-updated_at = "2026-07-03T00:00:00Z"
+updated_at = "2026-07-24T00:00:00Z"
+
+# --- OSC 9 progress rules (primary detection path, version-stable) ---
+# jcode emits `OSC 9 ;jcode:<state> BEL` on every full redraw when the
+# processing status changes. These rules win over all screen-scrape rules
+# because they carry a structured payload that cannot appear in conversation
+# text, eliminating false positives and stale-text issues.
+
+[[rules]]
+id = "osc_progress_working"
+state = "working"
+priority = 1100
+region = "osc_progress"
+visible_working = true
+contains = ["jcode:working"]
+
+[[rules]]
+id = "osc_progress_blocked"
+state = "blocked"
+priority = 1100
+region = "osc_progress"
+visible_blocker = true
+contains = ["jcode:blocked"]
+
+[[rules]]
+id = "osc_progress_idle"
+state = "idle"
+priority = 1100
+region = "osc_progress"
+visible_idle = true
+contains = ["jcode:idle"]
+
+# --- Screen-scrape fallback rules (lower priority, for terminals that strip OSC) ---
 
 [[rules]]
 id = "permission_choice_blocker"

--- a/website/agent-detection/jcode.toml
+++ b/website/agent-detection/jcode.toml
@@ -1,0 +1,76 @@
+id = "jcode"
+version = "2026.07.03.1"
+min_engine_version = 1
+updated_at = "2026-07-03T00:00:00Z"
+
+[[rules]]
+id = "permission_choice_blocker"
+state = "blocked"
+priority = 300
+region = "bottom_non_empty_lines(8)"
+visible_blocker = true
+any = [
+  { contains = ["permission"], all = [{ any = [{ contains = ["allow once"] }, { contains = ["always allow"] }, { contains = ["allow"] }] }, { any = [{ contains = ["deny"] }, { contains = ["reject"] }, { contains = ["cancel"] }] }] },
+  { contains = ["approve?"], all = [{ any = [{ contains = ["allow"] }, { contains = ["yes"] }] }, { any = [{ contains = ["reject"] }, { contains = ["no"] }, { contains = ["cancel"] }] }] },
+  { contains = ["confirm action"], all = [{ any = [{ contains = ["allow"] }, { contains = ["yes"] }, { contains = ["proceed"] }] }, { any = [{ contains = ["reject"] }, { contains = ["no"] }, { contains = ["cancel"] }] }] },
+]
+
+[[rules]]
+id = "question_input_blocker"
+state = "blocked"
+priority = 290
+region = "bottom_non_empty_lines(6)"
+visible_blocker = true
+any = [
+  { contains = ["enter your response"], any = [{ contains = ["continue"] }, { contains = ["submit"] }, { contains = ["cancel"] }] },
+  { contains = ["asking user"], any = [{ contains = ["enter your response"] }, { contains = ["awaiting input"] }, { contains = ["waiting for user"] }] },
+  { contains = ["awaiting input"], any = [{ contains = ["enter"] }, { contains = ["type"] }, { contains = ["respond"] }] },
+]
+
+[[rules]]
+id = "spinner_working"
+state = "working"
+priority = 100
+region = "bottom_non_empty_lines(3)"
+visible_working = true
+line_regex = ['^\s*[\u2800-\u28FF]\s+.*\p{Alphabetic}']
+
+[[rules]]
+id = "tool_bar_working"
+state = "working"
+priority = 95
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+line_regex = [
+  '^\s*[·●]{3}\s+\S+\s+[·●]{3}(?:\s+·\s+.*)?$',
+]
+
+[[rules]]
+id = "tool_status_working"
+state = "working"
+priority = 90
+region = "bottom_non_empty_lines(4)"
+visible_working = true
+any = [
+  { contains = ["running tool"] },
+  { contains = ["executing tool"] },
+  { contains = ["network disconnected, waiting to retry"] },
+]
+
+[[rules]]
+id = "ready_prompt_idle"
+state = "idle"
+priority = 80
+region = "bottom_non_empty_lines(3)"
+visible_idle = true
+any = [
+  { contains = ["session ready"] },
+  { contains = ["ready for input"] },
+  { line_regex = ['^\s*❯\s*$'] },
+]
+not = [
+  { contains = ["processing"] },
+  { contains = ["embedding"] },
+  { contains = ["running tool"] },
+  { contains = ["executing"] },
+]


### PR DESCRIPTION
## Summary

Adds structured OSC 9 progress detection rules to the jcode agent manifest, enabling reliable working/idle/blocked state detection without relying on screen-scraping.

## Changes

- **`src/detect/manifests/jcode.toml`** + **`website/agent-detection/jcode.toml`**: Added 3 OSC progress rules at priority 1100 that match jcode's emitted payloads:
  - `osc_progress_working` → `jcode:working` → state=working
  - `osc_progress_blocked` → `jcode:blocked` → state=blocked  
  - `osc_progress_idle` → `jcode:idle` → state=idle
- Screen-scrape fallback rules remain at lower priority (80-300) for terminals that strip OSC sequences.
- **`src/detect/mod.rs`**: Added test `jcode_osc_progress_rules_detect_working_and_idle` covering all 3 OSC states plus screen-scrape fallback.
- Bumped manifest version to `2026.07.24.1`.

## How it works

jcode (companion PR: alecuba16/jcode#4) emits `ESC]9;jcode:<state> BEL` on every TUI redraw when status changes. herdr's `AgentOscStateTracker` captures the OSC 9 payload, and the new priority-1100 rules match it directly. This eliminates false positives from conversation text matching and version-dependent spinner/regex patterns.

## Priority ordering

| Priority | Rule | Region |
|----------|------|--------|
| 1100 | osc_progress_working | osc_progress |
| 1100 | osc_progress_blocked | osc_progress |
| 1100 | osc_progress_idle | osc_progress |
| 300 | permission_choice_blocker | bottom_non_empty_lines(8) |
| 290 | question_input_blocker | bottom_non_empty_lines(6) |
| 100 | spinner_working | bottom_non_empty_lines(3) |
| 80 | ready_prompt_idle | bottom_non_empty_lines(3) |

## Testing

- Manifest validated via tomllib: 3 OSC rules, correct contains values, priority ordering confirmed.
- Test covers all 3 OSC states (working/idle/blocked) plus screen-scrape fallback with no OSC.
- End-to-end byte sequence validated: jcode emits `ESC]9;jcode:<state>BEL`, herdr parser extracts `jcode:<state>` as payload, manifest `contains` rule matches.

## Note

Herdr build fails locally due to Zig v0.16.0 vs required v0.15.2 mismatch in vendored libghostty-vt (pre-existing, unrelated to these changes). Validated via toml parsing and test code inspection instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting **jcode** sessions and displaying working, blocked, and idle states.
  * Added reliable status detection through progress signals, with terminal-text fallback support.
  * Added a dedicated sound notification override for jcode, including configuration support.
* **Documentation**
  * Updated configuration guidance and agent detection documentation to include jcode.
* **Tests**
  * Added coverage for jcode status detection, fallback behavior, and sound configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->