### PR TITLE
fix(ipc): probe_stream_closed returns Ok(false) for successful reads

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -160,7 +160,7 @@ fn probe_stream_closed(stream: &mut LocalStream) -> io::Result<bool> {
     let mut probe = [0u8; 1];
     let status = match stream.read(&mut probe) {
         Ok(0) => Ok(true),
-        Ok(_) => Ok(true),
+        Ok(_) => Ok(false),
         Err(err)
             if matches!(
                 err.kind(),


### PR DESCRIPTION
`Ok(_)` arm in `probe_stream_closed` returned `Ok(true)` (stream closed) instead of `Ok(false)` (stream open). A successful read means the peer is alive; treating it as EOF caused premature connection teardown and silent byte loss.

refs #2154