### PR TITLE
fix: use distinct status shapes in spaces sidebar

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -842,7 +842,7 @@ mod tests {
         let line1 = buffer_row_text(buffer, card, card.y);
         let line2 = buffer_row_text(buffer, card, card.y + 1);
 
-        assert!(line1.starts_with(" · one"));
+        assert!(line1.starts_with(" ○ one"));
         assert!(!line1.contains("1 one"));
         assert_eq!(line2, "   main");
 

--- a/src/ui/mobile.rs
+++ b/src/ui/mobile.rs
@@ -11,7 +11,7 @@ use super::sidebar::{
     next_entry_is_indented_workspace, workspace_list_entries_expanded, AgentPanelEntry,
     WorkspaceListEntry,
 };
-use super::status::{agent_icon, state_dot};
+use super::status::agent_icon;
 use super::text::{display_width_u16, truncate_end};
 use crate::app::state::{Palette, ToastKind, ToastNotification};
 use crate::app::AppState;
@@ -320,14 +320,7 @@ fn render_header_status(
     };
 
     let (state, seen) = ws.aggregate_state(&app.terminals);
-    let (dot, dot_style) = if matches!(state, AgentState::Working) {
-        (
-            super::spinner_frame(app.spinner_tick),
-            Style::default().fg(p.yellow),
-        )
-    } else {
-        state_dot(state, seen, p)
-    };
+    let (dot, dot_style) = agent_icon(state, seen, app.spinner_tick, p);
     let tab_label = mobile_tab_status(ws);
     let row1 = Rect::new(area.x, area.y, area.width, 1);
     let tab_w = display_width_u16(&tab_label)
@@ -576,7 +569,7 @@ fn render_mobile_switcher_content(
         let selected = *ws_idx == app.selected;
         let bg = mobile_item_bg(selected, active, p);
         let (state, seen) = ws.aggregate_state(&app.terminals);
-        let (dot, dot_style) = state_dot(state, seen, p);
+        let (dot, dot_style) = agent_icon(state, seen, app.spinner_tick, p);
 
         let mut title_spans = vec![Span::styled("  ", Style::default().bg(bg))];
         // Worktrees of the same space render as branches off their parent, so a
@@ -1375,6 +1368,110 @@ mod tests {
 
         assert!(row.contains("tab 2"), "mobile tab row: {row:?}");
         assert!(!row.contains("tab 3"), "mobile tab row: {row:?}");
+    }
+
+    fn mobile_header_status_glyph(state: AgentState, seen: bool) -> String {
+        let mut app = crate::app::state::AppState::test_new();
+        app.workspaces = vec![crate::workspace::Workspace::test_new("space")];
+        app.ensure_test_terminals();
+        app.active = Some(0);
+        app.selected = 0;
+
+        let pane = app.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.workspaces[0].tabs[0].panes[&pane]
+            .attached_terminal_id
+            .clone();
+        app.terminals.get_mut(&terminal_id).unwrap().state = state;
+        app.workspaces[0].tabs[0].panes.get_mut(&pane).unwrap().seen = seen;
+
+        let backend = ratatui::backend::TestBackend::new(24, 3);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_header_status(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 24, 3),
+                )
+            })
+            .unwrap();
+
+        // Header status row is [" ", glyph, " ", name], so the glyph is the
+        // second cell of the row.
+        terminal.backend().buffer()[(1, 0)].symbol().to_string()
+    }
+
+    #[test]
+    fn mobile_header_status_uses_distinct_glyphs_for_blocked_and_done() {
+        let blocked = mobile_header_status_glyph(AgentState::Blocked, true);
+        let done = mobile_header_status_glyph(AgentState::Idle, false);
+
+        assert_ne!(
+            blocked, done,
+            "blocked and done spaces must render distinct shapes in the mobile header, not just colors"
+        );
+    }
+
+    #[test]
+    fn mobile_switcher_list_uses_distinct_glyphs_for_blocked_and_done() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.workspaces = vec![
+            crate::workspace::Workspace::test_new("blocked"),
+            crate::workspace::Workspace::test_new("done"),
+        ];
+        app.ensure_test_terminals();
+        app.active = Some(0);
+        app.selected = 0;
+
+        let set_state = |app: &mut crate::app::state::AppState, ws_idx: usize, state| {
+            let pane = app.workspaces[ws_idx].tabs[0].root_pane;
+            let terminal_id = app.workspaces[ws_idx].tabs[0].panes[&pane]
+                .attached_terminal_id
+                .clone();
+            app.terminals.get_mut(&terminal_id).unwrap().state = state;
+        };
+        set_state(&mut app, 0, AgentState::Blocked);
+        set_state(&mut app, 1, AgentState::Idle);
+        let done_pane = app.workspaces[1].tabs[0].root_pane;
+        app.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&done_pane)
+            .unwrap()
+            .seen = false;
+
+        // No detected agents, so the agents block is empty and the blocked shape
+        // can only originate from a space row's status glyph.
+        assert!(agent_panel_entries(&app).is_empty());
+
+        let backend = ratatui::backend::TestBackend::new(40, 20);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_mobile_switcher_content(
+                    &app,
+                    &TerminalRuntimeRegistry::new(),
+                    frame,
+                    Rect::new(0, 0, 40, 20),
+                )
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let rendered: String = (0..buffer.area.height)
+            .flat_map(|y| (0..buffer.area.width).map(move |x| (x, y)))
+            .map(|(x, y)| buffer[(x, y)].symbol())
+            .collect();
+
+        // Blocked renders "◉" and done renders "●": distinct shapes, not just colors.
+        assert!(
+            rendered.contains('◉'),
+            "blocked space should render the distinct ◉ shape: {rendered:?}"
+        );
+        assert!(
+            rendered.contains('●'),
+            "done space should render the ● shape: {rendered:?}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use super::scrollbar::{render_scrollbar, should_show_scrollbar};
-use super::status::{agent_icon, state_dot, state_label, state_label_color};
+use super::status::{agent_icon, state_label, state_label_color};
 use super::text::{display_width, display_width_u16, truncate_end};
 use crate::app::state::{AgentPanelSort, Palette};
 use crate::app::{AppState, Mode};
@@ -663,7 +663,7 @@ pub(super) fn render_sidebar_collapsed(app: &AppState, frame: &mut Frame, area: 
             break;
         }
         let (agg_state, agg_seen) = ws.aggregate_state(&app.terminals);
-        let (icon, icon_style) = state_dot(agg_state, agg_seen, p);
+        let (icon, icon_style) = agent_icon(agg_state, agg_seen, app.spinner_tick, p);
         let is_selected = visible_idx == app.selected && is_navigating;
         let is_active = Some(visible_idx) == app.active;
         let row_style = if is_selected {
@@ -879,7 +879,7 @@ fn render_workspace_list(
             Style::default().fg(p.subtext0)
         };
 
-        let (icon, icon_style) = state_dot(agg_state, agg_seen, p);
+        let (icon, icon_style) = agent_icon(agg_state, agg_seen, app.spinner_tick, p);
         let label = ws.display_name_from(&app.terminals, terminal_runtimes);
         let mut line1 = Vec::new();
         let mut show_workspace_icon = true;
@@ -889,7 +889,7 @@ fn render_workspace_list(
             let icon = if collapsed { "▸" } else { "▾" };
             let (state_icon, state_style) = if collapsed {
                 let (state, seen) = space_aggregate_state(app, &key);
-                state_dot(state, seen, p)
+                agent_icon(state, seen, app.spinner_tick, p)
             } else {
                 (icon, Style::default().fg(p.accent))
             };
@@ -1463,6 +1463,65 @@ mod tests {
                 render_workspace_list(&app, &runtimes, frame, Rect::new(0, 0, 15, 6), false)
             })
             .expect("workspace list should render");
+    }
+
+    #[test]
+    fn workspace_list_uses_distinct_glyphs_for_blocked_and_done() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.workspaces = vec![Workspace::test_new("blocked"), Workspace::test_new("done")];
+        app.ensure_test_terminals();
+        app.active = Some(0);
+        app.selected = 0;
+        app.mode = Mode::Terminal;
+
+        let set_state = |app: &mut crate::app::state::AppState, ws_idx: usize, state| {
+            let pane = app.workspaces[ws_idx].tabs[0].root_pane;
+            let terminal_id = app.workspaces[ws_idx].tabs[0].panes[&pane]
+                .attached_terminal_id
+                .clone();
+            app.terminals.get_mut(&terminal_id).unwrap().state = state;
+        };
+        set_state(&mut app, 0, AgentState::Blocked);
+        set_state(&mut app, 1, AgentState::Idle);
+        // Idle + unseen is the "done" state on the second row.
+        let done_pane = app.workspaces[1].tabs[0].root_pane;
+        app.workspaces[1].tabs[0]
+            .panes
+            .get_mut(&done_pane)
+            .unwrap()
+            .seen = false;
+
+        app.view.workspace_card_areas = vec![
+            crate::app::state::WorkspaceCardArea {
+                ws_idx: 0,
+                rect: Rect::new(0, 1, 20, 1),
+                indented: false,
+            },
+            crate::app::state::WorkspaceCardArea {
+                ws_idx: 1,
+                rect: Rect::new(0, 2, 20, 1),
+                indented: false,
+            },
+        ];
+
+        let mut terminal = Terminal::new(TestBackend::new(20, 6)).expect("test terminal");
+        let runtimes = crate::terminal::TerminalRuntimeRegistry::new();
+        terminal
+            .draw(|frame| {
+                render_workspace_list(&app, &runtimes, frame, Rect::new(0, 0, 20, 6), false)
+            })
+            .expect("workspace list should render");
+
+        // The leading glyph sits one cell past the row's left edge: line is
+        // [" ", icon, " ", label].
+        let buf = terminal.backend().buffer();
+        let blocked_glyph = buf[(1, 1)].symbol().to_string();
+        let done_glyph = buf[(1, 2)].symbol().to_string();
+
+        assert_ne!(
+            blocked_glyph, done_glyph,
+            "blocked and done spaces must render distinct shapes, not just colors"
+        );
     }
 
     fn workspace_with_worktree_space(

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -193,16 +193,6 @@ pub(super) fn render_config_diagnostic(frame: &mut Frame, area: Rect, message: &
     }
 }
 
-pub(super) fn state_dot(state: AgentState, seen: bool, p: &Palette) -> (&'static str, Style) {
-    match (state, seen) {
-        (AgentState::Blocked, _) => ("●", Style::default().fg(p.red)),
-        (AgentState::Working, _) => ("●", Style::default().fg(p.yellow)),
-        (AgentState::Idle, false) => ("●", Style::default().fg(p.teal)),
-        (AgentState::Idle, true) => ("○", Style::default().fg(p.green)),
-        (AgentState::Unknown, _) => ("·", Style::default().fg(p.overlay0)),
-    }
-}
-
 pub(super) fn agent_icon(
     state: AgentState,
     seen: bool,


### PR DESCRIPTION
The spaces sidebar and the mobile views told agent status apart almost only by color. Blocked, working, and done-unseen all rendered as the same filled dot, so a colorblind user saw one dot for three different states. The agents panel already solved this with agent_icon, which gives every state its own shape. Point the sidebar and mobile views at that same function and delete state_dot, the color-only mapping they used to call.

Closes #2260