### PR TITLE
docs: add Claude Code state detection requirement 

### DIFF
--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -53,10 +53,10 @@ herdr integration uninstall grok
 
 Herdr uses integrations in two different ways:
 
-| Integration type    | Agents                                                                                          | Effect                                                                                                                                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, MastraCode                       | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
-| Session identity    | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection.                                                                               |
+| Integration type | Agents | Effect |
+| --- | --- | --- |
+| Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, MastraCode | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
+| Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
 
 Custom socket integrations can also report state when they define state that is not visible in the native terminal UI.
 

--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -53,10 +53,10 @@ herdr integration uninstall grok
 
 Herdr uses integrations in two different ways:
 
-| Integration type | Agents | Effect |
-| --- | --- | --- |
-| Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, MastraCode | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
-| Session identity | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection. |
+| Integration type    | Agents                                                                                          | Effect                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Lifecycle authority | Pi, OMP, Kimi Code CLI, OpenCode, Kilo Code CLI, Hermes Agent, MastraCode                       | When installed and actively reporting for the pane, hook or plugin events author `idle`, `working`, and `blocked`. Herdr does not also use screen manifest fallback for that same lifecycle authority. |
+| Session identity    | Claude Code, Codex, GitHub Copilot CLI, Devin CLI, Droid, Qoder CLI, Cursor Agent CLI, Grok CLI | The integration reports native session references for restore. State still comes from Herdr's screen manifest detection.                                                                               |
 
 Custom socket integrations can also report state when they define state that is not visible in the native terminal UI.
 
@@ -109,6 +109,8 @@ herdr integration install claude
 The hook reports Claude Code session identity to the local Herdr socket on session start. Claude Code state comes from Herdr's screen manifest detection.
 
 Herdr uses `~/.claude` by default, or `CLAUDE_CONFIG_DIR` when set. The Claude config directory must already exist. Install writes `hooks/herdr-agent-state.sh` and updates `settings.json` with Herdr hook entries. Uninstall removes the matching hook entries and deletes the hook script.
+
+Avoid setting `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` because it breaks Claude Code state detection. See [Herdr issue #1630](https://github.com/herdrdev/herdr/issues/1630).
 
 ## Codex
 

--- a/docs/next/website/src/content/docs/ja/integrations.mdx
+++ b/docs/next/website/src/content/docs/ja/integrations.mdx
@@ -108,6 +108,8 @@ herdr integration install claude
 
 Herdr はデフォルトで `~/.claude` を使い、`CLAUDE_CONFIG_DIR` が設定されていればそちらを使います。Claude の設定ディレクトリはあらかじめ存在している必要があります。インストールは `hooks/herdr-agent-state.sh` を書き込み、`settings.json` に Herdr のフックエントリを追加します。アンインストールは一致するフックエントリを削除し、フックスクリプトを削除します。
 
+`CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` を設定しないでください。状態検出が機能しなくなります。調査の詳細は [Herdr issue #1630](https://github.com/herdrdev/herdr/issues/1630) を参照してください。
+
 ## Codex
 
 Codex フックをインストールします:

--- a/docs/next/website/src/content/docs/zh-cn/integrations.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/integrations.mdx
@@ -108,6 +108,8 @@ herdr integration install claude
 
 Herdr 默认使用 `~/.claude`,设置了 `CLAUDE_CONFIG_DIR` 时使用后者。Claude 配置目录必须已经存在。安装会写入 `hooks/herdr-agent-state.sh`,并向 `settings.json` 添加 Herdr 钩子条目。卸载会移除匹配的钩子条目并删除钩子脚本。
 
+避免设置 `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1`,否则状态检测会失效。调查详情见 [Herdr issue #1630](https://github.com/herdrdev/herdr/issues/1630)。
+
 ## Codex
 
 安装 Codex 钩子:


### PR DESCRIPTION
Clarifies in the `Integrations > Claude Code` section that `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` should NOT be set or it'll break the state detection.

refs #1630