### PR TITLE
fix(nix): include SKILL.md in the package fileset

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -48,6 +48,7 @@ rustPlatform.buildRustPackage {
         ../build.rs
         ../Cargo.lock
         ../Cargo.toml
+        ../SKILL.md
       ]
     );
   };


### PR DESCRIPTION
Fixes #1889

## Problem

`nix build .#default` fails on `master`:

```text
error: couldn't read `src/../SKILL.md`: No such file or directory (os error 2)
   --> src/main.rs:428:21
const SKILL: &str = include_str!("../SKILL.md");
```

`cb2e17a4` added the `include_str!` but `nix/package.nix` builds from an explicit `lib.fileset.unions` allowlist that doesn't list `SKILL.md`. The file is in the repo, so `cargo build` from a clone is fine — it just never reaches the Nix sandbox, so `packages.default` fails for every flake consumer.

## Change

One line: add `../SKILL.md` to the unions list.

## Verification

At `19cd372`:

- **before** — `nix build .#default` fails with the error above
- **after** — builds, and the feature works end to end:

```console
$ herdr --skill | head -3
---
name: herdr
description: "Control Herdr, a terminal multiplexer for coding agents. ..."

$ herdr --skill | wc -c
10140          # byte-for-byte identical to SKILL.md
```