### PR TITLE
feat: add Goose agent detection via screen manifests

### DIFF
--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -618,6 +618,7 @@ rows = [[{ token = "git_status", fg = "#ff00aa" }], [{ token = "$jj", bold = tru
             Agent::Droid,
             Agent::Amp,
             Agent::Grok,
+            Agent::Goose,
             Agent::Hermes,
             Agent::Kilo,
             Agent::Qodercli,

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -247,6 +247,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("droid", include_str!("manifests/droid.toml")),
     ("gemini", include_str!("manifests/gemini.toml")),
     ("grok", include_str!("manifests/grok.toml")),
+    ("goose", include_str!("manifests/goose.toml")),
     ("hermes", include_str!("manifests/hermes.toml")),
     ("kilo", include_str!("manifests/kilo.toml")),
     ("kimi", include_str!("manifests/kimi.toml")),

--- a/src/detect/manifests/goose.toml
+++ b/src/detect/manifests/goose.toml
@@ -1,0 +1,67 @@
+id = "goose"
+version = "2026.07.30.1"
+min_engine_version = 2
+updated_at = "2026-07-30T06:00:00Z"
+aliases = ["goose-cli", "herdr:goose"]
+
+[[rules]]
+id = "approval_prompt"
+state = "blocked"
+priority = 900
+region = "bottom_non_empty_lines(14)"
+visible_blocker = true
+any = [
+  { contains = ["? Do you allow this tool call?"] },
+  { contains = ["? Goose would like to call the above tool, do you allow?"] },
+  { contains = ["? Approve this action?"] },
+  { contains = ["? Approve?"] },
+]
+all = [
+  { any = [
+    { contains = ["Allow"] },
+    { contains = ["Deny"] },
+  ]},
+]
+
+[[rules]]
+id = "thinking_interrupt"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(5)"
+visible_working = true
+contains = ["Ctrl+C to interrupt"]
+
+[[rules]]
+id = "tool_call_working"
+state = "working"
+priority = 400
+region = "whole_recent"
+visible_working = true
+line_regex = ['^\s{2}▸']
+
+[[rules]]
+id = "progress_bar_working"
+state = "working"
+priority = 300
+region = "whole_recent"
+visible_working = true
+regex = ['━━━━[━╌]+\s+\d+%']
+
+[[rules]]
+id = "error_blocked"
+state = "blocked"
+priority = 200
+region = "bottom_non_empty_lines(5)"
+visible_blocker = true
+contains = ["Insufficient credits"]
+
+[[rules]]
+id = "banner_idle"
+state = "idle"
+priority = 100
+region = "last_non_empty_above_prompt_box"
+visible_idle = true
+any = [
+  { contains = ["goose is ready"] },
+  { line_regex = ['^\s{2}__\( O\)>'] },
+]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -58,6 +58,7 @@ pub enum Agent {
     Droid,
     Amp,
     Grok,
+    Goose,
     Hermes,
     Kilo,
     Qodercli,
@@ -65,7 +66,7 @@ pub enum Agent {
 }
 
 impl Agent {
-    pub const ALL: [Self; 21] = [
+    pub const ALL: [Self; 22] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -83,13 +84,14 @@ impl Agent {
         Self::Droid,
         Self::Amp,
         Self::Grok,
+        Self::Goose,
         Self::Hermes,
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -105,6 +107,7 @@ impl Agent {
         Self::Droid,
         Self::Amp,
         Self::Grok,
+        Self::Goose,
         Self::Hermes,
         Self::Kilo,
         Self::Qodercli,
@@ -131,6 +134,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Droid => "droid",
         Agent::Amp => "amp",
         Agent::Grok => "grok",
+        Agent::Goose => "goose",
         Agent::Hermes => "hermes",
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
@@ -157,6 +161,7 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
         Agent::Droid => "droid",
         Agent::Amp => "amp",
         Agent::Grok => "grok",
+        Agent::Goose => "goose",
         Agent::Hermes => "hermes",
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
@@ -193,6 +198,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "droid" => Some(Agent::Droid),
         "amp" | "amp-local" => Some(Agent::Amp),
         "grok" | "grok-build" => Some(Agent::Grok),
+        "goose" | "goose-cli" => Some(Agent::Goose),
         "hermes" | "hermes-agent" => Some(Agent::Hermes),
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
@@ -680,6 +686,8 @@ mod tests {
         assert_eq!(identify_agent("ghcs"), Some(Agent::GithubCopilot));
         assert_eq!(identify_agent("grok"), Some(Agent::Grok));
         assert_eq!(identify_agent("grok-build"), Some(Agent::Grok));
+        assert_eq!(identify_agent("goose"), Some(Agent::Goose));
+        assert_eq!(identify_agent("goose-cli"), Some(Agent::Goose));
         assert_eq!(identify_agent("hermes"), Some(Agent::Hermes));
         assert_eq!(identify_agent("hermes-agent"), Some(Agent::Hermes));
         assert_eq!(identify_agent("kilo"), Some(Agent::Kilo));
@@ -708,6 +716,8 @@ mod tests {
         assert_eq!(parse_agent_label("amp-local"), Some(Agent::Amp));
         assert_eq!(parse_agent_label("kiro-cli"), Some(Agent::Kiro));
         assert_eq!(parse_agent_label("grok-build"), Some(Agent::Grok));
+        assert_eq!(parse_agent_label("goose"), Some(Agent::Goose));
+        assert_eq!(parse_agent_label("goose-cli"), Some(Agent::Goose));
         assert_eq!(parse_agent_label("hermes-agent"), Some(Agent::Hermes));
         assert_eq!(parse_agent_label("maki"), Some(Agent::Maki));
         assert_eq!(parse_agent_label("kilo-code"), Some(Agent::Kilo));
@@ -742,6 +752,7 @@ mod tests {
             (Agent::Droid, "droid"),
             (Agent::Amp, "amp"),
             (Agent::Grok, "grok"),
+            (Agent::Goose, "goose"),
             (Agent::Hermes, "hermes"),
             (Agent::Kilo, "kilo"),
             (Agent::Qodercli, "qodercli"),

--- a/website/agent-detection/goose.toml
+++ b/website/agent-detection/goose.toml
@@ -1,0 +1,67 @@
+id = "goose"
+version = "2026.07.30.1"
+min_engine_version = 2
+updated_at = "2026-07-30T06:00:00Z"
+aliases = ["goose-cli", "herdr:goose"]
+
+[[rules]]
+id = "approval_prompt"
+state = "blocked"
+priority = 900
+region = "bottom_non_empty_lines(14)"
+visible_blocker = true
+any = [
+  { contains = ["? Do you allow this tool call?"] },
+  { contains = ["? Goose would like to call the above tool, do you allow?"] },
+  { contains = ["? Approve this action?"] },
+  { contains = ["? Approve?"] },
+]
+all = [
+  { any = [
+    { contains = ["Allow"] },
+    { contains = ["Deny"] },
+  ]},
+]
+
+[[rules]]
+id = "thinking_interrupt"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(5)"
+visible_working = true
+contains = ["Ctrl+C to interrupt"]
+
+[[rules]]
+id = "tool_call_working"
+state = "working"
+priority = 400
+region = "whole_recent"
+visible_working = true
+line_regex = ['^\s{2}▸']
+
+[[rules]]
+id = "progress_bar_working"
+state = "working"
+priority = 300
+region = "whole_recent"
+visible_working = true
+regex = ['━━━━[━╌]+\s+\d+%']
+
+[[rules]]
+id = "error_blocked"
+state = "blocked"
+priority = 200
+region = "bottom_non_empty_lines(5)"
+visible_blocker = true
+contains = ["Insufficient credits"]
+
+[[rules]]
+id = "banner_idle"
+state = "idle"
+priority = 100
+region = "last_non_empty_above_prompt_box"
+visible_idle = true
+any = [
+  { contains = ["goose is ready"] },
+  { line_regex = ['^\s{2}__\( O\)>'] },
+]

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -41,6 +41,10 @@ id = "grok"
 path = "grok.toml"
 
 [[agents]]
+id = "goose"
+path = "goose.toml"
+
+[[agents]]
 id = "hermes"
 path = "hermes.toml"
 


### PR DESCRIPTION
Adds Goose (github.com/block/goose) as a recognized agent in Herdr's screen detection system.

Changes:
- Agent enum variant + process-name detection (goose, goose-cli)
- Screen manifest: blocked (approval prompts), working (thinking indicators, tool calls), idle (ready banner)
- Website manifest + index entry
- Sidebar config + test coverage

Integration plugin (hooks) left for follow-up - Goose uses Open Plugins standard.