### PR TITLE
Feat/hover feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ __pycache__/
 
 /.wrangler/
 **/.wrangler/
+# Local Pi runtime state
+.atl/

--- a/.scratch/hover-feedback/PRD.md
+++ b/.scratch/hover-feedback/PRD.md
@@ -1,0 +1,63 @@
+# Spec: Subtle hover feedback for TUI interactive elements
+
+## Problem Statement
+
+The user is facing a lack of visual hover feedback when passing the mouse cursor over interactive links/buttons in the Herdr TUI (such as `new`, `menu`, tab scroll controls, and workspace/agent list cards). This makes it difficult to verify if the mouse cursor is correctly positioned before clicking, and violates the mouse-first design principle of the application.
+
+## Solution
+
+Introduce a subtle hover feedback mechanism using the existing TUI color palette. When the mouse moves over an interactive element:
+- The `new` and `menu` buttons in the sidebar footer change color from `p.overlay0` (muted gray) to `p.text` (soft white).
+- Tab bar buttons (like `+`) change from `p.overlay1` to `p.text`.
+- Tab scroll controls (`<` and `>`) highlight their background from `p.surface0` to `p.surface1`.
+- Sidebar workspace list cards (if not already active/selected) change their text color from `p.subtext0` to `p.text`.
+- Sidebar agent list entries highlight their name and icon to `p.text`.
+- To prevent hover highlights from getting "stuck" when the user switches to keyboard navigation or loses window focus, the hover state is immediately cleared when any key is pressed or when the host terminal loses focus (`OuterFocusLost`).
+
+## User Stories
+
+1. As a Herdr user, I want the "new" and "menu" footer links to turn soft white when my mouse hovers over them, so that I get immediate visual confirmation that they are clickable.
+2. As a Herdr user, I want the "+" tab button to turn soft white on mouse hover, so that I know I am aiming correctly to create a tab.
+3. As a Herdr user, I want the "<" and ">" scroll buttons in the tab bar to highlight their background slightly on hover, so that I have feedback before clicking them.
+4. As a Herdr user, I want inactive workspace cards in the sidebar to light up to soft white on hover, so that I can easily tell which workspace I am about to select.
+5. As a Herdr user, I want agent list entries in the sidebar to highlight their text to soft white on hover, so that I get visual feedback when pointing at them.
+6. As a Herdr user, I want all hover highlights to immediately disappear when I press any key on my keyboard, so that the UI remains clean and doesn't get stuck in a hover state.
+7. As a Herdr user, I want hover highlights to disappear when the Herdr window loses focus, so that the interface doesn't show outdated hover states when I am working in another application.
+
+## Implementation Decisions
+
+- **State Additions:**
+  - Add `last_mouse_position: Option<(u16, u16)>` to `AppState` in `src/app/state.rs`.
+- **Event Handling:**
+  - Update `route_client_events_from` in `src/app/mod.rs` to:
+    - Save the coordinates to `self.state.last_mouse_position` on `RawInputEvent::Mouse`.
+    - Clear `last_mouse_position` to `None` on any key event (`RawInputEvent::Key`) or focus loss (`RawInputEvent::OuterFocusLost`).
+- **Hit-Testing Helpers:**
+  - Implement helper methods on `AppState`:
+    - `is_new_button_hovered() -> bool`
+    - `is_menu_button_hovered() -> bool`
+    - `hovered_workspace_idx() -> Option<usize>`
+    - `hovered_agent_pane_id() -> Option<PaneId>`
+    - `hovered_tab_idx() -> Option<usize>`
+    - `is_new_tab_hovered() -> bool`
+    - `is_tab_scroll_left_hovered() -> bool`
+    - `is_tab_scroll_right_hovered() -> bool`
+- **TUI Rendering updates:**
+  - Update `src/ui/sidebar.rs` to render `new`, `menu`, and inactive workspaces/agents using `p.text` if hovered.
+  - Update `src/ui/tabs.rs` to render `+` using `p.text`, and `<` / `>` using `p.surface1` bg if hovered.
+
+## Testing Decisions
+
+- Test mouse move events: simulate mouse movement to specific component coordinates using `app.handle_mouse` and assert corresponding hover state flags in `AppState`.
+- Test hover clear: verify that key presses or focus loss reset `last_mouse_position` to `None`.
+- Test render integration: render sidebar and tab bar with mock hover coordinates and assert that the expected colors (`p.text` / `p.surface1`) are written to the test buffer.
+
+## Out of Scope
+
+- Flashy hover animations, transition delays, or layout layout reflows on hover.
+- Custom color definitions (only existing colors from the theme palette will be used).
+- Interactive hover elements inside the main terminal grids (ghostty terminals handle their own hover/mouse events).
+
+## Further Notes
+
+- Since Herdr is a mouse-first TUI, this lays the foundation for future interactive elements (like hover tooltips or click actions) by establishing standard mouse-position tracking in `AppState`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,15 @@
 AGENTS.md
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs for this repo live as markdown files under `.scratch/`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Standard triage labels are used (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout with a global `CONTEXT.md` and ADRs under `docs/adr/`. See `docs/agents/domain.md`.

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -44,6 +44,7 @@ mod overlays;
 mod selection;
 mod settings;
 mod sidebar;
+mod tabs;
 mod terminal;
 
 pub(crate) use self::{

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -264,6 +264,7 @@ impl App {
         source_id: super::InputSourceId,
         mouse: MouseEvent,
     ) {
+        self.state.last_mouse_position = Some((mouse.column, mouse.row));
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 self.pending_url_click_sources.remove(&source_id);

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -4041,4 +4041,52 @@ mod tests {
         app.handle_raw_input_event(event).await;
         assert_eq!(app.state.last_mouse_position, None);
     }
+
+    #[test]
+    fn new_button_hover_returns_true_when_position_inside() {
+        let mut app = app_for_mouse_test();
+        app.state.view.sidebar_rect = Rect::new(0, 0, 26, 20);
+        let rect = app.state.sidebar_new_button_rect();
+        // With sidebar_rect set, the footer should be at row 19
+        assert!(!app.state.sidebar_collapsed, "sidebar should be expanded");
+        app.state.last_mouse_position = Some((rect.x + 1, rect.y));
+        assert!(app.state.is_new_button_hovered());
+    }
+
+    #[test]
+    fn new_button_hover_returns_false_outside() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = Some((0, 0));
+        assert!(!app.state.is_new_button_hovered());
+        app.state.last_mouse_position = None;
+        assert!(!app.state.is_new_button_hovered());
+    }
+
+    #[test]
+    fn menu_button_hover_returns_true_when_position_inside() {
+        let mut app = app_for_mouse_test();
+        app.state.view.sidebar_rect = Rect::new(0, 0, 26, 20);
+        let rect = app.state.global_launcher_rect();
+        app.state.last_mouse_position = Some((rect.x + 1, rect.y));
+        assert!(app.state.is_menu_button_hovered());
+    }
+
+    #[test]
+    fn hovered_workspace_idx_returns_correct_index() {
+        let mut app = app_for_mouse_test();
+        use crate::app::state::WorkspaceCardArea;
+        app.state.view.workspace_card_areas = vec![
+            WorkspaceCardArea { ws_idx: 0, rect: Rect::new(0, 2, 25, 1), indented: false },
+            WorkspaceCardArea { ws_idx: 1, rect: Rect::new(0, 3, 25, 1), indented: false },
+            WorkspaceCardArea { ws_idx: 2, rect: Rect::new(0, 4, 25, 1), indented: false },
+        ];
+        app.state.last_mouse_position = Some((5, 3));
+        assert_eq!(app.state.hovered_workspace_idx(), Some(1));
+    }
+
+    #[test]
+    fn hovered_workspace_idx_returns_none_without_position() {
+        let app = app_for_mouse_test();
+        assert_eq!(app.state.hovered_workspace_idx(), None);
+    }
 }

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -1843,7 +1843,7 @@ fn apply_scroll(scroll: &mut usize, delta: i16, max_scroll: usize) {
 
 #[cfg(test)]
 mod tests {
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
     use ratatui::layout::{Direction, Rect};
 
     use super::super::{
@@ -3972,5 +3972,73 @@ mod tests {
         };
 
         assert_eq!(wheel_routing(input_state), WheelRouting::HostScroll);
+    }
+
+    #[test]
+    fn mouse_move_records_last_mouse_position() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = None;
+        app.handle_mouse(mouse(MouseEventKind::Moved, 7, 11));
+        assert_eq!(app.state.last_mouse_position, Some((7, 11)));
+    }
+
+    #[test]
+    fn focus_lost_clears_last_mouse_position() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = Some((3, 4));
+        app.route_client_events(
+            vec![crate::raw_input::RawInputEvent::OuterFocusLost],
+            false,
+        );
+        assert_eq!(app.state.last_mouse_position, None);
+    }
+
+    #[test]
+    fn key_press_clears_last_mouse_position() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = Some((9, 9));
+        app.route_client_events(
+            vec![crate::raw_input::RawInputEvent::Key(
+                crate::input::TerminalKey::new(KeyCode::Char('j'), KeyModifiers::empty())
+                    .with_kind(KeyEventKind::Press),
+            )],
+            false,
+        );
+        assert_eq!(app.state.last_mouse_position, None);
+    }
+
+    #[tokio::test]
+    async fn raw_input_event_records_mouse_position() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = None;
+        let event = crate::raw_input::RawInputEvent::Mouse(crossterm::event::MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: 5,
+            row: 8,
+            modifiers: KeyModifiers::empty(),
+        });
+        app.handle_raw_input_event(event).await;
+        assert_eq!(app.state.last_mouse_position, Some((5, 8)));
+    }
+
+    #[tokio::test]
+    async fn raw_input_event_key_clears_mouse_position() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = Some((3, 3));
+        let event = crate::raw_input::RawInputEvent::Key(
+            crate::input::TerminalKey::new(KeyCode::Char('x'), KeyModifiers::empty())
+                .with_kind(KeyEventKind::Press),
+        );
+        app.handle_raw_input_event(event).await;
+        assert_eq!(app.state.last_mouse_position, None);
+    }
+
+    #[tokio::test]
+    async fn raw_input_event_focus_lost_clears_mouse_position() {
+        let mut app = app_for_mouse_test();
+        app.state.last_mouse_position = Some((3, 3));
+        let event = crate::raw_input::RawInputEvent::OuterFocusLost;
+        app.handle_raw_input_event(event).await;
+        assert_eq!(app.state.last_mouse_position, None);
     }
 }

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -196,6 +196,51 @@ impl AppState {
         Rect::new(x, footer.y, width, footer.height)
     }
 
+    pub(crate) fn is_new_button_hovered(&self) -> bool {
+        let Some((col, row)) = self.last_mouse_position else { return false };
+        let rect = self.sidebar_new_button_rect();
+        col >= rect.x
+            && col < rect.x + rect.width
+            && row >= rect.y
+            && row < rect.y + rect.height
+    }
+
+    pub(crate) fn is_menu_button_hovered(&self) -> bool {
+        let Some((col, row)) = self.last_mouse_position else { return false };
+        let rect = self.global_launcher_rect();
+        col >= rect.x
+            && col < rect.x + rect.width
+            && row >= rect.y
+            && row < rect.y + rect.height
+    }
+
+    pub(crate) fn hovered_workspace_idx(&self) -> Option<usize> {
+        let (col, row) = self.last_mouse_position?;
+        self.view.workspace_card_areas.iter().find_map(|card| {
+            if col >= card.rect.x
+                && col < card.rect.x + card.rect.width
+                && row >= card.rect.y
+                && row < card.rect.y + card.rect.height
+            {
+                Some(card.ws_idx)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(crate) fn hovered_agent_details(&self) -> Option<(usize, usize, crate::layout::PaneId)> {
+        let (col, row) = self.last_mouse_position?;
+        let detail_area = self.agent_panel_rect();
+        if detail_area == Rect::default()
+            || col < detail_area.x
+            || col >= detail_area.x + detail_area.width
+        {
+            return None;
+        }
+        self.agent_detail_target_at(row)
+    }
+
     pub(crate) fn global_menu_labels(&self) -> Vec<&'static str> {
         let mut labels = vec!["settings", "keybinds", "reload config"];
         if self.update_available.is_some() {

--- a/src/app/input/tabs.rs
+++ b/src/app/input/tabs.rs
@@ -1,0 +1,137 @@
+use crate::app::state::AppState;
+
+impl AppState {
+    pub(crate) fn is_new_tab_hovered(&self) -> bool {
+        let Some((col, row)) = self.last_mouse_position else {
+            return false;
+        };
+        let rect = self.view.new_tab_hit_area;
+        rect.width > 0
+            && col >= rect.x
+            && col < rect.x + rect.width
+            && row >= rect.y
+            && row < rect.y + rect.height
+    }
+
+    pub(crate) fn is_tab_scroll_left_hovered(&self) -> bool {
+        let Some((col, row)) = self.last_mouse_position else {
+            return false;
+        };
+        let rect = self.view.tab_scroll_left_hit_area;
+        rect.width > 0
+            && col >= rect.x
+            && col < rect.x + rect.width
+            && row >= rect.y
+            && row < rect.y + rect.height
+    }
+
+    pub(crate) fn is_tab_scroll_right_hovered(&self) -> bool {
+        let Some((col, row)) = self.last_mouse_position else {
+            return false;
+        };
+        let rect = self.view.tab_scroll_right_hit_area;
+        rect.width > 0
+            && col >= rect.x
+            && col < rect.x + rect.width
+            && row >= rect.y
+            && row < rect.y + rect.height
+    }
+
+    pub(crate) fn hovered_tab_idx(&self) -> Option<usize> {
+        let (col, row) = self.last_mouse_position?;
+        self.view
+            .tab_hit_areas
+            .iter()
+            .enumerate()
+            .find(|(_, rect)| {
+                rect.width > 0
+                    && col >= rect.x
+                    && col < rect.x + rect.width
+                    && row >= rect.y
+                    && row < rect.y + rect.height
+            })
+            .map(|(idx, _)| idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    fn test_app_with_tab_areas() -> AppState {
+        let mut app = AppState::test_new();
+        app.view.tab_bar_rect = Rect::new(0, 0, 80, 1);
+        app.view.tab_hit_areas = vec![
+            Rect::new(0, 0, 10, 1),
+            Rect::new(11, 0, 10, 1),
+            Rect::new(22, 0, 10, 1),
+        ];
+        app.view.tab_scroll_left_hit_area = Rect::new(60, 0, 3, 1);
+        app.view.tab_scroll_right_hit_area = Rect::new(64, 0, 3, 1);
+        app.view.new_tab_hit_area = Rect::new(68, 0, 3, 1);
+        app
+    }
+
+    #[test]
+    fn new_tab_hovered_inside() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((69, 0));
+        assert!(app.is_new_tab_hovered());
+    }
+
+    #[test]
+    fn new_tab_hovered_outside_or_no_mouse() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((0, 0));
+        assert!(!app.is_new_tab_hovered());
+        app.last_mouse_position = None;
+        assert!(!app.is_new_tab_hovered());
+    }
+
+    #[test]
+    fn tab_scroll_left_hovered_inside() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((61, 0));
+        assert!(app.is_tab_scroll_left_hovered());
+    }
+
+    #[test]
+    fn tab_scroll_right_hovered_inside() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((65, 0));
+        assert!(app.is_tab_scroll_right_hovered());
+    }
+
+    #[test]
+    fn tab_scroll_buttons_not_hovered_outside() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((50, 0));
+        assert!(!app.is_tab_scroll_left_hovered());
+        assert!(!app.is_tab_scroll_right_hovered());
+    }
+
+    #[test]
+    fn hovered_tab_idx_returns_correct_index() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((12, 0));
+        assert_eq!(app.hovered_tab_idx(), Some(1));
+    }
+
+    #[test]
+    fn hovered_tab_idx_returns_none_outside_or_no_mouse() {
+        let mut app = test_app_with_tab_areas();
+        app.last_mouse_position = Some((100, 0));
+        assert_eq!(app.hovered_tab_idx(), None);
+        app.last_mouse_position = None;
+        assert_eq!(app.hovered_tab_idx(), None);
+    }
+
+    #[test]
+    fn hovered_tab_idx_ignores_zero_width_areas() {
+        let mut app = test_app_with_tab_areas();
+        app.view.tab_hit_areas[1] = Rect::new(11, 0, 0, 1);
+        app.last_mouse_position = Some((12, 0));
+        assert_eq!(app.hovered_tab_idx(), None);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -612,6 +612,7 @@ impl App {
             pending_agent_notifications: std::collections::HashMap::new(),
             copy_feedback: None,
             outer_terminal_focus: None,
+            last_mouse_position: None,
             prefix_code,
             prefix_mods,
             default_sidebar_width: config.ui.sidebar_width,
@@ -1615,6 +1616,7 @@ impl App {
             let previous_mode = self.state.mode;
             match event {
                 crate::raw_input::RawInputEvent::Key(key) => {
+                    self.state.last_mouse_position = None;
                     let pressed_key_id = pressed_key_identity(source_id, &key);
                     match key.kind {
                         crossterm::event::KeyEventKind::Press => {
@@ -1668,6 +1670,7 @@ impl App {
                     if self.state.popup_pane.is_some() || self.state.mouse_capture {
                         self.handle_mouse_event_headless(source_id, mouse);
                     } else {
+                        self.state.last_mouse_position = Some((mouse.column, mouse.row));
                         self.state
                             .handle_pane_mouse_only(&self.terminal_runtimes, mouse);
                     }
@@ -1696,6 +1699,7 @@ impl App {
                     self.send_outer_focus_event(crate::ghostty::FocusEvent::Gained);
                 }
                 crate::raw_input::RawInputEvent::OuterFocusLost => {
+                    self.state.last_mouse_position = None;
                     self.release_input_source_headless(source_id);
                     self.send_outer_focus_event(crate::ghostty::FocusEvent::Lost);
                 }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -139,6 +139,7 @@ impl App {
         let previous_mode = self.state.mode;
         let changed = match event {
             crate::raw_input::RawInputEvent::Key(key) => {
+                self.state.last_mouse_position = None;
                 let pressed_key_id = pressed_key_identity(super::LOCAL_INPUT_SOURCE, &key);
                 match key.kind {
                     crossterm::event::KeyEventKind::Press => {
@@ -201,6 +202,7 @@ impl App {
                 if self.state.popup_pane.is_some() || self.state.mouse_capture {
                     self.handle_mouse(mouse);
                 } else {
+                    self.state.last_mouse_position = Some((mouse.column, mouse.row));
                     self.state
                         .handle_pane_mouse_only(&self.terminal_runtimes, mouse);
                 }
@@ -216,6 +218,7 @@ impl App {
                 true
             }
             crate::raw_input::RawInputEvent::OuterFocusLost => {
+                self.state.last_mouse_position = None;
                 self.release_input_source(super::LOCAL_INPUT_SOURCE).await;
                 self.send_outer_focus_event(crate::ghostty::FocusEvent::Lost);
                 self.state.outer_terminal_focus = Some(false);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1476,6 +1476,11 @@ pub struct AppState {
     /// Last reported focus state for the outer terminal hosting herdr.
     /// None means unsupported or not yet reported, which preserves active-pane suppression.
     pub outer_terminal_focus: Option<bool>,
+    /// Last known screen-space position of the mouse cursor.
+    /// Cleared on any key press or when the host terminal loses focus so the
+    /// UI never shows a stale hover highlight while the user is on the
+    /// keyboard or working in another window.
+    pub last_mouse_position: Option<(u16, u16)>,
     // Config
     pub prefix_code: KeyCode,
     pub prefix_mods: KeyModifiers,
@@ -1857,6 +1862,7 @@ impl AppState {
             pending_agent_notifications: std::collections::HashMap::new(),
             copy_feedback: None,
             outer_terminal_focus: None,
+            last_mouse_position: None,
             prefix_code: KeyCode::Char('b'),
             prefix_mods: KeyModifiers::CONTROL,
             default_sidebar_width: 26,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1143,6 +1143,7 @@ fn render_workspace_list(
     let metrics = workspace_list_scroll_metrics(app, area);
     let scrollbar_rect = workspace_list_scrollbar_rect(app, area);
     let cards = &app.view.workspace_card_areas;
+    let hovered_ws = app.hovered_workspace_idx();
 
     for card in cards {
         let i = card.ws_idx;
@@ -1152,7 +1153,8 @@ fn render_workspace_list(
         let selected = i == app.selected && is_navigating;
         let is_active = Some(i) == app.active;
         let is_dragged = dragged_ws_idx == Some(i);
-        let highlighted = selected || is_active || is_dragged;
+        let is_hovered = hovered_ws == Some(i);
+        let highlighted = selected || is_active || is_dragged || is_hovered;
         let (agg_state, agg_seen) = ws.aggregate_state(&app.terminals);
 
         if highlighted {
@@ -1174,7 +1176,7 @@ fn render_workspace_list(
             }
         }
 
-        let name_style = if selected || is_active || is_dragged {
+        let name_style = if selected || is_active || is_dragged || is_hovered {
             Style::default().fg(p.text).add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(p.subtext0)
@@ -1283,22 +1285,24 @@ fn render_workspace_list(
 
     if app.mouse_capture && list_bottom > area.y {
         let new_rect = app.sidebar_new_button_rect();
+        let new_fg = if app.is_new_button_hovered() { p.text } else { p.overlay0 };
         frame.render_widget(
-            Paragraph::new(Span::styled(" new", Style::default().fg(p.overlay0))),
+            Paragraph::new(Span::styled(" new", Style::default().fg(new_fg))),
             new_rect,
         );
 
         let menu_rect = app.global_launcher_rect();
+        let menu_fg = if app.is_menu_button_hovered() { p.text } else { p.overlay0 };
         let menu_line = if app.global_menu_attention_badge_visible() {
             Line::from(vec![
                 Span::styled(
                     "● ",
                     Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
                 ),
-                Span::styled("menu", Style::default().fg(p.overlay0)),
+                Span::styled("menu", Style::default().fg(menu_fg)),
             ])
         } else {
-            Line::from(vec![Span::styled("menu", Style::default().fg(p.overlay0))])
+            Line::from(vec![Span::styled("menu", Style::default().fg(menu_fg))])
         };
         frame.render_widget(
             Paragraph::new(menu_line).alignment(Alignment::Right),
@@ -1370,6 +1374,7 @@ fn render_agent_detail(
     let scroll = app.agent_panel_scroll.min(metrics.max_offset_from_bottom);
     let mut row_y = body.y;
     let body_bottom = body.y + body.height;
+    let hovered_agent = app.hovered_agent_details();
     for (index, detail) in details.iter().enumerate().skip(scroll) {
         let label_color = state_label_color(detail.state, detail.seen, p);
         let rows = resolved_agent_rows(app, detail);
@@ -1384,7 +1389,8 @@ fn render_agent_detail(
         } else {
             Style::default()
         };
-        let name_style = if is_active {
+        let is_hovered = hovered_agent == Some((detail.ws_idx, detail.tab_idx, detail.pane_id));
+        let name_style = if is_active || is_hovered {
             Style::default().fg(p.text).add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(p.subtext0).add_modifier(Modifier::BOLD)
@@ -1395,7 +1401,10 @@ fn render_agent_detail(
             Style::default().fg(label_color).add_modifier(Modifier::DIM)
         };
         let agent_style = Style::default().fg(p.overlay0).add_modifier(Modifier::DIM);
-        let state_icon = agent_icon(detail.state, detail.seen, app.spinner_tick, p);
+        let mut state_icon = agent_icon(detail.state, detail.seen, app.spinner_tick, p);
+        if is_hovered {
+            state_icon.1 = Style::default().fg(p.text);
+        }
 
         for (row_index, resolved) in rows.iter().take(height as usize).enumerate() {
             let mut spans = vec![Span::raw(if row_index == 0 { " " } else { "   " })];

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -284,12 +284,15 @@ pub(super) fn render_tab_bar(app: &AppState, frame: &mut Frame, area: Rect) {
         && last_visible_idx.is_some_and(|idx| idx + 1 < ws.tabs.len());
 
     if app.mouse_capture && app.view.tab_scroll_left_hit_area.width > 0 {
+        let left_hovered = app.is_tab_scroll_left_hovered();
         let style = if can_scroll_left {
-            Style::default().fg(p.overlay1).bg(p.surface0)
+            let bg = if left_hovered { p.surface1 } else { p.surface0 };
+            Style::default().fg(p.overlay1).bg(bg)
         } else {
+            let bg = if left_hovered { p.surface1 } else { p.surface0 };
             Style::default()
                 .fg(p.overlay0)
-                .bg(p.surface0)
+                .bg(bg)
                 .add_modifier(Modifier::DIM)
         };
         frame.render_widget(
@@ -299,12 +302,23 @@ pub(super) fn render_tab_bar(app: &AppState, frame: &mut Frame, area: Rect) {
     }
 
     if app.mouse_capture && app.view.tab_scroll_right_hit_area.width > 0 {
+        let right_hovered = app.is_tab_scroll_right_hovered();
         let style = if can_scroll_right {
-            Style::default().fg(p.overlay1).bg(p.surface0)
+            let bg = if right_hovered {
+                p.surface1
+            } else {
+                p.surface0
+            };
+            Style::default().fg(p.overlay1).bg(bg)
         } else {
+            let bg = if right_hovered {
+                p.surface1
+            } else {
+                p.surface0
+            };
             Style::default()
                 .fg(p.overlay0)
-                .bg(p.surface0)
+                .bg(bg)
                 .add_modifier(Modifier::DIM)
         };
         frame.render_widget(
@@ -321,6 +335,7 @@ pub(super) fn render_tab_bar(app: &AppState, frame: &mut Frame, area: Rect) {
             continue;
         }
         let active = idx == ws.active_tab;
+        let hovered = Some(idx) == app.hovered_tab_idx();
         let style = if active {
             let base = Style::default().fg(panel_contrast_fg(p)).bg(p.accent);
             if tab.is_auto_named() {
@@ -328,6 +343,8 @@ pub(super) fn render_tab_bar(app: &AppState, frame: &mut Frame, area: Rect) {
             } else {
                 base.add_modifier(Modifier::BOLD)
             }
+        } else if hovered {
+            Style::default().fg(p.text).bg(p.surface0)
         } else if tab.is_auto_named() {
             Style::default()
                 .fg(p.overlay0)
@@ -361,8 +378,13 @@ pub(super) fn render_tab_bar(app: &AppState, frame: &mut Frame, area: Rect) {
     }
 
     if app.mouse_capture && app.view.new_tab_hit_area.width > 0 {
+        let fg = if app.is_new_tab_hovered() {
+            p.text
+        } else {
+            p.overlay1
+        };
         frame.render_widget(
-            Paragraph::new(" + ").style(Style::default().fg(p.overlay1)),
+            Paragraph::new(" + ").style(Style::default().fg(fg)),
             app.view.new_tab_hit_area,
         );
     }
@@ -503,5 +525,93 @@ mod tests {
 
         let row = buffer_row_text(terminal.backend().buffer(), app.view.tab_bar_rect, 0);
         assert!(row.contains('馈'), "tab row: {row:?}");
+    }
+
+    #[test]
+    fn inactive_tab_uses_text_foreground_when_hovered() {
+        let mut app = AppState::test_new();
+        let mut ws = Workspace::test_new("test");
+        ws.test_add_tab(Some("second"));
+        ws.active_tab = 0;
+
+        app.active = Some(0);
+        app.workspaces = vec![ws];
+        app.view.tab_bar_rect = Rect::new(0, 0, 40, 1);
+        let view = compute_tab_bar_view(&app.workspaces[0], app.view.tab_bar_rect, 0, true, false);
+        app.view.tab_hit_areas = view.tab_hit_areas;
+        app.view.new_tab_hit_area = view.new_tab_hit_area;
+
+        // Hover the second (inactive) tab.
+        let rect = app.view.tab_hit_areas[1];
+        app.last_mouse_position = Some((rect.x + 1, rect.y));
+
+        let backend = TestBackend::new(40, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_tab_bar(&app, frame, app.view.tab_bar_rect))
+            .unwrap();
+
+        let style = terminal.backend().buffer()[(rect.x + 1, rect.y)].style();
+        assert_eq!(style.fg, Some(app.palette.text));
+        assert_eq!(style.bg, Some(app.palette.surface0));
+    }
+
+    #[test]
+    fn new_tab_button_uses_text_foreground_when_hovered() {
+        let mut app = AppState::test_new();
+        let ws = Workspace::test_new("test");
+
+        app.active = Some(0);
+        app.workspaces = vec![ws];
+        app.view.tab_bar_rect = Rect::new(0, 0, 40, 1);
+        let view = compute_tab_bar_view(&app.workspaces[0], app.view.tab_bar_rect, 0, true, true);
+        app.view.tab_hit_areas = view.tab_hit_areas;
+        app.view.new_tab_hit_area = view.new_tab_hit_area;
+
+        let rect = app.view.new_tab_hit_area;
+        assert!(rect.width > 0, "new tab hit area should be present");
+        app.last_mouse_position = Some((rect.x + 1, rect.y));
+
+        let backend = TestBackend::new(40, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_tab_bar(&app, frame, app.view.tab_bar_rect))
+            .unwrap();
+
+        let style = terminal.backend().buffer()[(rect.x + 1, rect.y)].style();
+        assert_eq!(style.fg, Some(app.palette.text));
+    }
+
+    #[test]
+    fn tab_scroll_buttons_use_surface1_background_when_hovered() {
+        let mut app = AppState::test_new();
+        let mut ws = Workspace::test_new("test");
+        // Add enough tabs to force overflow and scroll buttons.
+        for i in 1..=10 {
+            ws.test_add_tab(Some(&format!("tab{i}")));
+        }
+        ws.active_tab = ws.tabs.len() - 1;
+
+        app.active = Some(0);
+        app.workspaces = vec![ws];
+        app.view.tab_bar_rect = Rect::new(0, 0, 30, 1);
+        let view = compute_tab_bar_view(&app.workspaces[0], app.view.tab_bar_rect, 0, true, true);
+        app.view.tab_hit_areas = view.tab_hit_areas;
+        app.view.tab_scroll_left_hit_area = view.scroll_left_hit_area;
+        app.view.tab_scroll_right_hit_area = view.scroll_right_hit_area;
+        app.view.new_tab_hit_area = view.new_tab_hit_area;
+
+        let rect = app.view.tab_scroll_left_hit_area;
+        assert!(rect.width > 0, "left scroll button should be present");
+        app.last_mouse_position = Some((rect.x + 1, rect.y));
+
+        let backend = TestBackend::new(30, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_tab_bar(&app, frame, app.view.tab_bar_rect))
+            .unwrap();
+
+        let style = terminal.backend().buffer()[(rect.x + 1, rect.y)].style();
+        assert_eq!(style.bg, Some(app.palette.surface1));
     }
 }

--- a/tickets.md
+++ b/tickets.md
@@ -1,0 +1,41 @@
+# Tickets: Subtle hover feedback for TUI interactive elements
+
+Implementation of subtle visual hover feedback on Herdr TUI components using the existing color palette, cleared on keypress and focus loss. See `.scratch/hover-feedback/PRD.md`.
+
+Work the **frontier**: any ticket whose blockers are all done. For a purely linear chain that means top to bottom.
+
+## Mouse Position Tracking & Clear Logic
+
+**What to build:** The infrastructure in `AppState` to store and update the mouse coordinates, and the logic to clear them on keypresses and window focus loss.
+
+**Blocked by:** None — can start immediately.
+
+- [ ] Add `last_mouse_position: Option<(u16, u16)>` to `AppState` in `src/app/state.rs`.
+- [ ] Initialize `last_mouse_position` as `None` in production and test constructors of `AppState`.
+- [ ] Update `route_client_events_from` in `src/app/mod.rs` to set `last_mouse_position = Some((mouse.column, mouse.row))` on mouse moves/events.
+- [ ] Update `route_client_events_from` in `src/app/mod.rs` to set `last_mouse_position = None` on any key pressed or `OuterFocusLost`.
+- [ ] Add unit tests in `src/app/input/mouse.rs` verifying tracking and clear logic works as expected.
+
+## Sidebar Hover Indicators (Footer, Workspaces, Agents)
+
+**What to build:** Hit-testing helper methods on `AppState` for sidebar elements, and rendering styling in the sidebar components to light up hovered items to soft white (`p.text`).
+
+**Blocked by:** Mouse Position Tracking & Clear Logic
+
+- [ ] Implement `is_new_button_hovered` and `is_menu_button_hovered` on `AppState`.
+- [ ] Implement `hovered_workspace_idx` on `AppState` using `workspace_card_areas`.
+- [ ] Implement `hovered_agent_pane_id` on `AppState` using `agent_panel_rect` and `agent_detail_target_at`.
+- [ ] Update `src/ui/sidebar.rs` to draw `new`, `menu`, inactive workspaces, and agents with `p.text` when hovered.
+- [ ] Add tests in `src/ui/sidebar.rs` or `src/app/input/mouse.rs` asserting render styling when hover is simulated.
+
+## Tab Bar Hover Indicators (New Tab, Scroll Controls, Tabs)
+
+**What to build:** Hit-testing helper methods on `AppState` for tab bar elements, and rendering styling in the tab bar components to light up hovered items (`p.text` for tabs/plus, `p.surface1` for scroll backgrounds).
+
+**Blocked by:** Mouse Position Tracking & Clear Logic
+
+- [ ] Implement `is_new_tab_hovered`, `is_tab_scroll_left_hovered`, and `is_tab_scroll_right_hovered` on `AppState`.
+- [ ] Implement `hovered_tab_idx` on `AppState` using `tab_hit_areas`.
+- [ ] Update `src/ui/tabs.rs` to draw `+` and inactive tabs with `p.text` when hovered.
+- [ ] Update `src/ui/tabs.rs` to draw `<` and `>` with `p.surface1` background when hovered.
+- [ ] Add tests in `src/ui/tabs.rs` or `src/app/input/mouse.rs` asserting render styling when hover is simulated.


### PR DESCRIPTION
Summary

   Add subtle visual hover feedback to all interactive TUI elements using the
 existing
   color palette. Mouse position is tracked in `AppState`, cleared on keypress and
   focus loss to prevent stale highlights.

   ## Changes

   | File | Change |
   |------|--------|
   | `src/app/state.rs` | Add `last_mouse_position: Option<(u16, u16)>` to
 `AppState`, cleared on key/focus loss |
   | `src/app/mod.rs` | Set mouse position on mouse events, clear on key/focus      lost |
   | `src/app/input/sidebar.rs` | Hit-test helpers: `is_new_button_hovered`,
 `is_menu_button_hovered`, `hovered_workspace_idx`, `hovered_agent_details` |
   | `src/app/input/tabs.rs` | Hit-test helpers: `is_new_tab_hovered`,
 `is_tab_scroll_left_hovered`, `is_tab_scroll_right_hovered`, `hovered_tab_idx` |
   | `src/ui/sidebar.rs` | Hover rendering: `new`/`menu` buttons and inactive
 workspaces/agents turn `p.text` on hover |
   | `src/ui/tabs.rs` | Hover rendering: `+` button and inactive tabs turn
 `p.text`; scroll controls get `p.surface1` background |