### PR TITLE
fix: open OSC 8 file links

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2240,7 +2240,9 @@ impl AppState {
             .into_iter()
             .find(|((x, y), _, _)| *x == screen_col && *y == screen_row)
         {
-            return safe_web_url(&uri).map(str::to_owned);
+            // Explicit OSC 8 metadata supplies the target even when the visible
+            // anchor is not a URL, but keep activation to safe local/web schemes.
+            return safe_osc8_url(&uri).map(str::to_owned);
         }
 
         let metrics = self.pane_scroll_metrics(terminal_runtimes, pane_id);
@@ -2293,6 +2295,10 @@ impl AppState {
 
 pub(crate) fn safe_web_url(url: &str) -> Option<&str> {
     (url.starts_with("http://") || url.starts_with("https://")).then_some(url)
+}
+
+fn safe_osc8_url(url: &str) -> Option<&str> {
+    (safe_web_url(url).is_some() || url.starts_with("file://")).then_some(url)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -1105,17 +1105,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pane_cell_url_resolver_prefers_osc8_hyperlink() {
-        let (app, _info) = app_with_screen_bytes(
-            b"\x1b]8;;https://example.com/hidden-target\x1b\\label\x1b]8;;\x1b\\",
+    async fn pane_cell_url_resolver_accepts_safe_osc8_hyperlink_metadata() {
+        // Explicit OSC 8 metadata supplies the target for both `https://` and
+        // `file://` links, while unsafe schemes remain inert.
+        let https_uri = "https://example.com/hidden-target";
+        let (https_app, _info) = app_with_screen_bytes(
+            format!("\x1b]8;;{https_uri}\x1b\\https://decoy-anchor.example/\x1b]8;;\x1b\\",)
+                .as_bytes(),
         );
-        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let https_pane_id = https_app.state.workspaces[0].tabs[0].root_pane;
 
         assert_eq!(
-            app.state
-                .url_at_pane_cell(&app.terminal_runtimes, pane_id, 0, 1)
+            https_app
+                .state
+                .url_at_pane_cell(&https_app.terminal_runtimes, https_pane_id, 0, 1)
                 .as_deref(),
-            Some("https://example.com/hidden-target")
+            Some(https_uri),
+            "https:// OSC 8 metadata must win over the visible anchor text"
+        );
+
+        let file_uri = "file:///home/user/notes.md";
+        let (file_app, _info) = app_with_screen_bytes(
+            format!("\x1b]8;;{file_uri}\x1b\\open me\x1b]8;;\x1b\\").as_bytes(),
+        );
+        let file_pane_id = file_app.state.workspaces[0].tabs[0].root_pane;
+
+        assert_eq!(
+            file_app
+                .state
+                .url_at_pane_cell(&file_app.terminal_runtimes, file_pane_id, 0, 1)
+                .as_deref(),
+            Some(file_uri),
+            "file:// OSC 8 metadata must resolve; v0.7.4 returned None here"
+        );
+
+        let (unsafe_app, _info) =
+            app_with_screen_bytes(b"\x1b]8;;javascript:alert(1)\x1b\\open me\x1b]8;;\x1b\\");
+        let unsafe_pane_id = unsafe_app.state.workspaces[0].tabs[0].root_pane;
+        assert_eq!(
+            unsafe_app
+                .state
+                .url_at_pane_cell(&unsafe_app.terminal_runtimes, unsafe_pane_id, 0, 1),
+            None,
+            "unsafe OSC 8 schemes must remain inert"
         );
     }
 


### PR DESCRIPTION
## What

- Let explicit OSC 8 `file://` metadata reach the existing modified-click opener.
- Preserve the existing `http://` / `https://` behavior.
- Keep unsafe schemes and plain-text `file://` strings inert.

## Reproduction

In Herdr 0.7.4 or 0.7.5, emit an OSC 8 file link and Ctrl-click its label:

```sh
printf '\033]8;;file:///tmp/example.txt\033\\open file\033]8;;\033\\\n'
```

Before this change, `url_at_pane_cell` drops the target through the HTTP-only `safe_web_url` filter. The added regression covers HTTP metadata precedence, `file://` acceptance, and unsafe-scheme rejection.

## Verification

- `cargo fmt --check` passes.
- Repository CI passes on macOS, Ubuntu, and Windows, including the Windows ConPTY package check.
- Local Rust execution was blocked before tests by the vendored `libghostty-vt` Zig build crashing in the Nix dev shell; repository CI completed the full check matrix successfully.
