### PR TITLE
fix(client): query host cell size when the ioctl reports no pixels

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1768,6 +1768,7 @@ impl App {
                         self.set_host_terminal_appearance(appearance, true);
                     }
                 }
+                crate::raw_input::RawInputEvent::HostCellSizeReport { .. } => {}
                 crate::raw_input::RawInputEvent::Unsupported => {}
             }
             self.sync_prefix_input_source(previous_mode);

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -257,8 +257,7 @@ impl App {
                 self.query_host_terminal_theme();
                 self.set_host_terminal_appearance(appearance, true)
             }
-            // Host cell size reports are consumed by the thin client, which owns the
-            // host terminal size; the monolithic runtime has no use for them.
+            // Cell size reports are consumed by the thin client, not the runtime.
             crate::raw_input::RawInputEvent::HostCellSizeReport { .. } => false,
             crate::raw_input::RawInputEvent::Unsupported => false,
         };

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -257,6 +257,9 @@ impl App {
                 self.query_host_terminal_theme();
                 self.set_host_terminal_appearance(appearance, true)
             }
+            // Host cell size reports are consumed by the thin client, which owns the
+            // host terminal size; the monolithic runtime has no use for them.
+            crate::raw_input::RawInputEvent::HostCellSizeReport { .. } => false,
             crate::raw_input::RawInputEvent::Unsupported => false,
         };
         self.sync_prefix_input_source(previous_mode);

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -10,7 +10,7 @@
 //! - We avoid duplicating parsing logic in the client
 //! - Host terminal control replies can be buffered or discarded before they leak
 
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 #[cfg(unix)]
@@ -39,14 +39,14 @@ pub fn stdin_reader_loop(
     event_tx: mpsc::Sender<ClientLoopEvent>,
     should_quit: &Arc<AtomicBool>,
     host_color_query_sent: bool,
-    pending_host_cell_size_queries: Arc<AtomicU16>,
+    host_cell_size_query_sent: bool,
     host_mouse_capture_active: Arc<AtomicBool>,
 ) {
     #[cfg(windows)]
     {
         let _ = (
             host_color_query_sent,
-            pending_host_cell_size_queries,
+            host_cell_size_query_sent,
             host_mouse_capture_active,
         );
         windows_stdin_reader_loop(event_tx, should_quit);
@@ -57,7 +57,7 @@ pub fn stdin_reader_loop(
         event_tx,
         should_quit,
         host_color_query_sent,
-        pending_host_cell_size_queries,
+        host_cell_size_query_sent,
         host_mouse_capture_active,
     );
 }
@@ -67,23 +67,26 @@ fn unix_stdin_reader_loop(
     event_tx: mpsc::Sender<ClientLoopEvent>,
     should_quit: &Arc<AtomicBool>,
     host_color_query_sent: bool,
-    pending_host_cell_size_queries: Arc<AtomicU16>,
+    host_cell_size_query_sent: bool,
     host_mouse_capture_active: Arc<AtomicBool>,
 ) {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
     let mut scratch = [0u8; 4096];
     let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-    arm_host_reply_holds(&mut framer, host_color_query_sent);
+    if host_color_query_sent {
+        framer.host_color_query_sent();
+        framer.enable_host_color_scheme_change_tracking();
+    }
+    if host_cell_size_query_sent {
+        framer.host_cell_size_query_sent();
+    }
     let mut pending_palette = Vec::new();
 
     while !should_quit.load(Ordering::Acquire) {
         match reader.read(&mut scratch) {
             Ok(0) => break,
             Ok(n) => {
-                // The main loop counts a query before writing it, so every reply
-                // in this read is covered by draining the counter first.
-                arm_pending_host_cell_size_queries(&mut framer, &pending_host_cell_size_queries);
                 if !send_unix_input_chunks(
                     framer.push(&scratch[..n]),
                     &event_tx,
@@ -97,12 +100,6 @@ fn unix_stdin_reader_loop(
                     host_mouse_capture_active.load(Ordering::Acquire),
                 );
                 if stdin_read_ready(&reader, timeout_ms) == Some(false) {
-                    // A query may have been issued while this thread waited, and
-                    // its reply must not be released as a plain Escape below.
-                    arm_pending_host_cell_size_queries(
-                        &mut framer,
-                        &pending_host_cell_size_queries,
-                    );
                     let had_pending = framer.has_pending_input();
                     let chunks = framer.flush_timeout();
                     let held_escape = had_pending && chunks.is_empty();
@@ -116,22 +113,13 @@ fn unix_stdin_reader_loop(
                             &reader,
                             crate::raw_input::RAW_INPUT_IDLE_FLUSH_TIMEOUT_MS,
                         ) == Some(false)
-                    {
-                        // A resize re-query may have registered while waiting on
-                        // the held escape; drain it so the flush keeps holding
-                        // for the reply in flight instead of releasing the
-                        // escape as a plain Escape key.
-                        arm_pending_host_cell_size_queries(
-                            &mut framer,
-                            &pending_host_cell_size_queries,
-                        );
-                        if !send_unix_input_chunks(
+                        && !send_unix_input_chunks(
                             framer.flush_timeout(),
                             &event_tx,
                             &mut pending_palette,
-                        ) {
-                            return;
-                        }
+                        )
+                    {
+                        return;
                     }
                 }
             }
@@ -142,31 +130,6 @@ fn unix_stdin_reader_loop(
                 break;
             }
         }
-    }
-}
-
-/// Tells the framer that host color replies are outstanding so a reply that is
-/// split at its ESC introducer is not released as a plain Escape key.
-#[cfg(unix)]
-fn arm_host_reply_holds(
-    framer: &mut crate::raw_input::RawInputByteFramer,
-    host_color_query_sent: bool,
-) {
-    if host_color_query_sent {
-        framer.host_color_query_sent();
-        framer.enable_host_color_scheme_change_tracking();
-    }
-}
-
-/// Registers the cell size queries the main loop has issued since the last
-/// drain, so their replies are held even when several are in flight.
-#[cfg(unix)]
-fn arm_pending_host_cell_size_queries(
-    framer: &mut crate::raw_input::RawInputByteFramer,
-    pending_host_cell_size_queries: &AtomicU16,
-) {
-    for _ in 0..pending_host_cell_size_queries.swap(0, Ordering::AcqRel) {
-        framer.host_cell_size_query_sent();
     }
 }
 
@@ -556,109 +519,6 @@ mod tests {
             2
         );
         assert!(pending.is_empty());
-    }
-
-    #[test]
-    fn cell_size_query_holds_reply_split_at_its_escape_introducer() {
-        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        let pending = AtomicU16::new(1);
-        arm_pending_host_cell_size_queries(&mut framer, &pending);
-        assert_eq!(pending.load(Ordering::Acquire), 0);
-
-        assert!(framer.push(b"\x1b").is_empty());
-        assert!(framer.flush_timeout().is_empty());
-        assert_eq!(
-            framer.push(b"[6;21;10t"),
-            vec![b"\x1b[6;21;10t".to_vec()],
-            "the split cell size reply must not leak as an Escape key"
-        );
-    }
-
-    #[test]
-    fn escape_is_not_held_when_no_host_query_was_sent() {
-        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        arm_host_reply_holds(&mut framer, false);
-        arm_pending_host_cell_size_queries(&mut framer, &AtomicU16::new(0));
-
-        assert!(framer.push(b"\x1b").is_empty());
-        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
-    }
-
-    #[test]
-    fn concurrent_cell_size_queries_hold_every_reply() {
-        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        // The initial query and a resize re-query are drained in one batch.
-        let pending = AtomicU16::new(2);
-        arm_pending_host_cell_size_queries(&mut framer, &pending);
-
-        assert_eq!(
-            framer.push(b"\x1b[6;21;10t"),
-            vec![b"\x1b[6;21;10t".to_vec()]
-        );
-
-        assert!(framer.push(b"\x1b").is_empty());
-        assert!(framer.flush_timeout().is_empty());
-        assert_eq!(
-            framer.push(b"[6;42;20t"),
-            vec![b"\x1b[6;42;20t".to_vec()],
-            "the second reply must not leak as an Escape key either"
-        );
-    }
-
-    #[test]
-    fn resize_requery_rearms_the_framer_after_the_first_reply() {
-        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        let pending = AtomicU16::new(1);
-        arm_pending_host_cell_size_queries(&mut framer, &pending);
-
-        assert_eq!(
-            framer.push(b"\x1b[6;21;10t"),
-            vec![b"\x1b[6;21;10t".to_vec()]
-        );
-
-        // A resize re-query is registered before its reply is framed.
-        pending.store(1, Ordering::Release);
-        arm_pending_host_cell_size_queries(&mut framer, &pending);
-
-        assert!(framer.push(b"\x1b").is_empty());
-        assert!(framer.flush_timeout().is_empty());
-        assert_eq!(framer.push(b"[6;42;20t"), vec![b"\x1b[6;42;20t".to_vec()]);
-
-        // No query is left outstanding, so Escape stays responsive.
-        assert!(framer.push(b"\x1b").is_empty());
-        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
-    }
-
-    #[test]
-    fn second_held_escape_flush_drains_a_requery_registered_while_waiting() {
-        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        let pending = AtomicU16::new(1);
-        arm_pending_host_cell_size_queries(&mut framer, &pending);
-
-        // First timeout flush: the escape introducer of the reply arrives
-        // alone, so it is held rather than released as a plain Escape.
-        assert!(framer.push(b"\x1b").is_empty());
-        let had_pending = framer.has_pending_input();
-        let chunks = framer.flush_timeout();
-        assert!(had_pending && chunks.is_empty(), "escape must be held");
-
-        // A resize re-query is registered on the shared counter while this
-        // thread waits for stdin to go quiet again, before the second flush.
-        pending.store(1, Ordering::Release);
-
-        // Draining the counter before the second flush must keep the framer
-        // holding for the reply in flight instead of releasing the held
-        // escape as a plain Escape key.
-        arm_pending_host_cell_size_queries(&mut framer, &pending);
-        assert_eq!(
-            framer.flush_timeout(),
-            Vec::<Vec<u8>>::new(),
-            "the held escape must not leak once a requery is drained"
-        );
-
-        // The delayed, split reply must still reassemble into a single
-        // HostCellSizeReport instead of leaking through as loose bytes.
-        assert_eq!(framer.push(b"[6;21;10t"), vec![b"\x1b[6;21;10t".to_vec()]);
     }
 
     #[test]

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -39,11 +39,16 @@ pub fn stdin_reader_loop(
     event_tx: mpsc::Sender<ClientLoopEvent>,
     should_quit: &Arc<AtomicBool>,
     host_color_query_sent: bool,
+    host_cell_size_query_sent: bool,
     host_mouse_capture_active: Arc<AtomicBool>,
 ) {
     #[cfg(windows)]
     {
-        let _ = (host_color_query_sent, host_mouse_capture_active);
+        let _ = (
+            host_color_query_sent,
+            host_cell_size_query_sent,
+            host_mouse_capture_active,
+        );
         windows_stdin_reader_loop(event_tx, should_quit);
     }
 
@@ -52,6 +57,7 @@ pub fn stdin_reader_loop(
         event_tx,
         should_quit,
         host_color_query_sent,
+        host_cell_size_query_sent,
         host_mouse_capture_active,
     );
 }
@@ -61,16 +67,18 @@ fn unix_stdin_reader_loop(
     event_tx: mpsc::Sender<ClientLoopEvent>,
     should_quit: &Arc<AtomicBool>,
     host_color_query_sent: bool,
+    host_cell_size_query_sent: bool,
     host_mouse_capture_active: Arc<AtomicBool>,
 ) {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
     let mut scratch = [0u8; 4096];
     let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-    if host_color_query_sent {
-        framer.host_color_query_sent();
-        framer.enable_host_color_scheme_change_tracking();
-    }
+    arm_host_reply_holds(
+        &mut framer,
+        host_color_query_sent,
+        host_cell_size_query_sent,
+    );
     let mut pending_palette = Vec::new();
 
     while !should_quit.load(Ordering::Acquire) {
@@ -120,6 +128,23 @@ fn unix_stdin_reader_loop(
                 break;
             }
         }
+    }
+}
+
+/// Tells the framer which host terminal replies are outstanding so a reply that
+/// is split at its ESC introducer is not released as a plain Escape key.
+#[cfg(unix)]
+fn arm_host_reply_holds(
+    framer: &mut crate::raw_input::RawInputByteFramer,
+    host_color_query_sent: bool,
+    host_cell_size_query_sent: bool,
+) {
+    if host_color_query_sent {
+        framer.host_color_query_sent();
+        framer.enable_host_color_scheme_change_tracking();
+    }
+    if host_cell_size_query_sent {
+        framer.host_cell_size_query_sent();
     }
 }
 
@@ -509,6 +534,29 @@ mod tests {
             2
         );
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn cell_size_query_holds_reply_split_at_its_escape_introducer() {
+        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
+        arm_host_reply_holds(&mut framer, false, true);
+
+        assert!(framer.push(b"\x1b").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert_eq!(
+            framer.push(b"[6;21;10t"),
+            vec![b"\x1b[6;21;10t".to_vec()],
+            "the split cell size reply must not leak as an Escape key"
+        );
+    }
+
+    #[test]
+    fn escape_is_not_held_when_no_host_query_was_sent() {
+        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
+        arm_host_reply_holds(&mut framer, false, false);
+
+        assert!(framer.push(b"\x1b").is_empty());
+        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
     }
 
     #[test]

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -10,7 +10,7 @@
 //! - We avoid duplicating parsing logic in the client
 //! - Host terminal control replies can be buffered or discarded before they leak
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::Arc;
 
 #[cfg(unix)]
@@ -39,14 +39,14 @@ pub fn stdin_reader_loop(
     event_tx: mpsc::Sender<ClientLoopEvent>,
     should_quit: &Arc<AtomicBool>,
     host_color_query_sent: bool,
-    host_cell_size_query_sent: bool,
+    pending_host_cell_size_queries: Arc<AtomicU16>,
     host_mouse_capture_active: Arc<AtomicBool>,
 ) {
     #[cfg(windows)]
     {
         let _ = (
             host_color_query_sent,
-            host_cell_size_query_sent,
+            pending_host_cell_size_queries,
             host_mouse_capture_active,
         );
         windows_stdin_reader_loop(event_tx, should_quit);
@@ -57,7 +57,7 @@ pub fn stdin_reader_loop(
         event_tx,
         should_quit,
         host_color_query_sent,
-        host_cell_size_query_sent,
+        pending_host_cell_size_queries,
         host_mouse_capture_active,
     );
 }
@@ -67,24 +67,23 @@ fn unix_stdin_reader_loop(
     event_tx: mpsc::Sender<ClientLoopEvent>,
     should_quit: &Arc<AtomicBool>,
     host_color_query_sent: bool,
-    host_cell_size_query_sent: bool,
+    pending_host_cell_size_queries: Arc<AtomicU16>,
     host_mouse_capture_active: Arc<AtomicBool>,
 ) {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
     let mut scratch = [0u8; 4096];
     let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-    arm_host_reply_holds(
-        &mut framer,
-        host_color_query_sent,
-        host_cell_size_query_sent,
-    );
+    arm_host_reply_holds(&mut framer, host_color_query_sent);
     let mut pending_palette = Vec::new();
 
     while !should_quit.load(Ordering::Acquire) {
         match reader.read(&mut scratch) {
             Ok(0) => break,
             Ok(n) => {
+                // The main loop counts a query before writing it, so every reply
+                // in this read is covered by draining the counter first.
+                arm_pending_host_cell_size_queries(&mut framer, &pending_host_cell_size_queries);
                 if !send_unix_input_chunks(
                     framer.push(&scratch[..n]),
                     &event_tx,
@@ -98,6 +97,12 @@ fn unix_stdin_reader_loop(
                     host_mouse_capture_active.load(Ordering::Acquire),
                 );
                 if stdin_read_ready(&reader, timeout_ms) == Some(false) {
+                    // A query may have been issued while this thread waited, and
+                    // its reply must not be released as a plain Escape below.
+                    arm_pending_host_cell_size_queries(
+                        &mut framer,
+                        &pending_host_cell_size_queries,
+                    );
                     let had_pending = framer.has_pending_input();
                     let chunks = framer.flush_timeout();
                     let held_escape = had_pending && chunks.is_empty();
@@ -131,19 +136,27 @@ fn unix_stdin_reader_loop(
     }
 }
 
-/// Tells the framer which host terminal replies are outstanding so a reply that
-/// is split at its ESC introducer is not released as a plain Escape key.
+/// Tells the framer that host color replies are outstanding so a reply that is
+/// split at its ESC introducer is not released as a plain Escape key.
 #[cfg(unix)]
 fn arm_host_reply_holds(
     framer: &mut crate::raw_input::RawInputByteFramer,
     host_color_query_sent: bool,
-    host_cell_size_query_sent: bool,
 ) {
     if host_color_query_sent {
         framer.host_color_query_sent();
         framer.enable_host_color_scheme_change_tracking();
     }
-    if host_cell_size_query_sent {
+}
+
+/// Registers the cell size queries the main loop has issued since the last
+/// drain, so their replies are held even when several are in flight.
+#[cfg(unix)]
+fn arm_pending_host_cell_size_queries(
+    framer: &mut crate::raw_input::RawInputByteFramer,
+    pending_host_cell_size_queries: &AtomicU16,
+) {
+    for _ in 0..pending_host_cell_size_queries.swap(0, Ordering::AcqRel) {
         framer.host_cell_size_query_sent();
     }
 }
@@ -539,7 +552,9 @@ mod tests {
     #[test]
     fn cell_size_query_holds_reply_split_at_its_escape_introducer() {
         let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        arm_host_reply_holds(&mut framer, false, true);
+        let pending = AtomicU16::new(1);
+        arm_pending_host_cell_size_queries(&mut framer, &pending);
+        assert_eq!(pending.load(Ordering::Acquire), 0);
 
         assert!(framer.push(b"\x1b").is_empty());
         assert!(framer.flush_timeout().is_empty());
@@ -553,8 +568,54 @@ mod tests {
     #[test]
     fn escape_is_not_held_when_no_host_query_was_sent() {
         let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
-        arm_host_reply_holds(&mut framer, false, false);
+        arm_host_reply_holds(&mut framer, false);
+        arm_pending_host_cell_size_queries(&mut framer, &AtomicU16::new(0));
 
+        assert!(framer.push(b"\x1b").is_empty());
+        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
+    }
+
+    #[test]
+    fn concurrent_cell_size_queries_hold_every_reply() {
+        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
+        // The initial query and a resize re-query are drained in one batch.
+        let pending = AtomicU16::new(2);
+        arm_pending_host_cell_size_queries(&mut framer, &pending);
+
+        assert_eq!(
+            framer.push(b"\x1b[6;21;10t"),
+            vec![b"\x1b[6;21;10t".to_vec()]
+        );
+
+        assert!(framer.push(b"\x1b").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert_eq!(
+            framer.push(b"[6;42;20t"),
+            vec![b"\x1b[6;42;20t".to_vec()],
+            "the second reply must not leak as an Escape key either"
+        );
+    }
+
+    #[test]
+    fn resize_requery_rearms_the_framer_after_the_first_reply() {
+        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
+        let pending = AtomicU16::new(1);
+        arm_pending_host_cell_size_queries(&mut framer, &pending);
+
+        assert_eq!(
+            framer.push(b"\x1b[6;21;10t"),
+            vec![b"\x1b[6;21;10t".to_vec()]
+        );
+
+        // A resize re-query is registered before its reply is framed.
+        pending.store(1, Ordering::Release);
+        arm_pending_host_cell_size_queries(&mut framer, &pending);
+
+        assert!(framer.push(b"\x1b").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert_eq!(framer.push(b"[6;42;20t"), vec![b"\x1b[6;42;20t".to_vec()]);
+
+        // No query is left outstanding, so Escape stays responsive.
         assert!(framer.push(b"\x1b").is_empty());
         assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
     }

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -116,13 +116,22 @@ fn unix_stdin_reader_loop(
                             &reader,
                             crate::raw_input::RAW_INPUT_IDLE_FLUSH_TIMEOUT_MS,
                         ) == Some(false)
-                        && !send_unix_input_chunks(
+                    {
+                        // A resize re-query may have registered while waiting on
+                        // the held escape; drain it so the flush keeps holding
+                        // for the reply in flight instead of releasing the
+                        // escape as a plain Escape key.
+                        arm_pending_host_cell_size_queries(
+                            &mut framer,
+                            &pending_host_cell_size_queries,
+                        );
+                        if !send_unix_input_chunks(
                             framer.flush_timeout(),
                             &event_tx,
                             &mut pending_palette,
-                        )
-                    {
-                        return;
+                        ) {
+                            return;
+                        }
                     }
                 }
             }
@@ -618,6 +627,38 @@ mod tests {
         // No query is left outstanding, so Escape stays responsive.
         assert!(framer.push(b"\x1b").is_empty());
         assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
+    }
+
+    #[test]
+    fn second_held_escape_flush_drains_a_requery_registered_while_waiting() {
+        let mut framer = crate::raw_input::RawInputByteFramer::for_host_input();
+        let pending = AtomicU16::new(1);
+        arm_pending_host_cell_size_queries(&mut framer, &pending);
+
+        // First timeout flush: the escape introducer of the reply arrives
+        // alone, so it is held rather than released as a plain Escape.
+        assert!(framer.push(b"\x1b").is_empty());
+        let had_pending = framer.has_pending_input();
+        let chunks = framer.flush_timeout();
+        assert!(had_pending && chunks.is_empty(), "escape must be held");
+
+        // A resize re-query is registered on the shared counter while this
+        // thread waits for stdin to go quiet again, before the second flush.
+        pending.store(1, Ordering::Release);
+
+        // Draining the counter before the second flush must keep the framer
+        // holding for the reply in flight instead of releasing the held
+        // escape as a plain Escape key.
+        arm_pending_host_cell_size_queries(&mut framer, &pending);
+        assert_eq!(
+            framer.flush_timeout(),
+            Vec::<Vec<u8>>::new(),
+            "the held escape must not leak once a requery is drained"
+        );
+
+        // The delayed, split reply must still reassemble into a single
+        // HostCellSizeReport instead of leaking through as loose bytes.
+        assert_eq!(framer.push(b"[6;21;10t"), vec![b"\x1b[6;21;10t".to_vec()]);
     }
 
     #[test]

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -422,6 +422,7 @@ fn windows_client_input_event_from_raw(
         crate::raw_input::RawInputEvent::HostDefaultColor { .. }
         | crate::raw_input::RawInputEvent::HostPaletteColors { .. }
         | crate::raw_input::RawInputEvent::HostColorSchemeChanged(_)
+        | crate::raw_input::RawInputEvent::HostCellSizeReport { .. }
         | crate::raw_input::RawInputEvent::Unsupported => None,
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1326,6 +1326,12 @@ async fn run_client_loop(
     // Spawn the stdin reader thread.
     let will_query_host_terminal_theme =
         state.attach_escape.is_none() && should_query_host_terminal_theme();
+    // Terminals behind ConPTY report no pixel size through the ioctl, so ask the
+    // host terminal directly instead of falling back to an assumed cell size.
+    // This is decided before the reader starts so the framer knows that a reply
+    // is outstanding.
+    let will_query_host_cell_size = state.attach_escape.is_none()
+        && host_cell_size_query_required(state.kitty_graphics_enabled);
     let stdin_quit = should_quit.clone();
     let stdin_tx = event_tx.clone();
     let stdin_mouse_capture_active = host_mouse_capture_active.clone();
@@ -1334,6 +1340,7 @@ async fn run_client_loop(
             stdin_tx,
             &stdin_quit,
             will_query_host_terminal_theme,
+            will_query_host_cell_size,
             stdin_mouse_capture_active,
         );
     });
@@ -1342,10 +1349,6 @@ async fn run_client_loop(
         query_host_terminal_theme();
     }
 
-    // Terminals behind ConPTY report no pixel size through the ioctl, so ask the
-    // host terminal directly instead of falling back to an assumed cell size.
-    let will_query_host_cell_size = state.attach_escape.is_none()
-        && host_cell_size_query_required(state.kitty_graphics_enabled);
     if will_query_host_cell_size {
         query_host_cell_size();
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -16,7 +16,7 @@ mod input;
 
 use std::collections::HashSet;
 use std::io::{self, BufRead, Write as _};
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -1330,20 +1330,15 @@ async fn run_client_loop(
     // host terminal directly instead of falling back to an assumed cell size.
     let will_query_host_cell_size = state.attach_escape.is_none()
         && host_cell_size_query_required(state.kitty_graphics_enabled);
-    // Cell size queries outstanding towards the host terminal. The stdin reader
-    // drains this counter so the framer holds every reply, including the ones
-    // triggered by later resizes.
-    let pending_host_cell_size_queries = Arc::new(AtomicU16::new(0));
     let stdin_quit = should_quit.clone();
     let stdin_tx = event_tx.clone();
     let stdin_mouse_capture_active = host_mouse_capture_active.clone();
-    let stdin_pending_cell_size_queries = pending_host_cell_size_queries.clone();
     std::thread::spawn(move || {
         input::stdin_reader_loop(
             stdin_tx,
             &stdin_quit,
             will_query_host_terminal_theme,
-            stdin_pending_cell_size_queries,
+            will_query_host_cell_size,
             stdin_mouse_capture_active,
         );
     });
@@ -1353,7 +1348,7 @@ async fn run_client_loop(
     }
 
     if will_query_host_cell_size {
-        query_host_cell_size(&pending_host_cell_size_queries);
+        query_host_cell_size();
     }
 
     // Spawn the resize poller thread.
@@ -1549,11 +1544,6 @@ async fn run_client_loop(
                 };
                 if let Err(e) = write_to_server(&mut write_stream, &msg) {
                     return Err(ClientError::ConnectionLost(e));
-                }
-                // A resize can also follow a font size change, so re-ask the host
-                // terminal for its cell size whenever it is the size authority.
-                if will_query_host_cell_size {
-                    query_host_cell_size(&pending_host_cell_size_queries);
                 }
             }
             ClientLoopEvent::ServerMessage(msg) => match msg {
@@ -2130,9 +2120,6 @@ const DEFAULT_CELL_WIDTH_PX: u32 = 8;
 const DEFAULT_CELL_HEIGHT_PX: u32 = 16;
 
 /// Cell size derived from the terminal size ioctl, if it reports pixels.
-///
-/// Terminals behind ConPTY (WSL) always report zero pixels here, which is what
-/// makes the XTWINOPS query below necessary.
 fn ioctl_cell_size() -> Option<(u32, u32)> {
     let size = crossterm::terminal::window_size().ok()?;
     if size.columns == 0 || size.rows == 0 || size.width == 0 || size.height == 0 {
@@ -2144,8 +2131,7 @@ fn ioctl_cell_size() -> Option<(u32, u32)> {
     ))
 }
 
-/// Cell size used when the ioctl reports no pixels: the size reported by the
-/// host terminal if one arrived, otherwise the historical default.
+/// Cell size used when the ioctl reports no pixels.
 fn cell_size_fallback(reported: u64) -> (u32, u32) {
     unpack_cell_size(reported).unwrap_or((DEFAULT_CELL_WIDTH_PX, DEFAULT_CELL_HEIGHT_PX))
 }
@@ -2174,12 +2160,8 @@ fn current_terminal_geometry(
     (cols, rows, cell_width_px, cell_height_px)
 }
 
-/// Reads the terminal geometry before the handshake is sent.
-///
-/// At this point the host terminal cannot have reported a cell size yet (the
-/// query is only sent after the handshake completes), so this always reads
-/// geometry with no reported cell size available, leaving the ioctl and the
-/// default fallback as the only sources.
+/// Reads the terminal geometry before the handshake, before any host cell
+/// size report can exist.
 fn initial_terminal_geometry(kitty_graphics_enabled: bool) -> (u16, u16, u32, u32) {
     current_terminal_geometry(kitty_graphics_enabled, &AtomicU64::new(0))
 }
@@ -2195,13 +2177,9 @@ fn resize_report_required(
 
 /// Watches the terminal size and sends resize events when it changes.
 ///
-/// `initial_cell_width`/`initial_cell_height` must match the cell size sent
-/// to the server during the handshake, so the poller's baseline agrees with
-/// what the server already knows. Reading a fresh baseline here instead would
-/// race the host terminal's CSI 16t response: if it lands in the shared
-/// `reported_cell_size` cache before this thread starts, `last_size` would
-/// already reflect the reported value and the first real change would never
-/// be detected as a difference.
+/// The baseline cell size must match what the handshake sent to the server:
+/// reading a fresh one here would race the host cell size reply and could
+/// swallow the first change.
 fn resize_poll_loop(
     resize_tx: tokio::sync::mpsc::Sender<ClientLoopEvent>,
     initial_cols: u16,
@@ -2259,34 +2237,16 @@ fn write_host_terminal_theme_query(mut writer: impl io::Write) -> io::Result<()>
 /// XTWINOPS request for the host terminal cell size in pixels.
 const HOST_CELL_SIZE_QUERY: &[u8] = b"\x1b[16t";
 
-/// Sends the cell size query and registers it with the stdin framer.
-///
-/// Every issued query has to be registered because the query is re-sent on
-/// resize, so more than one reply can be in flight.
-fn query_host_cell_size(pending_queries: &AtomicU16) {
-    register_pending_host_cell_size_query(pending_queries);
+fn query_host_cell_size() {
     let _ = write_host_cell_size_query(io::stdout());
-}
-
-/// Counts one more outstanding cell size reply for the stdin reader thread.
-///
-/// This runs before the query reaches stdout, so the reply can never be framed
-/// before the reader knows that it is coming.
-fn register_pending_host_cell_size_query(pending_queries: &AtomicU16) {
-    let _ = pending_queries.fetch_update(Ordering::AcqRel, Ordering::Acquire, |awaited| {
-        Some(awaited.saturating_add(1))
-    });
 }
 
 fn should_query_host_cell_size() -> bool {
     !cfg!(windows)
 }
 
-/// Returns whether the host terminal has to be asked for its cell size.
-///
-/// Only pane graphics need pixel dimensions, and the query is limited to hosts
-/// whose terminal size ioctl reports no pixels, so terminals that already
-/// answer the ioctl keep their current behaviour.
+/// Only pane graphics need pixel dimensions, and only when the ioctl cannot
+/// provide them.
 fn host_cell_size_query_required(kitty_graphics_enabled: bool) -> bool {
     kitty_graphics_enabled && should_query_host_cell_size() && ioctl_cell_size().is_none()
 }
@@ -2296,10 +2256,6 @@ fn write_host_cell_size_query(mut writer: impl io::Write) -> io::Result<()> {
     writer.flush()
 }
 
-/// Records a host cell size report so the resize poller picks it up.
-///
-/// Only the byte-oriented (Unix) stdin path can observe these reports; Windows
-/// clients never send the query.
 #[cfg(any(unix, test))]
 fn store_reported_cell_size(reported_cell_size: &AtomicU64, width_px: u32, height_px: u32) {
     let packed = pack_cell_size(width_px, height_px);
@@ -2651,62 +2607,20 @@ mod tests {
     }
 
     #[test]
-    fn host_cell_size_query_is_limited_to_pane_graphics_clients() {
-        assert!(!host_cell_size_query_required(false));
-    }
-
-    #[test]
-    fn pending_host_cell_size_queries_accumulate_and_saturate() {
-        let pending = AtomicU16::new(0);
-        register_pending_host_cell_size_query(&pending);
-        register_pending_host_cell_size_query(&pending);
-
-        assert_eq!(pending.load(Ordering::Acquire), 2);
-
-        pending.store(u16::MAX, Ordering::Release);
-        register_pending_host_cell_size_query(&pending);
-
-        assert_eq!(pending.load(Ordering::Acquire), u16::MAX);
-    }
-
-    #[test]
     fn cell_size_fallback_prefers_reported_size_over_default() {
         assert_eq!(cell_size_fallback(0), (8, 16));
         assert_eq!(cell_size_fallback(pack_cell_size(10, 21)), (10, 21));
-        // Partial reports never reach the cache, but must not be trusted anyway.
         assert_eq!(cell_size_fallback(pack_cell_size(10, 0)), (8, 16));
         assert_eq!(cell_size_fallback(pack_cell_size(0, 21)), (8, 16));
     }
 
     #[test]
     fn reported_cell_size_is_taken_from_host_cell_size_events() {
-        let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[6;21;10t");
-        assert_eq!(reported_cell_size_from_events(&events), Some((10, 21)));
-
         let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[?997;1n");
         assert_eq!(reported_cell_size_from_events(&events), None);
-    }
 
-    #[test]
-    fn reported_cell_size_from_events_uses_the_last_report_in_a_batch() {
         let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[6;21;10t\x1b[6;18;9t");
         assert_eq!(reported_cell_size_from_events(&events), Some((9, 18)));
-    }
-
-    #[test]
-    fn stored_cell_size_reaches_the_resize_poller_fallback() {
-        let reported = AtomicU64::new(0);
-        assert_eq!(
-            cell_size_fallback(reported.load(Ordering::Acquire)),
-            (8, 16)
-        );
-
-        store_reported_cell_size(&reported, 10, 21);
-
-        assert_eq!(
-            cell_size_fallback(reported.load(Ordering::Acquire)),
-            (10, 21)
-        );
     }
 
     #[test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -16,7 +16,7 @@ mod input;
 
 use std::collections::HashSet;
 use std::io::{self, BufRead, Write as _};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -1158,7 +1158,7 @@ fn run_client_with_mode(
 
     // Get the terminal geometry before handshake (before raw mode).
     let (cols, rows, cell_width_px, cell_height_px) =
-        current_terminal_geometry(kitty_graphics_enabled);
+        initial_terminal_geometry(kitty_graphics_enabled);
 
     // Perform handshake while the stream is still in blocking mode.
     let negotiated_encoding = match do_handshake(
@@ -1239,6 +1239,8 @@ fn run_client_with_mode(
             stream,
             cols,
             rows,
+            cell_width_px,
+            cell_height_px,
             should_quit,
             loop_config,
             negotiated_encoding,
@@ -1283,6 +1285,8 @@ async fn run_client_loop(
     stream: LocalStream,
     cols: u16,
     rows: u16,
+    initial_cell_width_px: u32,
+    initial_cell_height_px: u32,
     should_quit: Arc<AtomicBool>,
     config: ClientLoopConfig,
     negotiated_encoding: RenderEncoding,
@@ -1312,6 +1316,9 @@ async fn run_client_loop(
     };
     debug!(?negotiated_encoding, "client render encoding active");
     let host_mouse_capture_active = Arc::new(AtomicBool::new(state.mouse_capture_active));
+    // Cell size reported by the host terminal, packed as width<<32 | height.
+    // Zero means the host has not reported one.
+    let reported_cell_size = Arc::new(AtomicU64::new(0));
 
     // Channel for events from the stdin, resize, and server reader threads.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<ClientLoopEvent>(256);
@@ -1335,12 +1342,30 @@ async fn run_client_loop(
         query_host_terminal_theme();
     }
 
+    // Terminals behind ConPTY report no pixel size through the ioctl, so ask the
+    // host terminal directly instead of falling back to an assumed cell size.
+    let will_query_host_cell_size = state.attach_escape.is_none()
+        && host_cell_size_query_required(state.kitty_graphics_enabled);
+    if will_query_host_cell_size {
+        query_host_cell_size();
+    }
+
     // Spawn the resize poller thread.
     let resize_quit = should_quit.clone();
     let resize_tx = event_tx.clone();
+    let resize_cell_size = reported_cell_size.clone();
     let kitty_graphics_enabled = state.kitty_graphics_enabled;
     std::thread::spawn(move || {
-        resize_poll_loop(resize_tx, cols, rows, kitty_graphics_enabled, &resize_quit);
+        resize_poll_loop(
+            resize_tx,
+            cols,
+            rows,
+            initial_cell_width_px,
+            initial_cell_height_px,
+            kitty_graphics_enabled,
+            &resize_cell_size,
+            &resize_quit,
+        );
     });
 
     // Spawn the server reader thread (blocking reads from the socket).
@@ -1429,6 +1454,9 @@ async fn run_client_loop(
                     if crate::raw_input::events_require_host_terminal_theme_query(&events) {
                         query_host_terminal_theme();
                     }
+                    if let Some((width_px, height_px)) = reported_cell_size_from_events(&events) {
+                        store_reported_cell_size(&reported_cell_size, width_px, height_px);
+                    }
                     data
                 };
                 if should_bridge_clipboard_image_paste(
@@ -1515,6 +1543,11 @@ async fn run_client_loop(
                 };
                 if let Err(e) = write_to_server(&mut write_stream, &msg) {
                     return Err(ClientError::ConnectionLost(e));
+                }
+                // A resize can also follow a font size change, so re-ask the host
+                // terminal for its cell size whenever it is the size authority.
+                if will_query_host_cell_size {
+                    query_host_cell_size();
                 }
             }
             ClientLoopEvent::ServerMessage(msg) => match msg {
@@ -2085,23 +2118,64 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 // Resize polling
 // ---------------------------------------------------------------------------
 
-fn current_terminal_geometry(kitty_graphics_enabled: bool) -> (u16, u16, u32, u32) {
+/// Cell size assumed when neither the terminal size ioctl nor the host
+/// terminal reports pixel dimensions.
+const DEFAULT_CELL_WIDTH_PX: u32 = 8;
+const DEFAULT_CELL_HEIGHT_PX: u32 = 16;
+
+/// Cell size derived from the terminal size ioctl, if it reports pixels.
+///
+/// Terminals behind ConPTY (WSL) always report zero pixels here, which is what
+/// makes the XTWINOPS query below necessary.
+fn ioctl_cell_size() -> Option<(u32, u32)> {
+    let size = crossterm::terminal::window_size().ok()?;
+    if size.columns == 0 || size.rows == 0 || size.width == 0 || size.height == 0 {
+        return None;
+    }
+    Some((
+        (size.width as u32 / size.columns as u32).max(1),
+        (size.height as u32 / size.rows as u32).max(1),
+    ))
+}
+
+/// Cell size used when the ioctl reports no pixels: the size reported by the
+/// host terminal if one arrived, otherwise the historical default.
+fn cell_size_fallback(reported: u64) -> (u32, u32) {
+    unpack_cell_size(reported).unwrap_or((DEFAULT_CELL_WIDTH_PX, DEFAULT_CELL_HEIGHT_PX))
+}
+
+#[cfg(any(unix, test))]
+fn pack_cell_size(width_px: u32, height_px: u32) -> u64 {
+    (u64::from(width_px) << 32) | u64::from(height_px)
+}
+
+fn unpack_cell_size(packed: u64) -> Option<(u32, u32)> {
+    let width_px = (packed >> 32) as u32;
+    let height_px = (packed & u64::from(u32::MAX)) as u32;
+    (width_px > 0 && height_px > 0).then_some((width_px, height_px))
+}
+
+fn current_terminal_geometry(
+    kitty_graphics_enabled: bool,
+    reported_cell_size: &AtomicU64,
+) -> (u16, u16, u32, u32) {
     let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
     if !kitty_graphics_enabled {
         return (cols, rows, 0, 0);
     }
-    let Ok(size) = crossterm::terminal::window_size() else {
-        return (cols, rows, 8, 16);
-    };
-    if size.columns == 0 || size.rows == 0 || size.width == 0 || size.height == 0 {
-        return (cols, rows, 8, 16);
-    }
-    (
-        cols,
-        rows,
-        (size.width as u32 / size.columns as u32).max(1),
-        (size.height as u32 / size.rows as u32).max(1),
-    )
+    let (cell_width_px, cell_height_px) = ioctl_cell_size()
+        .unwrap_or_else(|| cell_size_fallback(reported_cell_size.load(Ordering::Acquire)));
+    (cols, rows, cell_width_px, cell_height_px)
+}
+
+/// Reads the terminal geometry before the handshake is sent.
+///
+/// At this point the host terminal cannot have reported a cell size yet (the
+/// query is only sent after the handshake completes), so this always reads
+/// geometry with no reported cell size available, leaving the ioctl and the
+/// default fallback as the only sources.
+fn initial_terminal_geometry(kitty_graphics_enabled: bool) -> (u16, u16, u32, u32) {
+    current_terminal_geometry(kitty_graphics_enabled, &AtomicU64::new(0))
 }
 
 /// Reports polled changes and signalled resizes that return to the same size.
@@ -2114,16 +2188,25 @@ fn resize_report_required(
 }
 
 /// Watches the terminal size and sends resize events when it changes.
+///
+/// `initial_cell_width`/`initial_cell_height` must match the cell size sent
+/// to the server during the handshake, so the poller's baseline agrees with
+/// what the server already knows. Reading a fresh baseline here instead would
+/// race the host terminal's CSI 16t response: if it lands in the shared
+/// `reported_cell_size` cache before this thread starts, `last_size` would
+/// already reflect the reported value and the first real change would never
+/// be detected as a difference.
 fn resize_poll_loop(
     resize_tx: tokio::sync::mpsc::Sender<ClientLoopEvent>,
     initial_cols: u16,
     initial_rows: u16,
+    initial_cell_width: u32,
+    initial_cell_height: u32,
     kitty_graphics_enabled: bool,
+    reported_cell_size: &AtomicU64,
     should_quit: &Arc<AtomicBool>,
 ) {
     crate::platform::watch_terminal_resize_signal();
-    let (_, _, initial_cell_width, initial_cell_height) =
-        current_terminal_geometry(kitty_graphics_enabled);
     let mut last_size = (
         initial_cols,
         initial_rows,
@@ -2133,7 +2216,7 @@ fn resize_poll_loop(
     while !should_quit.load(Ordering::Acquire) {
         std::thread::sleep(Duration::from_millis(100));
         let signalled = crate::platform::take_terminal_resize_signal();
-        let new_size = current_terminal_geometry(kitty_graphics_enabled);
+        let new_size = current_terminal_geometry(kitty_graphics_enabled, reported_cell_size);
         if resize_report_required(signalled, new_size, last_size) {
             last_size = new_size;
             if resize_tx
@@ -2165,6 +2248,56 @@ fn write_host_terminal_theme_query(mut writer: impl io::Write) -> io::Result<()>
     let query = crate::terminal_theme::host_terminal_theme_query_sequence();
     writer.write_all(query.as_bytes())?;
     writer.flush()
+}
+
+/// XTWINOPS request for the host terminal cell size in pixels.
+const HOST_CELL_SIZE_QUERY: &[u8] = b"\x1b[16t";
+
+fn query_host_cell_size() {
+    let _ = write_host_cell_size_query(io::stdout());
+}
+
+fn should_query_host_cell_size() -> bool {
+    !cfg!(windows)
+}
+
+/// Returns whether the host terminal has to be asked for its cell size.
+///
+/// Only pane graphics need pixel dimensions, and the query is limited to hosts
+/// whose terminal size ioctl reports no pixels, so terminals that already
+/// answer the ioctl keep their current behaviour.
+fn host_cell_size_query_required(kitty_graphics_enabled: bool) -> bool {
+    kitty_graphics_enabled && should_query_host_cell_size() && ioctl_cell_size().is_none()
+}
+
+fn write_host_cell_size_query(mut writer: impl io::Write) -> io::Result<()> {
+    writer.write_all(HOST_CELL_SIZE_QUERY)?;
+    writer.flush()
+}
+
+/// Records a host cell size report so the resize poller picks it up.
+///
+/// Only the byte-oriented (Unix) stdin path can observe these reports; Windows
+/// clients never send the query.
+#[cfg(any(unix, test))]
+fn store_reported_cell_size(reported_cell_size: &AtomicU64, width_px: u32, height_px: u32) {
+    let packed = pack_cell_size(width_px, height_px);
+    if reported_cell_size.swap(packed, Ordering::AcqRel) != packed {
+        debug!(width_px, height_px, "host terminal reported cell size");
+    }
+}
+
+#[cfg(any(unix, test))]
+fn reported_cell_size_from_events(
+    events: &[crate::raw_input::RawInputEvent],
+) -> Option<(u32, u32)> {
+    events.iter().rev().find_map(|event| match event {
+        crate::raw_input::RawInputEvent::HostCellSizeReport {
+            width_px,
+            height_px,
+        } => Some((*width_px, *height_px)),
+        _ => None,
+    })
 }
 
 fn init_logging() {
@@ -2481,6 +2614,64 @@ mod tests {
     #[test]
     fn host_terminal_theme_query_is_disabled_on_windows() {
         assert_eq!(should_query_host_terminal_theme(), !cfg!(windows));
+    }
+
+    #[test]
+    fn write_host_cell_size_query_emits_xtwinops_request() {
+        let mut output = Vec::new();
+        write_host_cell_size_query(&mut output).unwrap();
+
+        assert_eq!(output, b"\x1b[16t");
+    }
+
+    #[test]
+    fn host_cell_size_query_is_disabled_on_windows() {
+        assert_eq!(should_query_host_cell_size(), !cfg!(windows));
+    }
+
+    #[test]
+    fn host_cell_size_query_is_limited_to_pane_graphics_clients() {
+        assert!(!host_cell_size_query_required(false));
+    }
+
+    #[test]
+    fn cell_size_fallback_prefers_reported_size_over_default() {
+        assert_eq!(cell_size_fallback(0), (8, 16));
+        assert_eq!(cell_size_fallback(pack_cell_size(10, 21)), (10, 21));
+        // Partial reports never reach the cache, but must not be trusted anyway.
+        assert_eq!(cell_size_fallback(pack_cell_size(10, 0)), (8, 16));
+        assert_eq!(cell_size_fallback(pack_cell_size(0, 21)), (8, 16));
+    }
+
+    #[test]
+    fn reported_cell_size_is_taken_from_host_cell_size_events() {
+        let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[6;21;10t");
+        assert_eq!(reported_cell_size_from_events(&events), Some((10, 21)));
+
+        let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[?997;1n");
+        assert_eq!(reported_cell_size_from_events(&events), None);
+    }
+
+    #[test]
+    fn reported_cell_size_from_events_uses_the_last_report_in_a_batch() {
+        let events = crate::raw_input::parse_raw_input_bytes_sync(b"\x1b[6;21;10t\x1b[6;18;9t");
+        assert_eq!(reported_cell_size_from_events(&events), Some((9, 18)));
+    }
+
+    #[test]
+    fn stored_cell_size_reaches_the_resize_poller_fallback() {
+        let reported = AtomicU64::new(0);
+        assert_eq!(
+            cell_size_fallback(reported.load(Ordering::Acquire)),
+            (8, 16)
+        );
+
+        store_reported_cell_size(&reported, 10, 21);
+
+        assert_eq!(
+            cell_size_fallback(reported.load(Ordering::Acquire)),
+            (10, 21)
+        );
     }
 
     #[test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -16,7 +16,7 @@ mod input;
 
 use std::collections::HashSet;
 use std::io::{self, BufRead, Write as _};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -1328,19 +1328,22 @@ async fn run_client_loop(
         state.attach_escape.is_none() && should_query_host_terminal_theme();
     // Terminals behind ConPTY report no pixel size through the ioctl, so ask the
     // host terminal directly instead of falling back to an assumed cell size.
-    // This is decided before the reader starts so the framer knows that a reply
-    // is outstanding.
     let will_query_host_cell_size = state.attach_escape.is_none()
         && host_cell_size_query_required(state.kitty_graphics_enabled);
+    // Cell size queries outstanding towards the host terminal. The stdin reader
+    // drains this counter so the framer holds every reply, including the ones
+    // triggered by later resizes.
+    let pending_host_cell_size_queries = Arc::new(AtomicU16::new(0));
     let stdin_quit = should_quit.clone();
     let stdin_tx = event_tx.clone();
     let stdin_mouse_capture_active = host_mouse_capture_active.clone();
+    let stdin_pending_cell_size_queries = pending_host_cell_size_queries.clone();
     std::thread::spawn(move || {
         input::stdin_reader_loop(
             stdin_tx,
             &stdin_quit,
             will_query_host_terminal_theme,
-            will_query_host_cell_size,
+            stdin_pending_cell_size_queries,
             stdin_mouse_capture_active,
         );
     });
@@ -1350,7 +1353,7 @@ async fn run_client_loop(
     }
 
     if will_query_host_cell_size {
-        query_host_cell_size();
+        query_host_cell_size(&pending_host_cell_size_queries);
     }
 
     // Spawn the resize poller thread.
@@ -1550,7 +1553,7 @@ async fn run_client_loop(
                 // A resize can also follow a font size change, so re-ask the host
                 // terminal for its cell size whenever it is the size authority.
                 if will_query_host_cell_size {
-                    query_host_cell_size();
+                    query_host_cell_size(&pending_host_cell_size_queries);
                 }
             }
             ClientLoopEvent::ServerMessage(msg) => match msg {
@@ -2256,8 +2259,23 @@ fn write_host_terminal_theme_query(mut writer: impl io::Write) -> io::Result<()>
 /// XTWINOPS request for the host terminal cell size in pixels.
 const HOST_CELL_SIZE_QUERY: &[u8] = b"\x1b[16t";
 
-fn query_host_cell_size() {
+/// Sends the cell size query and registers it with the stdin framer.
+///
+/// Every issued query has to be registered because the query is re-sent on
+/// resize, so more than one reply can be in flight.
+fn query_host_cell_size(pending_queries: &AtomicU16) {
+    register_pending_host_cell_size_query(pending_queries);
     let _ = write_host_cell_size_query(io::stdout());
+}
+
+/// Counts one more outstanding cell size reply for the stdin reader thread.
+///
+/// This runs before the query reaches stdout, so the reply can never be framed
+/// before the reader knows that it is coming.
+fn register_pending_host_cell_size_query(pending_queries: &AtomicU16) {
+    let _ = pending_queries.fetch_update(Ordering::AcqRel, Ordering::Acquire, |awaited| {
+        Some(awaited.saturating_add(1))
+    });
 }
 
 fn should_query_host_cell_size() -> bool {
@@ -2635,6 +2653,20 @@ mod tests {
     #[test]
     fn host_cell_size_query_is_limited_to_pane_graphics_clients() {
         assert!(!host_cell_size_query_required(false));
+    }
+
+    #[test]
+    fn pending_host_cell_size_queries_accumulate_and_saturate() {
+        let pending = AtomicU16::new(0);
+        register_pending_host_cell_size_query(&pending);
+        register_pending_host_cell_size_query(&pending);
+
+        assert_eq!(pending.load(Ordering::Acquire), 2);
+
+        pending.store(u16::MAX, Ordering::Release);
+        register_pending_host_cell_size_query(&pending);
+
+        assert_eq!(pending.load(Ordering::Acquire), u16::MAX);
     }
 
     #[test]

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -139,6 +139,13 @@ pub enum RawInputEvent {
         colors: Vec<(u8, RgbColor)>,
     },
     HostColorSchemeChanged(HostAppearance),
+    // Read only by the Unix client; other targets parse and route the report
+    // without inspecting the dimensions.
+    #[cfg_attr(not(any(unix, test)), allow(dead_code))]
+    HostCellSizeReport {
+        width_px: u32,
+        height_px: u32,
+    },
     Unsupported,
 }
 
@@ -748,6 +755,16 @@ fn extract_one_event(buffer: &[u8]) -> Option<(RawInputEvent, usize)> {
             return Some((RawInputEvent::HostColorSchemeChanged(appearance), seq_len));
         }
 
+        if let Some((width_px, height_px)) = parse_host_cell_size_report(&buffer[..seq_len]) {
+            return Some((
+                RawInputEvent::HostCellSizeReport {
+                    width_px,
+                    height_px,
+                },
+                seq_len,
+            ));
+        }
+
         if let Some(mouse) = parse_sgr_mouse(seq) {
             return Some((RawInputEvent::Mouse(mouse), seq_len));
         }
@@ -796,6 +813,27 @@ fn parse_host_color_scheme_report(buffer: &[u8]) -> Option<HostAppearance> {
         GHOSTTY_COLOR_SCHEME_LIGHT_REPORT => Some(HostAppearance::Light),
         _ => None,
     }
+}
+
+/// Parses an XTWINOPS cell size report (`CSI 6 ; height ; width t`).
+///
+/// The report orders height before width, while the result is returned as
+/// `(width_px, height_px)` to match the rest of the cell size plumbing. Reports
+/// with a different leading parameter (for example the `CSI 4 t` window pixel
+/// report), a different parameter count, or a zero dimension are rejected.
+fn parse_host_cell_size_report(buffer: &[u8]) -> Option<(u32, u32)> {
+    let body = buffer.strip_prefix(b"\x1b[")?.strip_suffix(b"t")?;
+    let text = std::str::from_utf8(body).ok()?;
+    let mut params = text.split(';');
+    if params.next()? != "6" {
+        return None;
+    }
+    let height_px = params.next()?.parse::<u32>().ok()?;
+    let width_px = params.next()?.parse::<u32>().ok()?;
+    if params.next().is_some() || width_px == 0 || height_px == 0 {
+        return None;
+    }
+    Some((width_px, height_px))
 }
 
 fn starts_with_incomplete_default_color_response(buffer: &[u8]) -> bool {
@@ -1383,6 +1421,65 @@ mod tests {
             events[0],
             RawInputEvent::HostColorSchemeChanged(HostAppearance::Dark)
         ));
+    }
+
+    #[test]
+    fn parses_host_cell_size_report() {
+        let events = parse_raw_input_bytes_sync(b"\x1b[6;21;10t");
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            RawInputEvent::HostCellSizeReport {
+                width_px: 10,
+                height_px: 21,
+            }
+        ));
+    }
+
+    #[test]
+    fn raw_input_framer_reassembles_split_host_cell_size_report() {
+        let mut framer = RawInputFramer::default();
+
+        assert!(framer.push(b"\x1b[6;21").is_empty());
+        let events = framer.push(b";10t");
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            RawInputEvent::HostCellSizeReport {
+                width_px: 10,
+                height_px: 21,
+            }
+        ));
+    }
+
+    #[test]
+    fn host_cell_size_report_parser_is_exact() {
+        for bytes in [
+            // Zero dimensions carry no usable cell size.
+            b"\x1b[6;0;10t".as_slice(),
+            b"\x1b[6;21;0t".as_slice(),
+            // Missing or extra parameters.
+            b"\x1b[6;21t".as_slice(),
+            b"\x1b[6;21;10;3t".as_slice(),
+            // Other XTWINOPS reports must not be mistaken for a cell size.
+            b"\x1b[4;1610;777t".as_slice(),
+            b"\x1b[8;37;161t".as_slice(),
+            // Non-numeric parameters.
+            b"\x1b[6;21;1-t".as_slice(),
+        ] {
+            assert!(
+                parse_host_cell_size_report(bytes).is_none(),
+                "bytes: {bytes:?}"
+            );
+            let events = parse_raw_input_bytes_sync(bytes);
+            assert_eq!(events.len(), 1, "bytes: {bytes:?}");
+            assert!(
+                !matches!(events[0], RawInputEvent::HostCellSizeReport { .. }),
+                "bytes: {bytes:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -258,10 +258,16 @@ impl RawInputByteFramer {
     /// reply split at its ESC introducer stitches back together instead of
     /// leaking, same as the host color reply window above.
     ///
+    /// The cell size query is re-sent on every resize, so outstanding replies
+    /// accumulate instead of resetting: a reply that arrives while another
+    /// query is still in flight must keep the hold window open.
+    ///
     /// Only the Unix client sends the cell size query.
     #[cfg(any(unix, test))]
     pub(crate) fn host_cell_size_query_sent(&mut self) {
-        self.host_cell_size_replies_awaited = HOST_CELL_SIZE_QUERY_REPLIES;
+        self.host_cell_size_replies_awaited = self
+            .host_cell_size_replies_awaited
+            .saturating_add(HOST_CELL_SIZE_QUERY_REPLIES);
         self.held_pending_host_reply_esc = false;
     }
 
@@ -2639,6 +2645,29 @@ mod tests {
         );
 
         // Window closed: a later lone Escape flushes immediately.
+        assert!(framer.push(b"\x1b").is_empty());
+        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
+    }
+
+    #[test]
+    fn holds_split_cell_size_reply_while_a_second_query_is_outstanding() {
+        let mut framer = RawInputByteFramer::default();
+        // The initial query plus a resize re-query are both outstanding.
+        framer.host_cell_size_query_sent();
+        framer.host_cell_size_query_sent();
+
+        assert_eq!(
+            framer.push(b"\x1b[6;21;10t"),
+            vec![b"\x1b[6;21;10t".to_vec()]
+        );
+
+        // The second reply is split at its ESC introducer and must still be
+        // held, because one query remains unanswered.
+        assert!(framer.push(b"\x1b").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert_eq!(framer.push(b"[6;42;20t"), vec![b"\x1b[6;42;20t".to_vec()]);
+
+        // Both replies arrived: a later lone Escape flushes immediately.
         assert!(framer.push(b"\x1b").is_empty());
         assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
     }

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -291,6 +291,9 @@ impl RawInputByteFramer {
         let mut chunks = self.drain_available_chunks();
 
         if let Some(family) = self.discard_until {
+            if family == ControlStringFamily::HostReplyCsi {
+                return chunks;
+            }
             if family == ControlStringFamily::OrphanedSgrMouseTail {
                 self.buffer.clear();
                 self.discard_until = None;
@@ -361,12 +364,37 @@ impl RawInputByteFramer {
             return chunks;
         }
 
+        if self.host_cell_size_replies_awaited > 0 && self.buffer.as_slice() == b"\x1b[" {
+            if !self.held_pending_host_reply_esc {
+                self.held_pending_host_reply_esc = true;
+                tracing::trace!("holding incomplete cell size reply one flush");
+                return chunks;
+            }
+            self.host_cell_size_replies_awaited = 0;
+            self.held_pending_host_reply_esc = false;
+        }
+
+        if self.host_cell_size_replies_awaited > 0
+            && starts_with_incomplete_host_cell_size_report(&self.buffer)
+        {
+            tracing::debug!(
+                len = self.buffer.len(),
+                "discarding incomplete host cell size report after input timeout"
+            );
+            self.host_cell_size_replies_awaited = 0;
+            self.held_pending_host_reply_esc = false;
+            self.discard_until = Some(ControlStringFamily::HostReplyCsi);
+            self.discarded_tail_bytes = 0;
+            self.buffer.clear();
+            return chunks;
+        }
+
         if starts_with_incomplete_host_color_scheme_report(&self.buffer) {
             tracing::debug!(
                 len = self.buffer.len(),
                 "discarding incomplete host color scheme report after input timeout"
             );
-            self.discard_until = Some(ControlStringFamily::HostColorSchemeCsi);
+            self.discard_until = Some(ControlStringFamily::HostReplyCsi);
             self.discarded_tail_bytes = 0;
             self.buffer.clear();
             return chunks;
@@ -444,6 +472,15 @@ impl RawInputByteFramer {
             }
 
             if let Some(family) = self.discard_until {
+                if family == ControlStringFamily::HostReplyCsi {
+                    if discard_host_reply_csi_tail(&mut self.buffer, &mut self.discarded_tail_bytes)
+                    {
+                        self.discard_until = None;
+                        self.discarded_tail_bytes = 0;
+                        continue;
+                    }
+                    break;
+                }
                 if family == ControlStringFamily::OrphanedSgrMouseTail {
                     if discard_orphaned_sgr_mouse_tail(
                         &mut self.buffer,
@@ -524,9 +561,7 @@ fn plausible_control_string_tail(family: ControlStringFamily, buffer: &[u8]) -> 
                 )
         }),
         ControlStringFamily::StTerminated => buffer.last() == Some(&ESC),
-        ControlStringFamily::HostColorSchemeCsi => buffer
-            .iter()
-            .all(|byte| byte.is_ascii_digit() || matches!(*byte, b';' | b'?' | b'n')),
+        ControlStringFamily::HostReplyCsi => false,
         ControlStringFamily::OrphanedSgrMouseTail => buffer
             .iter()
             .all(|byte| byte.is_ascii_digit() || matches!(*byte, b';' | b'M' | b'm')),
@@ -810,7 +845,7 @@ fn extract_one_event(buffer: &[u8]) -> Option<(RawInputEvent, usize)> {
 enum ControlStringFamily {
     Osc,
     StTerminated,
-    HostColorSchemeCsi,
+    HostReplyCsi,
     OrphanedSgrMouseTail,
 }
 
@@ -864,6 +899,26 @@ fn starts_with_incomplete_host_color_scheme_report(buffer: &[u8]) -> bool {
         && (GHOSTTY_COLOR_SCHEME_DARK_REPORT.starts_with(buffer)
             || GHOSTTY_COLOR_SCHEME_LIGHT_REPORT.starts_with(buffer))
         && buffer.len() < GHOSTTY_COLOR_SCHEME_DARK_REPORT.len()
+}
+
+fn starts_with_incomplete_host_cell_size_report(buffer: &[u8]) -> bool {
+    let Some(body) = buffer.strip_prefix(b"\x1b[") else {
+        return false;
+    };
+    if body.is_empty() || body.last() == Some(&b't') {
+        return false;
+    }
+
+    let mut params = body.split(|byte| *byte == b';');
+    if params.next() != Some(b"6".as_slice()) {
+        return false;
+    }
+    let height = params.next();
+    let width = params.next();
+    params.next().is_none()
+        && height.is_none_or(|value| value.iter().all(u8::is_ascii_digit))
+        && width.is_none_or(|value| value.iter().all(u8::is_ascii_digit))
+        && !(height.is_some_and(<[u8]>::is_empty) && width.is_some())
 }
 
 fn control_string(buffer: &[u8]) -> Option<ControlString> {
@@ -1011,6 +1066,29 @@ fn discard_or_buffer_orphaned_sgr_mouse_tail(
     }
 }
 
+fn discard_host_reply_csi_tail(buffer: &mut Vec<u8>, discarded_tail_bytes: &mut usize) -> bool {
+    let remaining = MAX_DISCARDED_CONTROL_TAIL_BYTES.saturating_sub(*discarded_tail_bytes);
+    let inspected = buffer.len().min(remaining);
+
+    for index in 0..inspected {
+        match buffer[index] {
+            0x20..=0x3f => {}
+            0x40..=0x7e => {
+                buffer.drain(..=index);
+                return true;
+            }
+            _ => {
+                buffer.drain(..index);
+                return true;
+            }
+        }
+    }
+
+    buffer.drain(..inspected);
+    *discarded_tail_bytes = discarded_tail_bytes.saturating_add(inspected);
+    *discarded_tail_bytes >= MAX_DISCARDED_CONTROL_TAIL_BYTES
+}
+
 fn discard_orphaned_sgr_mouse_tail(buffer: &mut Vec<u8>, discarded_tail_bytes: &mut usize) -> bool {
     let remaining = MAX_DISCARDED_CONTROL_TAIL_BYTES.saturating_sub(*discarded_tail_bytes);
     let inspected = buffer.len().min(remaining);
@@ -1065,10 +1143,7 @@ fn control_string_terminator_for_family(
     match family {
         ControlStringFamily::Osc => osc_string_terminator(buffer),
         ControlStringFamily::StTerminated => st_string_terminator(buffer),
-        ControlStringFamily::HostColorSchemeCsi => buffer
-            .iter()
-            .position(|byte| *byte == b'n')
-            .map(|idx| idx + 1),
+        ControlStringFamily::HostReplyCsi => None,
         ControlStringFamily::OrphanedSgrMouseTail => buffer
             .iter()
             .position(|byte| matches!(*byte, b'M' | b'm'))
@@ -2578,6 +2653,66 @@ mod tests {
                 height_px: 21,
             }
         ));
+    }
+
+    #[test]
+    fn timed_out_host_cell_size_reply_fragments_do_not_leak() {
+        for (prefix, tail) in [
+            (b"\x1b[6".as_slice(), b";21;10t".as_slice()),
+            (b"\x1b[6;".as_slice(), b"21;10t".as_slice()),
+            (b"\x1b[6;21;".as_slice(), b"10t".as_slice()),
+        ] {
+            let mut framer = RawInputByteFramer::default();
+            framer.host_cell_size_query_sent();
+
+            assert!(framer.push(prefix).is_empty(), "prefix: {prefix:?}");
+            assert!(framer.flush_timeout().is_empty(), "prefix: {prefix:?}");
+            assert!(framer.push(tail).is_empty(), "tail: {tail:?}");
+            assert_eq!(framer.push(b"a"), vec![b"a".to_vec()]);
+        }
+    }
+
+    #[test]
+    fn split_host_cell_size_reply_after_csi_intro_gets_one_more_flush() {
+        let mut framer = RawInputByteFramer::default();
+        framer.host_cell_size_query_sent();
+
+        assert!(framer.push(b"\x1b[").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert_eq!(framer.push(b"6;21;10t"), vec![b"\x1b[6;21;10t".to_vec()]);
+
+        let mut alt_bracket = RawInputByteFramer::default();
+        alt_bracket.host_cell_size_query_sent();
+        assert!(alt_bracket.push(b"\x1b[").is_empty());
+        assert!(alt_bracket.flush_timeout().is_empty());
+        assert_eq!(alt_bracket.flush_timeout(), vec![b"\x1b[".to_vec()]);
+    }
+
+    #[test]
+    fn malformed_host_reply_tail_preserves_following_input() {
+        let mut framer = RawInputByteFramer::default();
+        framer.host_cell_size_query_sent();
+
+        assert!(framer.push(b"\x1b[6;21").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert_eq!(
+            framer.push(b";10xabc"),
+            vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]
+        );
+    }
+
+    #[test]
+    fn host_reply_tail_discard_is_bounded_across_pushes() {
+        let mut framer = RawInputByteFramer::default();
+        framer.host_cell_size_query_sent();
+
+        assert!(framer.push(b"\x1b[6;21").is_empty());
+        assert!(framer.flush_timeout().is_empty());
+        assert!(framer.push(&[b'1'; 64]).is_empty());
+        assert_eq!(
+            framer.push(&[b'2'; 67]),
+            vec![b"2".to_vec(), b"2".to_vec(), b"2".to_vec()]
+        );
     }
 
     #[test]

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -216,12 +216,16 @@ pub(crate) struct RawInputByteFramer {
     discarded_tail_bytes: usize,
     lone_escape_recently_flushed: bool,
     host_color_replies_awaited: u16,
-    held_pending_color_esc: bool,
+    host_cell_size_replies_awaited: u16,
+    held_pending_host_reply_esc: bool,
     host_color_scheme_change_tracking: bool,
     split_coalesced_escape: bool,
 }
 
 const HOST_COLOR_QUERY_REPLIES: u16 = 258;
+// Only the Unix client sends the cell size query.
+#[cfg(any(unix, test))]
+const HOST_CELL_SIZE_QUERY_REPLIES: u16 = 1;
 const MAX_ORPHANED_SGR_MOUSE_TAIL_BYTES: usize = 32;
 
 impl RawInputByteFramer {
@@ -247,7 +251,22 @@ impl RawInputByteFramer {
     /// at its ESC introducer stitches back together instead of leaking (#549).
     pub(crate) fn host_color_query_sent(&mut self) {
         self.host_color_replies_awaited = HOST_COLOR_QUERY_REPLIES;
-        self.held_pending_color_esc = false;
+        self.held_pending_host_reply_esc = false;
+    }
+
+    /// Hold a lone trailing ESC for one idle flush so an XTWINOPS cell size
+    /// reply split at its ESC introducer stitches back together instead of
+    /// leaking, same as the host color reply window above.
+    ///
+    /// Only the Unix client sends the cell size query.
+    #[cfg(any(unix, test))]
+    pub(crate) fn host_cell_size_query_sent(&mut self) {
+        self.host_cell_size_replies_awaited = HOST_CELL_SIZE_QUERY_REPLIES;
+        self.held_pending_host_reply_esc = false;
+    }
+
+    fn awaiting_host_reply(&self) -> bool {
+        self.host_color_replies_awaited > 0 || self.host_cell_size_replies_awaited > 0
     }
 
     pub(crate) fn enable_host_color_scheme_change_tracking(&mut self) {
@@ -372,14 +391,15 @@ impl RawInputByteFramer {
         }
 
         if self.buffer.as_slice() == [ESC] {
-            if self.host_color_replies_awaited > 0 && !self.held_pending_color_esc {
-                self.held_pending_color_esc = true;
-                tracing::trace!("holding lone escape one flush while awaiting host color reply");
+            if self.awaiting_host_reply() && !self.held_pending_host_reply_esc {
+                self.held_pending_host_reply_esc = true;
+                tracing::trace!("holding lone escape one flush while awaiting host reply");
                 return chunks;
             }
             // No continuation arrived; give up the window so Escape is not delayed again.
             self.host_color_replies_awaited = 0;
-            self.held_pending_color_esc = false;
+            self.host_cell_size_replies_awaited = 0;
+            self.held_pending_host_reply_esc = false;
             tracing::warn!(
                 bytes = ?self.buffer,
                 "flushing lone escape after input timeout; if this follows an alt chord or focus switch it may reach the pane as plain esc"
@@ -466,12 +486,15 @@ impl RawInputByteFramer {
                 RawInputEvent::HostDefaultColor { .. } | RawInputEvent::HostPaletteColors { .. }
             ) {
                 self.host_color_replies_awaited = self.host_color_replies_awaited.saturating_sub(1);
+            } else if matches!(event, RawInputEvent::HostCellSizeReport { .. }) {
+                self.host_cell_size_replies_awaited =
+                    self.host_cell_size_replies_awaited.saturating_sub(1);
             } else if self.host_color_scheme_change_tracking
                 && matches!(event, RawInputEvent::HostColorSchemeChanged(_))
             {
                 self.host_color_query_sent();
             }
-            self.held_pending_color_esc = false;
+            self.held_pending_host_reply_esc = false;
             chunks.push(self.buffer[..consumed].to_vec());
             self.buffer.drain(..consumed);
         }
@@ -2566,6 +2589,58 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn holds_lone_escape_and_stitches_split_host_cell_size_reply() {
+        let mut framer = RawInputByteFramer::default();
+        framer.host_cell_size_query_sent();
+
+        // The XTWINOPS reply is split right at its ESC introducer.
+        assert!(framer.push(b"\x1b").is_empty());
+        // The idle flush must not release the ESC as an Escape key while the
+        // cell size reply is still outstanding.
+        assert!(framer.flush_timeout().is_empty());
+
+        // The rest of the reply arrives and stitches back together instead of
+        // leaking its payload into the focused pane.
+        let chunks = framer.push(b"[6;21;10t");
+        assert_eq!(chunks, vec![b"\x1b[6;21;10t".to_vec()]);
+        let (event, _) = extract_one_event(&chunks[0]).unwrap();
+        assert!(matches!(
+            event,
+            RawInputEvent::HostCellSizeReport {
+                width_px: 10,
+                height_px: 21,
+            }
+        ));
+    }
+
+    #[test]
+    fn gives_up_holding_lone_escape_awaiting_host_cell_size_reply() {
+        let mut framer = RawInputByteFramer::default();
+        framer.host_cell_size_query_sent();
+
+        assert!(framer.push(b"\x1b").is_empty());
+        // First idle flush holds the escape.
+        assert!(framer.flush_timeout().is_empty());
+        // No continuation arrived; the second idle flush releases it as Escape.
+        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
+    }
+
+    #[test]
+    fn stops_holding_lone_escape_after_host_cell_size_reply_completes() {
+        let mut framer = RawInputByteFramer::default();
+        framer.host_cell_size_query_sent();
+
+        assert_eq!(
+            framer.push(b"\x1b[6;21;10t"),
+            vec![b"\x1b[6;21;10t".to_vec()]
+        );
+
+        // Window closed: a later lone Escape flushes immediately.
+        assert!(framer.push(b"\x1b").is_empty());
+        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
     }
 
     #[test]

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -139,8 +139,7 @@ pub enum RawInputEvent {
         colors: Vec<(u8, RgbColor)>,
     },
     HostColorSchemeChanged(HostAppearance),
-    // Read only by the Unix client; other targets parse and route the report
-    // without inspecting the dimensions.
+    // The dimensions are only read by the Unix client.
     #[cfg_attr(not(any(unix, test)), allow(dead_code))]
     HostCellSizeReport {
         width_px: u32,
@@ -223,7 +222,6 @@ pub(crate) struct RawInputByteFramer {
 }
 
 const HOST_COLOR_QUERY_REPLIES: u16 = 258;
-// Only the Unix client sends the cell size query.
 #[cfg(any(unix, test))]
 const HOST_CELL_SIZE_QUERY_REPLIES: u16 = 1;
 const MAX_ORPHANED_SGR_MOUSE_TAIL_BYTES: usize = 32;
@@ -254,20 +252,11 @@ impl RawInputByteFramer {
         self.held_pending_host_reply_esc = false;
     }
 
-    /// Hold a lone trailing ESC for one idle flush so an XTWINOPS cell size
-    /// reply split at its ESC introducer stitches back together instead of
-    /// leaking, same as the host color reply window above.
-    ///
-    /// The cell size query is re-sent on every resize, so outstanding replies
-    /// accumulate instead of resetting: a reply that arrives while another
-    /// query is still in flight must keep the hold window open.
-    ///
-    /// Only the Unix client sends the cell size query.
+    /// Same hold window as `host_color_query_sent`, for the XTWINOPS cell size
+    /// reply. Only the Unix client sends this query.
     #[cfg(any(unix, test))]
     pub(crate) fn host_cell_size_query_sent(&mut self) {
-        self.host_cell_size_replies_awaited = self
-            .host_cell_size_replies_awaited
-            .saturating_add(HOST_CELL_SIZE_QUERY_REPLIES);
+        self.host_cell_size_replies_awaited = HOST_CELL_SIZE_QUERY_REPLIES;
         self.held_pending_host_reply_esc = false;
     }
 
@@ -844,12 +833,8 @@ fn parse_host_color_scheme_report(buffer: &[u8]) -> Option<HostAppearance> {
     }
 }
 
-/// Parses an XTWINOPS cell size report (`CSI 6 ; height ; width t`).
-///
-/// The report orders height before width, while the result is returned as
-/// `(width_px, height_px)` to match the rest of the cell size plumbing. Reports
-/// with a different leading parameter (for example the `CSI 4 t` window pixel
-/// report), a different parameter count, or a zero dimension are rejected.
+/// Parses an XTWINOPS cell size report (`CSI 6 ; height ; width t`) into
+/// `(width_px, height_px)`; note the reply orders height first.
 fn parse_host_cell_size_report(buffer: &[u8]) -> Option<(u32, u32)> {
     let body = buffer.strip_prefix(b"\x1b[")?.strip_suffix(b"t")?;
     let text = std::str::from_utf8(body).ok()?;
@@ -1467,23 +1452,6 @@ mod tests {
     }
 
     #[test]
-    fn raw_input_framer_reassembles_split_host_cell_size_report() {
-        let mut framer = RawInputFramer::default();
-
-        assert!(framer.push(b"\x1b[6;21").is_empty());
-        let events = framer.push(b";10t");
-
-        assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0],
-            RawInputEvent::HostCellSizeReport {
-                width_px: 10,
-                height_px: 21,
-            }
-        ));
-    }
-
-    #[test]
     fn host_cell_size_report_parser_is_exact() {
         for bytes in [
             // Zero dimensions carry no usable cell size.
@@ -1500,12 +1468,6 @@ mod tests {
         ] {
             assert!(
                 parse_host_cell_size_report(bytes).is_none(),
-                "bytes: {bytes:?}"
-            );
-            let events = parse_raw_input_bytes_sync(bytes);
-            assert_eq!(events.len(), 1, "bytes: {bytes:?}");
-            assert!(
-                !matches!(events[0], RawInputEvent::HostCellSizeReport { .. }),
                 "bytes: {bytes:?}"
             );
         }
@@ -2604,12 +2566,8 @@ mod tests {
 
         // The XTWINOPS reply is split right at its ESC introducer.
         assert!(framer.push(b"\x1b").is_empty());
-        // The idle flush must not release the ESC as an Escape key while the
-        // cell size reply is still outstanding.
         assert!(framer.flush_timeout().is_empty());
 
-        // The rest of the reply arrives and stitches back together instead of
-        // leaking its payload into the focused pane.
         let chunks = framer.push(b"[6;21;10t");
         assert_eq!(chunks, vec![b"\x1b[6;21;10t".to_vec()]);
         let (event, _) = extract_one_event(&chunks[0]).unwrap();
@@ -2623,18 +2581,6 @@ mod tests {
     }
 
     #[test]
-    fn gives_up_holding_lone_escape_awaiting_host_cell_size_reply() {
-        let mut framer = RawInputByteFramer::default();
-        framer.host_cell_size_query_sent();
-
-        assert!(framer.push(b"\x1b").is_empty());
-        // First idle flush holds the escape.
-        assert!(framer.flush_timeout().is_empty());
-        // No continuation arrived; the second idle flush releases it as Escape.
-        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
-    }
-
-    #[test]
     fn stops_holding_lone_escape_after_host_cell_size_reply_completes() {
         let mut framer = RawInputByteFramer::default();
         framer.host_cell_size_query_sent();
@@ -2645,29 +2591,6 @@ mod tests {
         );
 
         // Window closed: a later lone Escape flushes immediately.
-        assert!(framer.push(b"\x1b").is_empty());
-        assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
-    }
-
-    #[test]
-    fn holds_split_cell_size_reply_while_a_second_query_is_outstanding() {
-        let mut framer = RawInputByteFramer::default();
-        // The initial query plus a resize re-query are both outstanding.
-        framer.host_cell_size_query_sent();
-        framer.host_cell_size_query_sent();
-
-        assert_eq!(
-            framer.push(b"\x1b[6;21;10t"),
-            vec![b"\x1b[6;21;10t".to_vec()]
-        );
-
-        // The second reply is split at its ESC introducer and must still be
-        // held, because one query remains unanswered.
-        assert!(framer.push(b"\x1b").is_empty());
-        assert!(framer.flush_timeout().is_empty());
-        assert_eq!(framer.push(b"[6;42;20t"), vec![b"\x1b[6;42;20t".to_vec()]);
-
-        // Both replies arrived: a later lone Escape flushes immediately.
         assert!(framer.push(b"\x1b").is_empty());
         assert_eq!(framer.flush_timeout(), vec![b"\x1b".to_vec()]);
     }


### PR DESCRIPTION
## Summary

- query the host terminal's cell size with XTWINOPS (`CSI 16 t`) once during
  attach when the terminal size ioctl reports zero pixels, and parse the
  `CSI 6 ; height ; width t` reply on the client's existing stdin path
- cache the reported size and let the existing resize poller propagate it to
  the server — no wire protocol or server changes
- keep the 8x16 fallback for terminals that never reply, and leave terminals
  whose ioctl reports pixels untouched

Under WSL, ConPTY zeroes the pixel fields of TIOCGWINSZ, so the client sent the
hardcoded 8x16 fallback to the server and pane graphics rendered at roughly 60%
of the real pixel count (blurry). The outer terminal knows the real cell size
and reports it over XTWINOPS: WezTerm answers `CSI 16 t` with 10x21 px.

### Root cause vs. the issue

Issue #2146 pointed at `HostCellSize::try_from_terminal` in
`src/kitty_graphics.rs`. That path only serves the monolithic `--no-session`
mode; in the default client/server mode the value that reaches rendering comes
from `current_terminal_geometry` in `src/client/mod.rs`, which had the same
zero-pixel blind spot. Same problem and same goal as the issue, different
location — this PR fixes the client path. The monolithic path is left as is to
keep the change focused; happy to follow up if wanted.

**Files to review (5, +305 / -27):**

| File | Why |
|---|---|
| `src/client/mod.rs` *(start here)* | query gating, cell-size cache, fallback order, resize poller baseline |
| `src/raw_input.rs` | `CSI 6 ; h ; w t` parser and the new `HostCellSizeReport` event |
| `src/app/runtime.rs`, `src/app/mod.rs`, `src/client/input.rs` | exhaustive-match arms for the new event (no behavior change) |

## Design notes

- the query is sent once at attach, next to the existing host theme query, and
  the stdin framer is armed the same one-shot way — at most one reply is ever
  in flight
- the reply feeds an `AtomicU64` cache read by the resize poller; the poller's
  baseline starts from the handshake values, so the first report reliably
  triggers a resize message
- live font-size tracking (re-querying after resize) is out of scope, per
  review; so is the monolithic path
- Windows clients never send the query, mirroring
  `should_query_host_terminal_theme`

## Verification

- `just ci` (fmt + clippy + nextest) and `just windows-lint` — clean; failing
  tests on the dev box are identical on a clean master worktree, so no
  regressions from this change
- live WSL smoke (WezTerm + WSL2): browser plugin pane goes from blurry to
  sharp on attach; cell size 8x16 → 10x21

refs #2146
