### PR TITLE
fix: catppuccin mocha and rose pine "surface_dim" theme colours

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -145,7 +145,7 @@ impl Palette {
             panel_bg: Color::Rgb(24, 24, 37),
             surface0: Color::Rgb(49, 50, 68),
             surface1: Color::Rgb(69, 71, 90),
-            surface_dim: Color::Rgb(30, 30, 46),
+            surface_dim: Color::Rgb(49, 50, 68),
             overlay0: Color::Rgb(108, 112, 134),
             overlay1: Color::Rgb(127, 132, 156),
             text: Color::Rgb(205, 214, 244),

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -475,7 +475,7 @@ impl Palette {
             panel_bg: Color::Rgb(25, 23, 36),
             surface0: Color::Rgb(31, 29, 46),
             surface1: Color::Rgb(38, 35, 58),
-            surface_dim: Color::Rgb(25, 23, 36),
+            surface_dim: Color::Rgb(38, 35, 58),
             overlay0: Color::Rgb(110, 106, 134),
             overlay1: Color::Rgb(144, 140, 170),
             text: Color::Rgb(224, 222, 244),


### PR DESCRIPTION
Closes #1946 as well as fixing catppuccin mocha.

The issue with the previous colours is that they would vanish into the foreground if the user had a corresponding terminal theme set.

This PR swaps the colours out for respective palette colours that should be visible even with a matching terminal theme.