### PR TITLE
fix(sidebar): keep collapsed status dot visible past workspace 9

### DIFF
--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -808,8 +808,7 @@ pub(super) fn render_sidebar_collapsed(app: &AppState, frame: &mut Frame, area: 
 
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled(format!("{}", visible_idx + 1), num_style),
-                Span::styled(" ", row_style),
+                Span::styled(format!("{:<2}", visible_idx + 1), num_style),
                 Span::styled(icon, icon_style),
             ])),
             Rect::new(ws_area.x, y, ws_area.width, 1),
@@ -2155,6 +2154,43 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         assert_eq!(buffer[(detail_area.x, tenth_row)].symbol(), "1");
         assert_eq!(buffer[(detail_area.x + 1, tenth_row)].symbol(), "0");
         assert_eq!(buffer[(detail_area.x + 2, tenth_row)].symbol(), "·");
+    }
+
+    #[test]
+    fn collapsed_sidebar_keeps_workspace_status_visible_for_two_digit_positions() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.workspaces = (1..=10)
+            .map(|idx| Workspace::test_new(&format!("workspace-{idx}")))
+            .collect();
+        app.ensure_test_terminals();
+
+        let last = app.workspaces.len() - 1;
+        let pane = app.workspaces[last].tabs[0].root_pane;
+        let terminal_id = app.workspaces[last].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        let attached = app.terminals.get_mut(&terminal_id).unwrap();
+        attached.detected_agent = Some(Agent::Claude);
+        attached.state = AgentState::Working;
+
+        let area = Rect::new(0, 0, 4, 25);
+        let (ws_area, _, _) = collapsed_sidebar_sections(area);
+        let mut terminal = Terminal::new(TestBackend::new(area.width, area.height))
+            .expect("test terminal should initialize");
+
+        terminal
+            .draw(|frame| render_sidebar_collapsed(&app, frame, area))
+            .expect("collapsed sidebar should render");
+
+        let tenth_row = ws_area.y + 9;
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(ws_area.x, tenth_row)].symbol(), "1");
+        assert_eq!(buffer[(ws_area.x + 1, tenth_row)].symbol(), "0");
+        assert_eq!(buffer[(ws_area.x + 2, tenth_row)].symbol(), "●");
+        assert_eq!(
+            buffer[(ws_area.x + 2, tenth_row)].style().fg,
+            Some(app.palette.yellow)
+        );
     }
 
     #[test]


### PR DESCRIPTION
 The collapsed sidebar hides the status dot for workspaces at position 10
  and above.

  refs #2216

  ## Cause

  The collapsed sidebar content area is 3 columns wide (`COLLAPSED_WIDTH` is 4,
  minus the separator column). The workspace row drew the position number at its
  natural width plus a literal space span before the dot, so a two-digit position
  produced `10 ·` — 4 columns — and the dot fell outside the row rect.

  The agent list directly below already pads its position to two columns, so it
  was not affected.

  ## Change

  Pad the workspace position to two columns and drop the separate space span, so
  the workspace rows match the agent rows below them. Single-digit rows keep the
  dot in the same column as before.

  ## Verification

  On Windows:

  - `scripts/windows_check.ps1 -Mode check` passes: `cargo fmt --check`,
    `cargo clippy -D warnings`, the `windows_` (143) and
    `server::client_transport::tests` (22) filters, and `cargo build`.
  - `cargo test --bin herdr ui::` — 145 passed.
  - `cargo test --bin herdr sidebar` — 123 passed.

  I could not run `just ci` on this machine: the `tests/` integration suite is
  Unix-only and does not compile on Windows, and a full `cargo test --bin herdr`
  run hangs here. Leaving those to CI.

  New test `collapsed_sidebar_keeps_workspace_status_visible_for_two_digit_positions`
  fails without the change (`left: " ", right: "●"`).

  No docs change needed — the collapsed sidebar row layout is not described in
  the docs.