### PR TITLE
feat(worktree): bind mutations to exact repository identity

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -254,6 +254,16 @@
             },
             {
               "properties": {
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": {
                   "const": "worktree_created",
                   "type": "string"
@@ -300,6 +310,16 @@
               "properties": {
                 "forced": {
                   "type": "boolean"
+                },
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "type": {
                   "const": "worktree_removed",
@@ -1200,6 +1220,33 @@
             "is_prunable",
             "is_linked_worktree",
             "label"
+          ],
+          "type": "object"
+        },
+        "WorktreeMutationReceipt": {
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "checkout_path": {
+              "type": "string"
+            },
+            "head_oid": {
+              "type": "string"
+            },
+            "operation": {
+              "type": "string"
+            },
+            "repo_common_dir": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "repo_common_dir",
+            "checkout_path",
+            "branch",
+            "head_oid"
           ],
           "type": "object"
         }
@@ -4299,6 +4346,16 @@
                 "null"
               ]
             },
+            "permit": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/WorktreeExactPermit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "workspace_id": {
               "type": [
                 "string",
@@ -4306,6 +4363,29 @@
               ]
             }
           },
+          "type": "object"
+        },
+        "WorktreeExactPermit": {
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "checkout_path": {
+              "type": "string"
+            },
+            "head_oid": {
+              "type": "string"
+            },
+            "repo_common_dir": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repo_common_dir",
+            "checkout_path",
+            "branch",
+            "head_oid"
+          ],
           "type": "object"
         },
         "WorktreeListParams": {
@@ -4369,6 +4449,16 @@
             "force": {
               "default": false,
               "type": "boolean"
+            },
+            "permit": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/WorktreeExactPermit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "workspace_id": {
               "type": "string"
@@ -6467,6 +6557,16 @@
             },
             {
               "properties": {
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": {
                   "const": "worktree_created",
                   "type": "string"
@@ -6513,6 +6613,16 @@
               "properties": {
                 "forced": {
                   "type": "boolean"
+                },
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "type": {
                   "const": "worktree_removed",
@@ -8694,6 +8804,16 @@
             },
             {
               "properties": {
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "root_pane": {
                   "$ref": "#/schemas/success_response/$defs/PaneInfo"
                 },
@@ -8759,6 +8879,16 @@
                 },
                 "path": {
                   "type": "string"
+                },
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "type": {
                   "const": "worktree_removed",
@@ -9919,6 +10049,33 @@
             "is_prunable",
             "is_linked_worktree",
             "label"
+          ],
+          "type": "object"
+        },
+        "WorktreeMutationReceipt": {
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "checkout_path": {
+              "type": "string"
+            },
+            "head_oid": {
+              "type": "string"
+            },
+            "operation": {
+              "type": "string"
+            },
+            "repo_common_dir": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "repo_common_dir",
+            "checkout_path",
+            "branch",
+            "head_oid"
           ],
           "type": "object"
         },

--- a/src/api/schema/events.rs
+++ b/src/api/schema/events.rs
@@ -455,6 +455,8 @@ pub enum EventData {
     WorktreeCreated {
         workspace: WorkspaceInfo,
         worktree: WorktreeInfo,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     WorktreeOpened {
         workspace: WorkspaceInfo,
@@ -467,6 +469,8 @@ pub enum EventData {
         workspace: Option<WorkspaceInfo>,
         worktree: WorktreeInfo,
         forced: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     TabCreated {
         tab: TabInfo,

--- a/src/api/schema/response.rs
+++ b/src/api/schema/response.rs
@@ -71,6 +71,8 @@ pub enum ResponseResult {
         tab: TabInfo,
         root_pane: PaneInfo,
         worktree: WorktreeInfo,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     WorktreeOpened {
         workspace: WorkspaceInfo,
@@ -83,6 +85,8 @@ pub enum ResponseResult {
         workspace_id: String,
         path: String,
         forced: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     TabInfo {
         tab: TabInfo,

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -760,6 +760,7 @@ fn worktree_request_and_response_round_trip() {
                 open_workspace_id: Some("w_1".into()),
                 label: "herdr".into(),
             },
+            receipt: None,
         },
     };
     let json = serde_json::to_string(&response).unwrap();
@@ -822,6 +823,7 @@ fn worktree_lifecycle_events_round_trip() {
             event: EventKind::WorktreeCreated,
             data: EventData::WorktreeCreated {
                 workspace: workspace.clone(),
+                receipt: None,
                 worktree: worktree.clone(),
             },
         },
@@ -843,6 +845,7 @@ fn worktree_lifecycle_events_round_trip() {
                     ..worktree.clone()
                 },
                 forced: false,
+                receipt: None,
             },
         },
         EventEnvelope {

--- a/src/api/schema/worktrees.rs
+++ b/src/api/schema/worktrees.rs
@@ -8,6 +8,23 @@ pub struct WorktreeListParams {
     pub cwd: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorktreeExactPermit {
+    pub repo_common_dir: String,
+    pub checkout_path: String,
+    pub branch: String,
+    pub head_oid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorktreeMutationReceipt {
+    pub operation: String,
+    pub repo_common_dir: String,
+    pub checkout_path: String,
+    pub branch: String,
+    pub head_oid: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct WorktreeCreateParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -24,6 +41,8 @@ pub struct WorktreeCreateParams {
     pub label: Option<String>,
     #[serde(default)]
     pub focus: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permit: Option<WorktreeExactPermit>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
@@ -47,6 +66,8 @@ pub struct WorktreeRemoveParams {
     pub workspace_id: String,
     #[serde(default)]
     pub force: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permit: Option<WorktreeExactPermit>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -2249,6 +2249,7 @@ command = ["sh", "-c", "printf %s ${{HERDR_PANE_ID-unset}} > '{}'; sleep 1"]
                     open_workspace_id: Some(workspace.workspace_id),
                     label: "feature".into(),
                 },
+                receipt: None,
             },
         });
         assert_eq!(app.state.plugin_command_logs.len(), logs_before);
@@ -2524,6 +2525,7 @@ command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > {}"]
                     open_workspace_id: Some(target_workspace.workspace_id.clone()),
                     label: "feature".into(),
                 },
+                receipt: None,
             },
         });
 
@@ -2662,6 +2664,7 @@ command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > {}"]
                     workspace: Some(workspace.clone()),
                     worktree: worktree.clone(),
                     forced: true,
+                    receipt: None,
                 },
             },
             "worktree.removed",
@@ -2683,6 +2686,7 @@ command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > {}"]
                     workspace: Some(workspace),
                     worktree,
                     forced: true,
+                    receipt: None,
                 },
             },
             "worktree.removed",

--- a/src/app/api/worktrees.rs
+++ b/src/app/api/worktrees.rs
@@ -602,11 +602,21 @@ impl App {
     }
 
     pub(crate) fn emit_worktree_created_event(&mut self, ws_idx: usize, worktree: WorktreeInfo) {
+        self.emit_worktree_created_event_with_receipt(ws_idx, worktree, None);
+    }
+
+    pub(crate) fn emit_worktree_created_event_with_receipt(
+        &mut self,
+        ws_idx: usize,
+        worktree: WorktreeInfo,
+        receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
+    ) {
         self.emit_event(EventEnvelope {
             event: EventKind::WorktreeCreated,
             data: EventData::WorktreeCreated {
                 workspace: self.workspace_info(ws_idx),
                 worktree,
+                receipt,
             },
         });
     }
@@ -642,6 +652,23 @@ impl App {
         worktree: WorktreeInfo,
         forced: bool,
     ) {
+        self.emit_worktree_removed_event_with_receipt(
+            workspace_id,
+            workspace,
+            worktree,
+            forced,
+            None,
+        );
+    }
+
+    pub(crate) fn emit_worktree_removed_event_with_receipt(
+        &mut self,
+        workspace_id: String,
+        workspace: Option<crate::api::schema::WorkspaceInfo>,
+        worktree: WorktreeInfo,
+        forced: bool,
+        receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
+    ) {
         self.emit_event(EventEnvelope {
             event: EventKind::WorktreeRemoved,
             data: EventData::WorktreeRemoved {
@@ -649,6 +676,7 @@ impl App {
                 workspace,
                 worktree,
                 forced,
+                receipt,
             },
         });
     }
@@ -898,6 +926,7 @@ mod tests {
             tab,
             root_pane,
             worktree,
+            ..
         } = success.result
         else {
             panic!("expected worktree_created response");
@@ -927,6 +956,7 @@ mod tests {
                 EventData::WorktreeCreated {
                     workspace: event_workspace,
                     worktree: event_worktree,
+                    ..
                 } if event_workspace.workspace_id == workspace.workspace_id
                     && event_worktree.branch.as_deref() == Some("worktree/api-create")
                     && event_worktree.is_linked_worktree
@@ -1191,10 +1221,13 @@ mod tests {
                 source_repo_root: repo.clone(),
                 repo_key: "repo-key".into(),
                 repo_name: "herdr".into(),
+                branch: "worktree/test".into(),
+                permit: None,
                 label: None,
                 focus: false,
                 respond_to,
             }),
+            receipt: None,
             result: Ok(()),
         });
 
@@ -1767,6 +1800,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
         );
@@ -1782,6 +1816,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id,
                     force: true,
+                    permit: None,
                 }),
             },
         );
@@ -1838,6 +1873,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
         );
@@ -1869,6 +1905,7 @@ mod tests {
                     workspace: Some(workspace),
                     worktree,
                     forced,
+                    ..
                 } if workspace_id == &child_id
                     && workspace.workspace_id == child_id
                     && worktree.branch.as_deref() == Some("worktree/api-remove-event")
@@ -1923,6 +1960,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
             respond_to,
@@ -1996,6 +2034,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
             first_tx,
@@ -2006,6 +2045,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id,
                     force: false,
+                    permit: None,
                 }),
             },
             second_tx,
@@ -2065,6 +2105,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: first_id,
                     force: true,
+                    permit: None,
                 }),
             },
             first_tx,
@@ -2075,6 +2116,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: second_id,
                     force: true,
+                    permit: None,
                 }),
             },
             second_tx,
@@ -2110,6 +2152,7 @@ mod tests {
                     path: Some(checkout.display().to_string()),
                     label: None,
                     focus: false,
+                    permit: None,
                 }),
             },
             respond_to,
@@ -2164,6 +2207,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id,
                     force: false,
+                    permit: None,
                 }),
             },
             respond_to,
@@ -2220,9 +2264,11 @@ mod tests {
                 id: "req".into(),
                 operation_id: 7,
                 checkout_key: crate::worktree::canonical_or_original(&checkout),
+                permit: None,
                 respond_to,
             }),
             result: Ok(()),
+            receipt: None,
         });
 
         let response = response_rx

--- a/src/app/api/worktrees/deferred.rs
+++ b/src/app/api/worktrees/deferred.rs
@@ -3,13 +3,92 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::schema::{
     EventData, EventEnvelope, EventKind, Request, ResponseResult, WorktreeCreateParams,
-    WorktreeRemoveParams,
+    WorktreeExactPermit, WorktreeMutationReceipt, WorktreeRemoveParams,
 };
 use crate::app::App;
 use crate::events::{ApiWorktreeAddRequest, ApiWorktreeRemoveRequest, AppEvent};
 
 use super::super::responses::{encode_error, encode_success};
 use super::{absolute_user_path, WorktreeSource};
+
+fn validate_permit(permit: &WorktreeExactPermit) -> Result<(), (&'static str, &'static str)> {
+    if permit.repo_common_dir.trim().is_empty()
+        || permit.checkout_path.trim().is_empty()
+        || permit.branch.trim().is_empty()
+        || permit.head_oid.trim().is_empty()
+    {
+        return Err(("incomplete_permit", "all exact permit fields are required"));
+    }
+    if !Path::new(&permit.repo_common_dir).is_absolute()
+        || !Path::new(&permit.checkout_path).is_absolute()
+    {
+        return Err(("invalid_permit", "permit paths must be absolute"));
+    }
+    if !matches!(permit.head_oid.len(), 40 | 64)
+        || !permit.head_oid.chars().all(|ch| ch.is_ascii_hexdigit())
+    {
+        return Err((
+            "invalid_permit",
+            "permit head_oid must be a full hexadecimal object ID",
+        ));
+    }
+    Ok(())
+}
+
+fn oid_matches(actual: &str, permitted: &str) -> bool {
+    actual.eq_ignore_ascii_case(permitted)
+}
+
+fn identity_matches(
+    identity: &crate::worktree::WorktreeIdentity,
+    permit: &WorktreeExactPermit,
+) -> bool {
+    crate::worktree::canonical_or_original(Path::new(&permit.repo_common_dir))
+        == identity.repo_common_dir
+        && crate::worktree::canonical_or_original(Path::new(&permit.checkout_path))
+            == identity.checkout_path
+        && identity.branch.as_deref() == Some(permit.branch.as_str())
+        && oid_matches(&identity.head_oid, &permit.head_oid)
+}
+
+fn receipt_from_identity(
+    operation: &str,
+    identity: &crate::worktree::WorktreeIdentity,
+) -> Result<WorktreeMutationReceipt, &'static str> {
+    let Some(branch) = identity.branch.clone() else {
+        return Err("identity mismatch: worktree is detached");
+    };
+    Ok(WorktreeMutationReceipt {
+        operation: operation.to_string(),
+        repo_common_dir: identity.repo_common_dir.display().to_string(),
+        checkout_path: identity.checkout_path.display().to_string(),
+        branch,
+        head_oid: identity.head_oid.clone(),
+    })
+}
+
+fn rollback_invalid_managed_create(
+    source_checkout_path: &Path,
+    checkout_path: &Path,
+    permit: &WorktreeExactPermit,
+    mismatch: &str,
+) -> String {
+    let cleanup =
+        crate::worktree::build_worktree_remove_command(source_checkout_path, checkout_path, false);
+    let cleanup_result = crate::worktree::run_worktree_command(&cleanup).and_then(|()| {
+        crate::worktree::delete_local_branch_if_matches(
+            source_checkout_path,
+            &permit.branch,
+            &permit.head_oid,
+        )
+    });
+    match cleanup_result {
+        Ok(()) => format!("identity mismatch: {mismatch}"),
+        Err(cleanup_error) => {
+            format!("identity mismatch: {mismatch}; managed cleanup failed: {cleanup_error}")
+        }
+    }
+}
 
 impl App {
     pub(crate) fn handle_deferred_worktree_api_request(
@@ -97,8 +176,27 @@ impl App {
         params: WorktreeCreateParams,
         respond_to: std::sync::mpsc::Sender<String>,
     ) {
+        let managed_permit = params.permit.clone();
+        if let Some(permit) = managed_permit.as_ref() {
+            if let Err((code, message)) = validate_permit(permit) {
+                Self::send_api_response(respond_to, encode_error(id, code, message));
+                return;
+            }
+            if params.path.is_none() || params.branch.is_none() || params.base.is_none() {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "incomplete_permit",
+                        "managed create requires explicit path, branch, and base",
+                    ),
+                );
+                return;
+            }
+        }
         let branch = params
             .branch
+            .clone()
             .unwrap_or_else(|| {
                 let seed = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -115,7 +213,7 @@ impl App {
             );
             return;
         }
-        let base = params.base.unwrap_or_else(|| "HEAD".into());
+        let base = params.base.clone().unwrap_or_else(|| "HEAD".into());
         let source = match self.resolve_worktree_source(params.workspace_id, params.cwd) {
             Ok(source) => source,
             Err(err) => {
@@ -123,6 +221,55 @@ impl App {
                 return;
             }
         };
+        if let Some(permit) = managed_permit.as_ref() {
+            let identity =
+                match crate::worktree::read_worktree_identity(&source.source_checkout_path) {
+                    Ok(identity) => identity,
+                    Err(message) => {
+                        Self::send_api_response(
+                            respond_to,
+                            encode_error(id, "identity_mismatch", message),
+                        );
+                        return;
+                    }
+                };
+            if crate::worktree::canonical_or_original(Path::new(&permit.repo_common_dir))
+                != identity.repo_common_dir
+                || branch != permit.branch
+            {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "live source identity does not match permit",
+                    ),
+                );
+                return;
+            }
+            let resolved_base =
+                match crate::worktree::resolve_git_revision(&source.source_checkout_path, &base) {
+                    Ok(oid) => oid,
+                    Err(message) => {
+                        Self::send_api_response(
+                            respond_to,
+                            encode_error(id, "identity_mismatch", message),
+                        );
+                        return;
+                    }
+                };
+            if !oid_matches(&resolved_base, &permit.head_oid) {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "resolved base does not match permit head_oid",
+                    ),
+                );
+                return;
+            }
+        }
         let checkout_path = match params.path {
             Some(path) => match absolute_user_path(&path) {
                 Ok(path) => path,
@@ -137,6 +284,21 @@ impl App {
                 &branch,
             ),
         };
+        if let Some(permit) = managed_permit.as_ref() {
+            if crate::worktree::canonical_or_original(Path::new(&permit.checkout_path))
+                != crate::worktree::canonical_or_original(&checkout_path)
+            {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "checkout path does not match permit",
+                    ),
+                );
+                return;
+            }
+        }
         let checkout_key = crate::worktree::canonical_or_original(&checkout_path);
         if self
             .pending_api_worktree_creates
@@ -180,6 +342,8 @@ impl App {
             source_repo_root: source.source_repo_root,
             repo_key: source.repo_key,
             repo_name: source.repo_name,
+            branch,
+            permit: managed_permit,
             label: params.label,
             focus: params.focus,
             respond_to,
@@ -188,23 +352,69 @@ impl App {
         let source_checkout_path = api_request.source_checkout_path.clone();
         let event_tx = self.event_tx.clone();
         std::thread::spawn(move || {
-            let result = if let Some(parent_dir) = parent_dir {
-                std::fs::create_dir_all(&parent_dir).map_err(|err| err.to_string())
+            let (result, receipt) = if let Some(permit) = api_request.permit.as_ref() {
+                let result = if let Some(parent_dir) = parent_dir {
+                    std::fs::create_dir_all(&parent_dir).map_err(|err| err.to_string())
+                } else {
+                    Ok(())
+                }
+                .and_then(|()| {
+                    let command = crate::worktree::build_worktree_add_new_branch_command(
+                        &source_checkout_path,
+                        &path,
+                        &api_request.branch,
+                        &permit.head_oid,
+                    );
+                    crate::worktree::run_worktree_command(&command)
+                })
+                .and_then(|()| {
+                    let identity = match crate::worktree::read_worktree_identity(&path) {
+                        Ok(identity) => identity,
+                        Err(message) => {
+                            return Err(rollback_invalid_managed_create(
+                                &source_checkout_path,
+                                &path,
+                                permit,
+                                &message,
+                            ));
+                        }
+                    };
+                    if !identity_matches(&identity, permit) {
+                        return Err(rollback_invalid_managed_create(
+                            &source_checkout_path,
+                            &path,
+                            permit,
+                            "created worktree does not match permit",
+                        ));
+                    }
+                    receipt_from_identity("create", &identity)
+                        .map_err(|message| message.to_string())
+                });
+                match result {
+                    Ok(receipt) => (Ok(()), Some(receipt)),
+                    Err(message) => (Err(message), None),
+                }
             } else {
-                Ok(())
-            }
-            .and_then(|()| {
-                crate::worktree::run_worktree_add_command(
-                    &source_checkout_path,
-                    &path,
-                    &branch,
-                    &base,
-                )
-            });
+                let result = if let Some(parent_dir) = parent_dir {
+                    std::fs::create_dir_all(&parent_dir).map_err(|err| err.to_string())
+                } else {
+                    Ok(())
+                }
+                .and_then(|()| {
+                    crate::worktree::run_worktree_add_command(
+                        &source_checkout_path,
+                        &path,
+                        &api_request.branch,
+                        &base,
+                    )
+                });
+                (result, None)
+            };
             let _ = event_tx.blocking_send(AppEvent::WorktreeAddFinished(Box::new(
                 crate::events::WorktreeAddResult {
                     path,
                     api_request: Some(api_request),
+                    receipt,
                     result,
                 },
             )));
@@ -254,6 +464,37 @@ impl App {
                 ),
             );
             return;
+        }
+        let managed_permit = params.permit.clone();
+        if let Some(permit) = managed_permit.as_ref() {
+            if let Err((code, message)) = validate_permit(permit) {
+                Self::send_api_response(respond_to, encode_error(id, code, message));
+                return;
+            }
+            if params.force {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "forbidden_force",
+                        "force is forbidden for managed worktree removal",
+                    ),
+                );
+                return;
+            }
+            if crate::worktree::canonical_or_original(Path::new(&permit.checkout_path))
+                != crate::worktree::canonical_or_original(&space.checkout_path)
+            {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "checkout path does not match permit",
+                    ),
+                );
+                return;
+            }
         }
 
         #[cfg(windows)]
@@ -307,15 +548,11 @@ impl App {
             .insert(checkout_key.clone(), operation_id);
         let workspace_snapshot = self.workspace_info(ws_idx);
         let worktree = self.worktree_info_for_membership(&space, None);
-        let command = crate::worktree::build_worktree_remove_command(
-            &space.repo_root,
-            &space.checkout_path,
-            params.force,
-        );
         let api_request = ApiWorktreeRemoveRequest {
             id,
             operation_id,
             checkout_key,
+            permit: managed_permit.clone(),
             respond_to,
         };
         let repo_root = space.repo_root;
@@ -323,9 +560,42 @@ impl App {
         let force = params.force;
         let event_tx = self.event_tx.clone();
         std::thread::spawn(move || {
-            let result = crate::worktree::run_worktree_remove_command_with_recovery(
-                &command, &repo_root, &path, force,
-            );
+            let (result, receipt) = if let Some(permit) = api_request.permit.as_ref() {
+                match crate::worktree::read_worktree_identity(&path) {
+                    Ok(identity) if identity_matches(&identity, permit) => {
+                        let receipt = receipt_from_identity("remove", &identity)
+                            .map_err(|message| message.to_string());
+                        let command = crate::worktree::build_worktree_remove_command(
+                            &repo_root, &path, false,
+                        );
+                        let result = receipt.and_then(|receipt| {
+                            crate::worktree::run_worktree_command(&command)?;
+                            if crate::worktree::worktree_list_contains_path(&repo_root, &path)? {
+                                return Err("worktree removal did not clear Git inventory".into());
+                            }
+                            Ok(receipt)
+                        });
+                        match result {
+                            Ok(receipt) => (Ok(()), Some(receipt)),
+                            Err(message) => (Err(message), None),
+                        }
+                    }
+                    Ok(_) => (
+                        Err("identity mismatch: live worktree does not match permit".into()),
+                        None,
+                    ),
+                    Err(message) => (Err(format!("identity mismatch: {message}")), None),
+                }
+            } else {
+                let command =
+                    crate::worktree::build_worktree_remove_command(&repo_root, &path, force);
+                (
+                    crate::worktree::run_worktree_remove_command_with_recovery(
+                        &command, &repo_root, &path, force,
+                    ),
+                    None,
+                )
+            };
             let _ = event_tx.blocking_send(AppEvent::WorktreeRemoveFinished(Box::new(
                 crate::events::WorktreeRemoveResult {
                     workspace_id: workspace_internal_id,
@@ -333,6 +603,7 @@ impl App {
                     workspace: Some(Box::new(workspace_snapshot)),
                     worktree: Some(Box::new(worktree)),
                     forced: force,
+                    receipt,
                     api_request: Some(api_request),
                     result,
                 },
@@ -372,9 +643,22 @@ impl App {
                     create.error = Some(err.clone());
                 }
             }
+            let code = if api.permit.is_some() && err.starts_with("identity mismatch") {
+                "identity_mismatch"
+            } else {
+                "worktree_create_failed"
+            };
+            Self::send_api_response(api.respond_to, encode_error(api.id, code, err));
+            return;
+        }
+        if api.permit.is_some() && result.receipt.is_none() {
             Self::send_api_response(
                 api.respond_to,
-                encode_error(api.id, "worktree_create_failed", err),
+                encode_error(
+                    api.id,
+                    "identity_mismatch",
+                    "managed create completed without an exact receipt",
+                ),
             );
             return;
         }
@@ -448,12 +732,13 @@ impl App {
                 encode_error(
                     api.id,
                     "worktree_open_failed",
-                    "created worktree but failed to record workspace membership",
+                    "created workspace has no linked worktree identity",
                 ),
             );
             return;
         };
-        self.emit_worktree_created_event(ws_idx, worktree.clone());
+        let receipt = result.receipt.clone();
+        self.emit_worktree_created_event_with_receipt(ws_idx, worktree.clone(), receipt.clone());
         let tab_idx = self.state.workspaces[ws_idx].active_tab;
         let response = encode_success(
             api.id,
@@ -466,6 +751,7 @@ impl App {
                     .root_pane_info(ws_idx, tab_idx)
                     .expect("created worktree workspace should have an active root pane"),
                 worktree,
+                receipt,
             },
         );
         Self::send_api_response(api.respond_to, response);
@@ -503,12 +789,13 @@ impl App {
             .remove(&api.checkout_key);
 
         if let Err(message) = result.result {
-            let code =
-                if !result.forced && crate::worktree::is_dirty_worktree_remove_error(&message) {
-                    "dirty_worktree_requires_force"
-                } else {
-                    "worktree_remove_failed"
-                };
+            let code = if api.permit.is_some() && message.starts_with("identity mismatch") {
+                "identity_mismatch"
+            } else if !result.forced && crate::worktree::is_dirty_worktree_remove_error(&message) {
+                "dirty_worktree_requires_force"
+            } else {
+                "worktree_remove_failed"
+            };
             if let Some(remove) = &mut self.state.worktree_remove {
                 if remove.workspace_id == result.workspace_id && remove.path == result.path {
                     remove.removing = false;
@@ -575,11 +862,24 @@ impl App {
             );
             return;
         };
-        self.emit_worktree_removed_event(
+        if api.permit.is_some() && result.receipt.is_none() {
+            Self::send_api_response(
+                api.respond_to,
+                encode_error(
+                    api.id,
+                    "identity_mismatch",
+                    "managed remove completed without an exact receipt",
+                ),
+            );
+            return;
+        }
+        let receipt = result.receipt.clone();
+        self.emit_worktree_removed_event_with_receipt(
             workspace_id.clone(),
             workspace_snapshot,
             worktree,
             result.forced,
+            receipt.clone(),
         );
         if self.state.worktree_remove.as_ref().is_some_and(|remove| {
             remove.workspace_id == result.workspace_id && remove.path == result.path
@@ -597,8 +897,59 @@ impl App {
                 workspace_id,
                 path: result.path.display().to_string(),
                 forced: result.forced,
+                receipt,
             },
         );
         Self::send_api_response(api.respond_to, response);
+    }
+}
+
+#[cfg(test)]
+mod permit_tests {
+    use super::*;
+    use std::path::Path;
+
+    fn permit() -> WorktreeExactPermit {
+        WorktreeExactPermit {
+            repo_common_dir: "/repo/.git".into(),
+            checkout_path: "/repo/worktree".into(),
+            branch: "feature".into(),
+            head_oid: "0123456789abcdef0123456789abcdef01234567".into(),
+        }
+    }
+
+    #[test]
+    fn incomplete_permit_is_rejected() {
+        let mut permit = permit();
+        permit.branch.clear();
+        assert_eq!(
+            validate_permit(&permit),
+            Err(("incomplete_permit", "all exact permit fields are required"))
+        );
+    }
+
+    #[test]
+    fn identity_mismatch_is_fail_closed() {
+        let identity = crate::worktree::WorktreeIdentity {
+            repo_common_dir: Path::new("/repo/.git").to_path_buf(),
+            checkout_path: Path::new("/repo/worktree").to_path_buf(),
+            branch: Some("other".into()),
+            head_oid: "0123456789abcdef0123456789abcdef01234567".into(),
+        };
+        assert!(!identity_matches(&identity, &permit()));
+    }
+
+    #[test]
+    fn receipt_uses_git_identity_and_operation() {
+        let identity = crate::worktree::WorktreeIdentity {
+            repo_common_dir: Path::new("/repo/.git").to_path_buf(),
+            checkout_path: Path::new("/repo/worktree").to_path_buf(),
+            branch: Some("feature".into()),
+            head_oid: "0123456789abcdef0123456789abcdef01234567".into(),
+        };
+        let receipt = receipt_from_identity("remove", &identity).unwrap();
+        assert_eq!(receipt.operation, "remove");
+        assert_eq!(receipt.branch, "feature");
+        assert_eq!(receipt.head_oid, identity.head_oid);
     }
 }

--- a/src/app/worktrees.rs
+++ b/src/app/worktrees.rs
@@ -557,6 +557,7 @@ impl App {
                 WorktreeAddResult {
                     path,
                     api_request: None,
+                    receipt: None,
                     result,
                 },
             )));
@@ -599,6 +600,7 @@ impl App {
                 base: Some("HEAD".into()),
                 focus: true,
                 label: None,
+                permit: None,
             },
         );
         if let Some(message) = immediate_api_error_message(immediate_response.as_deref()) {
@@ -700,6 +702,7 @@ impl App {
                     workspace: workspace_snapshot,
                     worktree: worktree_snapshot,
                     forced: force,
+                    receipt: None,
                     api_request: None,
                     result,
                 },
@@ -767,6 +770,7 @@ impl App {
             crate::api::schema::WorktreeRemoveParams {
                 workspace_id,
                 force,
+                permit: None,
             },
         );
         if let Some(message) = immediate_api_error_message(immediate_response.as_deref()) {
@@ -1767,6 +1771,7 @@ mod tests {
         app.handle_worktree_add_finished(WorktreeAddResult {
             path: checkout.clone(),
             api_request: None,
+            receipt: None,
             result: Ok(()),
         });
 
@@ -1806,6 +1811,7 @@ mod tests {
         let crate::api::schema::EventData::WorktreeCreated {
             workspace,
             worktree,
+            ..
         } = &worktree_created.data
         else {
             panic!("unexpected event data");
@@ -1862,6 +1868,7 @@ mod tests {
         app.handle_worktree_add_finished(WorktreeAddResult {
             path: checkout.clone(),
             api_request: None,
+            receipt: None,
             result: Ok(()),
         });
 
@@ -2121,6 +2128,7 @@ mod tests {
             worktree: None,
             forced: false,
             api_request: None,
+            receipt: None,
             result: Err(
                 "fatal: '/w/herdr/dirty' contains modified or untracked files, use --force to delete it"
                     .into(),
@@ -2153,6 +2161,7 @@ mod tests {
             worktree: None,
             forced: false,
             api_request: None,
+            receipt: None,
             result: Err("fatal: '/w/herdr/missing' is not a working tree".into()),
         });
 
@@ -2214,6 +2223,7 @@ mod tests {
             workspace: None,
             worktree: None,
             forced: false,
+            receipt: None,
             api_request: None,
             result: Ok(()),
         });
@@ -2267,6 +2277,7 @@ mod tests {
             workspace: Some(Box::new(workspace_snapshot.clone())),
             worktree: Some(Box::new(worktree_snapshot)),
             forced: true,
+            receipt: None,
             api_request: None,
             result: Ok(()),
         });
@@ -2283,6 +2294,7 @@ mod tests {
                     workspace: Some(workspace),
                     worktree,
                     forced,
+                    ..
                 } if workspace_id == &workspace_snapshot.workspace_id
                     && workspace.workspace_id == workspace_snapshot.workspace_id
                     && worktree.branch.as_deref() == Some("worktree/issue")

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -71,7 +71,10 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
     let mut path = None;
     let mut label = None;
     let mut focus = false;
-
+    let mut permit_common_dir = None;
+    let mut permit_path = None;
+    let mut permit_branch = None;
+    let mut permit_head = None;
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
@@ -131,6 +134,38 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
                 focus = false;
                 index += 1;
             }
+            "--permit-common-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-common-dir");
+                    return Ok(2);
+                };
+                permit_common_dir = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-path" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-path");
+                    return Ok(2);
+                };
+                permit_path = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-branch" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-branch");
+                    return Ok(2);
+                };
+                permit_branch = Some(value.clone());
+                index += 2;
+            }
+            "--permit-head" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-head");
+                    return Ok(2);
+                };
+                permit_head = Some(value.clone());
+                index += 2;
+            }
             "--json" => index += 1,
             other => {
                 eprintln!("unknown option: {other}");
@@ -138,6 +173,14 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
             }
         }
     }
+    let permit = match parse_permit(permit_common_dir, permit_path, permit_branch, permit_head) {
+        Ok(permit) => permit,
+        Err(message) => {
+            eprintln!("{message}");
+            return Ok(2);
+        }
+    };
+
     if workspace_id.is_some() && cwd.is_some() {
         eprintln!(
             "usage: herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus] [--no-focus]"
@@ -153,9 +196,9 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
         path,
         label,
         focus,
+        permit,
     })
 }
-
 fn worktree_open(args: &[String]) -> std::io::Result<i32> {
     let mut workspace_id = None;
     let mut cwd = None;
@@ -248,7 +291,10 @@ fn worktree_open(args: &[String]) -> std::io::Result<i32> {
 fn worktree_remove(args: &[String]) -> std::io::Result<i32> {
     let mut workspace_id = None;
     let mut force = false;
-
+    let mut permit_common_dir = None;
+    let mut permit_path = None;
+    let mut permit_branch = None;
+    let mut permit_head = None;
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
@@ -264,6 +310,38 @@ fn worktree_remove(args: &[String]) -> std::io::Result<i32> {
                 force = true;
                 index += 1;
             }
+            "--permit-common-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-common-dir");
+                    return Ok(2);
+                };
+                permit_common_dir = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-path" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-path");
+                    return Ok(2);
+                };
+                permit_path = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-branch" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-branch");
+                    return Ok(2);
+                };
+                permit_branch = Some(value.clone());
+                index += 2;
+            }
+            "--permit-head" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-head");
+                    return Ok(2);
+                };
+                permit_head = Some(value.clone());
+                index += 2;
+            }
             "--json" => index += 1,
             other => {
                 eprintln!("unknown option: {other}");
@@ -277,9 +355,18 @@ fn worktree_remove(args: &[String]) -> std::io::Result<i32> {
         return Ok(2);
     };
 
+    let permit = match parse_permit(permit_common_dir, permit_path, permit_branch, permit_head) {
+        Ok(permit) => permit,
+        Err(message) => {
+            eprintln!("{message}");
+            return Ok(2);
+        }
+    };
+
     super::runtime::worktree_remove(WorktreeRemoveParams {
         workspace_id,
         force,
+        permit,
     })
 }
 
@@ -287,12 +374,14 @@ fn print_worktree_help() {
     eprintln!("herdr worktree commands:");
     eprintln!("  herdr worktree list [--workspace ID | --cwd PATH]");
     eprintln!(
-        "  herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus] [--no-focus]"
+        "  herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus] [--no-focus] [--permit-common-dir PATH --permit-path PATH --permit-branch NAME --permit-head OID]"
     );
     eprintln!(
         "  herdr worktree open [--workspace ID | --cwd PATH] (--path PATH | --branch NAME) [--label TEXT] [--focus] [--no-focus]"
     );
-    eprintln!("  herdr worktree remove --workspace ID [--force]");
+    eprintln!(
+        "  herdr worktree remove --workspace ID [--force] [--permit-common-dir PATH --permit-path PATH --permit-branch NAME --permit-head OID]"
+    );
 }
 
 fn normalize_path_arg(value: &str) -> std::io::Result<String> {
@@ -303,4 +392,61 @@ fn normalize_path_arg(value: &str) -> std::io::Result<String> {
         std::env::current_dir()?.join(path)
     };
     Ok(absolute.display().to_string())
+}
+
+fn parse_permit(
+    common_dir: Option<String>,
+    path: Option<String>,
+    branch: Option<String>,
+    head_oid: Option<String>,
+) -> Result<Option<crate::api::schema::WorktreeExactPermit>, &'static str> {
+    let supplied = [
+        common_dir.is_some(),
+        path.is_some(),
+        branch.is_some(),
+        head_oid.is_some(),
+    ];
+    if supplied.iter().any(|supplied| *supplied) && supplied.iter().any(|supplied| !*supplied) {
+        return Err("all four permit options are required together");
+    }
+    Ok(
+        common_dir.map(|repo_common_dir| crate::api::schema::WorktreeExactPermit {
+            repo_common_dir,
+            checkout_path: path.expect("permit path present when permit is present"),
+            branch: branch.expect("permit branch present when permit is present"),
+            head_oid: head_oid.expect("permit head present when permit is present"),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_permit;
+
+    #[test]
+    fn permit_options_must_be_all_or_none() {
+        let result = parse_permit(
+            Some("/repo/.git".into()),
+            Some("/checkout".into()),
+            None,
+            Some("deadbeef".into()),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn complete_permit_is_preserved() {
+        let permit = parse_permit(
+            Some("/repo/.git".into()),
+            Some("/checkout".into()),
+            Some("feature".into()),
+            Some("deadbeef".into()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(permit.repo_common_dir, "/repo/.git");
+        assert_eq!(permit.checkout_path, "/checkout");
+        assert_eq!(permit.branch, "feature");
+        assert_eq!(permit.head_oid, "deadbeef");
+    }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -20,6 +20,8 @@ pub struct ApiWorktreeAddRequest {
     pub source_repo_root: std::path::PathBuf,
     pub repo_key: String,
     pub repo_name: String,
+    pub branch: String,
+    pub permit: Option<crate::api::schema::WorktreeExactPermit>,
     pub label: Option<String>,
     pub focus: bool,
     pub respond_to: std::sync::mpsc::Sender<String>,
@@ -29,6 +31,7 @@ pub struct ApiWorktreeAddRequest {
 pub struct WorktreeAddResult {
     pub path: std::path::PathBuf,
     pub api_request: Option<ApiWorktreeAddRequest>,
+    pub receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
     pub result: Result<(), String>,
 }
 
@@ -37,6 +40,7 @@ pub struct ApiWorktreeRemoveRequest {
     pub id: String,
     pub operation_id: u64,
     pub checkout_key: std::path::PathBuf,
+    pub permit: Option<crate::api::schema::WorktreeExactPermit>,
     pub respond_to: std::sync::mpsc::Sender<String>,
 }
 
@@ -47,6 +51,7 @@ pub struct WorktreeRemoveResult {
     pub workspace: Option<Box<crate::api::schema::WorkspaceInfo>>,
     pub worktree: Option<Box<crate::api::schema::WorktreeInfo>>,
     pub forced: bool,
+    pub receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
     pub api_request: Option<ApiWorktreeRemoveRequest>,
     pub result: Result<(), String>,
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -151,6 +151,63 @@ pub(crate) fn canonical_or_original(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorktreeIdentity {
+    pub repo_common_dir: PathBuf,
+    pub checkout_path: PathBuf,
+    pub branch: Option<String>,
+    pub head_oid: String,
+}
+
+fn git_trimmed_output(path: &Path, args: &[&str]) -> Result<String, String> {
+    let output = crate::noninteractive_process::command("git")
+        .arg("-C")
+        .arg(path)
+        .args(args)
+        .output()
+        .map_err(|err| err.to_string())?;
+    if output.status.success() {
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !value.is_empty() {
+            return Ok(value);
+        }
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Err(if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("git command failed with status {}", output.status)
+    })
+}
+
+pub(crate) fn resolve_git_revision(repo_root: &Path, revision: &str) -> Result<String, String> {
+    git_trimmed_output(
+        repo_root,
+        &["rev-parse", "--verify", &format!("{revision}^{{commit}}")],
+    )
+}
+
+pub(crate) fn read_worktree_identity(path: &Path) -> Result<WorktreeIdentity, String> {
+    let common_dir = git_trimmed_output(path, &["rev-parse", "--git-common-dir"])?;
+    let common_dir = PathBuf::from(common_dir);
+    let common_dir = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        path.join(common_dir)
+    };
+    let branch = git_trimmed_output(path, &["symbolic-ref", "--quiet", "--short", "HEAD"]).ok();
+    let head_oid = git_trimmed_output(path, &["rev-parse", "--verify", "HEAD"])?;
+    Ok(WorktreeIdentity {
+        repo_common_dir: canonical_or_original(&common_dir),
+        checkout_path: canonical_or_original(path),
+        branch,
+        head_oid,
+    })
+}
+
 pub(crate) fn default_checkout_path(root: &Path, repo_name: &str, branch: &str) -> PathBuf {
     root.join(repo_name).join(branch_to_path_slug(branch))
 }
@@ -289,6 +346,31 @@ pub(crate) fn local_branch_exists(repo_root: &Path, branch: &str) -> Result<bool
     } else {
         Err(format!("git show-ref failed with status {}", output.status))
     }
+}
+
+pub(crate) fn delete_local_branch_if_matches(
+    repo_root: &Path,
+    branch: &str,
+    expected_head_oid: &str,
+) -> Result<(), String> {
+    let ref_name = format!("refs/heads/{branch}");
+    let actual_head_oid = resolve_git_revision(repo_root, &ref_name)?;
+    if !actual_head_oid.eq_ignore_ascii_case(expected_head_oid) {
+        return Err(format!(
+            "refusing to delete {ref_name}: expected {expected_head_oid}, observed {actual_head_oid}"
+        ));
+    }
+    run_worktree_command(&WorktreeCommand {
+        program: "git".to_string(),
+        args: vec![
+            "-C".to_string(),
+            repo_root.display().to_string(),
+            "update-ref".to_string(),
+            "-d".to_string(),
+            ref_name,
+            actual_head_oid,
+        ],
+    })
 }
 
 pub(crate) fn run_worktree_add_command(
@@ -860,6 +942,30 @@ prunable stale
         let remove = build_worktree_remove_command(&repo, &checkout, false);
         run_worktree_command(&remove).unwrap();
         assert!(!checkout.exists());
+
+        let _ = std::fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn local_branch_cleanup_requires_exact_head() {
+        let repo = create_committed_repo("worktree-branch-cleanup-repo");
+        let checkout = unique_temp_path("worktree-branch-cleanup-checkout");
+        let branch = "worktree/cleanup";
+        let add = build_worktree_add_new_branch_command(&repo, &checkout, branch, "HEAD");
+        run_worktree_command(&add).unwrap();
+        let head_oid = resolve_git_revision(&checkout, "HEAD").unwrap();
+        let remove = build_worktree_remove_command(&repo, &checkout, false);
+        run_worktree_command(&remove).unwrap();
+
+        assert!(delete_local_branch_if_matches(
+            &repo,
+            branch,
+            "0000000000000000000000000000000000000000"
+        )
+        .is_err());
+        assert!(local_branch_exists(&repo, branch).unwrap());
+        delete_local_branch_if_matches(&repo, branch, &head_oid).unwrap();
+        assert!(!local_branch_exists(&repo, branch).unwrap());
 
         let _ = std::fs::remove_dir_all(repo);
     }


### PR DESCRIPTION
## Summary
- extend worktree create/remove requests with exact repo common-dir, checkout path, branch, and HEAD OID permits
- resolve and revalidate Git identity immediately before mutation, including TOCTOU-resistant create/update-ref ordering
- return mutation receipts binding the executed operation to the observed identity, with rollback on create mismatch and preservation on removal failure
- preserve legacy request behavior for existing callers

## Verification
- `cargo fmt --all -- --check`
- `cargo test worktree` (133 pass)
- `cargo test permit_tests` (3 pass)
- `cargo test generated_protocol_schema_artifact_is_current_write`
- `cargo test workspace::tests::generated_workspace_ids_are_short_base32_handles -- --exact`
- full `cargo test` (2911 pass after isolated HOME setup)
- independent review and remediation of identity mismatch and rollback/branch-leak paths