### PR TITLE
fix: serialize agent prompt submission

### DIFF
--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -8,6 +8,10 @@ use crate::app::App;
 
 use super::responses::{encode_error, encode_error_body, encode_success};
 
+// Claude and Codex can absorb Enter while settling a bracketed paste. Keep the
+// delay inside one PTY actor command so later input cannot interleave with it.
+const PROMPT_SUBMISSION_SETTLE_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
+
 impl App {
     pub(super) fn handle_agent_list(&mut self, id: String) -> String {
         encode_success(
@@ -94,8 +98,13 @@ impl App {
                 ),
             );
         }
-        let bytes = crate::app::api_helpers::encode_api_submission(runtime, &params.text);
-        if let Err(err) = runtime.try_send_bytes(Bytes::from(bytes)) {
+        let (text, enter) =
+            crate::app::api_helpers::encode_api_submission_parts(runtime, &params.text);
+        if let Err(err) = runtime.try_send_submission(
+            Bytes::from(text),
+            Bytes::from(enter),
+            PROMPT_SUBMISSION_SETTLE_DELAY,
+        ) {
             return encode_error(id, "agent_prompt_failed", err.to_string());
         }
         let Some(agent) = self.agent_info(resolved.ws_idx, resolved.pane_id) else {
@@ -338,9 +347,10 @@ mod tests {
         };
         assert_eq!(agent.name.as_deref(), Some("reviewer"));
         assert_eq!(
-            rx.try_recv().unwrap(),
-            Bytes::from_static(b"\x1b[200~A != B\x1b[201~\r")
+            rx.recv().await.unwrap(),
+            Bytes::from_static(b"\x1b[200~A != B\x1b[201~")
         );
+        assert_eq!(rx.recv().await.unwrap(), Bytes::from_static(b"\r"));
         assert!(rx.try_recv().is_err());
 
         app.lookup_runtime_sender(0, pane_id)
@@ -356,7 +366,8 @@ mod tests {
         );
         let raw: SuccessResponse = serde_json::from_str(&raw).unwrap();
         assert!(matches!(raw.result, ResponseResult::AgentPrompted { .. }));
-        assert_eq!(rx.try_recv().unwrap(), Bytes::from_static(b"A != B\r"));
+        assert_eq!(rx.recv().await.unwrap(), Bytes::from_static(b"A != B"));
+        assert_eq!(rx.recv().await.unwrap(), Bytes::from_static(b"\r"));
         assert!(rx.try_recv().is_err());
 
         let rejected = app.handle_agent_prompt(

--- a/src/app/api_helpers.rs
+++ b/src/app/api_helpers.rs
@@ -52,13 +52,21 @@ pub(super) fn encode_api_submission(
     runtime: &crate::terminal::TerminalRuntime,
     text: &str,
 ) -> Vec<u8> {
-    let mut bytes = encode_api_text(runtime, text);
+    let (mut bytes, enter) = encode_api_submission_parts(runtime, text);
+    bytes.extend_from_slice(&enter);
+    bytes
+}
+
+pub(super) fn encode_api_submission_parts(
+    runtime: &crate::terminal::TerminalRuntime,
+    text: &str,
+) -> (Vec<u8>, Vec<u8>) {
+    let bytes = encode_api_text(runtime, text);
     let enter = crossterm::event::KeyEvent::new(
         crossterm::event::KeyCode::Enter,
         crossterm::event::KeyModifiers::NONE,
     );
-    bytes.extend_from_slice(&runtime.encode_terminal_key(enter.into()));
-    bytes
+    (bytes, runtime.encode_terminal_key(enter.into()))
 }
 
 pub(super) fn encode_api_input(

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1107,6 +1107,29 @@ impl PaneRuntimeIo {
             PaneRuntimeIo::TestChannel { sender, .. } => sender.try_send(bytes),
         }
     }
+
+    fn try_send_submission(
+        &self,
+        text: Bytes,
+        enter: Bytes,
+        delay: std::time::Duration,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        match self {
+            PaneRuntimeIo::Actor(actor) => actor.try_write_submission(text, enter, delay)?,
+            #[cfg(test)]
+            PaneRuntimeIo::TestChannel { sender, .. } => {
+                sender.try_send(text)?;
+                let sender = sender.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(delay).await;
+                    if let Err(err) = sender.try_send(enter) {
+                        warn!(%err, "failed to send delayed test pane input");
+                    }
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2626,6 +2649,15 @@ impl PaneRuntime {
 
     pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
         self.io.try_send_bytes(bytes)
+    }
+
+    pub fn try_send_submission(
+        &self,
+        text: Bytes,
+        enter: Bytes,
+        delay: std::time::Duration,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        self.io.try_send_submission(text, enter, delay)
     }
 
     pub async fn send_paste(&self, text: String) -> Result<(), mpsc::error::SendError<Bytes>> {

--- a/src/pty/actor.rs
+++ b/src/pty/actor.rs
@@ -35,6 +35,15 @@ mod windows {
         terminal_responses: Vec<Bytes>,
     }
 
+    enum PtyIoDataCommand {
+        WriteUserInput(Bytes),
+        WriteSubmission {
+            text: Bytes,
+            enter: Bytes,
+            delay: Duration,
+        },
+    }
+
     pub(crate) struct PtyIoActorConfig {
         pub pane_id: u32,
         pub master: Box<dyn MasterPty + Send>,
@@ -50,7 +59,7 @@ mod windows {
 
     #[derive(Clone)]
     pub(crate) struct PtyIoActorHandle {
-        data_tx: mpsc::Sender<Bytes>,
+        data_tx: mpsc::Sender<PtyIoDataCommand>,
         control_tx: std_mpsc::Sender<PtyIoControlCommand>,
         accepting: Arc<Mutex<bool>>,
     }
@@ -67,7 +76,13 @@ mod windows {
             {
                 return Err(mpsc::error::SendError(bytes));
             }
-            self.data_tx.send(bytes).await
+            self.data_tx
+                .send(PtyIoDataCommand::WriteUserInput(bytes))
+                .await
+                .map_err(|err| match err.0 {
+                    PtyIoDataCommand::WriteUserInput(bytes) => mpsc::error::SendError(bytes),
+                    PtyIoDataCommand::WriteSubmission { text, .. } => mpsc::error::SendError(text),
+                })
         }
 
         pub(crate) fn try_write_user_input(
@@ -81,7 +96,45 @@ mod windows {
             {
                 return Err(mpsc::error::TrySendError::Closed(bytes));
             }
-            self.data_tx.try_send(bytes)
+            self.data_tx
+                .try_send(PtyIoDataCommand::WriteUserInput(bytes))
+                .map_err(|err| match err {
+                    mpsc::error::TrySendError::Full(PtyIoDataCommand::WriteUserInput(bytes)) => {
+                        mpsc::error::TrySendError::Full(bytes)
+                    }
+                    mpsc::error::TrySendError::Closed(PtyIoDataCommand::WriteUserInput(bytes)) => {
+                        mpsc::error::TrySendError::Closed(bytes)
+                    }
+                    _ => unreachable!("user input send returned a different command"),
+                })
+        }
+
+        pub(crate) fn try_write_submission(
+            &self,
+            text: Bytes,
+            enter: Bytes,
+            delay: Duration,
+        ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+            if !*self
+                .accepting
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+            {
+                return Err(mpsc::error::TrySendError::Closed(text));
+            }
+            self.data_tx
+                .try_send(PtyIoDataCommand::WriteSubmission { text, enter, delay })
+                .map_err(|err| match err {
+                    mpsc::error::TrySendError::Full(PtyIoDataCommand::WriteSubmission {
+                        text,
+                        ..
+                    }) => mpsc::error::TrySendError::Full(text),
+                    mpsc::error::TrySendError::Closed(PtyIoDataCommand::WriteSubmission {
+                        text,
+                        ..
+                    }) => mpsc::error::TrySendError::Closed(text),
+                    _ => unreachable!("submission send returned a different command"),
+                })
         }
 
         pub(crate) fn resize(
@@ -132,16 +185,25 @@ mod windows {
                 .take_writer()
                 .map_err(|err| std::io::Error::other(err.to_string()))?;
             let writer = Arc::new(Mutex::new(writer));
-            let (data_tx, mut data_rx) = mpsc::channel::<Bytes>(1024);
+            let (data_tx, mut data_rx) = mpsc::channel::<PtyIoDataCommand>(1024);
             let (control_tx, control_rx) = std_mpsc::channel::<PtyIoControlCommand>();
             let accepting = Arc::new(Mutex::new(!initially_quiesced));
 
             {
                 let writer = Arc::clone(&writer);
                 std::thread::spawn(move || {
-                    while let Some(bytes) = data_rx.blocking_recv() {
-                        if write_all_locked(&writer, &bytes).is_err() {
-                            break;
+                    while let Some(command) = data_rx.blocking_recv() {
+                        match command {
+                            PtyIoDataCommand::WriteUserInput(bytes) => {
+                                if write_all_locked(&writer, &bytes).is_err() {
+                                    break;
+                                }
+                            }
+                            PtyIoDataCommand::WriteSubmission { text, enter, delay } => {
+                                if write_submission_locked(&writer, &text, &enter, delay).is_err() {
+                                    break;
+                                }
+                            }
                         }
                     }
                     debug!(pane_id, "windows pty writer thread exiting");
@@ -220,6 +282,22 @@ mod windows {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         writer.write_all(bytes)?;
+        writer.flush()
+    }
+
+    fn write_submission_locked(
+        writer: &Arc<Mutex<Box<dyn Write + Send>>>,
+        text: &[u8],
+        enter: &[u8],
+        delay: Duration,
+    ) -> std::io::Result<()> {
+        let mut writer = writer
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        writer.write_all(text)?;
+        writer.flush()?;
+        std::thread::sleep(delay);
+        writer.write_all(enter)?;
         writer.flush()
     }
 

--- a/src/pty/actor/unix.rs
+++ b/src/pty/actor/unix.rs
@@ -72,6 +72,11 @@ pub(crate) struct PtyIoActorConfig {
 
 enum PtyIoDataCommand {
     WriteUserInput(Bytes),
+    WriteSubmission {
+        text: Bytes,
+        enter: Bytes,
+        delay: Duration,
+    },
 }
 
 enum PtyIoControlCommand {
@@ -154,6 +159,40 @@ impl PtyIoActorHandle {
             Err(mpsc::error::TrySendError::Closed(PtyIoDataCommand::WriteUserInput(bytes))) => {
                 Err(mpsc::error::TrySendError::Closed(bytes))
             }
+            Err(_) => unreachable!("user input send returned a different command"),
+        }
+    }
+
+    pub(crate) fn try_write_submission(
+        &self,
+        text: Bytes,
+        enter: Bytes,
+        delay: Duration,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        let user_writes = self
+            .user_writes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !user_writes.accepting {
+            return Err(mpsc::error::TrySendError::Closed(text));
+        }
+        match self
+            .data_tx
+            .try_send(PtyIoDataCommand::WriteSubmission { text, enter, delay })
+        {
+            Ok(()) => {
+                self.wake_actor();
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(PtyIoDataCommand::WriteSubmission {
+                text,
+                ..
+            })) => Err(mpsc::error::TrySendError::Full(text)),
+            Err(mpsc::error::TrySendError::Closed(PtyIoDataCommand::WriteSubmission {
+                text,
+                ..
+            })) => Err(mpsc::error::TrySendError::Closed(text)),
+            Err(_) => unreachable!("submission send returned a different command"),
         }
     }
 
@@ -524,6 +563,13 @@ impl PtyIoActorRunner {
                     self.enqueue_write(bytes);
                 }
             }
+            PtyIoDataCommand::WriteSubmission { text, enter, delay } => {
+                if self.state == ActorState::Running {
+                    if let Err(err) = self.process_submission(text, enter, delay) {
+                        warn!(pane = self.pane_id, %err, "failed to flush prompt text before submit");
+                    }
+                }
+            }
         }
         false
     }
@@ -581,14 +627,20 @@ impl PtyIoActorRunner {
                 "PTY actor was released before handoff quiesce",
             ));
         }
-        let deadline = Instant::now() + HANDOFF_DRAIN_TIMEOUT;
+        self.drain_pending_writes(HANDOFF_DRAIN_TIMEOUT)?;
+        self.state = ActorState::Quiesced;
+        Ok(())
+    }
+
+    fn drain_pending_writes(&mut self, timeout: Duration) -> std::io::Result<()> {
+        let deadline = Instant::now() + timeout;
         self.flush_pending_writes_once();
         while !self.pending_writes.is_empty() {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
-                    "timed out draining PTY writes before handoff",
+                    "timed out draining PTY writes",
                 ));
             }
             let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
@@ -612,14 +664,34 @@ impl PtyIoActorRunner {
                 self.flush_pending_writes_once();
             }
         }
-        self.state = ActorState::Quiesced;
+        Ok(())
+    }
+
+    fn process_submission(
+        &mut self,
+        text: Bytes,
+        enter: Bytes,
+        delay: Duration,
+    ) -> std::io::Result<()> {
+        self.enqueue_write(text);
+        self.drain_pending_writes(HANDOFF_DRAIN_TIMEOUT)?;
+        std::thread::sleep(delay);
+        self.enqueue_write(enter);
         Ok(())
     }
 
     fn drain_pre_quiesce_commands(&mut self) {
-        while let Ok(PtyIoDataCommand::WriteUserInput(bytes)) = self.data_rx.try_recv() {
-            if self.state != ActorState::Released {
-                self.enqueue_write(bytes);
+        while let Ok(command) = self.data_rx.try_recv() {
+            if self.state == ActorState::Released {
+                continue;
+            }
+            match command {
+                PtyIoDataCommand::WriteUserInput(bytes) => self.enqueue_write(bytes),
+                PtyIoDataCommand::WriteSubmission { text, enter, delay } => {
+                    if let Err(err) = self.process_submission(text, enter, delay) {
+                        warn!(pane = self.pane_id, %err, "failed to flush queued prompt before handoff");
+                    }
+                }
             }
         }
     }
@@ -861,6 +933,59 @@ mod tests {
         let mut buf = [0u8; 5];
         peer.read_exact(&mut buf).expect("peer receives write");
         assert_eq!(&buf, b"hello");
+        handle.shutdown();
+    }
+
+    #[test]
+    fn actor_submission_separates_enter_and_serializes_following_input() {
+        let (handle, mut peer, _read_rx) = actor_with_socket_pair(false);
+        let delay = Duration::from_millis(30);
+
+        let start = Instant::now();
+        handle
+            .try_write_submission(
+                Bytes::from_static(b"text"),
+                Bytes::from_static(b"\r"),
+                delay,
+            )
+            .expect("submission accepted");
+        handle
+            .try_write_user_input(Bytes::from_static(b"next"))
+            .expect("following input accepted");
+
+        let mut text = [0u8; 4];
+        peer.read_exact(&mut text)
+            .expect("peer receives prompt text");
+        assert_eq!(&text, b"text");
+        let mut remainder = [0u8; 5];
+        peer.read_exact(&mut remainder)
+            .expect("peer receives enter before following input");
+        assert_eq!(&remainder, b"\rnext");
+        assert!(start.elapsed() >= delay);
+        handle.shutdown();
+    }
+
+    #[test]
+    fn handoff_preserves_submission_delay() {
+        let (handle, mut peer, _read_rx) = actor_with_socket_pair(false);
+        let delay = Duration::from_millis(30);
+        let start = Instant::now();
+        handle
+            .try_write_submission(
+                Bytes::from_static(b"text"),
+                Bytes::from_static(b"\r"),
+                delay,
+            )
+            .expect("submission accepted");
+
+        handle
+            .begin_handoff(Duration::from_secs(1))
+            .expect("handoff completes");
+        let mut submitted = [0u8; 5];
+        peer.read_exact(&mut submitted)
+            .expect("peer receives complete submission");
+        assert_eq!(&submitted, b"text\r");
+        assert!(start.elapsed() >= delay);
         handle.shutdown();
     }
 

--- a/src/terminal/runtime.rs
+++ b/src/terminal/runtime.rs
@@ -411,6 +411,15 @@ impl TerminalRuntime {
         self.0.try_send_bytes(bytes)
     }
 
+    pub fn try_send_submission(
+        &self,
+        text: Bytes,
+        enter: Bytes,
+        delay: std::time::Duration,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        self.0.try_send_submission(text, enter, delay)
+    }
+
     pub async fn send_paste(&self, text: String) -> Result<(), mpsc::error::SendError<Bytes>> {
         self.0.send_paste(text).await
     }


### PR DESCRIPTION
## Summary

- send bracketed prompt text and Enter as one ordered PTY submission
- preserve submission ordering during PTY handoff and across Unix/Windows channels
- cover delayed Enter delivery and subsequent-input serialization

Closes #1878

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --all-targets -- --test-threads=1`
  - 2,845 unit tests passed
  - API and auto-detect integration suites passed
  - CLI suite: 95 passed; 3 existing process-termination checks failed in Docker because child PIDs survived their timeout
- focused agent prompt, PTY serialization, and handoff tests passed