### PR TITLE
fix(skill): let natural-language Herdr mentions trigger the agent skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: herdr
-description: "Control Herdr, a terminal multiplexer for coding agents. Use only when the user explicitly mentions Herdr or asks to use Herdr to inspect or control panes, tabs, workspaces, commands, or another agent. Do not use merely because a task could benefit from a background terminal, delegation, or parallel work. Requires HERDR_ENV=1."
+description: "Control Herdr (also typed or transcribed as 'herder', 'herdr.dev', or 'the herdr skill'), a terminal multiplexer that runs coding agents in panes, tabs, and workspaces. Use whenever the user names Herdr as the thing to act with or through — 'use herdr', 'open this in herdr', 'have herdr do this', 'run this with herdr', 'use the herdr skill', 'let herdr manage the panes', 'have herdr open panes and orchestrate this' — or asks Herdr to split panes, open tabs or workspaces, start, prompt, or wait on another agent, read pane output, or orchestrate parallel work. Invoke on the mention; do not first ask what Herdr is or search for it. Do not use when Herdr is only discussed, compared, installed, or described rather than directed."
 ---
 
 # Herdr

--- a/tests/skill_frontmatter.rs
+++ b/tests/skill_frontmatter.rs
@@ -1,0 +1,114 @@
+//! Contract tests for the agent-skill frontmatter in `SKILL.md`.
+//!
+//! Slash invocation (`/herdr`) resolves by the skill's `name` and always
+//! loads the full skill body. Natural-language invocation is different: the
+//! only text an agent's router sees before deciding to load the skill is the
+//! frontmatter `description`. That single line is the entire trigger surface.
+//!
+//! These tests pin that surface so it keeps matching how users actually refer
+//! to Herdr (including the common "herder" spelling produced by humans and
+//! speech-to-text), keeps directive phrasings as exemplars, and keeps a
+//! suppression clause for mentions that describe Herdr without directing it.
+
+const SKILL: &str = include_str!("../SKILL.md");
+
+/// Directive phrasings that must be triggerable from the description alone.
+/// Each entry pairs a user utterance with the description substrings that
+/// give the router a lexical anchor for it.
+const DIRECTIVE_CASES: &[(&str, &[&str])] = &[
+    ("use herdr to open 3 panes and orchestrate the tasks", &["use herdr", "orchestrate"]),
+    ("open this in herdr", &["open this in herdr"]),
+    ("have herdr do this", &["have herdr do this"]),
+    ("run this with herdr", &["run this with herdr"]),
+    ("use the herdr skill", &["use the herdr skill"]),
+    ("let herdr manage the panes", &["let herdr manage the panes"]),
+    ("have herdr open panes and orchestrate", &["have herdr open panes and orchestrate this"]),
+    // Spoken/transcribed alias: users say and STT writes "herder".
+    ("have herder split a pane and start codex", &["herder", "split panes"]),
+];
+
+/// Descriptive mentions that must not be presented as triggers. The
+/// description cannot lexically exclude these, so it must carry an explicit
+/// suppression clause covering each verb.
+const DESCRIPTIVE_CASES: &[(&str, &str)] = &[
+    ("herdr is a terminal multiplexer I heard about", "discussed"),
+    ("how does herdr compare to tmux?", "compared"),
+    ("I installed herdr yesterday", "installed"),
+    ("someone described herdr on the podcast", "described"),
+];
+
+fn frontmatter() -> &'static str {
+    let rest = SKILL.strip_prefix("---\n").expect("SKILL.md must start with frontmatter");
+    let end = rest.find("\n---").expect("frontmatter must be terminated");
+    &rest[..end]
+}
+
+fn description() -> String {
+    let line = frontmatter()
+        .lines()
+        .find_map(|l| l.strip_prefix("description:"))
+        .expect("frontmatter must contain a description");
+    line.trim().trim_matches('"').to_lowercase()
+}
+
+/// Slash invocation resolves by skill name; it must stay `herdr`.
+#[test]
+fn skill_name_is_stable_for_slash_invocation() {
+    let name = frontmatter()
+        .lines()
+        .find_map(|l| l.strip_prefix("name:"))
+        .expect("frontmatter must contain a name");
+    assert_eq!(name.trim(), "herdr");
+}
+
+/// Every supported directive phrasing has a lexical anchor in the description.
+#[test]
+fn description_anchors_directive_phrasings() {
+    let desc = description();
+    for (utterance, anchors) in DIRECTIVE_CASES {
+        for anchor in *anchors {
+            assert!(desc.contains(anchor), "no anchor {anchor:?} for {utterance:?}");
+        }
+    }
+}
+
+/// The description names the alias spellings that reach it in practice.
+#[test]
+fn description_covers_alias_spellings() {
+    let desc = description();
+    for alias in ["herder", "herdr.dev", "the herdr skill"] {
+        assert!(desc.contains(alias), "missing alias {alias:?}");
+    }
+}
+
+/// The description opens affirmatively and tells the router to act on the
+/// mention instead of investigating first.
+#[test]
+fn description_is_affirmative_and_immediate() {
+    let desc = description();
+    let leads_with_restriction = desc.starts_with("use only") || desc.starts_with("do not");
+    assert!(!leads_with_restriction, "description must not lead with a restriction");
+    assert!(desc.contains("invoke on the mention"), "missing immediate-invocation directive");
+    let anti_investigation = "do not first ask what herdr is or search for it";
+    assert!(desc.contains(anti_investigation), "missing anti-investigation directive");
+}
+
+/// Descriptive mentions stay suppressed: the description keeps one negative
+/// clause naming each non-directive verb.
+#[test]
+fn description_suppresses_descriptive_mentions() {
+    let desc = description();
+    let clause = desc.split("do not use when").nth(1).expect("missing suppression clause");
+    for (utterance, verb) in DESCRIPTIVE_CASES {
+        assert!(clause.contains(verb), "clause misses {verb:?} for {utterance:?}");
+    }
+}
+
+/// The environment gate lives in the skill body, where the agent can run it,
+/// not in the description, where it reads as a pre-invocation precondition.
+#[test]
+fn env_gate_is_in_body_not_description() {
+    assert!(!description().contains("herdr_env"), "HERDR_ENV must not gate invocation");
+    let body = &SKILL[SKILL.find("\n---").expect("frontmatter end") + 4..];
+    assert!(body.contains("HERDR_ENV"), "body must keep the HERDR_ENV check");
+}


### PR DESCRIPTION
## Current behavior

With SKILL.md installed in Claude Code (and other skill-capable agents), `/herdr` works every time, but natural-language requests that explicitly name Herdr — `use herdr to open 3 panes and orchestrate the tasks`, `let herdr manage the panes` — frequently fail: the agent treats "herdr" as plain text, asks what it is, or goes searching for it instead of invoking the skill.

## Expected behavior

An explicit directive mention of Herdr invokes the skill without the slash command, which the current description already intends ("Use only when the user explicitly mentions Herdr").

## Cause

Slash invocation resolves by skill name and bypasses routing. Natural-language invocation routes on the frontmatter `description` alone, and that line works against itself:

- it leads with restrictions ("Use only when…", "Do not use…") and has no affirmative exemplars for a directive mention to match
- it never mentions "herder", which is how users type it and how speech-to-text transcribes it, so most real mentions have no lexical anchor
- "Requires HERDR_ENV=1" reads as a pre-invocation precondition the router can't evaluate, encouraging investigate-first behavior; the actionable check already lives in the skill body

## Change

Rewrites the description only (skill body untouched): affirmative-first, directive exemplars ("use herdr", "open this in herdr", "let herdr manage the panes", …), alias spellings ("herder", "herdr.dev", "the herdr skill"), an invoke-on-mention instruction, and a single suppression clause for mentions that discuss/compare/install/describe Herdr rather than direct it. Adds `tests/skill_frontmatter.rs` pinning that trigger vocabulary so the description can't regress silently.

## Repro

Fresh Claude Code session inside a Herdr pane, skill installed: `use herdr to open 3 panes and orchestrate the tasks`. Before: usually treated as plain text. After: invokes the skill on par with `/herdr`.

## Notes

- Tradeoff: "herder" is an English word, so descriptive mentions can occasionally trigger; the body's HERDR_ENV gate makes a wrong invocation a one-command abort. The suppression clause bounds this.
- No user-facing app behavior changes, so I believe no docs/next update is needed — flagging per CONTRIBUTING in case you want the agent-skill page to mention the trigger vocabulary.
- Environment: Herdr 0.7.5 stable, macOS (arm64), Ghostty, zsh; skill installed for Claude Code, Cursor, Gemini, Grok, codex.