### PR TITLE
fix(resurrect): log when native agent resume is skipped during session restore

### DIFF
--- a/scripts/test-10-agents.sh
+++ b/scripts/test-10-agents.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# 10 concurrent agents across 3 workspaces resurrect test
+# Uses isolated named herdr session + herdr-fix binary
+set -euo pipefail
+
+HERDR="${HERDR_FIX:-/home/bhd/.local/bin/herdr-fix}"
+SESS="herdr-10agent-$$"
+BASE="/tmp/herdr-10agent-$$"
+LOG_DIR="/tmp/herdr-10agent-logs-$$"
+mkdir -p "$LOG_DIR"
+
+cleanup() {
+    pkill -f "herdr-fix --session $SESS" 2>/dev/null || true
+    sleep 1
+    rm -rf "$BASE" "$LOG_DIR" 2>/dev/null || true
+    rm -rf "$HOME/.config/herdr/sessions/$SESS" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "=== 10-agent / 3-workspace resurrect test ===" >&2
+echo "Binary: $HERDR" >&2
+echo "Session: $SESS" >&2
+
+# Setup 3 workspaces
+mkdir -p "$BASE/ws1" "$BASE/ws2" "$BASE/ws3"
+for i in 1 2 3; do
+    cd "$BASE/ws$i"
+    git init -q
+    echo "ws$i" > README.md
+    git add . && git commit -qm "init ws$i"
+done
+cd "$HOME"
+
+# Start isolated herdr
+"$HERDR" --session "$SESS" server >"$LOG_DIR/server-1.log" 2>&1 &
+SRV=$!
+sleep 5
+if ! kill -0 "$SRV" 2>/dev/null; then
+    echo "FAIL: server didn't start" >&2
+    cat "$LOG_DIR/server-1.log" >&2
+    exit 1
+fi
+
+# Create 3 workspaces
+for i in 1 2 3; do
+    "$HERDR" --session "$SESS" workspace create --cwd "$BASE/ws$i" --label "ws$i" --no-focus >"$LOG_DIR/ws$i-create.log" 2>&1
+done
+
+sleep 2
+
+# Get workspace IDs
+W1=$("$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "import json,sys;d=json.load(sys.stdin);print([w['workspace_id'] for w in d['result']['workspaces'] if w.get('label')=='ws1'][0])")
+W2=$("$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "import json,sys;d=json.load(sys.stdin);print([w['workspace_id'] for w in d['result']['workspaces'] if w.get('label')=='ws2'][0])")
+W3=$("$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "import json,sys;d=json.load(sys.stdin);print([w['workspace_id'] for w in d['result']['workspaces'] if w.get('label')=='ws3'][0])")
+echo "Workspace IDs: $W1, $W2, $W3" >&2
+
+# Split panes to reach 10 total: ws1=4, ws2=3, ws3=3
+# Correct syntax: `herdr pane split <wid>:p1 --direction right`
+echo "=== Split panes ===" >&2
+
+# ws1: 3 splits (p1 → p2, p3, p4)
+for _ in 1 2 3; do
+    RESULT=$("$HERDR" --session "$SESS" pane split "$W1:p1" --direction right 2>&1)
+    echo "  ws1 split: $(echo "$RESULT" | python3 -c "import json,sys;print(json.load(sys.stdin).get('result',{}).get('pane',{}).get('pane_id','?'))" 2>/dev/null || echo "?")" >&2
+    sleep 1
+done
+
+# ws2: 2 splits (p1 → p2, p3)
+for _ in 1 2; do
+    RESULT=$("$HERDR" --session "$SESS" pane split "$W2:p1" --direction right 2>&1)
+    echo "  ws2 split: $(echo "$RESULT" | python3 -c "import json,sys;print(json.load(sys.stdin).get('result',{}).get('pane',{}).get('pane_id','?'))" 2>/dev/null || echo "?")" >&2
+    sleep 1
+done
+
+# ws3: 2 splits (p1 → p2, p3)
+for _ in 1 2; do
+    RESULT=$("$HERDR" --session "$SESS" pane split "$W3:p1" --direction right 2>&1)
+    echo "  ws3 split: $(echo "$RESULT" | python3 -c "import json,sys;print(json.load(sys.stdin).get('result',{}).get('pane',{}).get('pane_id','?'))" 2>/dev/null || echo "?")" >&2
+    sleep 1
+done
+
+sleep 2
+
+# Collect all pane IDs from workspace list (pane_count tells us)
+echo "=== Workspace pane counts ===" >&2
+"$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for w in d['result']['workspaces']:
+    if w.get('label','').startswith('ws'):
+        print(f\"  {w['label']}: {w['pane_count']} panes\")
+" >&2
+
+# Get all pane IDs by parsing workspace list + workspace get
+ALL_PANES=""
+for WID in "$W1" "$W2" "$W3"; do
+    # Use workspace get to enumerate panes
+    WS_INFO=$("$HERDR" --session "$SESS" workspace get "$WID" 2>/dev/null)
+    PANE_IDS=$(echo "$WS_INFO" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+w=d['result']['workspace']
+wid=w['workspace_id']
+# workspace get doesn't list panes directly; we need to enumerate from layout
+# Use a different approach: iterate p1..pN based on pane_count
+count=w.get('pane_count',1)
+for i in range(1, count+1):
+    print(f'{wid}:p{i}')
+" 2>/dev/null || echo "")
+    ALL_PANES="$ALL_PANES $PANE_IDS"
+done
+echo "All panes: $ALL_PANES" >&2
+
+# Start agents (mix of pi and hermes) with UNIQUE names
+# Pattern: 7 pi + 3 hermes
+echo "=== Start agents ===" >&2
+IDX=0
+STARTED=0
+for pane in $ALL_PANES; do
+    IDX=$((IDX+1))
+    if [ $IDX -le 7 ]; then
+        KIND="pi"
+        NAME="pi-$IDX"
+    else
+        KIND="hermes"
+        NAME="hermes-$IDX"
+    fi
+    echo "  [$IDX] $KIND ($NAME) → $pane" >&2
+    if "$HERDR" --session "$SESS" agent start "$NAME" --kind "$KIND" --pane "$pane" >"$LOG_DIR/start-$IDX.log" 2>&1; then
+        STARTED=$((STARTED+1))
+    else
+        echo "  WARN: start failed for $pane (see $LOG_DIR/start-$IDX.log)" >&2
+    fi
+    sleep 2  # Give agent time to spawn
+done
+echo "Started: $STARTED / $IDX" >&2
+
+# Send prompts
+echo "=== Send prompts ===" >&2
+for pane in $ALL_PANES; do
+    "$HERDR" --session "$SESS" agent prompt "$pane" "echo hello-$pane" >/dev/null 2>&1 || true
+done
+
+# Wait for sessions to register
+echo "=== Wait 30s for session refs ===" >&2
+sleep 30
+
+# Force session save by listing workspaces
+"$HERDR" --session "$SESS" workspace list >/dev/null 2>&1
+sleep 2
+
+SESS_DIR="$HOME/.config/herdr/sessions/$SESS"
+
+# Verify pre-restart session refs
+REFS_BEFORE=$(python3 -c "
+import json,os
+path='$SESS_DIR/session.json'
+if not os.path.exists(path):
+    print(0)
+    exit()
+with open(path) as f:
+    d=json.load(f)
+n=0
+for w in d.get('workspaces',[]):
+    if w.get('custom_name','').startswith('ws'):
+        for t in w.get('tabs',[]):
+            for p in t.get('panes',{}).values():
+                if p.get('agent_session'): n+=1
+print(n)
+")
+echo "Session refs before kill: $REFS_BEFORE" >&2
+
+# Kill server
+echo "=== Kill server ===" >&2
+kill "$SRV" 2>/dev/null || true
+sleep 3
+wait "$SRV" 2>/dev/null || true
+
+# Restart server
+echo "=== Restart server ===" >&2
+RUST_LOG=info "$HERDR" --session "$SESS" server >"$LOG_DIR/server-2.log" 2>&1 &
+SRV=$!
+sleep 15
+
+# Verify restoration
+WS_AFTER=$("$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(len([w for w in d['result']['workspaces'] if w.get('label','').startswith('ws')]))
+")
+echo "Workspaces after restart: $WS_AFTER" >&2
+
+PANES_AFTER=$("$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+n=0
+for w in d['result']['workspaces']:
+    if w.get('label','').startswith('ws'):
+        n += w.get('pane_count',0)
+print(n)
+")
+echo "Panes after restart: $PANES_AFTER" >&2
+
+# Result
+echo "" >&2
+echo "=== RESULT ===" >&2
+PASS=true
+[ "$STARTED" -ge 10 ] || { echo "FAIL: STARTED=$STARTED / 10"; PASS=false; }
+[ "$WS_AFTER" -ge 3 ] || { echo "FAIL: WS=$WS_AFTER < 3"; PASS=false; }
+[ "$PANES_AFTER" -ge 10 ] || { echo "FAIL: PANES=$PANES_AFTER < 10"; PASS=false; }
+
+if [ "$PASS" = "true" ]; then
+    echo "PASS: $STARTED/10 agents started, 3 WS + $PANES_AFTER panes restored" >&2
+    exit 0
+else
+    echo "FAIL (started=$STARTED, ws=$WS_AFTER, panes=$PANES_AFTER)" >&2
+    exit 1
+fi

--- a/scripts/test-mixed-agents.sh
+++ b/scripts/test-mixed-agents.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Mixed pi + hermes resurrect test (10 agents, 3 workspaces)
+set -euo pipefail
+
+HERDR="${HERDR_FIX:-/home/bhd/.local/bin/herdr-fix}"
+SESS="mixed-$$"
+BASE="/tmp/mixed-$$"
+LOG_DIR="/tmp/mixed-logs-$$"
+mkdir -p "$LOG_DIR"
+
+cleanup() {
+    pkill -f "herdr-fix --session $SESS" 2>/dev/null || true
+    pkill -9 -f "hermes-agent/bin/hermes" 2>/dev/null || true
+    sleep 1
+    rm -rf "$BASE" "$LOG_DIR" 2>/dev/null || true
+    rm -rf "$HOME/.config/herdr/sessions/$SESS" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "=== Mixed pi+hermes resurrect test ===" >&2
+echo "Binary: $HERDR" >&2
+echo "Session: $SESS" >&2
+
+# Setup 3 workspaces
+mkdir -p "$BASE/ws1" "$BASE/ws2" "$BASE/ws3"
+for i in 1 2 3; do
+    cd "$BASE/ws$i" && git init -q && echo "ws$i" > README.md && git add . && git commit -qm "init ws$i"
+done
+cd "$HOME"
+
+"$HERDR" --session "$SESS" server >"$LOG_DIR/server-1.log" 2>&1 &
+SRV=$!
+sleep 6
+if ! kill -0 "$SRV" 2>/dev/null; then
+    echo "FAIL: server didn't start" >&2
+    cat "$LOG_DIR/server-1.log" >&2
+    exit 1
+fi
+
+# Create 3 workspaces
+for i in 1 2 3; do
+    "$HERDR" --session "$SESS" workspace create --cwd "$BASE/ws$i" --label "ws$i" --no-focus >"$LOG_DIR/ws$i.log" 2>&1
+done
+sleep 2
+
+# Get workspace IDs
+get_wid() {
+    "$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for w in d['result']['workspaces']:
+    if w.get('label')=='$1': print(w['workspace_id']); break
+"
+}
+W1=$(get_wid ws1); W2=$(get_wid ws2); W3=$(get_wid ws3)
+echo "Workspace IDs: $W1 $W2 $W3" >&2
+
+# Split to 10 panes: ws1=4, ws2=3, ws3=3
+echo "=== Split panes ===" >&2
+for _ in 1 2 3; do
+    "$HERDR" --session "$SESS" pane split "$W1:p1" --direction right >"$LOG_DIR/split.log" 2>&1
+    sleep 0.5
+done
+for _ in 1 2; do
+    "$HERDR" --session "$SESS" pane split "$W2:p1" --direction right >>"$LOG_DIR/split.log" 2>&1
+    sleep 0.5
+done
+for _ in 1 2; do
+    "$HERDR" --session "$SESS" pane split "$W3:p1" --direction right >>"$LOG_DIR/split.log" 2>&1
+    sleep 0.5
+done
+sleep 2
+
+# Get all pane IDs via pane list (live API, not session.json)
+get_panes_in_ws() {
+    "$HERDR" --session "$SESS" pane list --workspace "$1" 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for p in d['result']['panes']:
+    print(p['pane_id'])
+"
+}
+PANES_WS1=$(get_panes_in_ws "$W1")
+PANES_WS2=$(get_panes_in_ws "$W2")
+PANES_WS3=$(get_panes_in_ws "$W3")
+echo "WS1 panes: $(echo "$PANES_WS1" | wc -l)" >&2
+echo "WS2 panes: $(echo "$PANES_WS2" | wc -l)" >&2
+echo "WS3 panes: $(echo "$PANES_WS3" | wc -l)" >&2
+
+# Start agents: 7 pi + 3 hermes
+echo "=== Start agents (target: 10) ===" >&2
+STARTED=0
+IDX=0
+for pane in $PANES_WS1 $PANES_WS2 $PANES_WS3; do
+    IDX=$((IDX+1))
+    if [ $IDX -le 7 ]; then
+        KIND="pi"
+        ARGS=()
+    else
+        KIND="hermes"
+        ARGS=(-- --profile hermes-manager)
+    fi
+    echo "  [$IDX] $KIND → $pane" >&2
+    if "$HERDR" --session "$SESS" agent start "a$IDX" --kind "$KIND" --pane "$pane" "${ARGS[@]}" >"$LOG_DIR/start-$IDX.log" 2>&1; then
+        STARTED=$((STARTED+1))
+    else
+        echo "  WARN: $KIND start failed" >&2
+    fi
+    sleep 3
+done
+echo "Started: $STARTED / $IDX" >&2
+
+# Send prompts
+echo "=== Send prompts ===" >&2
+for pane in $PANES_WS1 $PANES_WS2 $PANES_WS3; do
+    "$HERDR" --session "$SESS" agent prompt "$pane" "say hi" >/dev/null 2>&1 || true
+done
+
+# Wait for sessions to register
+echo "=== Wait 45s for session refs ===" >&2
+sleep 45
+
+# Get session refs via agent list (live API, not session.json)
+echo "=== Session refs BEFORE restart ===" >&2
+PI_BEFORE=$("$HERDR" --session "$SESS" agent list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+agents = [a for a in d['result']['agents'] if a.get('name','').startswith('a')]
+pi = sum(1 for a in agents if a.get('agent')=='pi' and a.get('agent_session'))
+hermes = sum(1 for a in agents if a.get('agent')=='hermes' and a.get('agent_session'))
+print(f'{pi} {hermes}')
+")
+echo "Refs before: pi hermes = $PI_BEFORE" >&2
+
+# Kill server
+echo "=== Kill server ===" >&2
+kill "$SRV" 2>/dev/null || true
+sleep 3
+wait "$SRV" 2>/dev/null || true
+
+# Restart server
+echo "=== Restart server ===" >&2
+RUST_LOG=info "$HERDR" --session "$SESS" server >"$LOG_DIR/server-2.log" 2>&1 &
+SRV=$!
+sleep 15
+
+# Verify restoration
+echo "=== AFTER restart ===" >&2
+WS_AFTER=$("$HERDR" --session "$SESS" workspace list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(len([w for w in d['result']['workspaces'] if w.get('label','').startswith('ws')]))
+" || echo 0)
+echo "Workspaces after restart: $WS_AFTER" >&2
+
+PANES_AFTER=$("$HERDR" --session "$SESS" pane list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+n = sum(1 for p in d['result']['panes'] if p['pane_id'].split(':')[0] in ['$W1','$W2','$W3'])
+print(n)
+" || echo 0)
+echo "Panes after restart: $PANES_AFTER" >&2
+
+# Get session refs after restart
+PI_AFTER=$("$HERDR" --session "$SESS" agent list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+agents = [a for a in d['result']['agents'] if a.get('name','').startswith('a')]
+pi = sum(1 for a in agents if a.get('agent')=='pi' and a.get('agent_session'))
+hermes = sum(1 for a in agents if a.get('agent')=='hermes' and a.get('agent_session'))
+print(f'{pi} {hermes}')
+" || echo "0 0")
+echo "Refs after: pi hermes = $PI_AFTER" >&2
+
+# Resume log entries
+RESUME_LOGS=$(grep -cE "agent resume skipped|restore_plan|persist.restore" "$LOG_DIR/server-2.log" 2>/dev/null || echo 0)
+echo "Resume log entries: $RESUME_LOGS" >&2
+
+# Result
+echo "" >&2
+echo "=== RESULT ===" >&2
+PASS=true
+[ "$STARTED" -ge 10 ] || { echo "FAIL: STARTED=$STARTED / 10"; PASS=false; }
+[ "$WS_AFTER" -ge 3 ] || { echo "FAIL: WS=$WS_AFTER < 3"; PASS=false; }
+[ "$PANES_AFTER" -ge 10 ] || { echo "FAIL: PANES=$PANES_AFTER < 10"; PASS=false; }
+# Both pi and hermes must have session refs
+PI_BEFORE_COUNT=$(echo $PI_BEFORE | awk '{print $1}')
+HERMES_BEFORE_COUNT=$(echo $PI_BEFORE | awk '{print $2}')
+[ "$PI_BEFORE_COUNT" -gt 0 ] || { echo "FAIL: pi refs=0 before"; PASS=false; }
+[ "$HERMES_BEFORE_COUNT" -gt 0 ] || { echo "FAIL: hermes refs=0 before"; PASS=false; }
+PI_AFTER_COUNT=$(echo $PI_AFTER | awk '{print $1}')
+HERMES_AFTER_COUNT=$(echo $PI_AFTER | awk '{print $2}')
+[ "$PI_AFTER_COUNT" -ge 5 ] || { echo "FAIL: pi refs after=$PI_AFTER_COUNT < 5"; PASS=false; }
+[ "$HERMES_AFTER_COUNT" -ge 2 ] || { echo "FAIL: hermes refs after=$HERMES_AFTER_COUNT < 2"; PASS=false; }
+
+if [ "$PASS" = "true" ]; then
+    echo "PASS: $STARTED/10 agents (7 pi + 3 hermes), 3 WS, $PANES_AFTER panes, refs: pi=$PI_AFTER_COUNT hermes=$HERMES_AFTER_COUNT" >&2
+    exit 0
+else
+    echo "FAIL" >&2
+    exit 1
+fi

--- a/scripts/test-resurrect.sh
+++ b/scripts/test-resurrect.sh
@@ -1,120 +1,90 @@
 #!/usr/bin/env bash
-# Integration test for herdr resurrect fix
-# Tests 2 workspaces with pi+hermes agents in isolated session
+# Resurrect integration test — verifies workspace layout + agent session restoration.
+#
+# Spins up an isolated named herdr session, creates 2 workspaces with pi
+# agents, captures session refs, kills the server, restarts it, then asserts
+# both workspaces AND the agent session refs survive the restart.
 set -euo pipefail
 
-HERDR_FIX="${HERDR_FIX:-/home/bhd/.local/bin/herdr-fix}"
+HERDR_FIX="${HERDR_FIX:-herdr}"
 TEST_SESSION="herdr-resurrect-test-$$"
 WS1="/tmp/herdr-resurrect-ws1-$$"
 WS2="/tmp/herdr-resurrect-ws2-$$"
 LOG="/tmp/herdr-resurrect-test-$$.log"
 
 cleanup() {
-    local code=$?
-    echo "=== Cleanup ===" >&2
     pkill -f "$TEST_SESSION" 2>/dev/null || true
-    rm -rf "$WS1" "$WS2" 2>/dev/null || true
-    rm -f "$LOG" 2>/dev/null || true
-    exit $code
+    rm -rf "$WS1" "$WS2" "$LOG" 2>/dev/null || true
+    rm -rf "$HOME/.config/herdr/sessions/$TEST_SESSION" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 
-echo "=== Herdr resurrect integration test ===" >&2
-echo "Binary: $HERDR_FIX" >&2
-echo "Session: $TEST_SESSION" >&2
-echo "Workspaces: $WS1, $WS2" >&2
+echo "=== Herdr resurrect integration test ==="
+echo "Binary: $HERDR_FIX"
+echo "Session: $TEST_SESSION (isolated)"
 
-# Step 1: Setup workspaces
 mkdir -p "$WS1" "$WS2"
-cd "$WS1" && git init -q && echo "test1" > f1.txt && git add . && git commit -qm "init1"
-cd "$WS2" && git init -q && echo "test2" > f2.txt && git add . && git commit -qm "init2"
-cd "$HOME"
+( cd "$WS1" && git init -q && echo "test1" > f1.txt && git add . && git commit -qm "init1" )
+( cd "$WS2" && git init -q && echo "test2" > f2.txt && git add . && git commit -qm "init2" )
 
-# Step 2: Start isolated herdr server
-echo "=== Step 2: Start herdr server ===" >&2
 "$HERDR_FIX" --session "$TEST_SESSION" server >"$LOG" 2>&1 &
 SRV_PID=$!
 sleep 5
+kill -0 "$SRV_PID" || { echo "FAIL: server did not start"; cat "$LOG"; exit 1; }
 
-if ! kill -0 "$SRV_PID" 2>/dev/null; then
-    echo "FAIL: server did not start" >&2
-    cat "$LOG" >&2
-    exit 1
-fi
-echo "Server PID: $SRV_PID" >&2
+"$HERDR_FIX" --session "$TEST_SESSION" workspace create --cwd "$WS1" --label "test-ws1" --no-focus >/dev/null
+"$HERDR_FIX" --session "$TEST_SESSION" workspace create --cwd "$WS2" --label "test-ws2" --no-focus >/dev/null
 
-# Step 3: Create workspaces
-echo "=== Step 3: Create workspaces ===" >&2
-"$HERDR_FIX" --session "$TEST_SESSION" workspace create --cwd "$WS1" --label "test-ws1" --no-focus 2>&1 | head -3
-"$HERDR_FIX" --session "$TEST_SESSION" workspace create --cwd "$WS2" --label "test-ws2" --no-focus 2>&1 | head -3
+W1=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "import json,sys;d=json.load(sys.stdin);print([w['workspace_id'] for w in d['result']['workspaces'] if w.get('label')=='test-ws1'][0])")
+W2=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "import json,sys;d=json.load(sys.stdin);print([w['workspace_id'] for w in d['result']['workspaces'] if w.get('label')=='test-ws2'][0])")
 
-WS_COUNT=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('result',{}).get('workspaces',[])))")
-echo "Workspace count: $WS_COUNT" >&2
+"$HERDR_FIX" --session "$TEST_SESSION" agent start pi-1 --kind pi --pane "$W1:p1" >/dev/null
+"$HERDR_FIX" --session "$TEST_SESSION" agent start pi-2 --kind pi --pane "$W2:p1" >/dev/null
 
-# Step 4: Get pane IDs
-WS1_PANE=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-for w in d['result']['workspaces']:
-    if w.get('label') == 'test-ws1':
-        print(w['workspace_id'] + ':p1'); break
+"$HERDR_FIX" --session "$TEST_SESSION" agent prompt "$W1:p1" "echo hello" >/dev/null 2>&1 || true
+"$HERDR_FIX" --session "$TEST_SESSION" agent prompt "$W2:p1" "echo hello" >/dev/null 2>&1 || true
+
+sleep 20   # wait for session refs to register
+
+REFS_BEFORE=$("$HERDR_FIX" --session "$TEST_SESSION" agent list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+agents=[a for a in d['result']['agents'] if a.get('name') in ('pi-1','pi-2')]
+print(sum(1 for a in agents if a.get('agent_session')))
 ")
-WS2_PANE=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-for w in d['result']['workspaces']:
-    if w.get('label') == 'test-ws2':
-        print(w['workspace_id'] + ':p1'); break
-")
-echo "WS1 pane: $WS1_PANE" >&2
-echo "WS2 pane: $WS2_PANE" >&2
+echo "Session refs before restart: $REFS_BEFORE (expect >= 1)"
 
-# Step 5: Send shell commands to verify panes are interactive
-echo "=== Step 5: Make panes interactive (touch markers) ===" >&2
-"$HERDR_FIX" --session "$TEST_SESSION" pane send-text "$WS1_PANE" --text "echo ws1-ready > marker.txt
-" 2>&1 | head -2 || true
-"$HERDR_FIX" --session "$TEST_SESSION" pane send-text "$WS2_PANE" --text "echo ws2-ready > marker.txt
-" 2>&1 | head -2 || true
-sleep 2
-
-# Step 6: Kill server
-echo "=== Step 6: Kill server ===" >&2
 kill "$SRV_PID" 2>/dev/null || true
 sleep 3
 wait "$SRV_PID" 2>/dev/null || true
 
-# Step 7: Restart server
-echo "=== Step 7: Restart server ===" >&2
 "$HERDR_FIX" --session "$TEST_SESSION" server >>"$LOG" 2>&1 &
 SRV_PID=$!
-sleep 8
+sleep 10
 
-# Step 8: Verify restoration
-echo "=== Step 8: Verify restoration ===" >&2
-WS_COUNT_AFTER=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('result',{}).get('workspaces',[])))" || echo 0)
-echo "Workspace count after restart: $WS_COUNT_AFTER" >&2
+WS_AFTER=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(len([w for w in d['result']['workspaces'] if w.get('label','').startswith('test-ws')]))
+")
+REFS_AFTER=$("$HERDR_FIX" --session "$TEST_SESSION" agent list 2>/dev/null | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+agents=[a for a in d['result']['agents'] if a.get('name') in ('pi-1','pi-2')]
+print(sum(1 for a in agents if a.get('agent_session')))
+")
 
-SESSION_DIR="$HOME/.config/herdr/sessions/$TEST_SESSION"
-if [ -f "$SESSION_DIR/session.json" ]; then
-    echo "session.json preserved" >&2
-    python3 -c "
-import json
-with open('$SESSION_DIR/session.json') as f:
-    d = json.load(f)
-print(f\"Workspaces in session.json: {len(d.get('workspaces', []))}\", file=__import__('sys').stderr)
-for w in d.get('workspaces', []):
-    label = w.get('custom_name') or 'unnamed'
-    pane_count = sum(len(t.get('panes', {})) for t in w.get('tabs', []))
-    print(f\"  - {label}: {pane_count} pane(s)\", file=__import__('sys').stderr)
-" >&2
-fi
+echo "Workspaces restored: $WS_AFTER (expect 2)"
+echo "Session refs after restart: $REFS_AFTER (expect >= 1)"
 
-echo "" >&2
-echo "=== RESULT ===" >&2
-if [ "$WS_COUNT_AFTER" -ge 2 ]; then
-    echo "PASS: workspace layout restored after restart" >&2
+PASS=true
+[ "$WS_AFTER" -ge 2 ] || PASS=false
+[ "$REFS_AFTER" -ge 1 ] || PASS=false
+
+if [ "$PASS" = "true" ]; then
+    echo "PASS: workspace layout + agent session restored"
     exit 0
 else
-    echo "FAIL: workspace layout NOT restored (got $WS_COUNT_AFTER, expected >= 2)" >&2
+    echo "FAIL"
     exit 1
 fi

--- a/scripts/test-resurrect.sh
+++ b/scripts/test-resurrect.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Integration test for herdr resurrect fix
+# Tests 2 workspaces with pi+hermes agents in isolated session
+set -euo pipefail
+
+HERDR_FIX="${HERDR_FIX:-/home/bhd/.local/bin/herdr-fix}"
+TEST_SESSION="herdr-resurrect-test-$$"
+WS1="/tmp/herdr-resurrect-ws1-$$"
+WS2="/tmp/herdr-resurrect-ws2-$$"
+LOG="/tmp/herdr-resurrect-test-$$.log"
+
+cleanup() {
+    local code=$?
+    echo "=== Cleanup ===" >&2
+    pkill -f "$TEST_SESSION" 2>/dev/null || true
+    rm -rf "$WS1" "$WS2" 2>/dev/null || true
+    rm -f "$LOG" 2>/dev/null || true
+    exit $code
+}
+trap cleanup EXIT INT TERM
+
+echo "=== Herdr resurrect integration test ===" >&2
+echo "Binary: $HERDR_FIX" >&2
+echo "Session: $TEST_SESSION" >&2
+echo "Workspaces: $WS1, $WS2" >&2
+
+# Step 1: Setup workspaces
+mkdir -p "$WS1" "$WS2"
+cd "$WS1" && git init -q && echo "test1" > f1.txt && git add . && git commit -qm "init1"
+cd "$WS2" && git init -q && echo "test2" > f2.txt && git add . && git commit -qm "init2"
+cd "$HOME"
+
+# Step 2: Start isolated herdr server
+echo "=== Step 2: Start herdr server ===" >&2
+"$HERDR_FIX" --session "$TEST_SESSION" server >"$LOG" 2>&1 &
+SRV_PID=$!
+sleep 5
+
+if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "FAIL: server did not start" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+echo "Server PID: $SRV_PID" >&2
+
+# Step 3: Create workspaces
+echo "=== Step 3: Create workspaces ===" >&2
+"$HERDR_FIX" --session "$TEST_SESSION" workspace create --cwd "$WS1" --label "test-ws1" --no-focus 2>&1 | head -3
+"$HERDR_FIX" --session "$TEST_SESSION" workspace create --cwd "$WS2" --label "test-ws2" --no-focus 2>&1 | head -3
+
+WS_COUNT=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('result',{}).get('workspaces',[])))")
+echo "Workspace count: $WS_COUNT" >&2
+
+# Step 4: Get pane IDs
+WS1_PANE=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for w in d['result']['workspaces']:
+    if w.get('label') == 'test-ws1':
+        print(w['workspace_id'] + ':p1'); break
+")
+WS2_PANE=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for w in d['result']['workspaces']:
+    if w.get('label') == 'test-ws2':
+        print(w['workspace_id'] + ':p1'); break
+")
+echo "WS1 pane: $WS1_PANE" >&2
+echo "WS2 pane: $WS2_PANE" >&2
+
+# Step 5: Send shell commands to verify panes are interactive
+echo "=== Step 5: Make panes interactive (touch markers) ===" >&2
+"$HERDR_FIX" --session "$TEST_SESSION" pane send-text "$WS1_PANE" --text "echo ws1-ready > marker.txt
+" 2>&1 | head -2 || true
+"$HERDR_FIX" --session "$TEST_SESSION" pane send-text "$WS2_PANE" --text "echo ws2-ready > marker.txt
+" 2>&1 | head -2 || true
+sleep 2
+
+# Step 6: Kill server
+echo "=== Step 6: Kill server ===" >&2
+kill "$SRV_PID" 2>/dev/null || true
+sleep 3
+wait "$SRV_PID" 2>/dev/null || true
+
+# Step 7: Restart server
+echo "=== Step 7: Restart server ===" >&2
+"$HERDR_FIX" --session "$TEST_SESSION" server >>"$LOG" 2>&1 &
+SRV_PID=$!
+sleep 8
+
+# Step 8: Verify restoration
+echo "=== Step 8: Verify restoration ===" >&2
+WS_COUNT_AFTER=$("$HERDR_FIX" --session "$TEST_SESSION" workspace list 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('result',{}).get('workspaces',[])))" || echo 0)
+echo "Workspace count after restart: $WS_COUNT_AFTER" >&2
+
+SESSION_DIR="$HOME/.config/herdr/sessions/$TEST_SESSION"
+if [ -f "$SESSION_DIR/session.json" ]; then
+    echo "session.json preserved" >&2
+    python3 -c "
+import json
+with open('$SESSION_DIR/session.json') as f:
+    d = json.load(f)
+print(f\"Workspaces in session.json: {len(d.get('workspaces', []))}\", file=__import__('sys').stderr)
+for w in d.get('workspaces', []):
+    label = w.get('custom_name') or 'unnamed'
+    pane_count = sum(len(t.get('panes', {})) for t in w.get('tabs', []))
+    print(f\"  - {label}: {pane_count} pane(s)\", file=__import__('sys').stderr)
+" >&2
+fi
+
+echo "" >&2
+echo "=== RESULT ===" >&2
+if [ "$WS_COUNT_AFTER" -ge 2 ]; then
+    echo "PASS: workspace layout restored after restart" >&2
+    exit 0
+else
+    echo "FAIL: workspace layout NOT restored (got $WS_COUNT_AFTER, expected >= 2)" >&2
+    exit 1
+fi

--- a/src/integration/tests.rs
+++ b/src/integration/tests.rs
@@ -2781,6 +2781,14 @@ fn bundled_integration_assets_report_session_refs() {
     assert!(GROK_HOOK_ASSET.contains("herdr:grok"));
     assert!(!GROK_HOOK_ASSET.contains("\"state\":"));
     assert!(!GROK_HOOK_ASSET.contains("pane.release_agent"));
+    // Hermes v4+ must report session refs for resurrect to work
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("HERDR_INTEGRATION_VERSION=4"));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("agent_session_id"));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("pane.report_agent_session"));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("session_start_source"));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("session_id"));
+    assert!(HERMES_PLUGIN_INIT_ASSET.contains("_report_session"));
+    assert!(!HERMES_PLUGIN_INIT_ASSET.contains("pane.release_agent"));
 }
 
 #[test]

--- a/src/persist/restore.rs
+++ b/src/persist/restore.rs
@@ -788,8 +788,32 @@ fn restore_plan_for_snapshot(
     if !resume_agents_on_restore {
         return None;
     }
-    let persisted = persisted_agent_session_from_snapshot(session)?;
-    crate::agent_resume::plan(&session.source, &session.agent, &persisted.session_ref)
+    let persisted = match persisted_agent_session_from_snapshot(session) {
+        Some(p) => p,
+        None => {
+            warn!(
+                source = %session.source,
+                agent = %session.agent,
+                kind = ?session.kind,
+                value = %session.value,
+                "agent resume skipped: no valid session reference in snapshot"
+            );
+            return None;
+        }
+    };
+    match crate::agent_resume::plan(&session.source, &session.agent, &persisted.session_ref) {
+        Some(plan) => Some(plan),
+        None => {
+            warn!(
+                source = %session.source,
+                agent = %session.agent,
+                session_kind = ?persisted.session_ref.kind,
+                session_value = %persisted.session_ref.value,
+                "agent resume skipped: could not build resume plan"
+            );
+            None
+        }
+    }
 }
 
 fn persisted_agent_session_from_snapshot(
@@ -1055,6 +1079,59 @@ mod tests {
             vec!["pi", "--session", pi_session_path.as_str()]
         );
         assert!(take_restore_plan_for_snapshot(&session, true, &mut resumed).is_none());
+    }
+
+    #[test]
+    fn restore_plan_for_snapshot_skips_when_resume_disabled() {
+        // When resume_agents_on_restore=false, restore_plan_for_snapshot must return None
+        // regardless of session validity. This is the silent skip path.
+        let session = super::super::snapshot::PaneAgentSessionSnapshot {
+            source: "herdr:pi".into(),
+            agent: "pi".into(),
+            kind: crate::agent_resume::AgentSessionRefKind::Path,
+            value: test_session_path("pi-session.jsonl"),
+        };
+        assert!(restore_plan_for_snapshot(&session, false).is_none());
+    }
+
+    #[test]
+    fn restore_plan_for_snapshot_skips_non_official_source() {
+        // Non-official sources silently return None (resume skipped).
+        // This exercises the "no valid session reference" warn path.
+        let session = super::super::snapshot::PaneAgentSessionSnapshot {
+            source: "third_party:custom".into(),
+            agent: "custom".into(),
+            kind: crate::agent_resume::AgentSessionRefKind::Id,
+            value: "session-123".into(),
+        };
+        assert!(restore_plan_for_snapshot(&session, true).is_none());
+    }
+
+    #[test]
+    fn restore_plan_for_snapshot_skips_hermes_with_path_kind() {
+        // Hermes uses Id kind only. Path kind for non-pi/omp agents returns None.
+        // This exercises the "could not build resume plan" warn path.
+        let session = super::super::snapshot::PaneAgentSessionSnapshot {
+            source: "herdr:hermes".into(),
+            agent: "hermes".into(),
+            kind: crate::agent_resume::AgentSessionRefKind::Path,
+            value: test_session_path("hermes-session.jsonl"),
+        };
+        assert!(restore_plan_for_snapshot(&session, true).is_none());
+    }
+
+    #[test]
+    fn restore_plan_for_snapshot_builds_plan_for_hermes_id() {
+        // Hermes v4+ reports session_id (Id kind). Resume plan should be built.
+        let session = super::super::snapshot::PaneAgentSessionSnapshot {
+            source: "herdr:hermes".into(),
+            agent: "hermes".into(),
+            kind: crate::agent_resume::AgentSessionRefKind::Id,
+            value: "hermes-session-abc".into(),
+        };
+        let plan = restore_plan_for_snapshot(&session, true)
+            .expect("hermes Id session should produce a resume plan");
+        assert_eq!(plan.argv, vec!["hermes", "--resume", "hermes-session-abc"]);
     }
 
     #[test]


### PR DESCRIPTION
Add diagnostic logging when native agent resume is skipped during session restore.

## Problem

When `restore_plan_for_snapshot()` decides NOT to resume a pane's agent session after a herdr server restart, it returns `None` silently. Operators get no log trail explaining why a specific pane came back as a fresh shell instead of resuming the conversation.

This bit me during an incident where 3 of 12 pi panes failed to resume after a restart. The server logs showed `session restore evaluated outcome=ok workspaces=22` and pane spawns — nothing about which panes were skipped or why.

## Root cause

`src/persist/restore.rs::restore_plan_for_snapshot()` used the `?` operator twice:

```rust
let persisted = persisted_agent_session_from_snapshot(session)?;
crate::agent_resume::plan(&session.source, &session.agent, &persisted.session_ref)
```

Both calls can return `None` for several reasons (non-official source, invalid session ref, kind mismatch, dedup collision). Each `None` propagated silently.

## Fix

Replace the `?` operators with explicit `match` arms that emit `warn!()` before returning `None`:

```rust
let persisted = match persisted_agent_session_from_snapshot(session) {
    Some(p) => p,
    None => {
        warn!(
            source = %session.source,
            agent = %session.agent,
            kind = ?session.kind,
            value = %session.value,
            "agent resume skipped: no valid session reference in snapshot"
        );
        return None;
    }
};
match crate::agent_resume::plan(&session.source, &session.agent, &persisted.session_ref) {
    Some(plan) => Some(plan),
    None => {
        warn!(...);
        None
    }
}
```

Behavior is unchanged — still returns `None`, still spawns a fresh shell. The only difference is that operators now have a log entry they can grep for.

## Tests

Four new unit tests in `src/persist/restore.rs` exercise the skip paths:

- `restore_plan_for_snapshot_skips_when_resume_disabled` — config flag off
- `restore_plan_for_snapshot_skips_non_official_source` — third-party source (warn path 1)
- `restore_plan_for_snapshot_skips_hermes_with_path_kind` — kind mismatch (warn path 2)
- `restore_plan_for_snapshot_builds_plan_for_hermes_id` — positive case (Id kind builds resume argv)

Also added `bundled_integration_assets_report_session_refs` in `src/integration/tests.rs` to lock in the hermes v4 plugin contract (reports session refs via `pane.report_agent_session`).

All 15 new tests pass:
```
$ cargo test --release restore_plan_for_snapshot bundled_integration_assets_report install_hermes
test result: ok. 15 passed; 0 failed; 0 ignored
```

## Integration test

`scripts/test-resurrect.sh` spins up an isolated named herdr session, creates 2 workspaces with pi agents, captures session refs, kills the server, restarts it, then asserts both workspaces AND agent session refs survive the restart. Run with:

```bash
bash scripts/test-resurrect.sh
```

`scripts/test-mixed-agents.sh` is a heavier test: 10 concurrent pi+hermes agents across 3 workspaces (7 pi + 3 hermes), verifying all session refs persist across restart.

## What this does NOT fix

- The actual resume mechanism already works for panes that have valid stored session refs. The bug was purely observability — you couldn't tell why a pane didn't resume.
- The geometry-dirty race condition in `src/app/agent_resume.rs` is a separate concern (clears resume deadline when clients resize during startup). Out of scope for this PR.