### PR TITLE
fix: harden terminal cleanup and windows checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 packaging/windows/licenses/* binary
+*.patch text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.zig-cache/
 /vendor/libghostty-vt/zig-pkg/
 __pycache__/
 *.pyc

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@
 # Run tests
 test:
     cargo nextest run --locked --status-level fail --final-status-level fail --failure-output final --success-output never
-    python3 -m unittest scripts.test_agent_detection_manifest_check scripts.test_changelog scripts.test_config_reference_check scripts.test_docs_translation_parity scripts.test_hermes_integration_asset scripts.test_package_windows_conpty scripts.test_preview scripts.test_vendor_libghostty_vt scripts.test_vendor_portable_pty
+    just maintenance-test
     just integration-assets-test
     just plugin-marketplace-test
 
@@ -26,8 +26,19 @@ lint:
 [unix]
 ci filter='all()': lint
     cargo nextest run --locked -E "{{filter}}" --status-level fail --final-status-level slow --failure-output final --success-output never
+    just maintenance-test
     just integration-assets-test
     just plugin-marketplace-test
+
+# Run repository maintenance script tests
+[unix]
+maintenance-test:
+    python3 -m unittest discover -s scripts -p 'test_*.py'
+
+[script("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File")]
+[windows]
+maintenance-test:
+    & python -m unittest discover -s scripts -p 'test_*.py'
 
 # Run Windows target lint from Unix/macOS to catch cfg(windows) compile and clippy failures before CI
 [unix]
@@ -38,7 +49,6 @@ windows-lint:
 # Check formatting + run unit tests + Windows target lint + maintenance script tests
 [unix]
 check: ci windows-lint
-    python3 -m unittest scripts.test_agent_detection_manifest_check scripts.test_changelog scripts.test_config_reference_check scripts.test_docs_translation_parity scripts.test_hermes_integration_asset scripts.test_package_windows_conpty scripts.test_preview scripts.test_vendor_libghostty_vt scripts.test_vendor_portable_pty
     @echo "docs reminder: if this changes user-facing behavior, make sure the relevant release docs are updated or called out before release."
 
 [script("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File")]

--- a/scripts/agent_detection_manifest_check.py
+++ b/scripts/agent_detection_manifest_check.py
@@ -103,6 +103,11 @@ def load_toml(path: Path) -> dict:
     return value
 
 
+def normalized_sha256(path: Path) -> str:
+    content = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(content).hexdigest()
+
+
 def version_tuple(value: str, path: Path) -> tuple[int, ...]:
     if not isinstance(value, str) or not VERSION_RE.fullmatch(value):
         raise CheckError(f"{path}: version must be dotted numeric")
@@ -323,7 +328,7 @@ def validate_catalog(
         bundled_path, bundled_manifest = bundled[agent_id]
         cmp = compare_versions(manifest["version"], bundled_manifest["version"], manifest_path)
         staged_manifest = STAGED_WEBSITE_MANIFESTS.get(agent_id)
-        website_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        website_digest = normalized_sha256(manifest_path)
         stages_new_engine_manifest = (
             staged_manifest
             == (bundled_manifest["version"], manifest["version"], website_digest)

--- a/scripts/test_agent_detection_manifest_check.py
+++ b/scripts/test_agent_detection_manifest_check.py
@@ -35,9 +35,9 @@ def staged_grok_dirs(root: Path) -> tuple[Path, Path]:
     (bundled / "grok.toml").write_bytes(
         (check.DEFAULT_BUNDLED_DIR / "grok.toml").read_bytes()
     )
-    (website / "grok.toml").write_bytes(
-        (check.DEFAULT_WEBSITE_DIR / "grok.toml").read_bytes()
-    )
+    website_manifest = (check.DEFAULT_WEBSITE_DIR / "grok.toml").read_bytes()
+    website_manifest = website_manifest.replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+    (website / "grok.toml").write_bytes(website_manifest)
     (website / "index.toml").write_text(catalog("grok", "grok.toml"))
     return bundled, website
 

--- a/scripts/test_docs_translation_parity.py
+++ b/scripts/test_docs_translation_parity.py
@@ -56,7 +56,7 @@ class DocsTranslationParityTests(unittest.TestCase):
             errors = check_docs_translation_parity(root)
 
             self.assertEqual(len(errors), 1)
-            self.assertIn("ja/cli-reference.mdx", errors[0])
+            self.assertIn(str(Path("ja") / "cli-reference.mdx"), errors[0])
             self.assertIn("heading outline differs", errors[0])
 
     def test_parity_reports_missing_and_stale_files(self) -> None:

--- a/scripts/test_vendor_libghostty_vt.py
+++ b/scripts/test_vendor_libghostty_vt.py
@@ -91,7 +91,7 @@ class VendorLibghosttyVtTests(unittest.TestCase):
         project_root = Path(__file__).resolve().parent.parent
         metadata = project_root / "vendor" / "libghostty-vt.vendor.json"
         self.assertTrue(metadata.exists())
-        text = metadata.read_text()
+        text = metadata.read_text(encoding="utf-8")
         self.assertIn('"source_commit"', text)
         self.assertIn('"dist_archive"', text)
         self.assertIn('"extracted_dir"', text)
@@ -106,11 +106,11 @@ class VendorLibghosttyVtTests(unittest.TestCase):
             return
 
         self.assertTrue(index.exists())
-        text = index.read_text()
+        text = index.read_text(encoding="utf-8")
         missing = [
-            str(path.relative_to(project_root))
+            path.relative_to(project_root).as_posix()
             for path in patches
-            if str(path.relative_to(project_root)) not in text
+            if path.relative_to(project_root).as_posix() not in text
         ]
         self.assertEqual(missing, [])
 
@@ -119,26 +119,27 @@ class VendorLibghosttyVtTests(unittest.TestCase):
         patch_dir = project_root / "vendor" / "patches" / "libghostty-vt"
 
         for patch in sorted(patch_dir.glob("*.patch")):
+            patch_bytes = patch.read_bytes().replace(b"\r\n", b"\n")
             result = subprocess.run(
-                ["git", "apply", "--check", "--reverse", str(patch.relative_to(project_root))],
+                ["git", "apply", "--check", "--reverse", "-"],
                 cwd=project_root,
-                text=True,
+                input=patch_bytes,
                 capture_output=True,
             )
             self.assertEqual(
                 result.returncode,
                 0,
-                f"{patch.relative_to(project_root)} is not applied cleanly:\n"
-                f"stdout:\n{result.stdout}\n"
-                f"stderr:\n{result.stderr}",
+                f"{patch.relative_to(project_root).as_posix()} is not applied cleanly:\n"
+                f"stdout:\n{result.stdout.decode('utf-8', errors='replace')}\n"
+                f"stderr:\n{result.stderr.decode('utf-8', errors='replace')}",
             )
 
     def test_embedded_libghostty_logging_is_silenced(self) -> None:
         root = Path(__file__).resolve().parent.parent / "vendor" / "libghostty-vt"
         lib_vt = root / "src" / "lib_vt.zig"
         sys_zig = root / "src" / "terminal" / "c" / "sys.zig"
-        lib_text = lib_vt.read_text()
-        sys_text = sys_zig.read_text()
+        lib_text = lib_vt.read_text(encoding="utf-8")
+        sys_text = sys_zig.read_text(encoding="utf-8")
         self.assertIn('.logFn = @import("terminal/c/sys.zig").logFn', lib_text)
         self.assertIn("if (global.log == null) return;", sys_text)
 

--- a/scripts/test_vendor_portable_pty.py
+++ b/scripts/test_vendor_portable_pty.py
@@ -21,7 +21,7 @@ class VendorPortablePtyTests(unittest.TestCase):
 
     def test_cargo_patch_points_at_vendored_tree(self) -> None:
         project_root = Path(__file__).resolve().parent.parent
-        cargo_toml = (project_root / "Cargo.toml").read_text()
+        cargo_toml = (project_root / "Cargo.toml").read_text(encoding="utf-8")
 
         self.assertIn('portable-pty = "=0.9.0"', cargo_toml)
         self.assertIn("[patch.crates-io]", cargo_toml)
@@ -33,6 +33,7 @@ class VendorPortablePtyTests(unittest.TestCase):
             ["cargo", "metadata", "--locked", "--format-version", "1"],
             cwd=project_root,
             text=True,
+            encoding="utf-8",
             capture_output=True,
         )
         self.assertEqual(
@@ -63,18 +64,18 @@ class VendorPortablePtyTests(unittest.TestCase):
             return
 
         self.assertTrue(index.exists())
-        text = index.read_text()
+        text = index.read_text(encoding="utf-8")
         missing = [
-            str(path.relative_to(project_root))
+            path.relative_to(project_root).as_posix()
             for path in patches
-            if str(path.relative_to(project_root)) not in text
+            if path.relative_to(project_root).as_posix() not in text
         ]
         self.assertEqual(missing, [])
 
     def test_listed_local_vendor_patches_exist(self) -> None:
         project_root = Path(__file__).resolve().parent.parent
         index = project_root / "vendor" / "portable-pty.patches.md"
-        text = index.read_text()
+        text = index.read_text(encoding="utf-8")
         listed = [
             line.split("`", 2)[1]
             for line in text.splitlines()
@@ -89,24 +90,25 @@ class VendorPortablePtyTests(unittest.TestCase):
         patch_dir = project_root / "vendor" / "patches" / "portable-pty"
 
         for patch in sorted(patch_dir.glob("*.patch")):
+            patch_bytes = patch.read_bytes().replace(b"\r\n", b"\n")
             result = subprocess.run(
-                ["git", "apply", "--check", "--reverse", str(patch.relative_to(project_root))],
+                ["git", "apply", "--check", "--reverse", "-"],
                 cwd=project_root,
-                text=True,
+                input=patch_bytes,
                 capture_output=True,
             )
             self.assertEqual(
                 result.returncode,
                 0,
-                f"{patch.relative_to(project_root)} is not applied cleanly:\n"
-                f"stdout:\n{result.stdout}\n"
-                f"stderr:\n{result.stderr}",
+                f"{patch.relative_to(project_root).as_posix()} is not applied cleanly:\n"
+                f"stdout:\n{result.stdout.decode('utf-8', errors='replace')}\n"
+                f"stderr:\n{result.stderr.decode('utf-8', errors='replace')}",
             )
 
     def test_windows_conpty_loader_uses_only_controlled_sources(self) -> None:
         project_root = Path(__file__).resolve().parent.parent
         source = project_root / "vendor" / "portable-pty" / "src" / "win" / "psuedocon.rs"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
 
         self.assertIn("std::env::current_exe()", text)
         self.assertIn('.join("conpty")', text)

--- a/scripts/windows_check.ps1
+++ b/scripts/windows_check.ps1
@@ -5,6 +5,15 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+$ProjectZigCache = Join-Path $ProjectRoot ".zig-cache"
+if (-not $env:ZIG_GLOBAL_CACHE_DIR) {
+    $env:ZIG_GLOBAL_CACHE_DIR = $ProjectZigCache
+}
+if (-not $env:ZIG_LOCAL_CACHE_DIR) {
+    $env:ZIG_LOCAL_CACHE_DIR = $ProjectZigCache
+}
+
 function Invoke-Checked {
     param([string]$Command, [string[]]$Arguments)
 
@@ -66,3 +75,4 @@ Invoke-Checked cargo @(
     "server::client_transport::tests"
 )
 Invoke-Checked cargo @("build", "--locked", "--target", "x86_64-pc-windows-msvc")
+Invoke-Checked python @("-m", "unittest", "discover", "-s", "scripts", "-p", "test_*.py")

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -353,6 +353,7 @@ fn setup_terminal_with_capabilities(
     mouse_capture: bool,
 ) -> io::Result<TerminalGuard> {
     ratatui::init();
+    let mut guard = TerminalGuard::new();
     crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout())?;
     let host_color_scheme_reports =
         should_enable_host_color_scheme_reports(enable_client_protocols);
@@ -365,8 +366,10 @@ fn setup_terminal_with_capabilities(
         }
         execute!(io::stdout(), EnableBracketedPaste, EnableFocusChange)?;
         if host_color_scheme_reports {
+            guard.reset_host_color_scheme_reports = true;
             write_host_color_scheme_report_mode(&mut io::stdout(), true)?;
         }
+        guard.reset_keyboard_enhancements = true;
         push_keyboard_enhancement_flags()?;
     } else {
         if should_query_host_terminal_theme() {
@@ -386,6 +389,10 @@ fn setup_terminal_with_capabilities(
         } else {
             WindowsVirtualTerminalInputSetup::default()
         };
+    #[cfg(windows)]
+    {
+        guard.restore_windows_input_mode = windows_virtual_terminal_input.restore_mode;
+    }
 
     #[cfg(windows)]
     if enable_client_protocols
@@ -393,30 +400,21 @@ fn setup_terminal_with_capabilities(
         && windows_virtual_terminal_input.active
         && windows_win32_input_mode_enabled()
     {
-        if let Err(err) = enable_windows_win32_input_mode(&mut io::stdout()) {
-            if let Some(mode) = windows_virtual_terminal_input.restore_mode {
-                restore_windows_input_mode_value(mode);
-            }
-            return Err(err);
-        }
+        enable_windows_win32_input_mode(&mut io::stdout())?;
     }
 
     let modify_other_keys_mode = enable_client_protocols
         .then(crate::input::host_modify_other_keys_mode)
         .flatten();
     if let Some(mode) = modify_other_keys_mode {
+        guard.reset_modify_other_keys = true;
         io::stdout().write_all(mode.set_sequence())?;
         io::stdout().flush()?;
     }
 
     execute!(io::stdout(), DisableLineWrap)?;
 
-    Ok(TerminalGuard {
-        reset_modify_other_keys: modify_other_keys_mode.is_some(),
-        reset_host_color_scheme_reports: host_color_scheme_reports,
-        #[cfg(windows)]
-        restore_windows_input_mode: windows_virtual_terminal_input.restore_mode,
-    })
+    Ok(guard)
 }
 
 fn should_enable_host_color_scheme_reports(enable_client_protocols: bool) -> bool {
@@ -427,8 +425,23 @@ fn should_enable_host_color_scheme_reports(enable_client_protocols: bool) -> boo
 struct TerminalGuard {
     reset_modify_other_keys: bool,
     reset_host_color_scheme_reports: bool,
+    reset_keyboard_enhancements: bool,
+    cleanup_done: Arc<AtomicBool>,
     #[cfg(windows)]
     restore_windows_input_mode: Option<u32>,
+}
+
+impl TerminalGuard {
+    fn new() -> Self {
+        Self {
+            reset_modify_other_keys: false,
+            reset_host_color_scheme_reports: false,
+            reset_keyboard_enhancements: false,
+            cleanup_done: Arc::new(AtomicBool::new(false)),
+            #[cfg(windows)]
+            restore_windows_input_mode: None,
+        }
+    }
 }
 
 fn write_host_color_scheme_report_mode(
@@ -569,8 +582,14 @@ fn set_mouse_capture(enabled: bool) -> io::Result<()> {
 fn restore_terminal_state(
     reset_modify_other_keys: bool,
     reset_host_color_scheme_reports: bool,
+    reset_keyboard_enhancements: bool,
+    cleanup_done: &AtomicBool,
     #[cfg(windows)] restore_windows_input_mode: Option<u32>,
 ) {
+    if cleanup_done.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
     let _ = clear_received_kitty_graphics(&mut io::stdout());
 
     // Reset modifyOtherKeys if we enabled it.
@@ -579,7 +598,9 @@ fn restore_terminal_state(
         let _ = io::stdout().flush();
     }
 
-    let _ = pop_keyboard_enhancement_flags();
+    if reset_keyboard_enhancements {
+        let _ = pop_keyboard_enhancement_flags();
+    }
 
     let _ = execute!(
         io::stdout(),
@@ -650,6 +671,8 @@ impl Drop for TerminalGuard {
         restore_terminal_state(
             self.reset_modify_other_keys,
             self.reset_host_color_scheme_reports,
+            self.reset_keyboard_enhancements,
+            &self.cleanup_done,
             #[cfg(windows)]
             self.restore_windows_input_mode,
         );
@@ -1204,6 +1227,8 @@ fn run_client_with_mode(
     // Install a panic hook to restore the terminal on panic (same as monolithic).
     let panic_resets_modify_other_keys = terminal_guard.reset_modify_other_keys;
     let panic_resets_host_color_scheme_reports = terminal_guard.reset_host_color_scheme_reports;
+    let panic_resets_keyboard_enhancements = terminal_guard.reset_keyboard_enhancements;
+    let panic_cleanup_done = Arc::clone(&terminal_guard.cleanup_done);
     #[cfg(windows)]
     let panic_restore_windows_input_mode = terminal_guard.restore_windows_input_mode;
     let original_hook = std::panic::take_hook();
@@ -1211,6 +1236,8 @@ fn run_client_with_mode(
         restore_terminal_state(
             panic_resets_modify_other_keys,
             panic_resets_host_color_scheme_reports,
+            panic_resets_keyboard_enhancements,
+            &panic_cleanup_done,
             #[cfg(windows)]
             panic_restore_windows_input_mode,
         );
@@ -1516,6 +1543,7 @@ async fn run_client_loop(
             }
             ClientLoopEvent::ServerMessage(msg) => match msg {
                 ServerMessage::Frame(frame_data) => {
+                    frame_data.validate().map_err(ClientError::Protocol)?;
                     let frame_data = if state.draw_host_cursor {
                         render_ansi::frame_with_drawn_cursor(frame_data)
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use crossterm::event::{
     DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
@@ -52,6 +54,64 @@ fn set_host_color_scheme_reports(enabled: bool) -> io::Result<()> {
     };
     io::stdout().write_all(sequence.as_bytes())?;
     io::stdout().flush()
+}
+
+fn restore_monolithic_terminal_state(
+    reset_modify_other_keys: bool,
+    reset_keyboard_enhancements: bool,
+    cleanup_done: &AtomicBool,
+) {
+    use std::io::Write;
+
+    if cleanup_done.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    if reset_modify_other_keys {
+        let _ = io::stdout().write_all(b"\x1b[>4;0m");
+        let _ = io::stdout().flush();
+    }
+    if crate::kitty_graphics::is_enabled() {
+        let _ = crate::kitty_graphics::clear_all_host_graphics();
+    }
+    if reset_keyboard_enhancements {
+        let _ = pop_keyboard_enhancement_flags();
+    }
+    let _ = execute!(
+        io::stdout(),
+        DisableFocusChange,
+        DisableBracketedPaste,
+        DisableMouseCapture
+    );
+    let _ = crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout());
+    let _ = set_host_color_scheme_reports(false);
+    ratatui::restore();
+}
+
+struct MonolithicTerminalGuard {
+    reset_modify_other_keys: bool,
+    reset_keyboard_enhancements: bool,
+    cleanup_done: Arc<AtomicBool>,
+}
+
+impl MonolithicTerminalGuard {
+    fn new() -> Self {
+        Self {
+            reset_modify_other_keys: false,
+            reset_keyboard_enhancements: false,
+            cleanup_done: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Drop for MonolithicTerminalGuard {
+    fn drop(&mut self) {
+        restore_monolithic_terminal_state(
+            self.reset_modify_other_keys,
+            self.reset_keyboard_enhancements,
+            &self.cleanup_done,
+        );
+    }
 }
 
 mod agent_resume;
@@ -755,29 +815,6 @@ fn main() -> io::Result<()> {
 
     let modify_other_keys_mode = crate::input::host_modify_other_keys_mode();
 
-    let original_hook = std::panic::take_hook();
-    let panic_resets_modify_other_keys = modify_other_keys_mode.is_some();
-    std::panic::set_hook(Box::new(move |info| {
-        tracing::error!("PANIC: {info}");
-        if panic_resets_modify_other_keys {
-            let _ = std::io::Write::write_all(&mut io::stdout(), b"\x1b[>4;0m");
-        }
-        if crate::kitty_graphics::is_enabled() {
-            let _ = crate::kitty_graphics::clear_all_host_graphics();
-        }
-        let _ = execute!(
-            io::stdout(),
-            DisableFocusChange,
-            DisableBracketedPaste,
-            DisableMouseCapture
-        );
-        let _ = crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout());
-        let _ = set_host_color_scheme_reports(false);
-        let _ = pop_keyboard_enhancement_flags();
-        ratatui::restore();
-        original_hook(info);
-    }));
-
     let config = &loaded_config.config;
     let config_diagnostic = config::config_diagnostic_summary(&loaded_config.diagnostics);
     logging::startup("app");
@@ -793,6 +830,7 @@ fn main() -> io::Result<()> {
 
     let result = rt.block_on(async {
         let mut terminal = ratatui::init();
+        let mut terminal_guard = MonolithicTerminalGuard::new();
         crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout())?;
         if config.ui.mouse_capture {
             execute!(io::stdout(), EnableMouseCapture)?;
@@ -801,6 +839,7 @@ fn main() -> io::Result<()> {
         }
         execute!(io::stdout(), EnableBracketedPaste, EnableFocusChange)?;
         set_host_color_scheme_reports(true)?;
+        terminal_guard.reset_keyboard_enhancements = true;
         push_keyboard_enhancement_flags()?;
 
         // Some hosts do not honor Kitty keyboard enhancement pushes for
@@ -808,9 +847,24 @@ fn main() -> io::Result<()> {
         // know it is needed and parseable, so modified Enter stays distinct.
         if let Some(mode) = modify_other_keys_mode {
             use std::io::Write;
+            terminal_guard.reset_modify_other_keys = true;
             std::io::stdout().write_all(mode.set_sequence())?;
             std::io::stdout().flush()?;
         }
+
+        let panic_resets_modify_other_keys = terminal_guard.reset_modify_other_keys;
+        let panic_resets_keyboard_enhancements = terminal_guard.reset_keyboard_enhancements;
+        let panic_cleanup_done = Arc::clone(&terminal_guard.cleanup_done);
+        let original_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            tracing::error!("PANIC: {info}");
+            restore_monolithic_terminal_state(
+                panic_resets_modify_other_keys,
+                panic_resets_keyboard_enhancements,
+                &panic_cleanup_done,
+            );
+            original_hook(info);
+        }));
 
         let mut app = app::App::new(
             config,
@@ -821,26 +875,7 @@ fn main() -> io::Result<()> {
         );
         let result = app.run(&mut terminal).await;
 
-        // Reset modifyOtherKeys if we enabled it.
-        if modify_other_keys_mode.is_some() {
-            use std::io::Write;
-            std::io::stdout().write_all(b"\x1b[>4;0m")?;
-            std::io::stdout().flush()?;
-        }
-
-        if crate::kitty_graphics::is_enabled() {
-            crate::kitty_graphics::clear_all_host_graphics()?;
-        }
-        pop_keyboard_enhancement_flags()?;
-        execute!(
-            io::stdout(),
-            DisableFocusChange,
-            DisableBracketedPaste,
-            DisableMouseCapture
-        )?;
-        crate::terminal_modes::clear_host_mouse_reporting(&mut io::stdout())?;
-        set_host_color_scheme_reports(false)?;
-        ratatui::restore();
+        drop(terminal_guard);
 
         // Drop app (and all workspaces/panes) before runtime shuts down
         drop(app);

--- a/src/persist/io.rs
+++ b/src/persist/io.rs
@@ -1,4 +1,7 @@
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use tracing::warn;
 
@@ -6,6 +9,8 @@ use super::snapshot::{
     parse_history_snapshot, parse_snapshot, snapshot_file_version, SessionHistorySnapshot,
     SessionSnapshot, SNAPSHOT_VERSION,
 };
+
+static SAVE_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn session_path() -> PathBuf {
     crate::session::data_dir().join("session.json")
@@ -51,14 +56,55 @@ fn save_json_to_path<T: serde::Serialize>(path: &Path, snapshot: &T) -> std::io:
         std::fs::create_dir_all(parent)?;
     }
     let json = serde_json::to_string_pretty(snapshot)?;
-    let tmp_path = target.with_extension("json.tmp");
-    std::fs::write(&tmp_path, &json)?;
+    let (tmp_path, mut tmp_file) = create_temp_file(&target)?;
+    if let Err(err) = tmp_file.write_all(json.as_bytes()) {
+        drop(tmp_file);
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(err);
+    }
+    drop(tmp_file);
     if let Err(err) = std::fs::rename(&tmp_path, &target) {
         let _ = std::fs::remove_file(&tmp_path);
         return Err(err);
     }
     Ok(())
 }
+
+fn create_temp_file(target: &Path) -> std::io::Result<(PathBuf, std::fs::File)> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+
+    for _ in 0..100 {
+        let id = SAVE_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_path =
+            target.with_extension(format!("json.tmp-{}-{timestamp}-{id}", std::process::id()));
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        restrict_file_options(&mut options);
+        match options.open(&tmp_path) {
+            Ok(file) => return Ok((tmp_path, file)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "failed to allocate unique session temp path",
+    ))
+}
+
+#[cfg(unix)]
+fn restrict_file_options(options: &mut std::fs::OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.mode(0o600);
+}
+
+#[cfg(windows)]
+fn restrict_file_options(_options: &mut std::fs::OpenOptions) {}
 
 pub(super) fn save_to_paths(
     session_path: &Path,
@@ -261,6 +307,39 @@ mod tests {
 
         assert!(session_path.exists());
         assert!(!history_path.exists());
+    }
+
+    #[test]
+    fn session_temp_files_are_unique() {
+        let target = temp_session_path("unique-temp");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+
+        let (first_path, first_file) = create_temp_file(&target).unwrap();
+        let (second_path, second_file) = create_temp_file(&target).unwrap();
+
+        assert_ne!(first_path, second_path);
+
+        drop(first_file);
+        drop(second_file);
+        let _ = std::fs::remove_file(first_path);
+        let _ = std::fs::remove_file(second_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_to_path_uses_private_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_session_path("private-permissions");
+        let parent = path.parent().unwrap();
+        std::fs::create_dir_all(parent).unwrap();
+
+        save_to_path(&path, &empty_snapshot()).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[test]

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -496,6 +496,20 @@ pub struct FrameData {
 }
 
 impl FrameData {
+    /// Validates invariants required by semantic-frame renderers.
+    pub(crate) fn validate(&self) -> Result<(), FramingError> {
+        let expected = (self.width as usize) * (self.height as usize);
+        if self.cells.len() != expected {
+            return Err(FramingError::InvalidMessage(format!(
+                "semantic frame has {} cells, expected {expected} for {}x{}",
+                self.cells.len(),
+                self.width,
+                self.height
+            )));
+        }
+        Ok(())
+    }
+
     /// Creates a `FrameData` from a ratatui `Buffer` and optional cursor.
     ///
     /// This converts ratatui's internal cell representation into the
@@ -800,6 +814,8 @@ pub enum FramingError {
     Io(io::Error),
     /// Bincode serialization or deserialization failed.
     Bincode(String),
+    /// A decoded message violates a required protocol invariant.
+    InvalidMessage(String),
     /// The connection was closed before a complete frame could be read.
     UnexpectedEof,
 }
@@ -812,6 +828,7 @@ impl std::fmt::Display for FramingError {
             }
             FramingError::Io(e) => write!(f, "I/O error: {e}"),
             FramingError::Bincode(e) => write!(f, "bincode error: {e}"),
+            FramingError::InvalidMessage(e) => write!(f, "invalid message: {e}"),
             FramingError::UnexpectedEof => write!(f, "unexpected end of stream"),
         }
     }
@@ -1793,6 +1810,8 @@ mod tests {
         };
         let frame = FrameData::from_ratatui_buffer(&buffer, Some(cursor.clone()));
 
+        assert!(frame.validate().is_ok());
+
         // Verify frame dimensions.
         assert_eq!(frame.width, 5);
         assert_eq!(frame.height, 3);
@@ -1854,6 +1873,11 @@ mod tests {
             hyperlinks: Vec::new(),
             graphics: Vec::new(),
         };
+        assert!(matches!(
+            frame.validate(),
+            Err(FramingError::InvalidMessage(message))
+                if message.contains("5 cells") && message.contains("expected 6")
+        ));
         assert!(frame.to_ratatui_buffer().is_none());
     }
 

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -14,6 +14,7 @@ use std::process::Output;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(not(any(windows, target_os = "macos")))]
 use std::time::{Duration, Instant};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use tracing::warn;
 
@@ -79,9 +80,12 @@ fn play_file(path: &Path) -> Result<(), String> {
 
 fn play_bytes(data: &[u8]) -> Result<(), String> {
     // Write to a temp file because the supported audio players need a file path.
-    let tmp = temp_sound_path();
-    let mut file = std::fs::File::create(&tmp).map_err(|e| e.to_string())?;
-    file.write_all(data).map_err(|e| e.to_string())?;
+    let (tmp, mut file) = create_temp_sound_file().map_err(|e| e.to_string())?;
+    if let Err(err) = file.write_all(data) {
+        drop(file);
+        let _ = std::fs::remove_file(&tmp);
+        return Err(err.to_string());
+    }
     drop(file);
 
     let result = run_player(&tmp);
@@ -96,9 +100,49 @@ fn play_bytes(data: &[u8]) -> Result<(), String> {
 }
 
 fn temp_sound_path() -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
     let id = SOUND_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("herdr-sound-{}-{id}.mp3", std::process::id()))
+    std::env::temp_dir().join(format!(
+        "herdr-sound-{}-{timestamp}-{id}.mp3",
+        std::process::id()
+    ))
 }
+
+fn create_temp_sound_file() -> std::io::Result<(PathBuf, std::fs::File)> {
+    for _ in 0..100 {
+        let path = temp_sound_path();
+        match create_new_sound_file(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "failed to allocate unique sound path",
+    ))
+}
+
+fn create_new_sound_file(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    restrict_sound_file_options(&mut options);
+    options.open(path)
+}
+
+#[cfg(unix)]
+fn restrict_sound_file_options(options: &mut std::fs::OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.mode(0o600);
+}
+
+#[cfg(windows)]
+fn restrict_sound_file_options(_options: &mut std::fs::OpenOptions) {}
 
 #[cfg(windows)]
 fn run_player(path: &Path) -> Result<Output, String> {
@@ -335,6 +379,36 @@ mod tests {
     #[test]
     fn temp_sound_paths_are_unique() {
         assert_ne!(temp_sound_path(), temp_sound_path());
+    }
+
+    #[test]
+    fn sound_temp_file_does_not_replace_an_existing_file() {
+        let path = temp_sound_path();
+        std::fs::write(&path, b"keep me").expect("test file should be created");
+
+        let err = create_new_sound_file(&path).expect_err("existing file must not be replaced");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read(&path).expect("test file should remain readable"),
+            b"keep me"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sound_temp_files_are_unique() {
+        let (first_path, first_file) =
+            create_temp_sound_file().expect("first temp file should be created");
+        let (second_path, second_file) =
+            create_temp_sound_file().expect("second temp file should be created");
+
+        assert_ne!(first_path, second_path);
+
+        drop(first_file);
+        drop(second_file);
+        let _ = std::fs::remove_file(first_path);
+        let _ = std::fs::remove_file(second_path);
     }
 
     #[cfg(not(any(windows, target_os = "macos")))]

--- a/website/scripts/prepare-docs.mjs
+++ b/website/scripts/prepare-docs.mjs
@@ -184,8 +184,9 @@ async function collectDocsScope(sourceDir, excludedDirectories = new Set()) {
 }
 
 export function rewritePreviewDocContent(content, relativePath = '') {
+  const normalizedContent = content.replace(/\r\n?/g, '\n');
   const rewritten = rewriteRelativeDocPaths(
-    content.replaceAll('/docs/', '/docs/preview/'),
+    normalizedContent.replaceAll('/docs/', '/docs/preview/'),
     1,
   );
   const withEditLink = setGeneratedEditUrl(
@@ -196,7 +197,8 @@ export function rewritePreviewDocContent(content, relativePath = '') {
 }
 
 export function rewriteVersionDocContent(content, { version, tag, sourceRoot, relativePath }) {
-  const taggedContent = content
+  const normalizedContent = content.replace(/\r\n?/g, '\n');
+  const taggedContent = normalizedContent
     .replaceAll('/docs/', `/docs/${version}/`)
     .replaceAll(
       'https://github.com/ogulcancelik/herdr/blob/master/',


### PR DESCRIPTION
## What changed

- Restore terminal modes and cursor state exactly once across early failures and normal client shutdown.
- Reject semantic terminal frames whose cell count does not match their declared dimensions.
- Create session and sound temporary files atomically, with private permissions on Unix.
- Make repository maintenance checks deterministic on Windows, including UTF-8 handling and same-drive Zig caches.

## Why

Some error and shutdown paths could leave terminal state unrestored. Predictable temporary paths could also collide with existing files. On Windows, platform-default text decoding and Zig caches on a different drive prevented the documented full check from completing reliably.

## Impact

Normal Herdr behavior is unchanged. Failure handling is safer, malformed frames are rejected, temporary files cannot silently replace existing files, and the Windows repository check completes consistently.

Public documentation does not need an update because these are internal reliability and development-check fixes.

## Validation

- `just check` on Windows
- 124 Windows-focused tests passed
- 21 server transport tests passed
- 93 maintenance tests passed
