### PR TITLE
fix(omp): support Windows session paths

### DIFF
--- a/src/integration/assets/herdr-agent-state.test.ts
+++ b/src/integration/assets/herdr-agent-state.test.ts
@@ -227,6 +227,17 @@ for (const integration of integrations) {
   });
 }
 
+test("OMP accepts POSIX and Windows session paths", async () => {
+  const { isAbsoluteSessionPath } = await importFresh("./omp/herdr-agent-state.ts");
+
+  expect(isAbsoluteSessionPath("/tmp/omp-session.jsonl")).toBe(true);
+  expect(isAbsoluteSessionPath("C:\\Users\\User\\.omp\\agent\\sessions\\omp-session.jsonl")).toBe(
+    true,
+  );
+  expect(isAbsoluteSessionPath("C:/Users/User/.omp/agent/sessions/omp-session.jsonl")).toBe(true);
+  expect(isAbsoluteSessionPath("relative/omp-session.jsonl")).toBe(false);
+});
+
 test("Pi reports idle only after the agent settles", async () => {
   const requests = await startRecordingServer("pi-settled");
   const { handlers, pi } = createExtensionHarness();

--- a/src/integration/assets/omp/herdr-agent-state.ts
+++ b/src/integration/assets/omp/herdr-agent-state.ts
@@ -2,10 +2,11 @@
 // managed by herdr; reinstalling or updating the integration overwrites this file.
 // add custom hooks/plugins beside this file instead of editing it.
 // HERDR_INTEGRATION_ID=omp
-// HERDR_INTEGRATION_VERSION=7
+// HERDR_INTEGRATION_VERSION=8
 // @ts-nocheck
 
 import net from "node:net";
+import path from "node:path";
 
 const HERDR_ENV = process.env.HERDR_ENV;
 const socketPath = process.env.HERDR_SOCKET_PATH;
@@ -84,11 +85,17 @@ function nextReportSeq(): number {
   return reportSeq;
 }
 
+export function isAbsoluteSessionPath(file: unknown): file is string {
+  return (
+    typeof file === "string" &&
+    (path.posix.isAbsolute(file) || path.win32.isAbsolute(file))
+  );
+}
+
 function updateSessionRef(ctx: any): void {
   try {
     const file = ctx?.sessionManager?.getSessionFile?.();
-    currentAgentSessionPath =
-      typeof file === "string" && file.startsWith("/") ? file : undefined;
+    currentAgentSessionPath = isAbsoluteSessionPath(file) ? file : undefined;
   } catch {
     currentAgentSessionPath = undefined;
   }

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -25,7 +25,7 @@ const PI_EXTENSION_ASSET: &str = include_str!("assets/pi/herdr-agent-state.ts");
 const PI_INTEGRATION_VERSION: u32 = 7;
 const OMP_EXTENSION_INSTALL_NAME: &str = "herdr-omp-agent-state.ts";
 const OMP_EXTENSION_ASSET: &str = include_str!("assets/omp/herdr-agent-state.ts");
-const OMP_INTEGRATION_VERSION: u32 = 7;
+const OMP_INTEGRATION_VERSION: u32 = 8;
 const CLAUDE_HOOK_INSTALL_NAME: &str = if cfg!(windows) {
     "herdr-agent-state.ps1"
 } else {


### PR DESCRIPTION
## Summary

- accept POSIX and Windows absolute OMP session paths
- retain the session-id fallback for relative or missing paths
- bump the managed OMP integration from v7 to v8

On Windows, `SessionManager.getSessionFile()` returns paths such as `C:\Users\User\.omp\agent\sessions\session.jsonl`. The current `file.startsWith("/")` check rejects them, so Herdr receives `kind: id` instead of `kind: path`.

## Verification

- `bun test src/integration/assets/herdr-agent-state.test.ts --test-name-pattern "OMP accepts POSIX and Windows session paths"` — 1 passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
- live Windows smoke: a newly started Herdr-managed OMP session reported `agent_session.kind = path` with a `C:\...jsonl` value
