### PR TITLE
fix: track opencode child session state

### DIFF
--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -16,6 +16,7 @@ let reportedRootSessionID;
 const sessionParents = new Map();
 const childStates = new Map();
 let ownedRootSessionID;
+let awaitingRootCreation = false;
 let rootState = "idle";
 const CHILD_EVENT_STATES = new Map([
   ["permission.asked", "blocked"],
@@ -132,6 +133,7 @@ function rootSessionIDFor(sessionID) {
 }
 
 function setOwnedRootSession(sessionID) {
+  awaitingRootCreation = false;
   if (sessionID === ownedRootSessionID) {
     return;
   }
@@ -164,6 +166,7 @@ function resetOwnedRootSession() {
   }
   childStates.clear();
   ownedRootSessionID = undefined;
+  awaitingRootCreation = true;
   reportedRootSessionID = undefined;
   rootState = "idle";
 }
@@ -263,6 +266,9 @@ export const HerdrAgentStatePlugin = async () => {
         : undefined;
     }
     if (!ownedRootSessionID) {
+      if (awaitingRootCreation && !canReplaceOwnedRoot) {
+        return undefined;
+      }
       setOwnedRootSession(rootSessionIDFor(sessionID));
     } else if (!belongsToOwnedTree(sessionID)) {
       // Once a root is owned, only a new session.created event may take over.

--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -158,6 +158,16 @@ function removeSessionSubtree(sessionID) {
   }
 }
 
+function resetOwnedRootSession() {
+  if (ownedRootSessionID) {
+    removeSessionSubtree(ownedRootSessionID);
+  }
+  childStates.clear();
+  ownedRootSessionID = undefined;
+  reportedRootSessionID = undefined;
+  rootState = "idle";
+}
+
 function request(method, params) {
   const pending = requestChain.then(() => requestOnce(method, params));
   requestChain = pending.catch(() => {});
@@ -370,6 +380,10 @@ export const HerdrAgentStatePlugin = async () => {
           await reportRootState("idle", sessionID);
           break;
         case "session.deleted":
+          if (role === "root") {
+            resetOwnedRootSession();
+            await reportState("idle");
+          }
           break;
         default:
           break;

--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -310,7 +310,10 @@ export const HerdrAgentStatePlugin = async () => {
       const properties = event?.properties ?? {};
       const sessionID = sessionIDFromProperties(properties);
       rememberSessionParent(properties);
-      const role = sessionRole(sessionID, type === "session.created");
+      const canReplaceOwnedRoot =
+        type === "session.created" &&
+        (!awaitingRootCreation || rootSessionIDFor(sessionID) === sessionID);
+      const role = sessionRole(sessionID, canReplaceOwnedRoot);
       const isForeignTopLevelUpdate =
         type === "session.updated" &&
         !attachedSessionID &&

--- a/src/integration/assets/opencode/herdr-agent-state.js
+++ b/src/integration/assets/opencode/herdr-agent-state.js
@@ -12,15 +12,21 @@ let reportSeq = Date.now() * 1000;
 let requestChain = Promise.resolve();
 let reportedRootSessionID;
 
-// Track child sessions so their events cannot replace the pane's root session.
-// Their user prompts still project state without attaching the child session id.
-const childSessions = new Set();
+// Track the owning root's session tree so child state never leaks across roots.
+const sessionParents = new Map();
+const childStates = new Map();
+let ownedRootSessionID;
+let rootState = "idle";
 const CHILD_EVENT_STATES = new Map([
   ["permission.asked", "blocked"],
   ["question.asked", "blocked"],
   ["permission.replied", "working"],
   ["question.replied", "working"],
   ["question.rejected", "working"],
+  ["tool.execute.before", "working"],
+  ["tool.execute.after", "working"],
+  ["session.compacted", "working"],
+  ["session.error", "blocked"],
 ]);
 
 function nextReportSeq() {
@@ -37,6 +43,7 @@ function sessionIDFromProperties(properties) {
 const SESSION_STATE_BY_STATUS = new Map([
   ["idle", "idle"],
   ["active", "working"],
+  ["blocked", "blocked"],
   ["busy", "working"],
   ["pending", "working"],
   ["retry", "working"],
@@ -50,6 +57,105 @@ function stateFromSessionStatus(status) {
   return typeof kind === "string"
     ? SESSION_STATE_BY_STATUS.get(kind.toLowerCase())
     : undefined;
+}
+
+function attachedSessionIDFromArgv(argv) {
+  // `process.argv[2]` is the OpenCode subcommand. Do not treat an arbitrary
+  // argument named "attach" as one, such as a normal session id or URL.
+  if (argv[2] !== "attach") {
+    return undefined;
+  }
+
+  for (let index = 3; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--session") {
+      return argv[index + 1] || undefined;
+    }
+    if (argument.startsWith("--session=")) {
+      return argument.slice("--session=".length) || undefined;
+    }
+  }
+  return undefined;
+}
+
+function childAggregateState() {
+  let hasWorking = rootState === "working";
+  if (rootState === "blocked") {
+    return "blocked";
+  }
+  for (const state of childStates.values()) {
+    if (state === "blocked") {
+      return "blocked";
+    }
+    if (state === "working") {
+      hasWorking = true;
+    }
+  }
+  return hasWorking ? "working" : rootState;
+}
+
+function rememberSessionParent(properties) {
+  const info = properties?.info;
+  if (!info?.id) {
+    return;
+  }
+  if (info.parentID) {
+    sessionParents.set(info.id, info.parentID);
+  } else {
+    sessionParents.delete(info.id);
+  }
+}
+
+function belongsToOwnedTree(sessionID) {
+  const visited = new Set();
+  let currentSessionID = sessionID;
+  while (currentSessionID && !visited.has(currentSessionID)) {
+    if (currentSessionID === ownedRootSessionID) {
+      return true;
+    }
+    visited.add(currentSessionID);
+    currentSessionID = sessionParents.get(currentSessionID);
+  }
+  return false;
+}
+
+function rootSessionIDFor(sessionID) {
+  const visited = new Set();
+  let rootSessionID = sessionID;
+  let parentSessionID = sessionParents.get(rootSessionID);
+  while (parentSessionID && !visited.has(parentSessionID)) {
+    visited.add(rootSessionID);
+    rootSessionID = parentSessionID;
+    parentSessionID = sessionParents.get(rootSessionID);
+  }
+  return rootSessionID;
+}
+
+function setOwnedRootSession(sessionID) {
+  if (sessionID === ownedRootSessionID) {
+    return;
+  }
+  ownedRootSessionID = sessionID;
+  childStates.clear();
+  rootState = "idle";
+}
+
+function removeSessionSubtree(sessionID) {
+  const removedSessionIDs = new Set([sessionID]);
+  let foundDescendant = true;
+  while (foundDescendant) {
+    foundDescendant = false;
+    for (const [childSessionID, parentSessionID] of sessionParents) {
+      if (removedSessionIDs.has(parentSessionID) && !removedSessionIDs.has(childSessionID)) {
+        removedSessionIDs.add(childSessionID);
+        foundDescendant = true;
+      }
+    }
+  }
+  for (const removedSessionID of removedSessionIDs) {
+    childStates.delete(removedSessionID);
+    sessionParents.delete(removedSessionID);
+  }
 }
 
 function request(method, params) {
@@ -131,26 +237,97 @@ export const HerdrAgentStatePlugin = async () => {
     return {};
   }
 
+  const attachedSessionID = attachedSessionIDFromArgv(process.argv);
+  if (attachedSessionID) {
+    setOwnedRootSession(attachedSessionID);
+  }
+  const sessionRole = (sessionID, canReplaceOwnedRoot = false) => {
+    if (!sessionID) {
+      return undefined;
+    }
+    if (attachedSessionID) {
+      return belongsToOwnedTree(sessionID)
+        ? sessionID === ownedRootSessionID
+          ? "root"
+          : "child"
+        : undefined;
+    }
+    if (!ownedRootSessionID) {
+      setOwnedRootSession(rootSessionIDFor(sessionID));
+    } else if (!belongsToOwnedTree(sessionID)) {
+      // Once a root is owned, only a new session.created event may take over.
+      // Stale status, idle, deletion, or update events from a prior top-level
+      // session must not reclaim ownership.
+      if (sessionParents.has(sessionID) || !canReplaceOwnedRoot) {
+        return undefined;
+      }
+      setOwnedRootSession(sessionID);
+    }
+    return sessionID === ownedRootSessionID ? "root" : "child";
+  };
+  const reportChildState = async (sessionID, state) => {
+    childStates.set(sessionID, state);
+    const aggregateState = childAggregateState();
+    if (aggregateState) {
+      await reportState(aggregateState);
+    }
+  };
+  const reportRootState = async (state, sessionID) => {
+    rootState = state;
+    await reportState(childAggregateState(), sessionID);
+  };
+
   return {
     "chat.message": async ({ sessionID }) => {
-      if (sessionID && childSessions.has(sessionID)) {
+      const role = sessionRole(sessionID);
+      if (sessionID && !role) {
         return;
       }
-      await reportState("working", sessionID);
+      if (role === "child") {
+        await reportChildState(sessionID, "working");
+        return;
+      }
+      await reportRootState("working", sessionID);
     },
     event: async ({ event }) => {
       const type = event?.type;
       const properties = event?.properties ?? {};
       const sessionID = sessionIDFromProperties(properties);
+      rememberSessionParent(properties);
+      const role = sessionRole(sessionID, type === "session.created");
+      const isForeignTopLevelUpdate =
+        type === "session.updated" &&
+        !attachedSessionID &&
+        sessionID &&
+        !role &&
+        !sessionParents.has(sessionID);
 
-      const info = properties.info;
-      if (info?.id && info.parentID) {
-        childSessions.add(info.id);
+      if (sessionID && !role && !isForeignTopLevelUpdate) {
+        return;
       }
-      if (sessionID && childSessions.has(sessionID)) {
+      if (role === "child") {
         const state = CHILD_EVENT_STATES.get(type);
         if (state) {
-          await reportState(state);
+          await reportChildState(sessionID, state);
+          return;
+        }
+        if (type === "session.status") {
+          const statusState = stateFromSessionStatus(properties.status);
+          if (statusState) {
+            await reportChildState(sessionID, statusState);
+          }
+          return;
+        }
+        if (type === "session.idle") {
+          await reportChildState(sessionID, "idle");
+          return;
+        }
+        if (type === "session.deleted") {
+          removeSessionSubtree(sessionID);
+          const aggregateState = childAggregateState();
+          if (aggregateState) {
+            await reportState(aggregateState);
+          }
         }
         return;
       }
@@ -163,14 +340,14 @@ export const HerdrAgentStatePlugin = async () => {
           await reportSession(sessionID, "new");
           break;
         case "session.updated":
-          if (sessionID && sessionID !== reportedRootSessionID) {
+          if (isForeignTopLevelUpdate || (sessionID && sessionID !== reportedRootSessionID)) {
             await reportSession(sessionID);
           }
           break;
         case "session.status": {
           const state = stateFromSessionStatus(properties.status);
           if (state) {
-            await reportState(state, sessionID);
+            await reportRootState(state, sessionID);
           } else {
             await reportSession(sessionID);
           }
@@ -182,15 +359,15 @@ export const HerdrAgentStatePlugin = async () => {
         case "question.replied":
         case "question.rejected":
         case "session.compacted":
-          await reportState("working", sessionID);
+          await reportRootState("working", sessionID);
           break;
         case "permission.asked":
         case "question.asked":
         case "session.error":
-          await reportState("blocked", sessionID);
+          await reportRootState("blocked", sessionID);
           break;
         case "session.idle":
-          await reportState("idle", sessionID);
+          await reportRootState("idle", sessionID);
           break;
         case "session.deleted":
           break;

--- a/src/integration/assets/opencode/herdr-agent-state.test.ts
+++ b/src/integration/assets/opencode/herdr-agent-state.test.ts
@@ -441,6 +441,35 @@ test("resets a deleted root and allows a new root to take over", async () => {
   ]);
 });
 
+test("does not reclaim a deleted root from events before a new root is created", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "root-a" } } });
+  await plugin["chat.message"]({ sessionID: "outside-chat" });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "outside-status", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.created", properties: { sessionID: "root-b" } } });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-b", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestState)).toEqual(["working", "idle", undefined, "working"]);
+  expect(requests.map(requestSessionID)).toEqual(["root-a", undefined, "root-b", "root-b"]);
+});
+
 test("does not treat a normal run session argument as attached ownership", async () => {
   process.argv = ["node", "opencode", "run", "--session", "child-session"];
   const plugin = await loadPlugin();

--- a/src/integration/assets/opencode/herdr-agent-state.test.ts
+++ b/src/integration/assets/opencode/herdr-agent-state.test.ts
@@ -5,6 +5,7 @@ const clients: FakeClient[] = [];
 const requestWaiters: Array<() => void> = [];
 let autoAcknowledge = true;
 let importCounter = 0;
+const originalArgv = process.argv;
 
 type FakeClient = {
   emit: (event: string) => void;
@@ -46,6 +47,7 @@ beforeEach(() => {
   process.env.HERDR_ENV = "1";
   process.env.HERDR_SOCKET_PATH = "test.sock";
   process.env.HERDR_PANE_ID = "test:p1";
+  process.argv = originalArgv;
 });
 
 async function loadPlugin() {
@@ -163,6 +165,401 @@ test("reports child prompts without replacing the root session", async () => {
     undefined,
     undefined,
   ]);
+});
+
+test("aggregates child state and restores the root state after children idle", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-session",
+        info: { id: "child-session", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-session", status: { type: "idle" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "child-session" } } });
+
+  expect(requests.map(requestState)).toEqual(["working", "working", "working", "idle"]);
+  expect(requests.map(requestSessionID)).toEqual([
+    "root-session",
+    undefined,
+    "root-session",
+    undefined,
+  ]);
+});
+
+test("returns idle after a child finishes before any root state arrives", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-session",
+        info: { id: "child-session", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "child-session" } } });
+
+  expect(requests.map(requestState)).toEqual(["working", "idle"]);
+  expect(requests.map(requestSessionID)).toEqual([undefined, undefined]);
+});
+
+test("clears child state when a new root replaces the owned tree", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-c",
+        info: { id: "child-c", parentID: "root-a" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-c", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.created", properties: { sessionID: "root-b" } } });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "root-b" } } });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-c", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestState)).toEqual(["working", "working", undefined, "idle"]);
+  expect(requests.map(requestSessionID)).toEqual(["root-a", undefined, "root-b", "root-b"]);
+});
+
+test("ignores a deleted prior root after replacement", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-a",
+        info: { id: "child-a", parentID: "root-a" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.created", properties: { sessionID: "root-b" } } });
+  await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "root-a" } } });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-b",
+        info: { id: "child-b", parentID: "root-b" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-b", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestState)).toEqual(["working", "working", undefined, "working"]);
+  expect(requests.map(requestSessionID)).toEqual(["root-a", undefined, "root-b", undefined]);
+});
+
+test("does not let a prior root update reclaim ownership", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.created", properties: { sessionID: "root-b" } } });
+  await plugin.event({ event: { type: "session.updated", properties: { sessionID: "root-a" } } });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-b", status: { type: "idle" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-b", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestState)).toEqual(["working", undefined, undefined, "idle", "working"]);
+  expect(requests.map(requestSessionID)).toEqual(["root-a", "root-b", "root-a", "root-b", "root-b"]);
+});
+
+test("clears deleted child descendants from the aggregate", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-session", status: { type: "idle" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-c",
+        info: { id: "child-c", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-d",
+        info: { id: "child-d", parentID: "child-c" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-d", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "permission.asked", properties: { sessionID: "child-d" } } });
+  await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "child-c" } } });
+  await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "child-d" } } });
+
+  expect(requests.map(requestState)).toEqual(["idle", "working", "blocked", "idle"]);
+  expect(requests.map(requestSessionID)).toEqual(["root-session", undefined, undefined, undefined]);
+});
+
+test("tracks an attached child session as the pane session", async () => {
+  process.argv = ["node", "opencode", "attach", "http://example.test", "--session", "child-session"];
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-session",
+        info: { id: "child-session", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "child-session" } } });
+
+  expect(requests.map(requestMethod)).toEqual([
+    "pane.report_agent_session",
+    "pane.report_agent",
+    "pane.report_agent",
+  ]);
+  expect(requests.map(requestState)).toEqual([undefined, "working", "idle"]);
+  expect(requests.map(requestSessionID)).toEqual([
+    "child-session",
+    "child-session",
+    "child-session",
+  ]);
+});
+
+test("recognizes an attached child session with equals syntax", async () => {
+  process.argv = ["node", "opencode", "attach", "http://example.test", "--session=child-session"];
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-session",
+        info: { id: "child-session", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestSessionID)).toEqual(["child-session", "child-session"]);
+});
+
+test("reattaches a child session before its creation event", async () => {
+  process.argv = ["node", "opencode", "attach", "http://example.test", "--session", "child-session"];
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "child-session" } } });
+
+  expect(requests.map(requestMethod)).toEqual(["pane.report_agent", "pane.report_agent"]);
+  expect(requests.map(requestState)).toEqual(["working", "idle"]);
+  expect(requests.map(requestSessionID)).toEqual(["child-session", "child-session"]);
+});
+
+test("prioritizes blocked and working states across multiple children", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-session", status: { type: "idle" } },
+    },
+  });
+  for (const childSessionID of ["child-a", "child-b"]) {
+    await plugin.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: childSessionID,
+          info: { id: childSessionID, parentID: "root-session" },
+        },
+      },
+    });
+  }
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-b", status: { type: "blocked" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "child-b" } } });
+  await plugin.event({ event: { type: "session.idle", properties: { sessionID: "child-a" } } });
+
+  expect(requests.map(requestState)).toEqual(["idle", "working", "blocked", "working", "idle"]);
+  expect(requests.map(requestSessionID)).toEqual([
+    "root-session",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ]);
+});
+
+test("ignores sessions outside an attached child tree", async () => {
+  process.argv = ["node", "opencode", "attach", "http://example.test", "--session", "child-c"];
+  const plugin = await loadPlugin();
+
+  for (const [sessionID, type] of [
+    ["parent-p", "session.status"],
+    ["parent-p", "session.idle"],
+    ["other-session", "session.status"],
+    ["other-session", "session.idle"],
+    ["parent-p", "session.updated"],
+  ]) {
+    await plugin.event({
+      event: {
+        type,
+        properties:
+          type === "session.status"
+            ? { sessionID, status: { type: "busy" } }
+            : { sessionID },
+      },
+    });
+  }
+
+  expect(requests).toHaveLength(0);
+
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-c",
+        info: { id: "child-c", parentID: "parent-p" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-c", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-d",
+        info: { id: "child-d", parentID: "child-c" },
+      },
+    },
+  });
+  await plugin.event({ event: { type: "permission.asked", properties: { sessionID: "child-d" } } });
+
+  expect(requests.map(requestMethod)).toEqual([
+    "pane.report_agent_session",
+    "pane.report_agent",
+    "pane.report_agent",
+  ]);
+  expect(requests.map(requestState)).toEqual([undefined, "working", "blocked"]);
+  expect(requests.map(requestSessionID)).toEqual(["child-c", "child-c", undefined]);
 });
 
 function requestMethod(request: unknown): unknown {

--- a/src/integration/assets/opencode/herdr-agent-state.test.ts
+++ b/src/integration/assets/opencode/herdr-agent-state.test.ts
@@ -5,7 +5,7 @@ const clients: FakeClient[] = [];
 const requestWaiters: Array<() => void> = [];
 let autoAcknowledge = true;
 let importCounter = 0;
-const originalArgv = process.argv;
+const originalArgv = [...process.argv];
 
 type FakeClient = {
   emit: (event: string) => void;
@@ -382,6 +382,88 @@ test("clears deleted child descendants from the aggregate", async () => {
 
   expect(requests.map(requestState)).toEqual(["idle", "working", "blocked", "idle"]);
   expect(requests.map(requestSessionID)).toEqual(["root-session", undefined, undefined, undefined]);
+});
+
+test("resets a deleted root and allows a new root to take over", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-session",
+        info: { id: "child-session", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-session", status: { type: "blocked" } },
+    },
+  });
+  await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "root-session" } } });
+  await plugin.event({ event: { type: "session.created", properties: { sessionID: "new-root" } } });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "new-root", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestState)).toEqual([
+    "working",
+    "working",
+    "blocked",
+    "idle",
+    undefined,
+    "working",
+  ]);
+  expect(requests.map(requestSessionID)).toEqual([
+    "root-session",
+    undefined,
+    "root-session",
+    undefined,
+    "new-root",
+    "new-root",
+  ]);
+});
+
+test("does not treat a normal run session argument as attached ownership", async () => {
+  process.argv = ["node", "opencode", "run", "--session", "child-session"];
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-session",
+        info: { id: "child-session", parentID: "root-session" },
+      },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "child-session", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestMethod)).toEqual(["pane.report_agent"]);
+  expect(requests.map(requestState)).toEqual(["working"]);
+  expect(requests.map(requestSessionID)).toEqual([undefined]);
 });
 
 test("tracks an attached child session as the pane session", async () => {

--- a/src/integration/assets/opencode/herdr-agent-state.test.ts
+++ b/src/integration/assets/opencode/herdr-agent-state.test.ts
@@ -441,6 +441,47 @@ test("resets a deleted root and allows a new root to take over", async () => {
   ]);
 });
 
+test("ignores a late child creation while waiting for a new root", async () => {
+  const plugin = await loadPlugin();
+
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-a", status: { type: "busy" } },
+    },
+  });
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-c",
+        info: { id: "child-c", parentID: "root-a" },
+      },
+    },
+  });
+  await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "root-a" } } });
+
+  await plugin.event({
+    event: {
+      type: "session.created",
+      properties: {
+        sessionID: "child-c",
+        info: { id: "child-c", parentID: "root-a" },
+      },
+    },
+  });
+  await plugin.event({ event: { type: "session.created", properties: { sessionID: "root-b" } } });
+  await plugin.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "root-b", status: { type: "busy" } },
+    },
+  });
+
+  expect(requests.map(requestState)).toEqual(["working", "idle", undefined, "working"]);
+  expect(requests.map(requestSessionID)).toEqual(["root-a", undefined, "root-b", "root-b"]);
+});
+
 test("does not reclaim a deleted root from events before a new root is created", async () => {
   const plugin = await loadPlugin();
 


### PR DESCRIPTION
## Summary

- aggregate child session state without letting a child idle event override an active root session
- treat `opencode attach --session` panes as owners of the attached child session
- ignore stale or foreign session lifecycle state and clear nested child state when its parent is deleted

## Testing

- `bun test src/integration/assets/herdr-agent-state.test.ts`
- `bun test src/integration/assets/opencode/herdr-agent-state.test.ts`

Refs #1362