### PR TITLE
fix(pi): capture isIdle before awaiting reportSession to avoid stale ctx throws

### DIFF
--- a/src/integration/assets/pi/herdr-agent-state.ts
+++ b/src/integration/assets/pi/herdr-agent-state.ts
@@ -228,9 +228,12 @@ export default function (pi) {
     }
     rootSession = true;
     updateSessionRef(ctx);
+    // Read isIdle synchronously: the captured ctx goes stale (and throws) if the
+    // session is replaced/reloaded while reportSession is in flight.
+    const wasActive = ctx?.isIdle?.() === false;
     await reportSession(event?.reason);
     // A reload can replace this extension mid-run without emitting another agent_start.
-    agentActive = ctx?.isIdle?.() === false;
+    agentActive = wasActive;
     publishState(true);
   });
 


### PR DESCRIPTION
## Problem

The pi integration's `session_start` handler awaited `reportSession()` (up to ~2s of socket retries) before reading `ctx.isIdle()`:

```ts
pi.on("session_start", async (event, ctx) => {
  ...
  await reportSession(event?.reason);
  agentActive = ctx?.isIdle?.() === false; // stale ctx if session replaced meanwhile
  publishState(true);
});
```

If the session is replaced/reloaded during that window (`ctx.newSession()` / `ctx.fork()` / `ctx.switchSession()` / `ctx.reload()`), pi invalidates the captured extension ctx and the post-await access throws `This extension ctx is stale after session replacement or reload`. Because the throw happens inside an async event handler, it surfaces as an unhandled promise rejection — which by default terminates the process on modern Node, killing the agent pane.

## Fix

Read `isIdle` synchronously before the await; the value cannot change across the report since a replacement emits a fresh `session_start` on the new runtime anyway:

```ts
const wasActive = ctx?.isIdle?.() === false;
await reportSession(event?.reason);
agentActive = wasActive;
```

## Verification

`bun test src/integration/assets/herdr-agent-state.test.ts` — 14/14 pass, including the reload-preserves-state and replacement-report tests.