### PR TITLE
fix: prefer native clipboard on WSL

### DIFF
--- a/src/selection.rs
+++ b/src/selection.rs
@@ -304,9 +304,12 @@ fn is_wsl() -> bool {
 fn should_prefer_osc52_for_env(
     ssh_connection: Option<&OsStr>,
     ssh_tty: Option<&OsStr>,
-    wsl: bool,
+    _wsl: bool,
 ) -> bool {
-    ssh_connection.is_some() || ssh_tty.is_some() || wsl
+    // WSL has a native clipboard bridge available to local terminal apps.
+    // Keep OSC 52 as the preferred path for SSH, where the remote process
+    // cannot access the attaching terminal's native clipboard directly.
+    ssh_connection.is_some() || ssh_tty.is_some()
 }
 
 fn should_prefer_osc52() -> bool {
@@ -366,8 +369,8 @@ mod tests {
     }
 
     #[test]
-    fn wsl_sessions_prefer_osc52() {
-        assert!(should_prefer_osc52_for_env(None, None, true));
+    fn wsl_sessions_use_native_clipboard_when_local() {
+        assert!(!should_prefer_osc52_for_env(None, None, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- prefer the native platform clipboard for local WSL sessions
- keep OSC 52 preferred for SSH sessions
- retain OSC 52 as the fallback when native clipboard writing fails
- add regression coverage for local WSL clipboard routing

## Problem

Herdr 0.7.5 forced OSC 52 for every WSL session. In Hyper under WSL, the OSC 52 sequence was not applied to the host clipboard, leaving the clipboard stale after selecting text in a pane. The native WSL clipboard bridge works correctly.

## Testing

- 
- 
-  (19 passed)