### PR TITLE
fix: ignore leaked herdr env inside tmux for nested-launch guard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ use crossterm::execute;
 
 pub(crate) const HERDR_ENV_VAR: &str = "HERDR_ENV";
 pub(crate) const HERDR_ENV_VALUE: &str = "1";
+// `TMUX` is set inside every tmux pane. herdr panes never set it, so a set
+// `TMUX` means `HERDR_ENV` was inherited from a tmux server whose launch shell
+// was a herdr pane, not set by herdr for this shell.
+const TMUX_ENV_VAR: &str = "TMUX";
 const NESTED_HERDR_MESSAGES: [&str; 6] = [
     "inception detected. we need to go deeper... said no one ever.",
     "recursion is a pathway to many abilities some consider to be... unnatural.",
@@ -432,11 +436,22 @@ pane_history = false
 const SKILL: &str = include_str!("../skills/herdr/SKILL.md");
 
 fn should_block_nested(config: &config::Config) -> bool {
-    should_block_nested_for_env(config, std::env::var(HERDR_ENV_VAR).ok().as_deref())
+    let herdr_env = std::env::var(HERDR_ENV_VAR).ok();
+    let inherited_from_tmux = std::env::var_os(TMUX_ENV_VAR).is_some();
+    should_block_nested_for_env(config, herdr_env.as_deref(), inherited_from_tmux)
 }
 
-fn should_block_nested_for_env(config: &config::Config, herdr_env: Option<&str>) -> bool {
-    !config.experimental.allow_nested && herdr_env == Some(HERDR_ENV_VALUE)
+fn should_block_nested_for_env(
+    config: &config::Config,
+    herdr_env: Option<&str>,
+    inherited_from_tmux: bool,
+) -> bool {
+    // `HERDR_ENV` is injected into every herdr-managed pane, but it leaks into
+    // the server-global environment when a tmux server is started from inside a
+    // herdr pane. Every session on that server then inherits `HERDR_ENV` even
+    // though those panes are not herdr-managed, so ignore the marker while
+    // inside tmux and let the launch proceed.
+    !config.experimental.allow_nested && herdr_env == Some(HERDR_ENV_VALUE) && !inherited_from_tmux
 }
 
 fn random_nested_message() -> &'static str {
@@ -865,20 +880,40 @@ mod tests {
     #[test]
     fn nested_herdr_blocks_when_env_is_set() {
         let config = config::Config::default();
-        assert!(should_block_nested_for_env(&config, Some(HERDR_ENV_VALUE)));
+        assert!(should_block_nested_for_env(
+            &config,
+            Some(HERDR_ENV_VALUE),
+            false
+        ));
     }
 
     #[test]
     fn nested_herdr_does_not_block_when_allowed() {
         let config: config::Config =
             toml::from_str("[experimental]\nallow_nested = true\n").unwrap();
-        assert!(!should_block_nested_for_env(&config, Some(HERDR_ENV_VALUE)));
+        assert!(!should_block_nested_for_env(
+            &config,
+            Some(HERDR_ENV_VALUE),
+            false
+        ));
     }
 
     #[test]
     fn nested_herdr_does_not_block_without_env() {
         let config = config::Config::default();
-        assert!(!should_block_nested_for_env(&config, None));
+        assert!(!should_block_nested_for_env(&config, None, false));
+    }
+
+    #[test]
+    fn nested_herdr_does_not_block_when_env_leaked_from_tmux() {
+        // A tmux server started from a herdr pane exports HERDR_ENV to every
+        // session, so the marker alone must not trigger the guard there.
+        let config = config::Config::default();
+        assert!(!should_block_nested_for_env(
+            &config,
+            Some(HERDR_ENV_VALUE),
+            true
+        ));
     }
 
     #[test]

--- a/tests/auto_detect.rs
+++ b/tests/auto_detect.rs
@@ -761,6 +761,7 @@ fn auto_detect_respects_nested_guard_before_auto_attach() {
         .env("HERDR_SOCKET_PATH", &api_socket)
         .env_remove("HERDR_CLIENT_SOCKET_PATH")
         .env("HERDR_ENV", "1")
+        .env_remove("TMUX")
         .output()
         .unwrap();
 

--- a/tests/cli/surface.rs
+++ b/tests/cli/surface.rs
@@ -567,6 +567,7 @@ fn explicit_client_command_respects_nested_guard() {
     let output = Command::new(env!("CARGO_BIN_EXE_herdr"))
         .arg("client")
         .env("HERDR_ENV", "1")
+        .env_remove("TMUX")
         .env("XDG_CONFIG_HOME", &base)
         .env_remove("HERDR_CONFIG_PATH")
         .output()


### PR DESCRIPTION
## What

The nested-launch guard blocks `herdr` when `HERDR_ENV=1` is set. That marker is injected into every herdr-managed pane, but it leaks into tmux's server-global environment when a tmux server is started from inside a herdr pane. Every session on that server then inherits `HERDR_ENV`, so the guard false-positives and refuses to launch herdr in unrelated tmux sessions that are not herdr panes. See #2135.

## Change

herdr panes never set `TMUX`, so a set `TMUX` means the `HERDR_ENV` marker was inherited from the tmux server rather than set by herdr for this shell. The guard now ignores the marker while `TMUX` is set.

Targeted heuristic for the documented tmux coexistence case (other multiplexers can leak similarly and are intentionally out of scope here). Trade-off: a launch that is genuinely nested *through* tmux (herdr pane -> tmux -> herdr) is no longer blocked. I think accepting that rare case is worth fixing the common false positive, but happy to drop this in favor of a deeper check (e.g. validating `HERDR_PANE_ID` against the live server) if that direction is preferred.

## Validation

- `cargo fmt --check` clean
- unit: adds `nested_herdr_does_not_block_when_env_leaked_from_tmux`; existing nested-guard unit tests pass
- integration: `auto_detect_respects_nested_guard_before_auto_attach` and `explicit_client_command_respects_nested_guard` pass; both now `env_remove("TMUX")` so they pin the non-tmux nested case deterministically

`just`/`cargo-nextest` were unavailable in this environment, so `just check` was not run; I used `cargo test` for the `bin`, `cli`, and `auto_detect` targets. 14 pre-existing failures in `detect::manifest*`, `server::headless`, and `workspace` reproduce identically on clean `upstream/master` (agent-detection manifest tests needing network/fixtures) and are unrelated to this change.

refs #2135
