### PR TITLE
fix: keep nested codex sessions from replacing pane owner

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2833,6 +2833,12 @@
             "pane_id": {
               "type": "string"
             },
+            "parent_agent_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "seq": {
               "format": "uint64",
               "minimum": 0,

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -341,6 +341,8 @@ pub struct PaneReportAgentSessionParams {
     pub agent_session_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_start_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_agent_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2827,14 +2827,16 @@ impl AppState {
                 seq,
                 session_ref,
                 session_start_source,
+                parent_session_ref,
             } => self
                 .update_terminal_state(pane_id, |terminal| {
-                    terminal.set_agent_session_ref_for_session_start(
+                    terminal.set_agent_session_ref_from_report(
                         source,
                         agent_label,
                         session_ref,
                         seq,
                         session_start_source,
+                        parent_session_ref,
                     )
                 })
                 .into_iter()

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1243,6 +1243,12 @@ impl App {
         let Some(agent_label) = normalize_reported_agent_label(&params.agent) else {
             return invalid_agent(id);
         };
+        let parent_session_ref = crate::agent_resume::session_ref_from_report(
+            &params.source,
+            &agent_label,
+            params.parent_agent_session_id,
+            None,
+        );
         self.handle_internal_event(crate::events::AppEvent::AgentSessionReported {
             pane_id,
             session_ref: crate::agent_resume::session_ref_from_report(
@@ -1257,6 +1263,7 @@ impl App {
             session_start_source: crate::agent_resume::normalize_session_start_source(
                 params.session_start_source,
             ),
+            parent_session_ref,
         });
 
         encode_success(id, ResponseResult::Ok {})

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1131,7 +1131,7 @@ fn pane_report_agent(args: &[String]) -> std::io::Result<i32> {
 
 fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
     let Some(raw_pane_id) = args.first() else {
-        eprintln!("usage: herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH] [--session-start-source SOURCE]");
+        eprintln!("usage: herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH] [--session-start-source SOURCE] [--parent-agent-session-id ID]");
         return Ok(2);
     };
 
@@ -1142,6 +1142,7 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
     let mut agent_session_id = None;
     let mut agent_session_path = None;
     let mut session_start_source = None;
+    let mut parent_agent_session_id = None;
 
     let mut index = 1;
     while index < args.len() {
@@ -1194,6 +1195,14 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
                 session_start_source = Some(value.clone());
                 index += 2;
             }
+            "--parent-agent-session-id" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --parent-agent-session-id");
+                    return Ok(2);
+                };
+                parent_agent_session_id = Some(value.clone());
+                index += 2;
+            }
             other => {
                 eprintln!("unknown option: {other}");
                 return Ok(2);
@@ -1222,6 +1231,7 @@ fn pane_report_agent_session(args: &[String]) -> std::io::Result<i32> {
             agent_session_id,
             agent_session_path,
             session_start_source,
+            parent_agent_session_id,
         },
     ))
 }
@@ -1511,7 +1521,7 @@ fn print_pane_help() {
     eprintln!("  herdr pane send-keys <pane_id> <key> [key ...]");
     eprintln!("  herdr pane wait-output <pane_id> (--match TEXT | --regex PATTERN) [--source visible|recent|recent-unwrapped] [--lines N] [--timeout MS] [--raw]");
     eprintln!("  herdr pane report-agent <pane_id> --source ID --agent LABEL --state idle|working|blocked|unknown [--message TEXT] [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
-    eprintln!("  herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]");
+    eprintln!("  herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH] [--session-start-source SOURCE] [--parent-agent-session-id ID]");
     eprintln!("  herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N]");
     eprintln!("  herdr pane report-metadata <pane_id> --source ID [--agent LABEL] [--applies-to-source ID] [--title TEXT|--clear-title] [--display-agent TEXT|--clear-display-agent] [--state-label STATUS=TEXT] [--clear-state-labels] [--token NAME=VALUE] [--clear-token NAME] [--seq N] [--ttl-ms N]");
     eprintln!("  herdr pane run <pane_id> <command>");

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -645,6 +645,7 @@ fn report_agent_session_command() -> Command {
         .arg(option("agent-session-id", "ID"))
         .arg(path_option("agent-session-path", "PATH"))
         .arg(option("session-start-source", "SOURCE"))
+        .arg(option("parent-agent-session-id", "ID"))
 }
 
 fn release_agent_command() -> Command {

--- a/src/events.rs
+++ b/src/events.rs
@@ -84,6 +84,7 @@ pub enum AppEvent {
         seq: Option<u64>,
         session_ref: Option<crate::agent_resume::AgentSessionRef>,
         session_start_source: Option<String>,
+        parent_session_ref: Option<crate::agent_resume::AgentSessionRef>,
     },
     /// Display-only agent metadata was reported for a pane.
     HookMetadataReported {

--- a/src/integration/assets/codex/herdr-agent-state.ps1
+++ b/src/integration/assets/codex/herdr-agent-state.ps1
@@ -2,7 +2,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=codex
-# HERDR_INTEGRATION_VERSION=6
+# HERDR_INTEGRATION_VERSION=7
 
 param([string]$Action = "")
 
@@ -39,6 +39,9 @@ try {
     )
     if ($payload.hook_event_name -eq "SessionStart" -and $payload.source -is [string] -and -not [string]::IsNullOrWhiteSpace($payload.source)) {
         $args += @("--session-start-source", "$($payload.source)")
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:CODEX_THREAD_ID) -and $env:CODEX_THREAD_ID -ne $sessionId) {
+        $args += @("--parent-agent-session-id", "$env:CODEX_THREAD_ID")
     }
     & herdr @args 2>$null | Out-Null
 } catch {

--- a/src/integration/assets/codex/herdr-agent-state.sh
+++ b/src/integration/assets/codex/herdr-agent-state.sh
@@ -3,7 +3,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=codex
-# HERDR_INTEGRATION_VERSION=6
+# HERDR_INTEGRATION_VERSION=7
 
 set -eu
 
@@ -56,6 +56,9 @@ request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):0
 report_seq = time.time_ns()
 session_id = hook_input.get("session_id")
 agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+parent_agent_session_id = os.environ.get("CODEX_THREAD_ID")
+if parent_agent_session_id == agent_session_id:
+    parent_agent_session_id = None
 session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
 if not isinstance(session_start_source, str) or not session_start_source:
     session_start_source = None
@@ -69,6 +72,8 @@ if agent_session_id:
     }
     if session_start_source:
         params["session_start_source"] = session_start_source
+    if parent_agent_session_id:
+        params["parent_agent_session_id"] = parent_agent_session_id
     request = {
         "id": request_id,
         "method": "pane.report_agent_session",

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -47,7 +47,7 @@ const CODEX_HOOK_ASSET: &str = if cfg!(windows) {
 } else {
     include_str!("assets/codex/herdr-agent-state.sh")
 };
-const CODEX_INTEGRATION_VERSION: u32 = 6;
+const CODEX_INTEGRATION_VERSION: u32 = 7;
 const KIMI_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -1238,7 +1238,7 @@ fn codex_v2_integration_status_is_outdated() {
 
     assert_eq!(codex.path, hook_path);
     assert_eq!(codex.installed_version, Some(2));
-    assert_eq!(codex.expected_version, 6);
+    assert_eq!(codex.expected_version, 7);
     assert_eq!(codex.state, IntegrationStatusKind::Outdated);
 
     std::env::remove_var("HOME");
@@ -2709,6 +2709,7 @@ fn bundled_integration_assets_report_session_refs() {
         CODEX_HOOK_ASSET.contains("session_start_source")
             || CODEX_HOOK_ASSET.contains("--session-start-source")
     );
+    assert!(CODEX_HOOK_ASSET.contains("CODEX_THREAD_ID"));
     assert!(
         CODEX_HOOK_ASSET.contains("pane.report_agent_session")
             || CODEX_HOOK_ASSET.contains("report-agent-session")

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -109,6 +109,7 @@ impl PaneLaunchEnv {
 }
 
 fn apply_pane_launch_env(cmd: &mut CommandBuilder, launch_env: &PaneLaunchEnv) {
+    cmd.env_remove("CODEX_THREAD_ID");
     for (key, value) in &launch_env.extra {
         cmd.env(key, value);
     }

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -1326,6 +1326,25 @@ impl TerminalState {
         seq: Option<u64>,
         session_start_source: Option<String>,
     ) -> Option<TerminalStateMutation> {
+        self.set_agent_session_ref_from_report(
+            source,
+            agent_label,
+            session_ref,
+            seq,
+            session_start_source,
+            None,
+        )
+    }
+
+    pub fn set_agent_session_ref_from_report(
+        &mut self,
+        source: String,
+        agent_label: String,
+        session_ref: Option<crate::agent_resume::AgentSessionRef>,
+        seq: Option<u64>,
+        session_start_source: Option<String>,
+        parent_session_ref: Option<crate::agent_resume::AgentSessionRef>,
+    ) -> Option<TerminalStateMutation> {
         let session_ref = session_ref?;
         let known_agent = crate::detect::parse_agent_label(&agent_label);
         let process_present = known_agent.is_some()
@@ -1411,6 +1430,19 @@ impl TerminalState {
             return None;
         }
         if self.known_agent_label_conflicts_with_detected_agent(&agent_label) {
+            return None;
+        }
+        let nested_session = parent_session_ref
+            .as_ref()
+            .is_some_and(|parent_session_ref| {
+                parent_session_ref != &session_ref
+                    && self.current_session_identity_for_persistence().is_some_and(
+                        |(current_source, current_agent, _, _)| {
+                            current_source == source && current_agent == agent_label
+                        },
+                    )
+            });
+        if nested_session {
             return None;
         }
         let session_replacement_allowed = Self::session_start_source_allows_session_replacement(
@@ -4398,6 +4430,44 @@ mod tests {
                 Some(next_session.as_str())
             );
         }
+
+        let mut terminal = test_terminal();
+        terminal
+            .set_agent_session_ref(
+                "herdr:codex".into(),
+                "codex".into(),
+                crate::agent_resume::AgentSessionRef::id("codex-session"),
+                Some(20),
+            )
+            .expect("initial session should be accepted");
+
+        let mutation = terminal.set_agent_session_ref_from_report(
+            "herdr:codex".into(),
+            "codex".into(),
+            crate::agent_resume::AgentSessionRef::id("nested-session"),
+            Some(21),
+            Some("startup".into()),
+            crate::agent_resume::AgentSessionRef::id("codex-session"),
+        );
+
+        assert!(mutation.is_none());
+        let mutation = terminal.set_agent_session_ref_from_report(
+            "herdr:codex".into(),
+            "codex".into(),
+            crate::agent_resume::AgentSessionRef::id("deeply-nested-session"),
+            Some(22),
+            Some("startup".into()),
+            crate::agent_resume::AgentSessionRef::id("nested-session"),
+        );
+
+        assert!(mutation.is_none());
+        assert_eq!(
+            terminal
+                .persisted_agent_session
+                .as_ref()
+                .map(|session| session.session_ref.value.as_str()),
+            Some("codex-session")
+        );
     }
 
     #[test]

--- a/tests/cli/hooks.rs
+++ b/tests/cli/hooks.rs
@@ -8,14 +8,6 @@ fn run_claude_hook(action: &str, hook_input: &str) -> Option<serde_json::Value> 
     )
 }
 
-fn run_codex_hook(action: &str, hook_input: &str) -> Option<serde_json::Value> {
-    run_shell_hook(
-        "src/integration/assets/codex/herdr-agent-state.sh",
-        &[action],
-        hook_input,
-    )
-}
-
 fn run_copilot_hook(hook_input: &str) -> Option<serde_json::Value> {
     run_shell_hook(
         "src/integration/assets/copilot/herdr-agent-state.sh",
@@ -151,14 +143,20 @@ fn claude_hook_reports_session_id_from_stdin() {
 
 #[test]
 fn codex_hook_reports_session_id_from_stdin() {
-    let request = run_codex_hook(
-        "session",
+    let request = run_shell_hook_with_env(
+        "src/integration/assets/codex/herdr-agent-state.sh",
+        &["session"],
         r#"{"hook_event_name":"SessionStart","session_id":"codex-session"}"#,
+        &[("CODEX_THREAD_ID", "parent-session")],
     )
     .expect("codex hook should report session identity");
 
     assert_eq!(request["method"], "pane.report_agent_session");
     assert_eq!(request["params"]["agent_session_id"], "codex-session");
+    assert_eq!(
+        request["params"]["parent_agent_session_id"],
+        "parent-session"
+    );
     assert!(request["params"].get("state").is_none());
 }
 


### PR DESCRIPTION
## Summary

- keep the pane's owning Codex session when a nested Codex process reports `SessionStart`
- pass the inherited parent thread ID through the Codex integration hook
- clear inherited `CODEX_THREAD_ID` when Herdr launches a new pane shell

## Testing

- `cargo test --locked --bin herdr codex_lifecycle_session_ref_replaces_existing_session_ref`
- `cargo test --locked --bin herdr codex_v2_integration_status_is_outdated`
- Windows PowerShell hook behavior check
- `cargo clippy --bin herdr --locked -- -D warnings`
- `cargo fmt --check`

Native `just ci` currently reaches Unix-only integration targets on Windows; GitHub CI will run the full suite.

Refs #1789