### PR TITLE
fix(cli): report non-UTF-8 arguments instead of panicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -464,8 +464,32 @@ fn exit_if_nested_disabled(config: &config::Config) {
     }
 }
 
+fn args_as_utf8<I>(args: I) -> Result<Vec<String>, String>
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    args.into_iter()
+        .enumerate()
+        .map(|(index, arg)| {
+            arg.into_string().map_err(|arg| {
+                format!(
+                    "argument {index} is not valid UTF-8: {}",
+                    arg.to_string_lossy()
+                )
+            })
+        })
+        .collect()
+}
+
 fn main() -> io::Result<()> {
-    let raw_args: Vec<String> = std::env::args().collect();
+    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("error: {err}");
+            eprintln!("run 'herdr --help' for usage");
+            std::process::exit(2);
+        }
+    };
     let args = match session::configure_from_args(&raw_args) {
         Ok(args) => args,
         Err(err) => {
@@ -904,5 +928,37 @@ mod tests {
         assert!(NESTED_HERDR_MESSAGES
             .iter()
             .all(|message| !message.starts_with("herdr:")));
+    }
+
+    #[cfg(unix)]
+    fn invalid_utf8_arg() -> std::ffi::OsString {
+        use std::os::unix::ffi::OsStringExt;
+        std::ffi::OsString::from_vec(vec![0xff])
+    }
+
+    #[cfg(windows)]
+    fn invalid_utf8_arg() -> std::ffi::OsString {
+        use std::os::windows::ffi::OsStringExt;
+        std::ffi::OsString::from_wide(&[0xd800])
+    }
+
+    #[test]
+    fn args_as_utf8_passes_through_valid_arguments() {
+        let args = ["herdr", "pane", "get", "pane-1"].map(std::ffi::OsString::from);
+        assert_eq!(
+            args_as_utf8(args).unwrap(),
+            ["herdr", "pane", "get", "pane-1"]
+        );
+    }
+
+    #[test]
+    fn args_as_utf8_reports_the_offending_argument_instead_of_panicking() {
+        let args = vec![
+            std::ffi::OsString::from("herdr"),
+            std::ffi::OsString::from("pane"),
+            invalid_utf8_arg(),
+        ];
+        let err = args_as_utf8(args).unwrap_err();
+        assert!(err.starts_with("argument 2 is not valid UTF-8:"), "{err}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,12 +471,8 @@ where
     args.into_iter()
         .enumerate()
         .map(|(index, arg)| {
-            arg.into_string().map_err(|arg| {
-                format!(
-                    "argument {index} is not valid UTF-8: {}",
-                    arg.to_string_lossy()
-                )
-            })
+            arg.into_string()
+                .map_err(|_| format!("argument {index} is not valid UTF-8"))
         })
         .collect()
 }
@@ -958,7 +954,9 @@ mod tests {
             std::ffi::OsString::from("pane"),
             invalid_utf8_arg(),
         ];
-        let err = args_as_utf8(args).unwrap_err();
-        assert!(err.starts_with("argument 2 is not valid UTF-8:"), "{err}");
+        assert_eq!(
+            args_as_utf8(args).unwrap_err(),
+            "argument 2 is not valid UTF-8"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Any argument that is not valid UTF-8 panics, on every subcommand:

```
$ herdr pane get $'\xff'
thread 'main' panicked at library/std/src/env.rs:875:51:
called `Result::unwrap()` on an `Err` value: "\xFF"
```

`main()` starts with `std::env::args().collect()`, which is documented as panicking on non-Unicode arguments.
The message points at libstd, so nothing indicates which argument was at fault.

## Fix

Read `std::env::args_os()` and report the first argument that is not valid UTF-8:

```
$ herdr pane get $'\xff'
error: argument 3 is not valid UTF-8: �
run 'herdr --help' for usage
```

## Verification

- `just ci`