### PR TITLE
fix: count ptmx master fds under devpts layouts

### DIFF
--- a/tests/live_handoff.rs
+++ b/tests/live_handoff.rs
@@ -414,7 +414,8 @@ fn server_ptmx_fd_count(pid: u32) -> usize {
     entries
         .filter_map(Result::ok)
         .filter_map(|entry| fs::read_link(entry.path()).ok())
-        .filter(|target| target == Path::new("/dev/ptmx"))
+        // ptmx master node: /dev/ptmx or /dev/pts/ptmx (devpts); slaves /dev/pts/<N> excluded.
+        .filter(|target| target == Path::new("/dev/ptmx") || target == Path::new("/dev/pts/ptmx"))
         .count()
 }
 
@@ -443,7 +444,7 @@ fn wait_for_server_ptmx_fd_count(pid: u32, expected: usize, timeout: Duration) {
         }
         thread::sleep(Duration::from_millis(25));
     }
-    panic!("server pid {pid} had {last_count} /dev/ptmx fds; expected {expected}");
+    panic!("server pid {pid} had {last_count} ptmx master fds; expected {expected}");
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
  ## What this fixes
  The test `live_server_holds_one_pty_master_fd_per_pane` fails on WSL2 and many containers.

  ## Why it happens
  The test counts a server's PTY master fds by reading `/proc/<pid>/fd` and keeping only links that resolve to exactly `/dev/ptmx`. On devpts setups such as WSL2, a master fd resolves to `/dev/pts/ptmx` instead, so the test counts zero masters and fails with "had 0 ptmx master fds; expected 1" even though the server holds the fd.

  ## What this changes
  Match both master node paths: `/dev/ptmx` and `/dev/pts/ptmx`. PTY slaves still resolve to `/dev/pts/<N>` and are not counted, so the one-master-per-pane check is unchanged.

  ## Tests
  Test-only change. Verified on a WSL2 host with `cargo nextest --retries 3`: the full suite passes (the previously failing test now passes; one unrelated live test is flaky
  and recovers on retry).

  ## Scope
  1 file, 5 changed lines.