### PR TITLE
docs: add simplified chinese readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md docs/versions website/latest.json website/src/content/docs website/src/data/config-reference.json docs/next/product-announcement.json
+          git add README.md README.zh-CN.md docs/versions website/latest.json website/src/content/docs website/src/data/config-reference.json docs/next/product-announcement.json
           git diff --cached --quiet || git commit -m "docs: update website manifest for v$VERSION"
           for attempt in 1 2 3; do
             git pull --rebase origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate product announcement
-        run: python3 scripts/changelog.py validate-product-announcement
+      - name: Validate release inputs
+        run: |
+          python3 scripts/changelog.py validate-product-announcement
+          test -f docs/next/README.md
+          test -f docs/next/README.zh-CN.md
 
   release:
     needs: [build, flake-check, validate-release-inputs]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 </p>
 
 <p align="center">
+  English · <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-666666?labelColor=333333" alt="Apache 2.0 license" /></a>
   <a href="https://github.com/ogulcancelik/herdr/releases"><img src="https://img.shields.io/github/downloads/ogulcancelik/herdr/total?labelColor=333333&color=666666" alt="total GitHub release downloads" /></a>
   <a href="https://github.com/ogulcancelik/herdr/stargazers"><img src="https://img.shields.io/github/stars/ogulcancelik/herdr?labelColor=333333&color=666666&logo=github" alt="GitHub stars" /></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,87 @@
+# herdr
+
+
+<p align="center">
+  <img src="assets/logo.png" alt="herdr" width="100" />
+</p>
+
+<p align="center">
+  <a href="https://herdr.dev">herdr.dev</a> · <a href="#安装">安装</a> · <a href="https://herdr.dev/zh-cn/docs/quick-start/">快速开始</a> · <a href="https://herdr.dev/zh-cn/docs/">文档</a> · <a href="#赞助">赞助</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · 简体中文
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-666666?labelColor=333333" alt="Apache 2.0 license" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/releases"><img src="https://img.shields.io/github/downloads/ogulcancelik/herdr/total?labelColor=333333&color=666666" alt="total GitHub release downloads" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/stargazers"><img src="https://img.shields.io/github/stars/ogulcancelik/herdr?labelColor=333333&color=666666&logo=github" alt="GitHub stars" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/releases/latest"><img src="https://img.shields.io/github/v/release/ogulcancelik/herdr?label=release&labelColor=333333&color=666666" alt="latest stable release" /></a>
+  <a href="https://formulae.brew.sh/formula/herdr"><img src="https://img.shields.io/homebrew/v/herdr?label=homebrew&labelColor=333333&color=666666" alt="Homebrew version" /></a>
+  <a href="https://x.com/herdrdev"><img src="https://img.shields.io/badge/follow-%40herdrdev-000000?logo=x&logoColor=white" alt="follow @herdrdev on X" /></a>
+</p>
+
+---
+
+https://github.com/user-attachments/assets/043ec09f-4bdd-41d5-aee0-8fda6b83e267
+
+**智能体复用器，住在你的终端里。**
+
+- **每个智能体一目了然**——`blocked`、`working`、`done`。真实的终端视图，而不是包装过的转述。
+- **分离后智能体继续运行**——从任意终端重新连接，或通过 ssh。会话在重启后依然保留。
+- **智能体也能使用 herdr**——纯 socket api：智能体可以创建窗格、读取输出、互相等待。[智能体技能 →](https://herdr.dev/zh-cn/docs/agent-skill/)
+- **键盘和鼠标都是一等公民**——tmux 风格的前缀键，*以及*点击、拖动、分割。按当下的场景选择，而不是被工具锁死。
+- **插件**——扩展窗格和工作流。[浏览插件市场 →](https://herdr.dev/plugins/)
+- **单个 rust 二进制，没有 electron**——运行在你已经在用的任何终端里。
+
+---
+
+## 安装
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+```
+
+或者 `brew install herdr` · `mise use -g herdr` · Windows 测试版：`powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"` · [二进制文件](https://github.com/ogulcancelik/herdr/releases)
+
+然后在工作所在的目录启动它：
+
+```bash
+herdr
+```
+
+运行你的智能体、分割窗格，然后安心离开。`ctrl+b q` 分离，`herdr` 重新连接。[快速开始 →](https://herdr.dev/zh-cn/docs/quick-start/)
+
+## 文档
+
+所有文档都在 [herdr.dev/docs](https://herdr.dev/zh-cn/docs/)：[快速开始](https://herdr.dev/zh-cn/docs/quick-start/) · [核心概念](https://herdr.dev/zh-cn/docs/concepts/) · [受支持的智能体](https://herdr.dev/zh-cn/docs/agents/) · [键盘](https://herdr.dev/zh-cn/docs/keyboard/) · [配置](https://herdr.dev/zh-cn/docs/configuration/) · [会话状态](https://herdr.dev/zh-cn/docs/session-state/) · [远程访问](https://herdr.dev/zh-cn/docs/persistence-remote/) · [集成](https://herdr.dev/zh-cn/docs/integrations/) · [插件](https://herdr.dev/zh-cn/docs/plugins/) · [socket api](https://herdr.dev/zh-cn/docs/socket-api/)
+
+## 赞助
+
+herdr 以全职方式公开开发。赞助将直接资助开发、稳定性，以及通往真正的智能体运行时之路。
+
+### 金牌
+
+<a href="https://terminaltrove.com/"><img src="assets/sponsors/terminal-trove.png" alt="Terminal Trove" width="200" /></a>
+
+[**→ 成为赞助者**](https://github.com/sponsors/ogulcancelik) · 企业/合作：hey@herdr.dev · 档位说明见 [SPONSORS.md](./SPONSORS.md)。谢谢 🐑
+
+## 智能体须知
+
+如果你是协助本仓库的 AI 智能体：在改动代码前阅读 [`AGENTS.md`](./AGENTS.md)，在创建 issue 或 PR 前阅读 [`CONTRIBUTING.md`](./CONTRIBUTING.md)。
+
+## 开发
+
+```bash
+git clone https://github.com/ogulcancelik/herdr
+cd herdr
+cargo build --release
+
+just test        # 单元测试
+just check       # 格式检查、测试和维护性检查
+```
+
+## 许可证
+
+herdr 基于 [Apache License 2.0](LICENSE) 许可证发布。

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -10,6 +10,10 @@
 </p>
 
 <p align="center">
+  English · <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-666666?labelColor=333333" alt="Apache 2.0 license" /></a>
   <a href="https://github.com/ogulcancelik/herdr/releases"><img src="https://img.shields.io/github/downloads/ogulcancelik/herdr/total?labelColor=333333&color=666666" alt="total GitHub release downloads" /></a>
   <a href="https://github.com/ogulcancelik/herdr/stargazers"><img src="https://img.shields.io/github/stars/ogulcancelik/herdr?labelColor=333333&color=666666&logo=github" alt="GitHub stars" /></a>

--- a/docs/next/README.zh-CN.md
+++ b/docs/next/README.zh-CN.md
@@ -17,7 +17,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-666666?labelColor=333333" alt="Apache 2.0 license" /></a>
   <a href="https://github.com/ogulcancelik/herdr/releases"><img src="https://img.shields.io/github/downloads/ogulcancelik/herdr/total?labelColor=333333&color=666666" alt="total GitHub release downloads" /></a>
   <a href="https://github.com/ogulcancelik/herdr/stargazers"><img src="https://img.shields.io/github/stars/ogulcancelik/herdr?labelColor=333333&color=666666&logo=github" alt="GitHub stars" /></a>
-  <a href="https://github.com/ogulcancelik/herdr/releases/latest"><img src="https://img.shields.io/github/v/release/herdr?label=release&labelColor=333333&color=666666" alt="latest stable release" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/releases/latest"><img src="https://img.shields.io/github/v/release/ogulcancelik/herdr?label=release&labelColor=333333&color=666666" alt="latest stable release" /></a>
   <a href="https://formulae.brew.sh/formula/herdr"><img src="https://img.shields.io/homebrew/v/herdr?label=homebrew&labelColor=333333&color=666666" alt="Homebrew version" /></a>
   <a href="https://x.com/herdrdev"><img src="https://img.shields.io/badge/follow-%40herdrdev-000000?logo=x&logoColor=white" alt="follow @herdrdev on X" /></a>
 </p>

--- a/docs/next/README.zh-CN.md
+++ b/docs/next/README.zh-CN.md
@@ -1,0 +1,87 @@
+# herdr
+
+
+<p align="center">
+  <img src="assets/logo.png" alt="herdr" width="100" />
+</p>
+
+<p align="center">
+  <a href="https://herdr.dev">herdr.dev</a> · <a href="#安装">安装</a> · <a href="https://herdr.dev/zh-cn/docs/quick-start/">快速开始</a> · <a href="https://herdr.dev/zh-cn/docs/">文档</a> · <a href="#赞助">赞助</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · 简体中文
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-666666?labelColor=333333" alt="Apache 2.0 license" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/releases"><img src="https://img.shields.io/github/downloads/ogulcancelik/herdr/total?labelColor=333333&color=666666" alt="total GitHub release downloads" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/stargazers"><img src="https://img.shields.io/github/stars/ogulcancelik/herdr?labelColor=333333&color=666666&logo=github" alt="GitHub stars" /></a>
+  <a href="https://github.com/ogulcancelik/herdr/releases/latest"><img src="https://img.shields.io/github/v/release/herdr?label=release&labelColor=333333&color=666666" alt="latest stable release" /></a>
+  <a href="https://formulae.brew.sh/formula/herdr"><img src="https://img.shields.io/homebrew/v/herdr?label=homebrew&labelColor=333333&color=666666" alt="Homebrew version" /></a>
+  <a href="https://x.com/herdrdev"><img src="https://img.shields.io/badge/follow-%40herdrdev-000000?logo=x&logoColor=white" alt="follow @herdrdev on X" /></a>
+</p>
+
+---
+
+https://github.com/user-attachments/assets/043ec09f-4bdd-41d5-aee0-8fda6b83e267
+
+**智能体复用器，住在你的终端里。**
+
+- **每个智能体一目了然**——`blocked`、`working`、`done`。真实的终端视图，而不是包装过的转述。
+- **分离后智能体继续运行**——从任意终端重新连接，或通过 ssh。会话在重启后依然保留。
+- **智能体也能使用 herdr**——纯 socket api：智能体可以创建窗格、读取输出、互相等待。[智能体技能 →](https://herdr.dev/zh-cn/docs/agent-skill/)
+- **键盘和鼠标都是一等公民**——tmux 风格的前缀键，*以及*点击、拖动、分割。按当下的场景选择，而不是被工具锁死。
+- **插件**——扩展窗格和工作流。[浏览插件市场 →](https://herdr.dev/plugins/)
+- **单个 rust 二进制，没有 electron**——运行在你已经在用的任何终端里。
+
+---
+
+## 安装
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+```
+
+或者 `brew install herdr` · `mise use -g herdr` · Windows 测试版：`powershell -ExecutionPolicy Bypass -c "irm https://herdr.dev/install.ps1 | iex"` · [二进制文件](https://github.com/ogulcancelik/herdr/releases)
+
+然后在工作所在的目录启动它：
+
+```bash
+herdr
+```
+
+运行你的智能体、分割窗格，然后安心离开。`ctrl+b q` 分离，`herdr` 重新连接。[快速开始 →](https://herdr.dev/zh-cn/docs/quick-start/)
+
+## 文档
+
+所有文档都在 [herdr.dev/docs](https://herdr.dev/zh-cn/docs/)：[快速开始](https://herdr.dev/zh-cn/docs/quick-start/) · [核心概念](https://herdr.dev/zh-cn/docs/concepts/) · [受支持的智能体](https://herdr.dev/zh-cn/docs/agents/) · [键盘](https://herdr.dev/zh-cn/docs/keyboard/) · [配置](https://herdr.dev/zh-cn/docs/configuration/) · [会话状态](https://herdr.dev/zh-cn/docs/session-state/) · [远程访问](https://herdr.dev/zh-cn/docs/persistence-remote/) · [集成](https://herdr.dev/zh-cn/docs/integrations/) · [插件](https://herdr.dev/zh-cn/docs/plugins/) · [socket api](https://herdr.dev/zh-cn/docs/socket-api/)
+
+## 赞助
+
+herdr 以全职方式公开开发。赞助将直接资助开发、稳定性，以及通往真正的智能体运行时之路。
+
+### 金牌
+
+<a href="https://terminaltrove.com/"><img src="assets/sponsors/terminal-trove.png" alt="Terminal Trove" width="200" /></a>
+
+[**→ 成为赞助者**](https://github.com/sponsors/ogulcancelik) · 企业/合作：hey@herdr.dev · 档位说明见 [SPONSORS.md](./SPONSORS.md)。谢谢 🐑
+
+## 智能体须知
+
+如果你是协助本仓库的 AI 智能体：在改动代码前阅读 [`AGENTS.md`](./AGENTS.md)，在创建 issue 或 PR 前阅读 [`CONTRIBUTING.md`](./CONTRIBUTING.md)。
+
+## 开发
+
+```bash
+git clone https://github.com/ogulcancelik/herdr
+cd herdr
+cargo build --release
+
+just test        # 单元测试
+just check       # 格式检查、测试和维护性检查
+```
+
+## 许可证
+
+herdr 基于 [Apache License 2.0](LICENSE) 许可证发布。

--- a/justfile
+++ b/justfile
@@ -80,6 +80,7 @@ release-docs-check:
     python3 scripts/config_reference_check.py
     node website/scripts/docs-versions.mjs check
     @test -f docs/next/README.md
+    @test -f docs/next/README.zh-CN.md
     @if ! diff -u CHANGELOG.md docs/next/CHANGELOG.md; then \
         echo "error: CHANGELOG.md differs from docs/next/CHANGELOG.md; finalize release notes before releasing"; \
         exit 1; \

--- a/website/scripts/docs-versions.integration.test.ts
+++ b/website/scripts/docs-versions.integration.test.ts
@@ -19,9 +19,11 @@ describe('documentation release publishing', () => {
     await write(root, 'website/src/data/config-reference.json', '{"stable":true}\n');
     await write(root, 'website/latest.json', '{"version":"0.9.0"}\n');
     await write(root, 'README.md', 'stable readme\n');
+    await write(root, 'README.zh-CN.md', 'stable readme zh-cn\n');
     await write(root, 'docs/next/website/src/content/docs/index.mdx', 'next docs\n');
     await write(root, 'docs/next/website/src/data/config-reference.json', '{"next":true}\n');
     await write(root, 'docs/next/README.md', 'next readme\n');
+    await write(root, 'docs/next/README.zh-CN.md', 'next readme zh-cn\n');
 
     git(root, ['init', '-q']);
     git(root, ['config', 'user.email', 'test@example.com']);
@@ -35,6 +37,7 @@ describe('documentation release publishing', () => {
     expect(await read(root, 'website/src/content/docs/index.mdx')).toBe('next docs\n');
     expect(await read(root, 'website/src/data/config-reference.json')).toBe('{"next":true}\n');
     expect(await read(root, 'README.md')).toBe('next readme\n');
+    expect(await read(root, 'README.zh-CN.md')).toBe('next readme zh-cn\n');
     expect(await read(root, 'docs/versions/1.0.0/website/src/content/docs/index.mdx')).toBe('next docs\n');
 
     const manifest = JSON.parse(await read(root, 'docs/versions/manifest.json'));

--- a/website/scripts/docs-versions.mjs
+++ b/website/scripts/docs-versions.mjs
@@ -240,9 +240,11 @@ export async function publishVersion(tag) {
     await rm(stableReferencePath, { force: true });
   }
 
-  const nextReadme = `docs/next/README.md`;
-  if (gitPathExists(tag, nextReadme)) {
-    await writeFile(resolve(repoRoot, 'README.md'), git(['show', `${tag}:${nextReadme}`], { binary: true }));
+  for (const readme of ['README.md', 'README.zh-CN.md']) {
+    const nextReadme = `docs/next/${readme}`;
+    if (gitPathExists(tag, nextReadme)) {
+      await writeFile(resolve(repoRoot, readme), git(['show', `${tag}:${nextReadme}`], { binary: true }));
+    }
   }
 
   const entries = new Map(manifest.versions.map((entry) => [entry.version, entry]));


### PR DESCRIPTION
Approved in discussion #1976.

Adds a Simplified Chinese translation of the README, staged in `docs/next/` so it ships with the next release:

- `docs/next/README.zh-CN.md` — full translation of `docs/next/README.md`. Terminology follows the existing zh-cn docs site; docs links point to the existing `/zh-cn/docs/` pages.
- `docs/next/README.md` — adds an `English · 简体中文` language line near the top.
- `website/scripts/docs-versions.mjs` (+ integration test) — release publishing previously promoted only `docs/next/README.md` to the repo root; it now also promotes `README.zh-CN.md`, so the language link won't 404 after release.

Notes:

- Relative links (`LICENSE`, `SPONSORS.md`, `AGENTS.md`, assets) mirror the English source: they 404 in the `docs/next/` staging view exactly like the English file, and resolve after release promotion.
- Validation: `bun test` (website), `node website/scripts/docs-versions.mjs check`, `test_docs_translation_parity`, and `cargo fmt --check` pass. The Rust suite was not run locally (zig 0.15.2 cannot link against the macOS 26 SDK on this machine, pre-existing and unrelated); no Rust code is touched, so CI covers it.

Disclosure: an AI assistant helped me prepare the translation; I've read it and can explain the content.
