### PR TITLE
fix(input): decode 0x1f as Ctrl+_ not Ctrl+- per ASCII standard

### DIFF
--- a/src/input/parse.rs
+++ b/src/input/parse.rs
@@ -792,7 +792,7 @@ mod tests {
             (b'\x1c', '\\'),
             (b'\x1d', ']'),
             (b'\x1e', '^'),
-            (b'\x1f', '-'),
+            (b'\x1f', '_'),
         ] {
             let key = parse_terminal_key_sequence(std::str::from_utf8(&[byte]).unwrap()).unwrap();
             assert_terminal_key_eq(

--- a/src/input/parse.rs
+++ b/src/input/parse.rs
@@ -119,7 +119,7 @@ fn parse_legacy_ctrl_char(ch: char) -> Option<TerminalKey> {
         28 => Some(TerminalKey::new(KeyCode::Char('\\'), KeyModifiers::CONTROL)),
         29 => Some(TerminalKey::new(KeyCode::Char(']'), KeyModifiers::CONTROL)),
         30 => Some(TerminalKey::new(KeyCode::Char('^'), KeyModifiers::CONTROL)),
-        31 => Some(TerminalKey::new(KeyCode::Char('-'), KeyModifiers::CONTROL)),
+        31 => Some(TerminalKey::new(KeyCode::Char('_'), KeyModifiers::CONTROL)),
         _ => None,
     }
 }


### PR DESCRIPTION
Byte 0x1f is the ASCII US (Unit Separator) control character, which corresponds to Ctrl+_. The decoder mapped it to Ctrl+- instead, breaking the Ctrl+_ encode/decode roundtrip and silently misfiring any keybinding assigned to Ctrl+_.

refs #2164