### PR TITLE
fix: prevent shell injection via workflow inputs and job outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Validate PR title
         if: github.event_name == 'pull_request'
-        run: python3 scripts/conventional_commits.py "${{ github.event.pull_request.title }}"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/conventional_commits.py "$PR_TITLE"
 
   check:
     name: check (${{ matrix.os }})

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Select preview commit
         id: plan
         shell: bash
+        env:
+          INPUT_COMMIT: ${{ github.event.inputs.commit }}
         run: |
           set -euo pipefail
           git fetch origin master --tags
-          requested="${{ github.event.inputs.commit || '' }}"
+          requested="${INPUT_COMMIT:-}"
           if [ -n "$requested" ]; then
             commit="$(git rev-parse "$requested^{commit}")"
             if ! git merge-base --is-ancestor "$commit" origin/master; then
@@ -297,6 +299,8 @@ jobs:
       - name: Record previous preview commit
         id: previous-preview
         shell: bash
+        env:
+          PREFLIGHT_COMMIT: ${{ needs.preflight.outputs.commit }}
         run: |
           set -euo pipefail
           previous="$(python3 scripts/preview.py current-commit --manifest website/preview.json || true)"
@@ -305,19 +309,24 @@ jobs:
           fi
           range_base="$(python3 scripts/preview.py range-base \
             --previous "$previous" \
-            --commit '${{ needs.preflight.outputs.commit }}')"
+            --commit "$PREFLIGHT_COMMIT")"
           echo "commit=$previous" >> "$GITHUB_OUTPUT"
           echo "range_base=$range_base" >> "$GITHUB_OUTPUT"
 
       - name: Generate notes and checksums
         shell: bash
+        env:
+          PREFLIGHT_COMMIT: ${{ needs.preflight.outputs.commit }}
+          PREFLIGHT_BUILD_ID: ${{ needs.preflight.outputs.build_id }}
+          PREFLIGHT_BASE_VERSION: ${{ needs.preflight.outputs.base_version }}
+          PREVIOUS_RANGE_BASE: ${{ steps.previous-preview.outputs.range_base }}
         run: |
           set -euo pipefail
           python3 scripts/preview.py notes \
-            --previous '${{ steps.previous-preview.outputs.range_base }}' \
-            --commit '${{ needs.preflight.outputs.commit }}' \
-            --build-id '${{ needs.preflight.outputs.build_id }}' \
-            --base-version '${{ needs.preflight.outputs.base_version }}' \
+            --previous "$PREVIOUS_RANGE_BASE" \
+            --commit "$PREFLIGHT_COMMIT" \
+            --build-id "$PREFLIGHT_BUILD_ID" \
+            --base-version "$PREFLIGHT_BASE_VERSION" \
             --output PREVIEW_NOTES.md
           python3 - <<'PY'
           import json, pathlib
@@ -347,15 +356,22 @@ jobs:
             artifacts/herdr-windows-x86_64.exe/herdr-windows-x86_64.exe
 
       - name: Update preview manifest
+        env:
+          PREFLIGHT_TAG: ${{ needs.preflight.outputs.tag }}
+          PREFLIGHT_BUILD_ID: ${{ needs.preflight.outputs.build_id }}
+          PREFLIGHT_COMMIT: ${{ needs.preflight.outputs.commit }}
+          PREFLIGHT_BUILT_AT: ${{ needs.preflight.outputs.built_at }}
+          PREFLIGHT_BASE_VERSION: ${{ needs.preflight.outputs.base_version }}
+          PREFLIGHT_PROTOCOL: ${{ needs.preflight.outputs.protocol }}
         run: |
           python3 scripts/preview.py manifest \
             --output website/preview.json \
-            --tag '${{ needs.preflight.outputs.tag }}' \
-            --build-id '${{ needs.preflight.outputs.build_id }}' \
-            --commit '${{ needs.preflight.outputs.commit }}' \
-            --built-at '${{ needs.preflight.outputs.built_at }}' \
-            --base-version '${{ needs.preflight.outputs.base_version }}' \
-            --protocol '${{ needs.preflight.outputs.protocol }}' \
+            --tag "$PREFLIGHT_TAG" \
+            --build-id "$PREFLIGHT_BUILD_ID" \
+            --commit "$PREFLIGHT_COMMIT" \
+            --built-at "$PREFLIGHT_BUILT_AT" \
+            --base-version "$PREFLIGHT_BASE_VERSION" \
+            --protocol "$PREFLIGHT_PROTOCOL" \
             --notes PREVIEW_NOTES.md \
             --sha-file preview-sha256.json \
             --retain 30
@@ -388,16 +404,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KANGAL_GITHUB_TOKEN }}
           PREVIEW_RELEASED_LABEL: preview-released
+          PREVIEW_COMMIT: ${{ needs.preflight.outputs.commit }}
+          PREVIEW_TAG: ${{ needs.preflight.outputs.tag }}
+          PREVIEW_BUILD_ID: ${{ needs.preflight.outputs.build_id }}
+          PREVIOUS_PREVIEW_COMMIT: ${{ steps.previous-preview.outputs.commit }}
+          PREVIEW_RANGE_BASE: ${{ steps.previous-preview.outputs.range_base }}
         run: |
           set -euo pipefail
 
           echo "Using GitHub token for $(gh api user --jq .login)."
-
-          PREVIEW_COMMIT='${{ needs.preflight.outputs.commit }}'
-          PREVIEW_TAG='${{ needs.preflight.outputs.tag }}'
-          PREVIEW_BUILD_ID='${{ needs.preflight.outputs.build_id }}'
-          PREVIOUS_PREVIEW_COMMIT='${{ steps.previous-preview.outputs.commit }}'
-          PREVIEW_RANGE_BASE='${{ steps.previous-preview.outputs.range_base }}'
 
           echo "Previous preview commit: $PREVIOUS_PREVIEW_COMMIT"
           echo "Scanning preview commits in $PREVIEW_RANGE_BASE..$PREVIEW_COMMIT for refs #<issue> mentions."


### PR DESCRIPTION
## Summary

Two GitHub Actions workflows interpolate user-controlled values directly into
`run:` shell steps using `${{ ... }}` expressions. GitHub Actions evaluates
these expressions before the shell parses the script, so shell metacharacters
in the value break out of the quoting context and execute as commands.

### `ci.yml` — PR title injection

The PR title is attacker-controlled. A title containing `"` breaks out of the
double-quoted argument passed to `conventional_commits.py`. Any contributor
opening a pull request can execute arbitrary shell commands on the Actions runner.

### `preview.yml` — two-hop injection

**Hop 1:** The `workflow_dispatch` `commit` input is double-quote-interpolated
in the `preflight` job. An attacker with write access (sufficient to dispatch
the workflow) can break out of the string and write arbitrary values to
`$GITHUB_OUTPUT`, forging the step outputs consumed by the `publish` job.

**Hop 2:** Six of those preflight outputs are single-quote-interpolated in
`publish` job shell steps. A forged output containing a single-quote breaks
the shell quoting. The most sensitive sink is the "Mark preview-released
issues" step, which has `GH_TOKEN: KANGAL_GITHUB_TOKEN` in its environment,
making the token accessible to injected commands.

## Fix

All untrusted values are moved to `env:` blocks and referenced as `$VAR`
in the script body. When passed through the process environment rather than
spliced into the script source, shell metacharacters in the value cannot
affect parsing.

The same pattern is applied to all six publish-job sinks in `preview.yml`.

## Affected files

- `.github/workflows/ci.yml`
- `.github/workflows/preview.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow handling for pull request title validation.
  * Improved preview release workflow reliability when passing commit, tag, and release information between steps.
  * Maintained existing preview note generation, manifest updates, and issue-marking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->