### PR TITLE
fix: expand copy-mode word-end window past a final wide glyph

### DIFF
--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -855,14 +855,14 @@ impl RetainedTextBuffer {
     }
 
     fn point_is_final_atom(&self, point: TerminalTextPoint) -> bool {
+        // Word motion targets are atom start points, so compare against the
+        // final atom's start point. Comparing against `end_col` would never
+        // match a wide glyph, whose end column is one past its start.
         self.atoms
             .iter()
             .rev()
             .find(|atom| atom.point.is_some())
-            .is_some_and(|atom| {
-                atom.point
-                    .is_some_and(|start| start.row == point.row && atom.end_col == point.col)
-            })
+            .is_some_and(|atom| atom.point == Some(point))
     }
 }
 
@@ -3288,6 +3288,30 @@ mod tests {
                 TerminalWordMotion::NextEnd,
             ),
             Some(text_match.end)
+        );
+    }
+
+    #[test]
+    fn live_terminal_word_end_expands_through_a_long_wide_soft_wrap() {
+        let (tx, _rx) = mpsc::channel(4);
+        let mut terminal = crate::ghostty::Terminal::new(2, 3, 200).unwrap();
+        let word = "界".repeat(66);
+        terminal.write(word.as_bytes());
+        let pane = PaneTerminal::new(GhosttyPaneTerminal::new(terminal, tx).unwrap());
+        let text_match = pane.search_text_matches(&word, true)[0];
+
+        // The word end sits on the head cell of the final wide glyph, past the
+        // initial read window, so the window has to expand to reach it.
+        assert_eq!(
+            pane.word_motion_target(
+                text_match.start.row,
+                text_match.start.col,
+                TerminalWordMotion::NextEnd,
+            ),
+            Some(TerminalTextPoint {
+                row: text_match.end.row,
+                col: 0,
+            })
         );
     }
 


### PR DESCRIPTION
## What happens

Copy mode `e` (next word end) stops at the read window boundary instead of the real end of the word. It triggers on a line that soft-wraps over more than 64 rows, with a wide (CJK) glyph as the last cell in the read window. The same case works fine with narrow characters.

In practice you hit this with a long CJK log line or a JSON blob that wraps as one logical line. A minimal repro is a 2-column pane with `界` written 66 times: pressing `e` from the top should land on row 65, but it stops at row 63.

## Why

`RetainedTextBuffer::point_is_final_atom` compared an atom's **end** column against the word-motion target's **start** column. Narrow cells have `end_col == start.col`, so it matched by accident. Wide cells have `end_col == start.col + 1`, so it never matched.

The only caller is `needs_more_future` in `word_motion_target`, which decides "the target landed on the last atom in the window, so double the window and look further". With a wide glyph that never fired, and the window was returned unexpanded.

`clippy::suspicious_operation_groupings` flags this line on its own too. Its suggested `point.end_col` does not compile, though — `TerminalTextPoint` only has `row` and `col`.

## The fix

Word-motion targets are always atom start points, given how `previous_point` and `next_point` are written, so compare against the final atom's start point directly.

Narrow cells behave exactly as before. `end_col == start.col` makes the new expression equivalent to the old one, the SpacerHead atom (`end_col: col`) is the same, and the hard-line-break atom is dropped by `find` because its `point` is `None`. There is also no case where only the old expression matched: a wide cell's `start.col + 1` is the spacer tail position, and no atom starts there.

Termination is unchanged. `window_rows` saturates at `total_rows`, and at that point either `ends_in_continuation` goes false or `reached_edge` goes true.

## Testing

Added `live_terminal_word_end_expands_through_a_long_wide_soft_wrap`, the wide-glyph twin of the adjacent `live_terminal_word_end_expands_through_a_long_soft_wrap`. Before the fix the motion returns row 63 and the test fails; after the fix it passes.

`just check` passes.

## Docs

The only user-visible change is that something broken starts working, and the copy-mode section in `keyboard.mdx` says nothing about wide characters, so I don't think this needs a docs update.

## Related

#1000 is also copy mode and full-width characters, but it is a different bug (single-cell `h`/`l` movement stopping mid-glyph) and this PR does not fix it.
