### PR TITLE
fix: clear host mouse reporting after leaving the alternate screen (#1713 / #1332)

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -595,6 +595,12 @@ fn restore_terminal_state(
     }
 
     ratatui::restore();
+    // Clear host mouse reporting again *after* leaving the alternate screen.
+    // Some terminals (e.g. Ghostty) track DEC private modes per screen buffer
+    // and restore the primary screen's saved mouse-tracking state on
+    // LeaveAlternateScreen, re-enabling it after the pre-restore clear above.
+    // See issue #1713 (follow-up to #939).
+    let _ = crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout());
     let _ = write_terminal_restore_postlude(&mut io::stdout(), reset_host_color_scheme_reports);
 
     #[cfg(windows)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -774,6 +774,10 @@ fn main() -> io::Result<()> {
         let _ = set_host_color_scheme_reports(false);
         let _ = pop_keyboard_enhancement_flags();
         ratatui::restore();
+        // Re-clear after leaving the alternate screen: some terminals restore
+        // the primary screen's saved mouse-tracking state on
+        // LeaveAlternateScreen, undoing the pre-restore clear. See issue #1713.
+        let _ = crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout());
         original_hook(info);
     }));
 
@@ -840,6 +844,10 @@ fn main() -> io::Result<()> {
         crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout())?;
         set_host_color_scheme_reports(false)?;
         ratatui::restore();
+        // Re-clear after leaving the alternate screen: some terminals restore
+        // the primary screen's saved mouse-tracking state on
+        // LeaveAlternateScreen, undoing the pre-restore clear. See issue #1713.
+        crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout())?;
 
         // Drop app (and all workspaces/panes) before runtime shuts down
         drop(app);

--- a/src/terminal_modes.rs
+++ b/src/terminal_modes.rs
@@ -61,4 +61,41 @@ mod tests {
             );
         }
     }
+
+    // Regression test for issue #1713: after leaving the alternate screen,
+    // teardown clears host mouse reporting a *second* time. Terminals that
+    // track DEC private modes per screen buffer restore the primary screen's
+    // saved mouse-tracking state on LeaveAlternateScreen, so a single
+    // pre-restore clear is not enough. This asserts that calling
+    // `clear_host_mouse_reporting` twice (mirroring the pre-restore and
+    // post-restore calls in the teardown paths) is idempotent and always
+    // re-emits the full disable sequence — including SGR mode 1006, the
+    // source of the stray `35;22;52M`-style reports in the bug report.
+    #[test]
+    fn second_clear_after_restore_reemits_full_disable_sequence() {
+        let mut output = Vec::new();
+
+        // Pre-restore clear (before ratatui::restore leaves the alt screen).
+        clear_host_mouse_reporting(&mut output).unwrap();
+        // Post-restore clear (the fix): must re-emit the disable sequence so
+        // the primary screen's restored mouse-tracking state is cleared.
+        clear_host_mouse_reporting(&mut output).unwrap();
+
+        let expected: Vec<u8> = if cfg!(windows) {
+            Vec::new()
+        } else {
+            let mut e = DISABLE_HOST_MOUSE_REPORTING_SEQUENCE.to_vec();
+            e.extend_from_slice(DISABLE_HOST_MOUSE_REPORTING_SEQUENCE);
+            e
+        };
+        assert_eq!(output, expected);
+
+        // On non-Windows, the SGR mouse disable (1006) — the mode responsible
+        // for the stray reports in issue #1713 — must appear twice after the
+        // pre- and post-restore clears.
+        if !cfg!(windows) {
+            let text = std::str::from_utf8(&output).unwrap();
+            assert_eq!(text.matches("\x1b[?1006l").count(), 2);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

After a remote/SSH disconnect (e.g. `herdr --remote <host>`), the local terminal is left in mouse-reporting mode and emits stray SGR mouse sequences (e.g. `35;22;52M`) on every mouse movement. Recovery requires running `reset`.

## Root cause

`clear_host_mouse_reporting()` ran *before* `ratatui::restore()` left the alternate screen. Terminals like Ghostty track DEC private modes **per screen buffer**, so leaving the alt screen on `LeaveAlternateScreen` restores the primary screen's still-enabled mouse-tracking state — undoing the pre-restore clear, with nothing clearing it afterwards.

This is a follow-up to #939, which added the clear but placed it before the alt screen was left (wrong ordering).

## Fix

Re-clear host mouse reporting immediately *after* each `ratatui::restore()` at all three teardown sites:

- `client::restore_terminal_state` (`src/client/mod.rs`) — the function reached via `TerminalGuard::Drop`
- the panic hook in `src/main.rs`
- the normal teardown in `src/main.rs`

The existing pre-restore clears are kept (the disable sequence is idempotent). The resulting order in `restore_terminal_state` is now: pre-restore clear -> `ratatui::restore()` (leaves alt screen) -> **post-restore clear** -> postlude, so the disable sequence lands on the primary screen after its saved mouse state is restored.

## Testing

- Build passes (`cargo build --bin herdr`).
- Full suite: **2851 pass**. A set of `detect::manifest*` tests (e.g. `detect::manifest::tests::local_override_shadows_cached_remote_manifest`, `detect::manifest_update::tests::process_agent_manifest_commits_newer_manifest_atomically`) is flaky under parallel execution due to shared global cache/config state — the exact failing set is non-deterministic across runs, all pass in isolation / single-threaded, and the **same tests fail identically on the pristine `master` tree**, so they are pre-existing and unrelated to this change.
- Added regression test `terminal_modes::tests::second_clear_after_restore_reemits_full_disable_sequence`, which asserts the pre/post-restore double-clear re-emits the full disable sequence (including SGR mode `1006l`, the source of the stray reports).

## Scope note

This fixes the `herdr --remote` teardown path (the path #1713 reports): the remote thin client sets up its terminal via `setup_terminal` -> `TerminalGuard`, whose `Drop` (and the client panic hook) call `restore_terminal_state()` — the function fixed here.

The `ssh -t <host> 'herdr agent attach ...'` direct-attach-over-plain-SSH path has a **separate root cause**: on abrupt disconnect the remote process receives `SIGHUP` and dies before any `Drop`/panic-hook teardown runs, so no cleanup fires at all. Fixing that requires a signal handler and **will be addressed in a separate follow-up PR**.

Because the `agent attach`/SIGHUP path remains, this does not fully close #1713. **Addresses the `--remote` path of #1713 and #1332; the `agent attach`/SIGHUP path will follow in a separate PR.**