### PR TITLE
fix: keep focus on the current workspace when another self-closes

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -3326,6 +3326,11 @@ impl AppState {
         self.mark_session_dirty();
 
         if should_close_workspace {
+            let active_workspace_id = self
+                .active
+                .and_then(|idx| self.workspaces.get(idx))
+                .map(|ws| ws.id.clone());
+            let selected_workspace_id = self.workspaces.get(self.selected).map(|ws| ws.id.clone());
             self.workspaces.remove(ws_idx);
             self.remove_unattached_terminal_ids(workspace_terminal_ids);
             if self.workspaces.is_empty() {
@@ -3335,14 +3340,29 @@ impl AppState {
                     self.mode = Mode::Navigate;
                 }
             } else {
+                // Keep focus on the previously focused workspace
+                if let Some(id) = active_workspace_id {
+                    if let Some(idx) = self.workspaces.iter().position(|ws| ws.id == id) {
+                        self.active = Some(idx);
+                    }
+                }
                 if let Some(active) = self.active {
                     if active >= self.workspaces.len() {
                         self.active = Some(self.workspaces.len() - 1);
                     }
                 }
+                if let Some(id) = selected_workspace_id {
+                    if let Some(idx) = self.workspaces.iter().position(|ws| ws.id == id) {
+                        self.selected = idx;
+                    }
+                }
                 if self.selected >= self.workspaces.len() {
                     self.selected = self.workspaces.len() - 1;
                 }
+                self.workspace_scroll = self
+                    .workspace_scroll
+                    .min(self.workspaces.len().saturating_sub(1));
+                self.ensure_workspace_visible(self.selected);
             }
         } else {
             self.remove_unattached_terminal_ids(pane_terminal_id);
@@ -4642,6 +4662,34 @@ mod tests {
         assert_eq!(state.workspaces[1].display_name(), "c");
         assert_eq!(state.selected, 0);
         assert_eq!(state.active, Some(0));
+        state.assert_invariants_for_test();
+    }
+
+    #[test]
+    fn pane_died_self_closing_earlier_workspace_keeps_focus() {
+        let names = (0..20).map(|i| format!("ws{i:02}")).collect::<Vec<_>>();
+        let name_refs = names.iter().map(String::as_str).collect::<Vec<_>>();
+        let mut state = app_with_workspaces(&name_refs);
+        state.selected = 1;
+        state.active = Some(1);
+        // Constrain the sidebar viewport so the focused workspace starts
+        // off-screen: 20 workspaces cannot all fit in 12 rows, so index 1 is
+        // hidden at maximum scroll regardless of individual card height.
+        state.view.sidebar_rect = ratatui::layout::Rect::new(0, 0, 30, 12);
+        state.workspace_scroll =
+            crate::ui::normalized_workspace_scroll(&state, state.view.sidebar_rect, usize::MAX / 2);
+        let cards = crate::ui::compute_workspace_card_areas(&state, state.view.sidebar_rect);
+        assert!(cards.iter().all(|card| card.ws_idx != 1));
+
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        state.handle_pane_died(pane_id);
+
+        assert_eq!(state.workspaces.len(), 19);
+        assert_eq!(state.workspaces[0].display_name(), "ws01");
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.active, Some(0));
+        let cards = crate::ui::compute_workspace_card_areas(&state, state.view.sidebar_rect);
+        assert!(cards.iter().any(|card| card.ws_idx == 0));
         state.assert_invariants_for_test();
     }
 


### PR DESCRIPTION
## Problem

When a workspace closes itself because its last pane's process ended, focus moves off the workspace the user was working in.

With workspaces `[x, y, z]` and focus on `y`, ending `x`'s last pane leaves the user on `z`.

`handle_pane_died` only *clamps* the stale indices after `self.workspaces.remove(ws_idx)`; it never *shifts* them down when the removed workspace sat before the focused one:

```rust
if let Some(active) = self.active {
    if active >= self.workspaces.len() {
        self.active = Some(self.workspaces.len() - 1);
    }
}
```

`active = 1` (`y`), removing index 0 leaves `[y, z]`. Now `1 < 2`, so no clamp fires and `active = 1` points at `z`.

This also explains why the reporter's three non-buggy cases only look correct by accident — in each, the stale index happened to exceed the new length and got clamped back onto the right workspace:

| Focused | Closes | Stale index | Clamped? | Result |
| --- | --- | --- | --- | --- |
| `y` (1 of 3) | `x` (0) | 1, len 2 | no | **wrong — lands on `z`** |
| `y` (1 of 3) | `z` (2) | 1, len 2 | no | correct, index still valid |
| `z` (2 of 3) | `x` (0) | 2, len 2 | yes | correct by coincidence |
| `y` (1 of 2) | `x` (0) | 1, len 1 | yes | correct by coincidence |

## Change

`close_selected_workspace` already handles this correctly: it captures the focused workspace's `id` before removal and re-resolves the index by that `id` afterward. `handle_pane_died` now does the same for both `active` and `selected`.

The existing clamp is kept as the fallback for when the removed workspace *was* the focused one, since its `id` no longer resolves. The empty-workspaces branch and the `Mode::Terminal` -> `Mode::Navigate` transition are untouched.

Two statements were also added to match `close_selected_workspace`'s non-empty branch:

```rust
self.workspace_scroll = self.workspace_scroll.min(self.workspaces.len().saturating_sub(1));
self.ensure_workspace_visible(self.selected);
```

Without them the indices resolve correctly but the sidebar scroll offset is left stale, so the focused workspace can end up scrolled out of view — `compute_view()` only clamps the offset to the valid maximum, which can still be wrong. `ensure_workspace_visible` is bounds-guarded and also covers the mobile switcher.

No protocol change; `PROTOCOL_VERSION` is untouched.

## Test

One regression test, `pane_died_self_closing_earlier_workspace_keeps_focus`, using `AppState::test_new()` — no PTYs.

It covers both halves in one test, and I verified it is not vacuous by removing each production change independently:

| Mutation | Result |
| --- | --- |
| remove the id-based resolution | fails: `left: 1, right: 0` — focus on the wrong workspace |
| remove `ensure_workspace_visible` | fails: `assertion failed: cards.iter().any(\|card\| card.ws_idx == 0)` — focused workspace hidden |
| both present | passes |

The test builds 20 workspaces against a 12-row `view.sidebar_rect` and scrolls to the maximum, so the focused workspace is provably off-screen before the removal no matter how tall an individual card is. It asserts that precondition explicitly, so the visibility assertion is doing real work rather than passing trivially.

The first version of this test used 3 workspaces and relied on them not all fitting in the viewport. That held on my machine and on Windows CI but not on ubuntu/macOS CI, where all three cards fit and the precondition failed. The counting argument above replaces that assumption.

`cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and the full `cargo nextest` suite pass. `assert_invariants_for_test()` is asserted at the end of the test.

refs #1621
