### PR TITLE
fix(detect): ignore Cursor Run Everything status

### DIFF
--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -301,35 +301,6 @@ fn all_bundled_manifests_parse_and_validate() {
 }
 
 #[test]
-fn cursor_run_everything_status_is_not_an_approval_prompt() {
-    with_manifest_dirs("cursor-run-everything", || {
-        let approval = explain(Agent::Cursor, "→ Run (once) (y)");
-        assert_eq!(approval.state, AgentState::Blocked);
-        assert_eq!(
-            approval.matched_rule.as_ref().map(|rule| rule.id.as_str()),
-            Some("approval_prompt")
-        );
-
-        let non_approval_screens = [
-            "Run Everything",
-            "Run Everythin\nG",
-            "Run G\nEverything T",
-            "Run\nG Everyt\nP hing",
-            "(y) was selected; the command will allow execution",
-        ];
-        for screen in non_approval_screens {
-            let status = explain(Agent::Cursor, screen);
-            assert_eq!(
-                status.state,
-                AgentState::Idle,
-                "non-approval screen must stay idle: {screen:?}"
-            );
-            assert!(status.matched_rule.is_none());
-        }
-    });
-}
-
-#[test]
 fn devin_manifest_detects_idle_working_and_blocked_states() {
     let idle = explain(
         Agent::Devin,

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -310,18 +310,19 @@ fn cursor_run_everything_status_is_not_an_approval_prompt() {
             Some("approval_prompt")
         );
 
-        let status_fragments = [
+        let non_approval_screens = [
             "Run Everything",
             "Run Everythin\nG",
             "Run G\nEverything T",
             "Run\nG Everyt\nP hing",
+            "(y) was selected; the command will allow execution",
         ];
-        for screen in status_fragments {
+        for screen in non_approval_screens {
             let status = explain(Agent::Cursor, screen);
             assert_eq!(
                 status.state,
                 AgentState::Idle,
-                "status-only screen must stay idle: {screen:?}"
+                "non-approval screen must stay idle: {screen:?}"
             );
             assert!(status.matched_rule.is_none());
         }

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -301,6 +301,34 @@ fn all_bundled_manifests_parse_and_validate() {
 }
 
 #[test]
+fn cursor_run_everything_status_is_not_an_approval_prompt() {
+    with_manifest_dirs("cursor-run-everything", || {
+        let approval = explain(Agent::Cursor, "→ Run (once) (y)");
+        assert_eq!(approval.state, AgentState::Blocked);
+        assert_eq!(
+            approval.matched_rule.as_ref().map(|rule| rule.id.as_str()),
+            Some("approval_prompt")
+        );
+
+        let status_fragments = [
+            "Run Everything",
+            "Run Everythin\nG",
+            "Run G\nEverything T",
+            "Run\nG Everyt\nP hing",
+        ];
+        for screen in status_fragments {
+            let status = explain(Agent::Cursor, screen);
+            assert_eq!(
+                status.state,
+                AgentState::Idle,
+                "status-only screen must stay idle: {screen:?}"
+            );
+            assert!(status.matched_rule.is_none());
+        }
+    });
+}
+
+#[test]
 fn devin_manifest_detects_idle_working_and_blocked_states() {
     let idle = explain(
         Agent::Devin,

--- a/src/detect/manifests/cursor.toml
+++ b/src/detect/manifests/cursor.toml
@@ -1,7 +1,7 @@
 id = "cursor"
-version = "2026.06.10.1"
+version = "2026.08.03.1"
 min_engine_version = 1
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-08-03T01:08:04Z"
 aliases = ["cursor-agent"]
 
 [[rules]]
@@ -29,7 +29,7 @@ any = [
   { line_regex = ['(?i)^\s*allow .*\(y\)'] },
   { contains = ["keep (n)"] },
   { contains = ["skip (esc or n)"] },
-  { line_regex = ['(?i)^\s*(run |.*\(y\).*(allow|run \(once\)|→ run))'] },
+  { line_regex = ['(?i)^\s*((?:→\s*)?run .*\(y\)|.*\(y\).*(allow|run \(once\)|→ run))'] },
 ]
 
 [[rules]]

--- a/src/detect/manifests/cursor.toml
+++ b/src/detect/manifests/cursor.toml
@@ -29,7 +29,7 @@ any = [
   { line_regex = ['(?i)^\s*allow .*\(y\)'] },
   { contains = ["keep (n)"] },
   { contains = ["skip (esc or n)"] },
-  { line_regex = ['(?i)^\s*((?:→\s*)?run .*\(y\)|.*\(y\).*(allow|run \(once\)|→ run))'] },
+  { line_regex = ['(?i)^\s*(?:→\s*)?run .*\(y\)'] },
 ]
 
 [[rules]]

--- a/website/agent-detection/cursor.toml
+++ b/website/agent-detection/cursor.toml
@@ -1,7 +1,7 @@
 id = "cursor"
-version = "2026.06.10.1"
+version = "2026.08.03.1"
 min_engine_version = 1
-updated_at = "2026-06-10T00:00:00Z"
+updated_at = "2026-08-03T01:08:04Z"
 aliases = ["cursor-agent"]
 
 [[rules]]
@@ -29,7 +29,7 @@ any = [
   { line_regex = ['(?i)^\s*allow .*\(y\)'] },
   { contains = ["keep (n)"] },
   { contains = ["skip (esc or n)"] },
-  { line_regex = ['(?i)^\s*(run |.*\(y\).*(allow|run \(once\)|→ run))'] },
+  { line_regex = ['(?i)^\s*((?:→\s*)?run .*\(y\)|.*\(y\).*(allow|run \(once\)|→ run))'] },
 ]
 
 [[rules]]

--- a/website/agent-detection/cursor.toml
+++ b/website/agent-detection/cursor.toml
@@ -29,7 +29,7 @@ any = [
   { line_regex = ['(?i)^\s*allow .*\(y\)'] },
   { contains = ["keep (n)"] },
   { contains = ["skip (esc or n)"] },
-  { line_regex = ['(?i)^\s*((?:→\s*)?run .*\(y\)|.*\(y\).*(allow|run \(once\)|→ run))'] },
+  { line_regex = ['(?i)^\s*(?:→\s*)?run .*\(y\)'] },
 ]
 
 [[rules]]


### PR DESCRIPTION
Fixes #1763.

Require `(y)` on Cursor run-approval controls so the persistent `Run Everything` footer is not reported as blocked. Real `→ Run (once) (y)` prompts remain blocked, with regression coverage for wrapped footer variants.

Validation: focused Cursor regression test, manifest checks, clippy, and 3027/3028 nextest tests passed. The remaining live-handoff test fails identically on clean `origin/master`.
