### PR TITLE
feat: add mistral vibe agent integration

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2119,7 +2119,8 @@
             "qodercli",
             "cursor",
             "mastracode",
-            "grok"
+            "grok",
+            "vibe"
           ],
           "type": "string"
         },
@@ -7113,7 +7114,8 @@
             "qodercli",
             "cursor",
             "mastracode",
-            "grok"
+            "grok",
+            "vibe"
           ],
           "type": "string"
         },

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -1010,6 +1010,17 @@
             "on",
             "off"
           ]
+        },
+        {
+          "key": "ui.sound.agents.vibe",
+          "type": "enum",
+          "default": "\"default\"",
+          "description": "Sound override for detected Mistral Vibe agents.",
+          "values": [
+            "default",
+            "on",
+            "off"
+          ]
         }
       ]
     },
@@ -1093,7 +1104,7 @@
           "key": "experimental.cjk_ime_agents",
           "type": "list of strings",
           "default": "[]",
-          "description": "Restrict `reveal_hidden_cursor_for_cjk_ime` to focused panes whose detected agent matches one of these names (case-insensitive). Empty list means apply to any focused pane. Unknown agent names are ignored; if the list contains no valid names, the reveal does not apply. Accepted names: pi, claude, codex, gemini, cursor, devin, cline, opencode, copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder, maki."
+          "description": "Restrict `reveal_hidden_cursor_for_cjk_ime` to focused panes whose detected agent matches one of these names (case-insensitive). Empty list means apply to any focused pane. Unknown agent names are ignored; if the list contains no valid names, the reveal does not apply. Accepted names: pi, claude, codex, gemini, cursor, devin, cline, opencode, copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder, maki, vibe."
         },
         {
           "key": "experimental.cjk_ime_cursor_shape",

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -89,6 +89,7 @@ pub fn is_reserved_native_state_source(source: &str, agent: &str) -> bool {
             | ("herdr:qodercli", "qodercli")
             | ("herdr:cursor", "cursor")
             | ("herdr:grok", "grok")
+            | ("herdr:vibe", "vibe")
     )
 }
 
@@ -190,6 +191,9 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
         ("herdr:grok", "grok", AgentSessionRefKind::Id) => {
             vec!["grok".into(), "--resume".into(), session_ref.value.clone()]
         }
+        ("herdr:vibe", "vibe", AgentSessionRefKind::Id) => {
+            vec!["vibe".into(), "--resume".into(), session_ref.value.clone()]
+        }
         _ => return None,
     };
 
@@ -225,6 +229,7 @@ pub(crate) fn is_official_agent_source(source: &str, agent: &str) -> bool {
             | ("herdr:kilo", "kilo")
             | ("herdr:cursor", "cursor")
             | ("herdr:grok", "grok")
+            | ("herdr:vibe", "vibe")
     )
 }
 
@@ -261,6 +266,7 @@ mod tests {
             "herdr:opencode",
             "opencode"
         ));
+        assert!(is_reserved_native_state_source("herdr:vibe", "vibe"));
     }
 
     #[test]
@@ -416,6 +422,16 @@ mod tests {
             .unwrap()
             .argv,
             vec!["grok", "--resume", "grok-session"]
+        );
+        assert_eq!(
+            plan(
+                "herdr:vibe",
+                "vibe",
+                &AgentSessionRef::id("vibe-session").unwrap()
+            )
+            .unwrap()
+            .argv,
+            vec!["vibe", "--resume", "vibe-session"]
         );
     }
 

--- a/src/api/schema/integrations.rs
+++ b/src/api/schema/integrations.rs
@@ -28,10 +28,11 @@ pub enum IntegrationTarget {
     Cursor,
     Mastracode,
     Grok,
+    Vibe,
 }
 
 impl IntegrationTarget {
-    pub(crate) const ALL: [Self; 15] = [
+    pub(crate) const ALL: [Self; 16] = [
         Self::Pi,
         Self::Omp,
         Self::Claude,
@@ -47,6 +48,7 @@ impl IntegrationTarget {
         Self::Cursor,
         Self::Mastracode,
         Self::Grok,
+        Self::Vibe,
     ];
 }
 

--- a/src/cli/integration.rs
+++ b/src/cli/integration.rs
@@ -103,13 +103,13 @@ fn parse_integration_target(
 ) -> std::io::Result<Option<IntegrationTarget>> {
     let Some(target) = args.first().map(|arg| arg.as_str()) else {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok|vibe>"
         );
         return Ok(None);
     };
     if args.len() != 1 {
         eprintln!(
-            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok>"
+            "usage: herdr integration {action} <pi|omp|claude|codex|copilot|devin|droid|kimi|opencode|kilo|hermes|qodercli|cursor|mastracode|grok|vibe>"
         );
         return Ok(None);
     }
@@ -130,10 +130,11 @@ fn parse_integration_target(
         "cursor" => IntegrationTarget::Cursor,
         "mastracode" => IntegrationTarget::Mastracode,
         "grok" => IntegrationTarget::Grok,
+        "vibe" => IntegrationTarget::Vibe,
         _ => {
             eprintln!("unknown integration target: {target}");
             eprintln!(
-                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, mastracode, grok"
+                "currently supported: pi, omp, claude, codex, copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor, mastracode, grok, vibe"
             );
             return Ok(None);
         }
@@ -159,6 +160,7 @@ fn print_integration_help() {
     eprintln!("  herdr integration install cursor");
     eprintln!("  herdr integration install mastracode");
     eprintln!("  herdr integration install grok");
+    eprintln!("  herdr integration install vibe");
     eprintln!("  herdr integration uninstall pi");
     eprintln!("  herdr integration uninstall omp");
     eprintln!("  herdr integration uninstall claude");
@@ -174,5 +176,6 @@ fn print_integration_help() {
     eprintln!("  herdr integration uninstall cursor");
     eprintln!("  herdr integration uninstall mastracode");
     eprintln!("  herdr integration uninstall grok");
+    eprintln!("  herdr integration uninstall vibe");
     eprintln!("  herdr integration status [--outdated-only]");
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -903,7 +903,7 @@ pub struct ExperimentalConfig {
     /// if the list contains no valid names, the reveal does not apply.
     /// Accepted names: pi, claude, codex, gemini, cursor, devin, cline,
     /// opencode, copilot, kimi, kiro, droid, amp, grok, hermes, kilo,
-    /// qodercli, qoder, maki.
+    /// qodercli, qoder, maki, vibe.
     /// Default: empty.
     pub cjk_ime_agents: Vec<String>,
     /// Cursor shape rendered for the IME anchor when

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -44,6 +44,7 @@ pub struct AgentSoundOverrides {
     pub kilo: AgentSoundSetting,
     pub qodercli: AgentSoundSetting,
     pub maki: AgentSoundSetting,
+    pub vibe: AgentSoundSetting,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -140,6 +141,7 @@ impl AgentSoundOverrides {
             Some(Agent::Kilo) => self.kilo,
             Some(Agent::Qodercli) => self.qodercli,
             Some(Agent::Maki) => self.maki,
+            Some(Agent::Vibe) => self.vibe,
             None => AgentSoundSetting::Default,
         }
     }
@@ -179,6 +181,7 @@ impl Default for AgentSoundOverrides {
             kilo: AgentSoundSetting::Default,
             qodercli: AgentSoundSetting::Default,
             maki: AgentSoundSetting::Default,
+            vibe: AgentSoundSetting::Default,
         }
     }
 }

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -256,6 +256,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("pi", include_str!("manifests/pi.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),
     ("copilot", include_str!("manifests/github-copilot.toml")),
+    ("vibe", include_str!("manifests/vibe.toml")),
 ];
 
 static MANIFEST_CACHE: OnceLock<RwLock<ManifestCache>> = OnceLock::new();

--- a/src/detect/manifests/vibe.toml
+++ b/src/detect/manifests/vibe.toml
@@ -1,0 +1,26 @@
+id = "vibe"
+version = "2026.07.16.1"
+min_engine_version = 3
+updated_at = "2026-07-28T00:00:00Z"
+aliases = ["mistral-vibe"]
+
+# Placeholder manifest. Mistral Vibe renders a full-screen Textual TUI, so
+# screen patterns (idle/working/blocked) require live evidence captured with
+# `herdr agent read <pane> --source detection --format text` and
+# `--format ansi` from a real vibe session.
+#
+# Use the herdr-throwaway-repro skill to drive a disposable session into the
+# target state, capture the bottom-buffer evidence, then encode explicit
+# AND/OR gates here. Copy the refined manifest to
+# ~/.config/herdr/agent-detection/vibe.toml and run
+# `herdr server reload-agent-manifests` to test before committing.
+#
+# Until real rules are added, detection returns Unknown and the pane relies on
+# PTY activity and the post_agent hook for session identity.
+[[rules]]
+id = "placeholder_skip"
+state = "unknown"
+priority = 0
+region = "whole_recent"
+skip_state_update = true
+regex = [".*"]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -62,10 +62,11 @@ pub enum Agent {
     Kilo,
     Qodercli,
     Maki,
+    Vibe,
 }
 
 impl Agent {
-    pub const ALL: [Self; 21] = [
+    pub const ALL: [Self; 22] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -87,9 +88,10 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Vibe,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -109,6 +111,7 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Vibe,
     ];
 }
 
@@ -135,6 +138,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Vibe => "vibe",
     }
 }
 
@@ -161,6 +165,7 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Vibe => "vibe",
     }
 }
 
@@ -197,6 +202,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "maki" => Some(Agent::Maki),
+        "vibe" | "mistral-vibe" => Some(Agent::Vibe),
         _ => None,
     }
 }
@@ -685,6 +691,8 @@ mod tests {
         assert_eq!(identify_agent("kilo"), Some(Agent::Kilo));
         assert_eq!(identify_agent("kilo-code"), Some(Agent::Kilo));
         assert_eq!(identify_agent("maki"), Some(Agent::Maki));
+        assert_eq!(identify_agent("vibe"), Some(Agent::Vibe));
+        assert_eq!(identify_agent("mistral-vibe"), Some(Agent::Vibe));
     }
 
     #[test]
@@ -711,6 +719,8 @@ mod tests {
         assert_eq!(parse_agent_label("hermes-agent"), Some(Agent::Hermes));
         assert_eq!(parse_agent_label("maki"), Some(Agent::Maki));
         assert_eq!(parse_agent_label("kilo-code"), Some(Agent::Kilo));
+        assert_eq!(parse_agent_label("vibe"), Some(Agent::Vibe));
+        assert_eq!(parse_agent_label("mistral-vibe"), Some(Agent::Vibe));
     }
 
     #[test]
@@ -746,6 +756,7 @@ mod tests {
             (Agent::Kilo, "kilo"),
             (Agent::Qodercli, "qodercli"),
             (Agent::Maki, "maki"),
+            (Agent::Vibe, "vibe"),
         ];
         assert_eq!(expected.len(), Agent::ALL.len());
         for (agent, executable) in expected {

--- a/src/integration/actions.rs
+++ b/src/integration/actions.rs
@@ -4,10 +4,10 @@ use super::registry::{integration_target_label, integration_target_supported};
 use super::targets::{
     install_claude, install_codex, install_copilot, install_cursor, install_devin, install_droid,
     install_grok, install_hermes, install_kilo, install_kimi, install_mastracode, install_omp,
-    install_opencode, install_pi, install_qodercli, uninstall_claude, uninstall_codex,
-    uninstall_copilot, uninstall_cursor, uninstall_devin, uninstall_droid, uninstall_grok,
-    uninstall_hermes, uninstall_kilo, uninstall_kimi, uninstall_mastracode, uninstall_omp,
-    uninstall_opencode, uninstall_pi, uninstall_qodercli,
+    install_opencode, install_pi, install_qodercli, install_vibe, uninstall_claude,
+    uninstall_codex, uninstall_copilot, uninstall_cursor, uninstall_devin, uninstall_droid,
+    uninstall_grok, uninstall_hermes, uninstall_kilo, uninstall_kimi, uninstall_mastracode,
+    uninstall_omp, uninstall_opencode, uninstall_pi, uninstall_qodercli, uninstall_vibe,
 };
 use super::version::{agent_version_requirement, enforce_agent_version};
 use super::{KIMI_MIN_VERSION, PI_EXTENSION_INSTALL_NAME};
@@ -213,6 +213,19 @@ fn install_target_inner(target: crate::api::schema::IntegrationTarget) -> io::Re
                 ),
                 format!(
                     "registered grok hook config at {}",
+                    installed.config_path.display()
+                ),
+            ]
+        }
+        crate::api::schema::IntegrationTarget::Vibe => {
+            let installed = install_vibe()?;
+            vec![
+                format!(
+                    "installed vibe integration hook to {}",
+                    installed.hook_path.display()
+                ),
+                format!(
+                    "ensured vibe hooks config at {}",
                     installed.config_path.display()
                 ),
             ]
@@ -593,6 +606,33 @@ pub(crate) fn uninstall_target(
             } else {
                 messages.push(format!(
                     "no grok hook config found at {}",
+                    result.config_path.display()
+                ));
+            }
+            messages
+        }
+        crate::api::schema::IntegrationTarget::Vibe => {
+            let result = uninstall_vibe()?;
+            let mut messages = Vec::new();
+            if result.removed_hook_file {
+                messages.push(format!(
+                    "removed vibe hook at {}",
+                    result.hook_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no vibe hook found at {}",
+                    result.hook_path.display()
+                ));
+            }
+            if result.updated_config {
+                messages.push(format!(
+                    "removed herdr vibe hook entries from {}",
+                    result.config_path.display()
+                ));
+            } else {
+                messages.push(format!(
+                    "no herdr vibe hook entries found in {}",
                     result.config_path.display()
                 ));
             }

--- a/src/integration/assets/vibe/herdr-agent-state.sh
+++ b/src/integration/assets/vibe/herdr-agent-state.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=vibe
+# HERDR_INTEGRATION_VERSION=1
+
+# Mistral Vibe has no SessionStart hook. It exposes only post_agent,
+# pre_tool, and post_tool (see vibe/core/hooks/models.py). The post_agent
+# event fires after each agent turn and carries the session_id, so herdr
+# learns the session identity from it. There is no action argument: each
+# hook type invokes its own command, so this script is registered solely
+# under the post_agent hook in ~/.vibe/hooks.toml.
+
+set -eu
+
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-vibe-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:vibe"
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+
+def first_text(*keys):
+    for key in keys:
+        value = hook_input.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+# Vibe's only session-scoped hook is post_agent (HookType.POST_AGENT,
+# hook_event_name "post_agent"). A missing field is allowed for forward
+# compatibility; any other event is not session identity, so skip it.
+hook_event_name = first_text("hook_event_name", "hookEventName")
+if hook_event_name not in (None, "", "post_agent"):
+    raise SystemExit(0)
+
+# Skip subagent/child sessions: parent_session_id being set means this is
+# a forked or nested session, not the pane's primary session.
+parent_session_id = hook_input.get("parent_session_id")
+if parent_session_id:
+    raise SystemExit(0)
+
+session_id = first_text("session_id", "sessionId")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+if not agent_session_id:
+    raise SystemExit(0)
+
+transcript_path = first_text("transcript_path")
+
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+params = {
+    "pane_id": pane_id,
+    "source": source,
+    "agent": "vibe",
+    "seq": report_seq,
+    "agent_session_id": agent_session_id,
+}
+if transcript_path:
+    params["agent_session_path"] = transcript_path
+request = {
+    "id": request_id,
+    "method": "pane.report_agent_session",
+    "params": params,
+}
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/src/integration/config_edit.rs
+++ b/src/integration/config_edit.rs
@@ -8,6 +8,7 @@ use super::command::{hook_command, legacy_bash_hook_command};
 use super::file_ops::legacy_bash_hook_path;
 use super::{
     HERMES_PLUGIN_INSTALL_NAME, KIMI_CONFIG_BLOCK_BEGIN, KIMI_CONFIG_BLOCK_END, KIMI_HOOK_EVENTS,
+    VIBE_CONFIG_BLOCK_BEGIN, VIBE_CONFIG_BLOCK_END,
 };
 
 pub(crate) fn ensure_hooks_object<'a>(
@@ -788,6 +789,75 @@ pub(crate) fn remove_kimi_config_block(content: &str) -> String {
         }
         if in_block {
             if line.trim() == KIMI_CONFIG_BLOCK_END {
+                in_block = false;
+            }
+            continue;
+        }
+        lines.push(line.to_string());
+    }
+
+    if !removed_block {
+        return content.to_string();
+    }
+
+    let mut result = join_toml_lines(lines, trailing_newline);
+    while result.ends_with("\n\n") {
+        result.pop();
+    }
+    if result == "\n" {
+        String::new()
+    } else {
+        result
+    }
+}
+
+/// Merge herdr's vibe `post_agent` hook into the user-owned `~/.vibe/hooks.toml`.
+///
+/// Vibe loads hooks from a single `hooks.toml` (see
+/// `vibe/core/config/harness_files/_harness_manager.py`) as `[[hooks]]`
+/// arrays. Unlike grok, there is no per-plugin merge directory, so herdr
+/// edits this shared file with delimited BEGIN/END markers to stay
+/// idempotent and preserve unrelated user hooks. Re-running install
+/// replaces the block; uninstall removes it.
+pub(crate) fn build_vibe_hooks_config_with_hooks(content: &str, hook_path: &Path) -> String {
+    let mut result = remove_vibe_hooks_config_block(content)
+        .trim_end_matches('\n')
+        .to_string();
+    if !result.is_empty() {
+        result.push('\n');
+        result.push('\n');
+    }
+
+    result.push_str(VIBE_CONFIG_BLOCK_BEGIN);
+    result.push('\n');
+    // Vibe has no action argument; each hook type invokes its own command,
+    // so the hook command is just `bash <script>` with no trailing action.
+    let command = hook_command(hook_path, None);
+    result.push_str(&format!(
+        "[[hooks]]\nname = {}\ntype = {}\ncommand = {}\ntimeout = 10.0\n\n",
+        toml_basic_string("herdr-agent-state"),
+        toml_basic_string("post_agent"),
+        toml_basic_string(&command)
+    ));
+    result.push_str(VIBE_CONFIG_BLOCK_END);
+    result.push('\n');
+    result
+}
+
+pub(crate) fn remove_vibe_hooks_config_block(content: &str) -> String {
+    let trailing_newline = content.ends_with('\n');
+    let mut lines = Vec::new();
+    let mut in_block = false;
+    let mut removed_block = false;
+
+    for line in content.lines() {
+        if line.trim() == VIBE_CONFIG_BLOCK_BEGIN {
+            in_block = true;
+            removed_block = true;
+            continue;
+        }
+        if in_block {
+            if line.trim() == VIBE_CONFIG_BLOCK_END {
                 in_block = false;
             }
             continue;

--- a/src/integration/env.rs
+++ b/src/integration/env.rs
@@ -21,6 +21,7 @@ pub(crate) const GROK_CONFIG_DIR_ENV_VAR: &str = "GROK_CONFIG_DIR";
 /// The grok CLI's own config-home override (documented alongside
 /// `$GROK_HOME/config.toml` and `$GROK_HOME/auth.json`).
 pub(crate) const GROK_HOME_ENV_VAR: &str = "GROK_HOME";
+pub(crate) const VIBE_HOME_ENV_VAR: &str = "VIBE_HOME";
 
 pub(crate) fn apply_pane_base_env(cmd: &mut CommandBuilder) {
     cmd.env(crate::api::SOCKET_PATH_ENV_VAR, crate::api::socket_path());
@@ -152,6 +153,10 @@ pub(crate) fn grok_dir() -> io::Result<PathBuf> {
     // The grok CLI honors GROK_HOME as its config home (config.toml,
     // auth.json, hooks/); mirror it so hook installs land where grok looks.
     config_dir_from_env_or_home(GROK_HOME_ENV_VAR, &[".grok"])
+}
+
+pub(crate) fn vibe_dir() -> io::Result<PathBuf> {
+    config_dir_from_env_or_home(VIBE_HOME_ENV_VAR, &[".vibe"])
 }
 
 pub(crate) fn home_dir() -> io::Result<PathBuf> {

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -219,6 +219,11 @@ const GROK_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
 const GROK_HOOK_CONFIG_INSTALL_NAME: &str = "herdr.json";
 const GROK_HOOK_ASSET: &str = include_str!("assets/grok/herdr-agent-state.sh");
 const GROK_INTEGRATION_VERSION: u32 = 1;
+const VIBE_HOOK_INSTALL_NAME: &str = "herdr-agent-state.sh";
+const VIBE_HOOK_ASSET: &str = include_str!("assets/vibe/herdr-agent-state.sh");
+const VIBE_INTEGRATION_VERSION: u32 = 1;
+const VIBE_CONFIG_BLOCK_BEGIN: &str = "# >>> herdr vibe integration";
+const VIBE_CONFIG_BLOCK_END: &str = "# <<< herdr vibe integration";
 const INTEGRATION_VERSION_MARKER: &str = "HERDR_INTEGRATION_VERSION=";
 
 pub(crate) const INSTALL_WARNING_PREFIX: &str = "warning:";

--- a/src/integration/registry.rs
+++ b/src/integration/registry.rs
@@ -23,6 +23,7 @@ pub(crate) fn integration_target_label(
         crate::api::schema::IntegrationTarget::Cursor => "cursor",
         crate::api::schema::IntegrationTarget::Mastracode => "mastracode",
         crate::api::schema::IntegrationTarget::Grok => "grok",
+        crate::api::schema::IntegrationTarget::Vibe => "vibe",
     }
 }
 
@@ -51,6 +52,7 @@ pub(crate) fn integration_target_command_names(
         crate::api::schema::IntegrationTarget::Cursor => cursor_command_names(),
         crate::api::schema::IntegrationTarget::Mastracode => &["mastracode"],
         crate::api::schema::IntegrationTarget::Grok => &["grok"],
+        crate::api::schema::IntegrationTarget::Vibe => &["vibe"],
     }
 }
 
@@ -259,7 +261,7 @@ fn integration_specs() -> [(
     crate::api::schema::IntegrationTarget,
     io::Result<PathBuf>,
     u32,
-); 15] {
+); 16] {
     [
         (
             crate::api::schema::IntegrationTarget::Pi,
@@ -338,6 +340,11 @@ fn integration_specs() -> [(
             crate::api::schema::IntegrationTarget::Grok,
             grok_dir().map(|dir| dir.join("hooks").join(super::GROK_HOOK_INSTALL_NAME)),
             super::GROK_INTEGRATION_VERSION,
+        ),
+        (
+            crate::api::schema::IntegrationTarget::Vibe,
+            vibe_dir().map(|dir| dir.join(super::VIBE_HOOK_INSTALL_NAME)),
+            super::VIBE_INTEGRATION_VERSION,
         ),
     ]
 }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -6,16 +6,17 @@ use serde_json::{json, Value};
 
 use super::command::{hook_command, shell_single_quote};
 use super::config_edit::{
-    build_codex_config_with_hooks, build_kimi_config_with_hooks, ensure_command_hook,
-    ensure_direct_command_hook, ensure_flat_command_hook, ensure_hermes_plugin_enabled,
-    ensure_hooks_object, ensure_simple_command_hook, hooks_object_if_present,
-    remove_direct_hook_commands, remove_flat_command_hook, remove_hermes_plugin_enabled,
-    remove_hook_commands, remove_kimi_config_block, remove_simple_command_hook,
+    build_codex_config_with_hooks, build_kimi_config_with_hooks,
+    build_vibe_hooks_config_with_hooks, ensure_command_hook, ensure_direct_command_hook,
+    ensure_flat_command_hook, ensure_hermes_plugin_enabled, ensure_hooks_object,
+    ensure_simple_command_hook, hooks_object_if_present, remove_direct_hook_commands,
+    remove_flat_command_hook, remove_hermes_plugin_enabled, remove_hook_commands,
+    remove_kimi_config_block, remove_simple_command_hook, remove_vibe_hooks_config_block,
 };
 use super::env::{
     claude_dir, codex_dir, copilot_dir, cursor_dir, devin_dir, droid_dir, grok_dir, hermes_dir,
     hermes_plugin_dir, kilo_dir, kimi_dir, mastracode_dir, omp_extension_dir, opencode_dir,
-    pi_extension_dir, qodercli_dir,
+    pi_extension_dir, qodercli_dir, vibe_dir,
 };
 use super::file_ops::{
     make_executable, remove_dir_all_if_exists, remove_file_if_exists, remove_legacy_bash_hook_file,
@@ -28,7 +29,7 @@ use super::types::{
     KiloInstallPaths, KiloUninstallResult, KimiInstallPaths, KimiUninstallResult,
     MastracodeInstallPaths, MastracodeUninstallResult, OmpInstallPaths, OmpUninstallResult,
     OpenCodeInstallPaths, OpenCodeUninstallResult, PiUninstallResult, QodercliInstallPaths,
-    QodercliUninstallResult,
+    QodercliUninstallResult, VibeInstallPaths, VibeUninstallResult,
 };
 use super::{
     CLAUDE_HOOK_ASSET, CLAUDE_HOOK_INSTALL_NAME, CODEX_HOOK_ASSET, CODEX_HOOK_INSTALL_NAME,
@@ -45,7 +46,7 @@ use super::{
     OMP_EXTENSION_ASSET, OMP_EXTENSION_INSTALL_NAME, OPENCODE_PLUGIN_ASSET,
     OPENCODE_PLUGIN_INSTALL_NAME, PI_EXTENSION_ASSET, PI_EXTENSION_INSTALL_NAME,
     QODERCLI_HOOK_ASSET, QODERCLI_HOOK_EVENTS, QODERCLI_HOOK_INSTALL_NAME,
-    QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS,
+    QODERCLI_REMOVED_LIFECYCLE_HOOK_EVENTS, VIBE_HOOK_ASSET, VIBE_HOOK_INSTALL_NAME,
 };
 
 fn ensure_extension_dir(dir: &Path, agent: &str) -> io::Result<()> {
@@ -1270,5 +1271,65 @@ pub(crate) fn uninstall_grok() -> io::Result<GrokUninstallResult> {
         config_path,
         removed_hook_file,
         removed_config_file,
+    })
+}
+
+pub(crate) fn install_vibe() -> io::Result<VibeInstallPaths> {
+    let dir = vibe_dir()?;
+    if !dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "vibe config directory not found at {}. install vibe cli first",
+            dir.display()
+        )));
+    }
+
+    // Vibe loads hooks from a single `hooks.toml` in its config dir (see
+    // `vibe/core/config/harness_files/_harness_manager.py`). There is no
+    // per-plugin merge directory like grok's `hooks/`, so herdr places the
+    // hook script at the config dir root and merges its `[[hooks]]` entry
+    // into the shared `hooks.toml` with delimited BEGIN/END markers.
+    let hook_path = dir.join(VIBE_HOOK_INSTALL_NAME);
+    fs::write(&hook_path, VIBE_HOOK_ASSET)?;
+    make_executable(&hook_path)?;
+
+    let config_path = dir.join("hooks.toml");
+    let existing_config = if config_path.is_file() {
+        fs::read_to_string(&config_path)?
+    } else {
+        String::new()
+    };
+    let new_config = build_vibe_hooks_config_with_hooks(&existing_config, &hook_path);
+    if new_config != existing_config {
+        fs::write(&config_path, new_config)?;
+    }
+
+    Ok(VibeInstallPaths {
+        hook_path,
+        config_path,
+    })
+}
+
+pub(crate) fn uninstall_vibe() -> io::Result<VibeUninstallResult> {
+    let dir = vibe_dir()?;
+    let hook_path = dir.join(VIBE_HOOK_INSTALL_NAME);
+    let config_path = dir.join("hooks.toml");
+    let mut updated_config = false;
+
+    if config_path.is_file() {
+        let existing_config = fs::read_to_string(&config_path)?;
+        let new_config = remove_vibe_hooks_config_block(&existing_config);
+        if new_config != existing_config {
+            fs::write(&config_path, new_config)?;
+            updated_config = true;
+        }
+    }
+
+    let removed_hook_file = remove_file_if_exists(&hook_path)?;
+
+    Ok(VibeUninstallResult {
+        hook_path,
+        config_path,
+        removed_hook_file,
+        updated_config,
     })
 }

--- a/src/integration/types.rs
+++ b/src/integration/types.rs
@@ -110,6 +110,20 @@ pub(crate) struct GrokUninstallResult {
 }
 
 #[derive(Debug)]
+pub(crate) struct VibeInstallPaths {
+    pub hook_path: PathBuf,
+    pub config_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct VibeUninstallResult {
+    pub hook_path: PathBuf,
+    pub config_path: PathBuf,
+    pub removed_hook_file: bool,
+    pub updated_config: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct QodercliUninstallResult {
     pub hook_path: PathBuf,
     pub settings_path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ pane_history = false
 # matches one of these names. Empty means apply to any focused pane.
 # If the list contains no valid names, the reveal does not apply.
 # Accepted: pi, claude, codex, gemini, cursor, devin, cline, opencode,
-# copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder.
+# copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder, vibe.
 # cjk_ime_agents = []
 # Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.
 # Values: block, steady_block (default), underline, steady_underline, bar, steady_bar.


### PR DESCRIPTION
Add vibe (mistral-vibe) agent to herdr, following the grok session-identity pattern adapted for vibe's post_agent hook system.

- detect: Agent::Vibe variant, label/executable/lookup, vibe.toml manifest
- agent_resume: source, reserved-source, plan, session_ref_from_snapshot
- integration: IntegrationTarget::Vibe, env, types, config_edit, targets, actions, registry, hook asset
- cli: parse_integration_target + usage
- config: sound, model, config-reference

Co-authored-by: pipeline