### PR TITLE
fix: preserve focus when closing a non-focused workspace

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1630,6 +1630,10 @@ impl AppState {
                 crate::logging::workspace_closed(&workspace_id);
             }
         }
+        let active_workspace_id = self
+            .active
+            .and_then(|idx| self.workspaces.get(idx))
+            .map(|ws| ws.id.clone());
         self.remove_plugin_pane_records(pane_ids);
         for idx in close_indices.iter().rev() {
             self.workspaces.remove(*idx);
@@ -1642,6 +1646,12 @@ impl AppState {
             self.tab_scroll = 0;
             self.tab_scroll_follow_active = true;
         } else {
+            // Keep focus on the previously focused workspace
+            if let Some(id) = active_workspace_id {
+                if let Some(idx) = self.workspaces.iter().position(|ws| ws.id == id) {
+                    self.selected = idx;
+                }
+            }
             if self.selected >= self.workspaces.len() {
                 self.selected = self.workspaces.len() - 1;
             }
@@ -4497,6 +4507,22 @@ mod tests {
         assert_eq!(state.workspaces.len(), 1);
         assert_eq!(state.selected, 0);
         assert_eq!(state.active, Some(0));
+    }
+
+    #[test]
+    fn close_non_focused_workspace_keeps_focus() {
+        let mut state = app_with_workspaces(&["a", "b", "c"]);
+        state.selected = 1;
+        state.active = Some(0);
+
+        state.close_selected_workspace();
+
+        assert_eq!(state.workspaces.len(), 2);
+        assert_eq!(state.workspaces[0].display_name(), "a");
+        assert_eq!(state.workspaces[1].display_name(), "c");
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.active, Some(0));
+        state.assert_invariants_for_test();
     }
 
     #[test]


### PR DESCRIPTION
## Context

In herdr `v0.7.5`, closing a workspace through `herdr workspace close <id>` or closing a non-active entry from the sidebar will bring the focus to whichever workspace slid into the closed slot, instead of leaving focus where the user was.

## Changes

- Capture the focused workspace's stable `id` before removal, then use the `id` to restore the `selected`/`active` to its new index.
- New test: `close_non_focused_workspace_keeps_focus` — `[a,b,c]`, focused on `a`, close middle `b` -> focus stays on `a` (previously jumped to `c`)

## Test plan

- `just ci` ✅
- Built the binary locally and manually validated the behavior fix.
  - Create workspace A, B , C.
  - Focus on workspace A.
  - Use the side panel to close workspace C.
  - Assert that we're still focused on workspace A.

refs #1328