### PR TITLE
fix: allow windows-native python command in commit hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,4 +4,8 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-python3 scripts/conventional_commits.py --message-file "$1"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+    python scripts/conventional_commits.py --message-file "$1"
+else
+    python3 scripts/conventional_commits.py --message-file "$1"
+fi


### PR DESCRIPTION
## Problem

During Windows testing and development, the commit-message hook repeatedly caused hiccups because it invokes `python3`. On Windows, `python3` can resolve to the Microsoft Store alias even when a working Python installation is available through `python`, so commits fail before the validator can run.

## Fix

Use `python` when the hook runs under Git for Windows (`OS=Windows_NT`) and keep `python3` everywhere else.

## Validation

- valid and invalid commit messages exercise the hook correctly in Git Bash on Windows
- the non-Windows branch continues to invoke `python3`
- `just check` passes on Windows