### PR TITLE
fix: list server live-handoff in cli help and completions

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Relicensed Herdr from AGPL-3.0-or-later to Apache-2.0.
 
 ### Fixed
+- `herdr server --help` and shell completions now list `herdr server live-handoff`, which was dispatched but missing from the CLI spec.
 - Agent prompts now wait briefly after sending text before pressing Enter, preventing prompts from remaining in agent composers without starting a turn. (#1878)
 - Empty clipboard writes from pane applications no longer erase existing clipboard contents or show a copied confirmation. (#1893)
 - Plain mouse movement no longer triggers continuous full renders while preserving Herdr menu hover and pane application mouse tracking. (#1865)

--- a/docs/next/website/src/content/docs/cli-reference.mdx
+++ b/docs/next/website/src/content/docs/cli-reference.mdx
@@ -85,13 +85,14 @@ compinit
 ```bash
 herdr server
 herdr server stop
+herdr server live-handoff [--import-exe <path>] [--expected-protocol <n>] [--expected-version <version>]
 herdr server reload-config
 herdr server agent-manifests [--json]
 herdr server update-agent-manifests [--json]
 herdr server reload-agent-manifests
 ```
 
-`herdr server` runs the headless server explicitly. Use it for supervised or service-style setups. `reload-config` applies reloadable settings without restarting panes. `agent-manifests` shows the active agent detection manifest sources, cached remote versions, and last remote update results. `update-agent-manifests` fetches remote manifest updates immediately, reloads them into the running server, and prints the updated manifest status; pass `--json` for the raw status response. `reload-agent-manifests` reloads agent detection manifests into the running server after local override edits.
+`herdr server` runs the headless server explicitly. Use it for supervised or service-style setups. `live-handoff` moves the running server's live panes to a freshly spawned server process without killing the pane processes; `herdr update --handoff` uses the same path automatically, and the flags let you pin the replacement binary and refuse the handoff on a protocol or version mismatch. `reload-config` applies reloadable settings without restarting panes. `agent-manifests` shows the active agent detection manifest sources, cached remote versions, and last remote update results. `update-agent-manifests` fetches remote manifest updates immediately, reloads them into the running server, and prints the updated manifest status; pass `--json` for the raw status response. `reload-agent-manifests` reloads agent detection manifests into the running server after local override edits.
 
 ## Notifications
 

--- a/docs/next/website/src/content/docs/ja/cli-reference.mdx
+++ b/docs/next/website/src/content/docs/ja/cli-reference.mdx
@@ -81,13 +81,14 @@ compinit
 ```bash
 herdr server
 herdr server stop
+herdr server live-handoff [--import-exe <path>] [--expected-protocol <n>] [--expected-version <version>]
 herdr server reload-config
 herdr server agent-manifests [--json]
 herdr server update-agent-manifests [--json]
 herdr server reload-agent-manifests
 ```
 
-`herdr server` はヘッドレスサーバーを明示的に起動します。監視下やサービス的な構成で使ってください。`reload-config` はペインを再起動せずにリロード可能な設定を適用します。`agent-manifests` は、アクティブなエージェント検出マニフェストのソース、キャッシュされたリモートバージョン、直近のリモート更新結果を表示します。`update-agent-manifests` はリモートマニフェストの更新を即座に取得し、実行中のサーバーにリロードして、更新後のマニフェスト状態を表示します。生のステータスレスポンスが欲しいときは `--json` を渡してください。`reload-agent-manifests` は、ローカルオーバーライドの編集後にエージェント検出マニフェストを実行中のサーバーにリロードします。
+`herdr server` はヘッドレスサーバーを明示的に起動します。監視下やサービス的な構成で使ってください。`live-handoff` は、ペインのプロセスを終了させずに、実行中のサーバーのライブペインを新しく起動したサーバープロセスへ引き渡します。`herdr update --handoff` も同じ経路を自動的に使います。フラグを指定すると、引き渡し先のバイナリを固定し、プロトコルやバージョンが一致しない場合は引き渡しを拒否できます。`reload-config` はペインを再起動せずにリロード可能な設定を適用します。`agent-manifests` は、アクティブなエージェント検出マニフェストのソース、キャッシュされたリモートバージョン、直近のリモート更新結果を表示します。`update-agent-manifests` はリモートマニフェストの更新を即座に取得し、実行中のサーバーにリロードして、更新後のマニフェスト状態を表示します。生のステータスレスポンスが欲しいときは `--json` を渡してください。`reload-agent-manifests` は、ローカルオーバーライドの編集後にエージェント検出マニフェストを実行中のサーバーにリロードします。
 
 ## 通知
 

--- a/docs/next/website/src/content/docs/zh-cn/cli-reference.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/cli-reference.mdx
@@ -81,13 +81,14 @@ compinit
 ```bash
 herdr server
 herdr server stop
+herdr server live-handoff [--import-exe <path>] [--expected-protocol <n>] [--expected-version <version>]
 herdr server reload-config
 herdr server agent-manifests [--json]
 herdr server update-agent-manifests [--json]
 herdr server reload-agent-manifests
 ```
 
-`herdr server` 显式运行无界面服务器,适合被监管或服务式的部署。`reload-config` 在不重启窗格的情况下应用可重载设置。`agent-manifests` 显示生效的智能体检测清单来源、缓存的远程版本和最近的远程更新结果。`update-agent-manifests` 立即拉取远程清单更新,重载到运行中的服务器,并打印更新后的清单状态;要原始状态响应就加 `--json`。`reload-agent-manifests` 在编辑本地覆盖后,把智能体检测清单重载到运行中的服务器。
+`herdr server` 显式运行无界面服务器,适合被监管或服务式的部署。`live-handoff` 把运行中服务器的活动窗格移交给新启动的服务器进程,而不会杀掉窗格里的进程;`herdr update --handoff` 自动走同一条路径,这些参数可以指定接管的二进制文件,并在协议或版本不匹配时拒绝移交。`reload-config` 在不重启窗格的情况下应用可重载设置。`agent-manifests` 显示生效的智能体检测清单来源、缓存的远程版本和最近的远程更新结果。`update-agent-manifests` 立即拉取远程清单更新,重载到运行中的服务器,并打印更新后的清单状态;要原始状态响应就加 `--json`。`reload-agent-manifests` 在编辑本地覆盖后,把智能体检测清单重载到运行中的服务器。
 
 ## 通知
 

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -159,6 +159,22 @@ fn server_command() -> Command {
     Command::new("server")
         .about("Run or control the headless server")
         .subcommand(Command::new("stop").about("Stop the running server"))
+        .subcommand(
+            Command::new("live-handoff")
+                .about("Hand off live panes to a new local server")
+                .arg(
+                    path_option("import-exe", "PATH")
+                        .help("Server binary to hand the live panes off to"),
+                )
+                .arg(
+                    option("expected-protocol", "VERSION")
+                        .help("Refuse the handoff unless the new server speaks this protocol"),
+                )
+                .arg(
+                    option("expected-version", "VERSION")
+                        .help("Refuse the handoff unless the new server reports this version"),
+                ),
+        )
         .subcommand(Command::new("reload-config").about("Reload config in the running server"))
         .subcommand(
             Command::new("agent-manifests")
@@ -1235,6 +1251,35 @@ mod tests {
         assert!(pane
             .get_subcommands()
             .any(|subcommand| subcommand.get_name() == "wait-output"));
+    }
+
+    #[test]
+    fn spec_covers_every_dispatched_server_subcommand() {
+        // Keep in sync with the dispatch table in `super::super::server`. The
+        // spec drives `-h`/`--help` and shell completion, so a subcommand that
+        // is dispatched but unlisted is invisible to users.
+        let cmd = super::command();
+        let server = command_path(&cmd, &["server"]);
+        let names: Vec<&str> = server
+            .get_subcommands()
+            .map(|subcommand| subcommand.get_name())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "stop",
+                "live-handoff",
+                "reload-config",
+                "agent-manifests",
+                "update-agent-manifests",
+                "reload-agent-manifests",
+            ]
+        );
+
+        let handoff = command_path(&cmd, &["server", "live-handoff"]);
+        assert!(has_option(handoff, "import-exe"));
+        assert!(has_option(handoff, "expected-protocol"));
+        assert!(has_option(handoff, "expected-version"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`herdr server live-handoff` is dispatched in `run_server_command` (`src/cli/server.rs:10`) and is a real, working command, but it is absent from `server_command()` in `src/cli/spec.rs`.

The spec drives `-h`/`--help` (via `spec::print_requested_help`, called from `src/cli.rs:76` before dispatch) and shell completion generation. The handwritten `print_server_help()` in `src/cli/server.rs:255` *does* list the command — so the two help paths disagree and the discoverable one is the incomplete one:

```
$ herdr server -h
Commands:
  stop                    Stop the running server
  reload-config           Reload config in the running server
  agent-manifests         Show active agent detection manifests
  update-agent-manifests  Fetch and reload agent detection manifests
  reload-agent-manifests  Reload local agent detection manifest overrides

$ herdr server help
herdr server commands:
  ...
  herdr server live-handoff   hand off live panes to a new local server
  ...
```

Same for completions:

```
$ herdr completion zsh | grep -c live-handoff          # 0
$ herdr completion zsh | grep -c reload-agent-manifests # 5
```

This matters because `live-handoff` is the recovery path you reach for manually when `herdr update --handoff` did not run or did not finish — exactly the moment when `--help` is where you look.

## Change

- Declare `live-handoff` in `server_command()` with its three options, matching `parse_live_handoff_params` (`--import-exe`, `--expected-protocol`, `--expected-version`).
- Add a regression test pinning the server subcommand set and the three options, so the spec and the dispatch table cannot drift apart silently again.
- Document the command in the CLI reference (en/ja/zh-cn) and add a `docs/next` changelog entry.

No behavior change to the command itself — it was already reachable, just undocumented.

## Verification

```
$ herdr server -h
Commands:
  stop                    Stop the running server
  live-handoff            Hand off live panes to a new local server
  reload-config           Reload config in the running server
  ...

$ herdr server live-handoff -h
Options:
      --import-exe <PATH>            Server binary to hand the live panes off to
      --expected-protocol <VERSION>  Refuse the handoff unless the new server speaks this protocol
      --expected-version <VERSION>   Refuse the handoff unless the new server reports this version

$ herdr completion zsh  | grep -c live-handoff   # 5
$ herdr completion bash | grep -c live-handoff   # 2
$ herdr completion fish | grep -c live-handoff   # 9
```

`just check` passes on macOS aarch64: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `just windows-lint`, 2954/2954 nextest, integration-assets and plugin-marketplace tests, and the 93 maintenance script tests.