### PR TITLE
fix: make native windows checks reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,33 +141,7 @@ jobs:
       - name: Run Windows checks
         if: matrix.kind == 'windows'
         shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          function Invoke-Checked {
-            param([string]$Command, [string[]]$Arguments)
-            & $Command @Arguments
-            if ($LASTEXITCODE -ne 0) {
-              throw "command failed with exit code $LASTEXITCODE`: $Command $($Arguments -join ' ')"
-            }
-          }
-          function Invoke-CargoWithZigCacheRecovery {
-            param([string[]]$Arguments)
-            & cargo @Arguments
-            if ($LASTEXITCODE -eq 0) {
-              return
-            }
-
-            Write-Warning "cargo compile failed; clearing Zig build caches and retrying once"
-            Remove-Item -Recurse -Force .zig-cache -ErrorAction SilentlyContinue
-            Remove-Item -Recurse -Force vendor/libghostty-vt/.zig-cache -ErrorAction SilentlyContinue
-            Remove-Item -Recurse -Force vendor/libghostty-vt/zig-out -ErrorAction SilentlyContinue
-            Invoke-Checked cargo $Arguments
-          }
-          Invoke-Checked cargo @("fmt", "--check")
-          Invoke-CargoWithZigCacheRecovery @("clippy", "--bin", "herdr", "--locked", "--target", "x86_64-pc-windows-msvc", "--", "-D", "warnings")
-          Invoke-Checked cargo @("test", "--locked", "--target", "x86_64-pc-windows-msvc", "--bin", "herdr", "windows_")
-          Invoke-Checked cargo @("test", "--locked", "--target", "x86_64-pc-windows-msvc", "--bin", "herdr", "server::client_transport::tests")
-          Invoke-Checked cargo @("build", "--locked", "--target", "x86_64-pc-windows-msvc")
+        run: .\scripts\windows_check.ps1 -Mode check
 
       - name: Smoke ConPTY pane
         if: matrix.kind == 'windows'

--- a/justfile
+++ b/justfile
@@ -12,25 +12,39 @@ test-one filter:
     cargo nextest run --locked "{{filter}}" --status-level fail --final-status-level fail --failure-output final --success-output never
 
 # Run fast local lint checks
+[unix]
 lint:
     cargo fmt --check
     cargo clippy --all-targets --locked -- -D warnings
 
+[script("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File")]
+[windows]
+lint:
+    & .\scripts\windows_check.ps1 -Mode lint
+
 # Run PR CI checks
+[unix]
 ci filter='all()': lint
     cargo nextest run --locked -E "{{filter}}" --status-level fail --final-status-level slow --failure-output final --success-output never
     just integration-assets-test
     just plugin-marketplace-test
 
 # Run Windows target lint from Unix/macOS to catch cfg(windows) compile and clippy failures before CI
+[unix]
 windows-lint:
     rustup target add x86_64-pc-windows-msvc
     LIBGHOSTTY_VT_SIMD=false cargo clippy --bin herdr --locked --target x86_64-pc-windows-msvc -- -D warnings
 
 # Check formatting + run unit tests + Windows target lint + maintenance script tests
+[unix]
 check: ci windows-lint
     python3 -m unittest scripts.test_agent_detection_manifest_check scripts.test_changelog scripts.test_config_reference_check scripts.test_docs_translation_parity scripts.test_hermes_integration_asset scripts.test_package_windows_conpty scripts.test_preview scripts.test_vendor_libghostty_vt scripts.test_vendor_portable_pty
     @echo "docs reminder: if this changes user-facing behavior, make sure the relevant release docs are updated or called out before release."
+
+[script("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File")]
+[windows]
+check:
+    & .\scripts\windows_check.ps1 -Mode check
 
 # Install repo-local git hooks
 install-hooks:

--- a/scripts/windows_check.ps1
+++ b/scripts/windows_check.ps1
@@ -1,0 +1,68 @@
+param(
+    [ValidateSet("lint", "check")]
+    [string]$Mode = "check"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Checked {
+    param([string]$Command, [string[]]$Arguments)
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "command failed with exit code $LASTEXITCODE`: $Command $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-CargoWithZigCacheRecovery {
+    param([string[]]$Arguments)
+
+    & cargo @Arguments
+    if ($LASTEXITCODE -eq 0) {
+        return
+    }
+
+    Write-Warning "cargo compile failed; clearing Zig build caches and retrying once"
+    Remove-Item -Recurse -Force .zig-cache -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force vendor/libghostty-vt/.zig-cache -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force vendor/libghostty-vt/zig-out -ErrorAction SilentlyContinue
+    Invoke-Checked cargo $Arguments
+}
+
+Invoke-Checked rustup @("target", "add", "x86_64-pc-windows-msvc")
+Invoke-Checked cargo @("fmt", "--check")
+Invoke-CargoWithZigCacheRecovery @(
+    "clippy",
+    "--bin",
+    "herdr",
+    "--locked",
+    "--target",
+    "x86_64-pc-windows-msvc",
+    "--",
+    "-D",
+    "warnings"
+)
+
+if ($Mode -eq "lint") {
+    return
+}
+
+Invoke-Checked cargo @(
+    "test",
+    "--locked",
+    "--target",
+    "x86_64-pc-windows-msvc",
+    "--bin",
+    "herdr",
+    "windows_"
+)
+Invoke-Checked cargo @(
+    "test",
+    "--locked",
+    "--target",
+    "x86_64-pc-windows-msvc",
+    "--bin",
+    "herdr",
+    "server::client_transport::tests"
+)
+Invoke-Checked cargo @("build", "--locked", "--target", "x86_64-pc-windows-msvc")

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1156,6 +1156,7 @@ mod tests {
 
     #[test]
     fn windows_shells_round_trip_agent_arguments_through_a_real_command() {
+        let _lock = crate::integration::integration_env_lock();
         let base = std::env::temp_dir().join(format!(
             "herdr-agent-argv-{}-{}",
             std::process::id(),


### PR DESCRIPTION
## Problem

While testing #1909 on native Windows, I ran the repository's local validation commands and encountered an existing Windows-only test flake plus a mismatch between local checks and the Windows CI lane so I had to run the static tests via wslc/docker.

`just lint` and `just check` currently use the Unix recipes on Windows. The resulting `cargo clippy --all-targets` invocation attempts to compile Unix-only integration-test targets and trips unrelated test-only warnings, so the canonical local commands fail before reaching the Windows checks that CI actually supports.

Separately, `windows_shells_round_trip_agent_arguments_through_a_real_command` reads the process-wide `PATH` while integration tests temporarily replace it. Under parallel execution, the shell test can therefore fail to find `powershell.exe` or `cmd.exe`.

## Fix

- Extract the existing inline Windows CI commands into `scripts/windows_check.ps1` with `lint` and `check` modes
- Select native PowerShell recipes for Windows while leaving the Unix recipes unchanged
- Have local Windows checks and Windows CI call the same script
- Allow the generated PowerShell recipes to run under the default Restricted execution policy using a process-scoped bypass
- Serialize the shell round-trip test with the existing integration environment lock

## Scope

On Windows, `just check` intentionally mirrors the currently supported Windows CI lane:

- formatting
- binary-only Windows Clippy
- the `windows_` unit-test filter
- client transport tests
- a Windows build

This does not attempt to make the Unix-only or unfiltered all-target test suites work on Windows. It does not change production or runtime behavior.

## Validation

- `just check` passes on native Windows: Clippy, 123 Windows tests, 21 client transport tests, and build
- The PowerShell recipes pass under Windows PowerShell 5.1 and PowerShell 7
- The recipes launch successfully from a parent process using Restricted execution policy
- The shell round-trip test passed 10 consecutive focused runs
- The shared script preserves the existing Windows CI commands and Zig-cache recovery behavior