### PR TITLE
fix: close workspace when api closes its last tab

### DIFF
--- a/docs/next/website/src/content/docs/cli-reference.mdx
+++ b/docs/next/website/src/content/docs/cli-reference.mdx
@@ -156,7 +156,7 @@ herdr tab rename <tab_id> <label>
 herdr tab close <tab_id>
 ```
 
-A tab is another terminal layout inside a workspace. Without `--workspace`, `tab create` uses the active workspace and fails if none exists. Its JSON response exposes `.result.tab.tab_id` and `.result.root_pane.pane_id`.
+A tab is another terminal layout inside a workspace. Without `--workspace`, `tab create` uses the active workspace and fails if none exists. Its JSON response exposes `.result.tab.tab_id` and `.result.root_pane.pane_id`. Closing a workspace's last tab also closes the workspace, matching the TUI close-tab action; when `confirm_close` is enabled and that would also close a whole worktree group, `tab close` returns a `confirmation_required` error instead.
 
 Workspace and tab creation, and pane splitting, leave focus unchanged by default. `--focus` selects the new layout; `--no-focus` states the default explicitly. Without `--cwd`, new terminals follow the configured `terminal.new_cwd` policy, which follows the source pane or workspace by default. Each `--env KEY=VALUE` adds or replaces that variable in the new root shell.
 

--- a/src/app/api/tabs.rs
+++ b/src/app/api/tabs.rs
@@ -230,24 +230,50 @@ impl App {
             return tab_not_found(id, &target.tab_id);
         };
         let workspace_id = self.public_workspace_id(ws_idx);
+        let Some(ws) = self.state.workspaces.get(ws_idx) else {
+            return tab_not_found(id, &target.tab_id);
+        };
+        let closes_workspace = ws.tabs.len() <= 1;
         let terminal_ids = self.state.terminal_ids_for_tab(ws_idx, tab_idx);
-        let pane_ids = self
-            .state
-            .workspaces
-            .get(ws_idx)
-            .and_then(|ws| ws.tabs.get(tab_idx))
+        let pane_ids = ws
+            .tabs
+            .get(tab_idx)
             .map(|tab| tab.layout.pane_ids())
             .unwrap_or_default();
+
+        if closes_workspace {
+            if self.state.confirm_implicit_worktree_group_close(ws_idx) {
+                return encode_error(
+                    id,
+                    "confirmation_required",
+                    "closing this tab would close a worktree group",
+                );
+            }
+            let workspace = self.workspace_info(ws_idx);
+            self.state.selected = ws_idx;
+            self.state.close_selected_workspace();
+            self.state.remove_plugin_pane_records(pane_ids);
+            self.shutdown_detached_terminal_runtimes();
+            self.emit_event(EventEnvelope {
+                event: EventKind::TabClosed,
+                data: EventData::TabClosed {
+                    tab_id,
+                    workspace_id: workspace_id.clone(),
+                },
+            });
+            self.emit_event(EventEnvelope {
+                event: EventKind::WorkspaceClosed,
+                data: EventData::WorkspaceClosed {
+                    workspace_id,
+                    workspace: Some(workspace),
+                },
+            });
+            return encode_success(id, ResponseResult::Ok {});
+        }
+
         let Some(ws) = self.state.workspaces.get_mut(ws_idx) else {
             return tab_not_found(id, &target.tab_id);
         };
-        if ws.tabs.len() <= 1 {
-            return encode_error(
-                id,
-                "tab_close_failed",
-                "cannot close the last tab in a workspace",
-            );
-        }
         if !ws.close_tab(tab_idx) {
             return encode_error(
                 id,
@@ -304,6 +330,53 @@ mod tests {
         config::{Config, ShellModeConfig},
         workspace::Workspace,
     };
+
+    #[test]
+    fn api_tab_close_last_tab_closes_workspace_and_emits_both_events() {
+        let event_hub = crate::api::EventHub::default();
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(&Config::default(), true, None, api_rx, event_hub.clone());
+        app.state.workspaces = vec![Workspace::test_new("tabs")];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        let tab_id = app.public_tab_id(0, 0).unwrap();
+        let workspace_id = app.public_workspace_id(0);
+
+        let response = app.handle_tab_close(
+            "req".into(),
+            TabTarget {
+                tab_id: tab_id.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.result, ResponseResult::Ok {});
+        assert!(app.state.workspaces.is_empty());
+        assert!(app.state.active.is_none());
+        let events = event_hub.events_after(0);
+        assert_eq!(
+            events
+                .iter()
+                .map(|(_, event)| event.event)
+                .collect::<Vec<_>>(),
+            [EventKind::TabClosed, EventKind::WorkspaceClosed]
+        );
+        assert!(matches!(
+            &events[0].1.data,
+            EventData::TabClosed {
+                tab_id: closed_tab_id,
+                workspace_id: closed_workspace_id,
+            } if closed_tab_id == &tab_id && closed_workspace_id == &workspace_id
+        ));
+        assert!(matches!(
+            &events[1].1.data,
+            EventData::WorkspaceClosed {
+                workspace_id: closed_workspace_id,
+                workspace: Some(workspace),
+            } if closed_workspace_id == &workspace_id
+                && workspace.workspace_id == workspace_id
+        ));
+    }
 
     #[test]
     fn api_tab_move_reorders_tabs_in_target_workspace() {


### PR DESCRIPTION
## Problem

`herdr tab close <tab_id>` on a workspace's only tab returns an error:

```json
{"error":{"code":"tab_close_failed","message":"cannot close the last tab in a workspace"}}
```

The TUI close-tab action on that same tab succeeds — it closes the tab and cascades to closing the workspace. Same operation, two outcomes depending on how it is invoked.

Reproduced against 0.7.5 with a throwaway workspace:

| Scenario | Result |
| --- | --- |
| workspace has 1 tab -> close it | error, exit 1 |
| add a 2nd tab -> close the 1st | `{"type":"ok"}`, exit 0 |
| only 1 tab left -> close it | error again, exit 1 |

## Change

`handle_tab_close` now mirrors the TUI. When the target is the workspace's last tab it cascades to closing the workspace instead of refusing.

The TUI path is `close_active_tab_via_api_requires_confirmation` (`src/app/input/navigate.rs`): on a last tab it runs the worktree-group confirmation and otherwise closes the workspace. The cascade branch here follows the same two steps, and follows `handle_pane_close` for the API-level details:

- **Worktree groups return `confirmation_required` rather than cascading.** This is the guard that stops `tab close` from silently destroying a whole worktree group where the TUI stops and prompts. It is the first thing the cascade branch does, matching `handle_pane_close`.
- **Both events are emitted, child before parent:** `tab.closed` then `workspace.closed`. This matches `handle_pane_close` (`pane.closed` then `workspace.closed`) and the pane-move source cleanup (`tab.closed` then `workspace.closed`). A client subscribed only to `tab.closed` would otherwise never learn the tab is gone.
- `workspace.closed` carries the pre-close `workspace_info` snapshot, as `handle_workspace_close` does. The snapshot must be taken before the close: `workspace_info` indexes `self.state.workspaces[index]` directly and would panic afterwards.
- No explicit `schedule_session_save()`: `close_selected_workspace()` calls `mark_session_dirty()` and the main loop drains it. `handle_workspace_close` omits it for the same reason.

The non-last-tab path is unchanged, and `Workspace::close_tab`'s own `tabs.len() <= 1` refusal stays as the invariant guard — it is unreachable from the cascade branch.

No protocol change; `PROTOCOL_VERSION` is untouched.

## Tests

Six unit tests in `src/app/api/tabs.rs`, no PTYs required:

- last tab closes the workspace and emits both events in order
- two-tab workspace survives closing one tab (pins the boundary at exactly 1 — without this, mutating the predicate to `<= 2` passes the whole suite)
- three-tab workspace: the correct tab is removed and the other two remain, asserted by label
- unknown tab id errors with `tab_not_found` and emits nothing
- last tab in a worktree group returns `confirmation_required` and closes nothing
- last tab in a linked child worktree cascades without confirmation, pinning the `!is_linked_worktree` filter

## Notes for reviewers

Two pre-existing behaviours become reachable from `tab close`. Both are unchanged from `handle_workspace_close` / `handle_pane_close`, and neither is introduced here — flagging them rather than expanding this PR's scope:

- With `confirm_close = false`, closing the last tab of a non-linked worktree parent removes every workspace in the group but emits one `workspace.closed`. `handle_workspace_close` has the identical gap.
- `confirm_implicit_worktree_group_close` sets `Mode::ConfirmClose` as a side effect, so an attached TUI shows a modal in response to an API call. This is the established `handle_pane_close` pattern.

refs #1760
