### PR TITLE
fix(socket_paths): remove dead if-branch in derive_client_socket_from_api_socketfix(socket_paths): remove dead if-branch in derive_client_socket_from_api_socket

### DIFF
--- a/src/server/socket_paths.rs
+++ b/src/server/socket_paths.rs
@@ -54,14 +54,6 @@ pub(crate) fn derive_client_socket_from_api_socket(api_socket_path: &Path) -> Pa
         .unwrap_or("herdr");
     let parent = api_socket_path.parent().unwrap_or_else(|| Path::new(""));
 
-    if api_socket_path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext == "sock")
-    {
-        return parent.join(format!("{stem}-client.sock"));
-    }
-
     parent.join(format!("{stem}-client.sock"))
 }
 


### PR DESCRIPTION
Both the if-branch and the fallthrough in `derive_client_socket_from_api_socket` returned the identical expression for every input. The conditional was dead code. Removed the unreachable branch, leaving only the single correct return.

refs #2156