### PR TITLE
feat(ui): support right-aligned desktop sidebar

### DIFF
--- a/docs/next/website/src/content/docs/configuration.mdx
+++ b/docs/next/website/src/content/docs/configuration.mdx
@@ -254,9 +254,15 @@ Color values accept hex, named colors, `rgb(r,g,b)`, or reset aliases like `rese
 
 ## UI and sidebar
 
-The sidebar is the main Herdr dashboard. Search `ui.` in the [Config reference](/docs/config-reference/) for sizing, collapsed mode, Agent panel ordering, mouse behavior, pane borders, and other presentation settings.
+The sidebar is the main Herdr dashboard. Search `ui.` in the
+[Config reference](/docs/config-reference/) for sizing, collapsed mode, Agent
+panel ordering, mouse behavior, pane borders, and other presentation settings.
+Set `sidebar_position = "right"` under `[ui]` to move the desktop sidebar to the
+right edge; the default is `"left"`.
 
-Set `tab_bar_position = "bottom"` under `[ui]` to place the desktop tab row below the terminal panes. Prefix, Navigate, Copy, and Resize mode bars temporarily replace the bottom tab row while active. The default is `"top"`.
+Set `tab_bar_position = "bottom"` under `[ui]` to place the desktop tab row
+below the terminal panes. Prefix, Navigate, Copy, and Resize mode bars
+temporarily replace the bottom tab row while active. The default is `"top"`.
 
 ### Sidebar row layouts
 

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -566,6 +566,16 @@
           "description": "Maximum sidebar width (columns) when expanded."
         },
         {
+          "key": "ui.sidebar_position",
+          "type": "enum",
+          "default": "left",
+          "description": "Place the desktop sidebar on the left or right edge.",
+          "values": [
+            "left",
+            "right"
+          ]
+        },
+        {
           "key": "ui.sidebar_start_collapsed",
           "type": "boolean",
           "default": "false",

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1557,6 +1557,7 @@ impl AppState {
         let (_, detail_area) = crate::ui::expanded_sidebar_sections(
             self.view.sidebar_rect,
             self.sidebar_section_split,
+            self.sidebar_position,
         );
         self.agent_panel_scroll = crate::ui::agent_panel_scroll_for_target(
             self,

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -3835,26 +3835,36 @@ mod tests {
     }
 
     #[test]
-    fn desktop_new_workspace_opens_prompt_when_enabled() {
-        let mut app = app_for_mouse_test();
-        app.state.workspaces = vec![Workspace::test_new("one")];
-        app.state.active = Some(0);
-        app.state.selected = 0;
-        app.state.mode = Mode::Terminal;
-        app.state.prompt_new_workspace_name = true;
+    fn desktop_new_workspace_opens_prompt_from_both_sidebar_positions() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = app_for_mouse_test();
+            app.state.workspaces = vec![Workspace::test_new("one")];
+            app.state.active = Some(0);
+            app.state.selected = 0;
+            app.state.mode = Mode::Terminal;
+            app.state.prompt_new_workspace_name = true;
+            app.state.sidebar_position = position;
 
-        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 120, 40));
-        let new_workspace = app.state.sidebar_new_button_rect();
-        app.handle_mouse(mouse(
-            MouseEventKind::Down(MouseButton::Left),
-            new_workspace.x + 1,
-            new_workspace.y,
-        ));
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 120, 40));
+            let new_workspace = app.state.sidebar_new_button_rect();
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                new_workspace.x + 1,
+                new_workspace.y,
+            ));
 
-        assert_eq!(app.state.mode, Mode::RenameWorkspace);
-        assert!(app.state.pending_workspace_create_cwd.is_some());
-        assert!(app.state.name_input_replace_on_type);
-        assert_eq!(app.state.workspaces.len(), 1);
+            assert_eq!(
+                app.state.mode,
+                Mode::RenameWorkspace,
+                "position: {position:?}"
+            );
+            assert!(app.state.pending_workspace_create_cwd.is_some());
+            assert!(app.state.name_input_replace_on_type);
+            assert_eq!(app.state.workspaces.len(), 1);
+        }
     }
 
     #[tokio::test]

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -10,7 +10,7 @@ impl AppState {
         if self.sidebar_collapsed || sidebar.width <= 1 || sidebar.height == 0 {
             return Rect::default();
         }
-        crate::ui::workspace_list_rect(sidebar, self.sidebar_section_split)
+        crate::ui::workspace_list_rect(sidebar, self.sidebar_section_split, self.sidebar_position)
     }
 
     pub(super) fn agent_panel_rect(&self) -> Rect {
@@ -18,8 +18,11 @@ impl AppState {
         if self.sidebar_collapsed || sidebar.width <= 1 || sidebar.height == 0 {
             return Rect::default();
         }
-        let (_, detail_area) =
-            crate::ui::expanded_sidebar_sections(sidebar, self.sidebar_section_split);
+        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+            sidebar,
+            self.sidebar_section_split,
+            self.sidebar_position,
+        );
         detail_area
     }
 
@@ -176,8 +179,17 @@ impl AppState {
 
     pub(crate) fn sidebar_new_button_rect(&self) -> Rect {
         let footer = self.sidebar_footer_rect();
-        let width = 5u16.min(footer.width.max(1));
-        Rect::new(footer.x, footer.y, width, footer.height)
+        let inset = u16::from(
+            self.sidebar_position == crate::config::SidebarPositionConfig::Right
+                && footer.width > 1,
+        );
+        let width = 5u16.min(footer.width.saturating_sub(inset).max(1));
+        Rect::new(
+            footer.x.saturating_add(inset),
+            footer.y,
+            width,
+            footer.height,
+        )
     }
 
     pub(crate) fn global_launcher_rect(&self) -> Rect {
@@ -238,7 +250,7 @@ impl AppState {
             return false;
         }
         let sidebar = self.view.sidebar_rect;
-        let toggle = crate::ui::expanded_sidebar_toggle_rect(sidebar);
+        let toggle = crate::ui::expanded_sidebar_toggle_rect(sidebar, self.sidebar_position);
         let on_toggle = toggle.width > 0
             && col >= toggle.x
             && col < toggle.x + toggle.width
@@ -246,16 +258,16 @@ impl AppState {
             && row < toggle.y + toggle.height;
         sidebar.width > 0
             && !on_toggle
-            && col == sidebar.x + sidebar.width.saturating_sub(1)
+            && crate::ui::sidebar_divider_x(sidebar, self.sidebar_position) == Some(col)
             && row >= sidebar.y
             && row < sidebar.y + sidebar.height
     }
 
     pub(super) fn on_sidebar_toggle(&self, col: u16, row: u16) -> bool {
         let rect = if self.sidebar_collapsed {
-            crate::ui::collapsed_sidebar_toggle_rect(self.view.sidebar_rect)
+            crate::ui::collapsed_sidebar_toggle_rect(self.view.sidebar_rect, self.sidebar_position)
         } else {
-            crate::ui::expanded_sidebar_toggle_rect(self.view.sidebar_rect)
+            crate::ui::expanded_sidebar_toggle_rect(self.view.sidebar_rect, self.sidebar_position)
         };
         rect.width > 0
             && col >= rect.x
@@ -266,7 +278,15 @@ impl AppState {
 
     pub(super) fn set_manual_sidebar_width(&mut self, divider_col: u16) {
         let sidebar = self.view.sidebar_rect;
-        let width = divider_col.saturating_sub(sidebar.x).saturating_add(1);
+        let width = match self.sidebar_position {
+            crate::config::SidebarPositionConfig::Left => {
+                divider_col.saturating_sub(sidebar.x).saturating_add(1)
+            }
+            crate::config::SidebarPositionConfig::Right => sidebar
+                .x
+                .saturating_add(sidebar.width)
+                .saturating_sub(divider_col),
+        };
         self.sidebar_width = width.clamp(self.sidebar_min_width, self.sidebar_max_width);
         self.sidebar_width_source = crate::app::state::SidebarWidthSource::Manual;
         self.mark_session_dirty();
@@ -279,6 +299,7 @@ impl AppState {
         let rect = crate::ui::sidebar_section_divider_rect(
             self.view.sidebar_rect,
             self.sidebar_section_split,
+            self.sidebar_position,
         );
         rect.width > 0
             && col >= rect.x
@@ -321,7 +342,8 @@ impl AppState {
             return None;
         }
 
-        let (ws_area, _, _) = crate::ui::collapsed_sidebar_sections(self.view.sidebar_rect);
+        let (ws_area, _, _) =
+            crate::ui::collapsed_sidebar_sections(self.view.sidebar_rect, self.sidebar_position);
         if ws_area == Rect::default() || row < ws_area.y || row >= ws_area.y + ws_area.height {
             return None;
         }
@@ -338,7 +360,8 @@ impl AppState {
             return None;
         }
 
-        let (_, _, detail_area) = crate::ui::collapsed_sidebar_sections(self.view.sidebar_rect);
+        let (_, _, detail_area) =
+            crate::ui::collapsed_sidebar_sections(self.view.sidebar_rect, self.sidebar_position);
         let detail_content_area = Rect::new(
             detail_area.x,
             detail_area.y,
@@ -473,6 +496,7 @@ impl AppState {
         let (_, detail_area) = crate::ui::expanded_sidebar_sections(
             self.view.sidebar_rect,
             self.sidebar_section_split,
+            self.sidebar_position,
         );
         let rect = crate::ui::agent_panel_toggle_rect(detail_area, self.agent_panel_sort);
         rect.width > 0
@@ -537,17 +561,24 @@ mod tests {
     };
 
     #[test]
-    fn clicking_launcher_opens_global_menu() {
-        let mut app = app_for_mouse_test();
-        let rect = app.state.global_launcher_rect();
+    fn clicking_launcher_opens_global_menu_from_both_sidebar_positions() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = app_for_mouse_test();
+            app.state.sidebar_position = position;
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
+            let rect = app.state.global_launcher_rect();
 
-        app.handle_mouse(mouse(
-            MouseEventKind::Down(MouseButton::Left),
-            rect.x + rect.width.saturating_sub(1),
-            rect.y,
-        ));
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                rect.x + rect.width.saturating_sub(1),
+                rect.y,
+            ));
 
-        assert_eq!(app.state.mode, Mode::GlobalMenu);
+            assert_eq!(app.state.mode, Mode::GlobalMenu, "position: {position:?}");
+        }
     }
 
     #[test]
@@ -844,27 +875,40 @@ mod tests {
     }
 
     #[test]
-    fn clicking_agent_panel_toggle_switches_sort() {
-        let mut app = app_for_mouse_test();
-        app.state.workspaces = vec![Workspace::test_new("test")];
-        app.state.active = Some(0);
-        app.state.selected = 0;
-        app.state.mode = Mode::Terminal;
-        app.state.agent_panel_scroll = 3;
+    fn clicking_agent_panel_toggle_switches_sort_from_both_positions() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = app_for_mouse_test();
+            app.state.workspaces = vec![Workspace::test_new("test")];
+            app.state.active = Some(0);
+            app.state.selected = 0;
+            app.state.mode = Mode::Terminal;
+            app.state.agent_panel_scroll = 3;
+            app.state.sidebar_position = position;
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
 
-        let (_, detail_area) = crate::ui::expanded_sidebar_sections(
-            app.state.view.sidebar_rect,
-            app.state.sidebar_section_split,
-        );
-        let toggle = crate::ui::agent_panel_toggle_rect(detail_area, app.state.agent_panel_sort);
-        app.handle_mouse(mouse(
-            MouseEventKind::Down(MouseButton::Left),
-            toggle.x,
-            toggle.y,
-        ));
+            let (_, detail_area) = crate::ui::expanded_sidebar_sections(
+                app.state.view.sidebar_rect,
+                app.state.sidebar_section_split,
+                app.state.sidebar_position,
+            );
+            let toggle =
+                crate::ui::agent_panel_toggle_rect(detail_area, app.state.agent_panel_sort);
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                toggle.x,
+                toggle.y,
+            ));
 
-        assert_eq!(app.state.agent_panel_sort, AgentPanelSort::Priority);
-        assert_eq!(app.state.agent_panel_scroll, 0);
+            assert_eq!(
+                app.state.agent_panel_sort,
+                AgentPanelSort::Priority,
+                "position: {position:?}"
+            );
+            assert_eq!(app.state.agent_panel_scroll, 0, "position: {position:?}");
+        }
     }
 
     #[test]
@@ -901,6 +945,7 @@ mod tests {
         let (_, detail_area) = crate::ui::expanded_sidebar_sections(
             app.state.view.sidebar_rect,
             app.state.sidebar_section_split,
+            app.state.sidebar_position,
         );
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
@@ -1076,8 +1121,10 @@ mod tests {
         app.state.view.sidebar_rect = Rect::new(0, 0, 4, 20);
         app.state.view.terminal_area = Rect::new(4, 0, 80, 20);
 
-        let (_, _, detail_area) =
-            crate::ui::collapsed_sidebar_sections(app.state.view.sidebar_rect);
+        let (_, _, detail_area) = crate::ui::collapsed_sidebar_sections(
+            app.state.view.sidebar_rect,
+            app.state.sidebar_position,
+        );
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             detail_area.x,
@@ -1121,8 +1168,10 @@ mod tests {
         set_state(&mut app, 0, first_pane, AgentState::Working);
         set_state(&mut app, 1, second_pane, AgentState::Blocked);
 
-        let (_, _, detail_area) =
-            crate::ui::collapsed_sidebar_sections(app.state.view.sidebar_rect);
+        let (_, _, detail_area) = crate::ui::collapsed_sidebar_sections(
+            app.state.view.sidebar_rect,
+            app.state.sidebar_position,
+        );
         app.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             detail_area.x,
@@ -1138,20 +1187,28 @@ mod tests {
     }
 
     #[test]
-    fn clicking_collapsed_sidebar_toggle_expands_sidebar() {
-        let mut app = app_for_mouse_test();
-        app.state.sidebar_collapsed = true;
-        app.state.view.sidebar_rect = Rect::new(0, 0, 4, 20);
-        app.state.view.terminal_area = Rect::new(4, 0, 80, 20);
+    fn clicking_collapsed_sidebar_toggle_expands_from_both_positions() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = app_for_mouse_test();
+            app.state.sidebar_collapsed = true;
+            app.state.sidebar_position = position;
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
 
-        let toggle = crate::ui::collapsed_sidebar_toggle_rect(app.state.view.sidebar_rect);
-        app.handle_mouse(mouse(
-            MouseEventKind::Down(MouseButton::Left),
-            toggle.x,
-            toggle.y,
-        ));
+            let toggle = crate::ui::collapsed_sidebar_toggle_rect(
+                app.state.view.sidebar_rect,
+                app.state.sidebar_position,
+            );
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                toggle.x,
+                toggle.y,
+            ));
 
-        assert!(!app.state.sidebar_collapsed);
+            assert!(!app.state.sidebar_collapsed, "position: {position:?}");
+        }
     }
 
     #[test]
@@ -1168,21 +1225,29 @@ mod tests {
     }
 
     #[test]
-    fn clicking_expanded_sidebar_toggle_collapses_sidebar() {
-        let mut app = app_for_mouse_test();
-        app.state.sidebar_collapsed = false;
-        app.state.view.sidebar_rect = Rect::new(0, 0, 26, 20);
-        app.state.view.terminal_area = Rect::new(26, 0, 80, 20);
+    fn clicking_expanded_sidebar_toggle_collapses_from_both_positions() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = app_for_mouse_test();
+            app.state.sidebar_collapsed = false;
+            app.state.sidebar_position = position;
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
 
-        let toggle = crate::ui::expanded_sidebar_toggle_rect(app.state.view.sidebar_rect);
-        app.handle_mouse(mouse(
-            MouseEventKind::Down(MouseButton::Left),
-            toggle.x,
-            toggle.y,
-        ));
+            let toggle = crate::ui::expanded_sidebar_toggle_rect(
+                app.state.view.sidebar_rect,
+                app.state.sidebar_position,
+            );
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                toggle.x,
+                toggle.y,
+            ));
 
-        assert!(app.state.sidebar_collapsed);
-        assert!(app.state.drag.is_none());
+            assert!(app.state.sidebar_collapsed, "position: {position:?}");
+            assert!(app.state.drag.is_none(), "position: {position:?}");
+        }
     }
 
     #[test]
@@ -1282,6 +1347,29 @@ mod tests {
         ));
 
         assert!(!app.state.collapsed_space_keys.contains("repo-key"));
+    }
+
+    #[test]
+    fn right_sidebar_scrollbar_uses_content_edge_for_hit_testing() {
+        let mut app = app_for_mouse_test();
+        app.state.sidebar_position = crate::config::SidebarPositionConfig::Right;
+        app.state.workspaces = (0..20)
+            .map(|idx| Workspace::test_new(&format!("workspace-{idx}")))
+            .collect();
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 30));
+
+        let list = app.state.workspace_list_rect();
+        let track = crate::ui::workspace_list_scrollbar_rect(&app.state, list)
+            .expect("right sidebar workspace list should scroll");
+
+        assert_eq!(track.x, list.x + list.width - 1);
+        assert!(track.x > app.state.view.sidebar_rect.x);
+        assert!(app
+            .state
+            .workspace_list_scrollbar_target_at(track.x, track.y)
+            .is_some());
     }
 
     #[test]
@@ -1847,6 +1935,31 @@ mod tests {
     }
 
     #[test]
+    fn dragging_right_sidebar_divider_tracks_both_directions() {
+        for (delta, expected_width) in [(-5i16, 31u16), (5, 21)] {
+            let mut app = app_for_mouse_test();
+            app.state.sidebar_position = crate::config::SidebarPositionConfig::Right;
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
+            let divider_col = app.state.view.sidebar_rect.x;
+
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                divider_col,
+                5,
+            ));
+            app.handle_mouse(mouse(
+                MouseEventKind::Drag(MouseButton::Left),
+                divider_col.saturating_add_signed(delta),
+                5,
+            ));
+
+            assert_eq!(app.state.sidebar_width, expected_width, "delta: {delta}");
+            let snapshot = capture_snapshot(&app.state);
+            assert_eq!(snapshot.sidebar_width, Some(expected_width));
+        }
+    }
+
+    #[test]
     fn dragging_sidebar_bottom_divider_still_sets_manual_width() {
         let mut app = app_for_mouse_test();
         let divider_col = app.state.view.sidebar_rect.x + app.state.view.sidebar_rect.width - 1;
@@ -1889,30 +2002,41 @@ mod tests {
     }
 
     #[test]
-    fn dragging_sidebar_section_divider_sets_split_ratio() {
-        let mut app = app_for_mouse_test();
-        let divider = crate::ui::sidebar_section_divider_rect(
-            app.state.view.sidebar_rect,
-            app.state.sidebar_section_split,
-        );
+    fn dragging_sidebar_section_divider_sets_split_ratio_from_both_positions() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = app_for_mouse_test();
+            app.state.sidebar_position = position;
+            crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
+            let divider = crate::ui::sidebar_section_divider_rect(
+                app.state.view.sidebar_rect,
+                app.state.sidebar_section_split,
+                app.state.sidebar_position,
+            );
 
-        app.handle_mouse(mouse(
-            MouseEventKind::Down(MouseButton::Left),
-            divider.x + 1,
-            divider.y,
-        ));
-        app.handle_mouse(mouse(
-            MouseEventKind::Drag(MouseButton::Left),
-            divider.x + 1,
-            divider.y + 4,
-        ));
+            app.handle_mouse(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                divider.x + 1,
+                divider.y,
+            ));
+            app.handle_mouse(mouse(
+                MouseEventKind::Drag(MouseButton::Left),
+                divider.x + 1,
+                divider.y + 4,
+            ));
 
-        assert!(app.state.sidebar_section_split > 0.5);
-        let snapshot = capture_snapshot(&app.state);
-        assert_eq!(
-            snapshot.sidebar_section_split,
-            Some(app.state.sidebar_section_split)
-        );
+            assert!(
+                app.state.sidebar_section_split > 0.5,
+                "position: {position:?}"
+            );
+            let snapshot = capture_snapshot(&app.state);
+            assert_eq!(
+                snapshot.sidebar_section_split,
+                Some(app.state.sidebar_section_split)
+            );
+        }
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -609,6 +609,7 @@ impl App {
             sidebar_width,
             sidebar_min_width,
             sidebar_max_width,
+            sidebar_position: config.ui.sidebar_position,
             mobile_width_threshold: config.ui.mobile_width_threshold,
             sidebar_width_source,
             sidebar_width_auto: false,
@@ -1413,6 +1414,7 @@ impl App {
                 }
                 self.state.sidebar_min_width = config.ui.sidebar_min_width;
                 self.state.sidebar_max_width = config.ui.sidebar_max_width;
+                self.state.sidebar_position = config.ui.sidebar_position;
                 self.state.sidebar_collapsed_mode = config.ui.sidebar_collapsed_mode;
                 self.state.mobile_width_threshold = config.ui.mobile_width_threshold;
                 // Re-clamp the live width to the new bounds. No source guard — bounds
@@ -2626,11 +2628,16 @@ mod tests {
     fn startup_uses_configured_sidebar_state() {
         let mut config = Config::default();
         config.ui.sidebar_start_collapsed = true;
+        config.ui.sidebar_position = crate::config::SidebarPositionConfig::Right;
         let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let app = App::new(&config, true, None, api_rx, crate::api::EventHub::default());
 
         assert!(app.state.sidebar_collapsed);
+        assert_eq!(
+            app.state.sidebar_position,
+            crate::config::SidebarPositionConfig::Right
+        );
     }
 
     #[test]
@@ -3086,9 +3093,9 @@ mod tests {
     }
 
     #[test]
-    fn reload_config_updates_sidebar_collapsed_mode() {
+    fn reload_config_updates_sidebar_presentation() {
         let _guard = config_env_lock().lock().unwrap();
-        let path = temp_config_path("reload-config-sidebar-collapsed-mode");
+        let path = temp_config_path("reload-config-sidebar-presentation");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::env::set_var(crate::config::CONFIG_PATH_ENV_VAR, &path);
 
@@ -3097,13 +3104,25 @@ mod tests {
             app.state.sidebar_collapsed_mode,
             crate::config::SidebarCollapsedModeConfig::Compact
         );
+        assert_eq!(
+            app.state.sidebar_position,
+            crate::config::SidebarPositionConfig::Left
+        );
 
-        std::fs::write(&path, "[ui]\nsidebar_collapsed_mode = \"hidden\"\n").unwrap();
+        std::fs::write(
+            &path,
+            "[ui]\nsidebar_collapsed_mode = \"hidden\"\nsidebar_position = \"right\"\n",
+        )
+        .unwrap();
         let report = app.reload_config();
         assert_eq!(report.status, crate::config::ConfigReloadStatus::Applied);
         assert_eq!(
             app.state.sidebar_collapsed_mode,
             crate::config::SidebarCollapsedModeConfig::Hidden
+        );
+        assert_eq!(
+            app.state.sidebar_position,
+            crate::config::SidebarPositionConfig::Right
         );
 
         std::env::remove_var(crate::config::CONFIG_PATH_ENV_VAR);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,6 @@
 use crate::config::{
-    Keybinds, NewTerminalCwdConfig, SoundConfig, TabBarPositionConfig, ToastConfig, ToastDelivery,
+    Keybinds, NewTerminalCwdConfig, SidebarPositionConfig, SoundConfig, TabBarPositionConfig,
+    ToastConfig, ToastDelivery,
 };
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::{Direction, Rect};
@@ -1468,6 +1469,7 @@ pub struct AppState {
     pub sidebar_width: u16,
     pub sidebar_min_width: u16,
     pub sidebar_max_width: u16,
+    pub sidebar_position: SidebarPositionConfig,
     pub mobile_width_threshold: u16,
     pub sidebar_width_source: SidebarWidthSource,
     pub sidebar_width_auto: bool,
@@ -1840,6 +1842,7 @@ impl AppState {
             sidebar_width: 26,
             sidebar_min_width: 18,
             sidebar_max_width: 36,
+            sidebar_position: SidebarPositionConfig::Left,
             mobile_width_threshold: crate::config::DEFAULT_MOBILE_WIDTH_THRESHOLD,
             sidebar_width_source: SidebarWidthSource::ConfigDefault,
             sidebar_width_auto: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,9 @@ pub use self::{
     model::{
         validated_sidebar_bounds, AgentPanelSortConfig, Config, ConfigReloadReport,
         ConfigReloadStatus, HostCursorModeConfig, NewTerminalCwdConfig, ShellModeConfig,
-        SidebarCollapsedModeConfig, TabBarPositionConfig, ToastClipboardPosition, ToastConfig,
-        ToastDelivery, ToastHerdrPosition, UpdateChannelConfig, MAX_TOAST_DELAY_SECONDS,
+        SidebarCollapsedModeConfig, SidebarPositionConfig, TabBarPositionConfig,
+        ToastClipboardPosition, ToastConfig, ToastDelivery, ToastHerdrPosition,
+        UpdateChannelConfig, MAX_TOAST_DELAY_SECONDS,
     },
     sidebar::{
         AgentSidebarToken, AgentsSidebarConfig, SidebarConfig, SidebarTokenStyle,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -123,6 +123,14 @@ pub enum SidebarCollapsedModeConfig {
     Hidden,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SidebarPositionConfig {
+    #[default]
+    Left,
+    Right,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RightClickPassthroughModifierConfig(Option<KeyModifiers>);
 
@@ -788,6 +796,8 @@ pub struct UiConfig {
     pub sidebar_min_width: u16,
     /// Maximum sidebar width (columns) when expanded. Default: 36.
     pub sidebar_max_width: u16,
+    /// Desktop sidebar placement. Default: left.
+    pub sidebar_position: SidebarPositionConfig,
     /// Start with the sidebar collapsed. Default: false.
     pub sidebar_start_collapsed: bool,
     /// Collapsed sidebar presentation. Default: compact.
@@ -1010,6 +1020,7 @@ impl Default for UiConfig {
             sidebar_width: 26,
             sidebar_min_width: 18,
             sidebar_max_width: 36,
+            sidebar_position: SidebarPositionConfig::Left,
             sidebar_start_collapsed: false,
             sidebar_collapsed_mode: SidebarCollapsedModeConfig::Compact,
             mobile_width_threshold: DEFAULT_MOBILE_WIDTH_THRESHOLD,
@@ -1407,6 +1418,23 @@ mobile_width_threshold = 96
         assert_eq!(config.ui.sidebar_min_width, 12);
         assert_eq!(config.ui.sidebar_max_width, 80);
         assert_eq!(config.ui.mobile_width_threshold, 96);
+    }
+
+    #[test]
+    fn sidebar_position_defaults_left_and_parses_right() {
+        assert_eq!(
+            Config::default().ui.sidebar_position,
+            SidebarPositionConfig::Left
+        );
+
+        let config: Config = toml::from_str(
+            r#"
+[ui]
+sidebar_position = "right"
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.ui.sidebar_position, SidebarPositionConfig::Right);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,9 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Maximum sidebar width when expanded (columns)
 # sidebar_max_width = 36
 
+# Desktop sidebar placement: "left" or "right".
+# sidebar_position = "left"
+
 # Start with the sidebar collapsed. Changes take effect on the next launch.
 # sidebar_start_collapsed = false
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -80,11 +80,11 @@ pub(crate) use self::{
         agent_panel_scroll_for_target, agent_panel_scroll_metrics, agent_panel_scrollbar_rect,
         agent_panel_toggle_rect, all_agent_panel_entries, collapsed_sidebar_sections,
         collapsed_sidebar_toggle_rect, compute_workspace_card_areas, expanded_sidebar_sections,
-        expanded_sidebar_toggle_rect, normalized_workspace_scroll, sidebar_section_divider_rect,
-        workspace_drop_slots, workspace_group_chevron_rect, workspace_list_entries,
-        workspace_list_entries_expanded, workspace_list_rect, workspace_list_scroll_metrics,
-        workspace_list_scrollbar_rect, workspace_parent_group_state, AgentPanelEntry,
-        WorkspaceListEntry,
+        expanded_sidebar_toggle_rect, normalized_workspace_scroll, sidebar_divider_x,
+        sidebar_section_divider_rect, workspace_drop_slots, workspace_group_chevron_rect,
+        workspace_list_entries, workspace_list_entries_expanded, workspace_list_rect,
+        workspace_list_scroll_metrics, workspace_list_scrollbar_rect, workspace_parent_group_state,
+        AgentPanelEntry, WorkspaceListEntry,
     },
 };
 
@@ -234,8 +234,18 @@ fn compute_view_internal(
             .clamp(app.sidebar_min_width, app.sidebar_max_width)
     };
 
-    let [sidebar_area, main_area] =
-        Layout::horizontal([Constraint::Length(sidebar_w), Constraint::Min(1)]).areas(area);
+    let (sidebar_area, main_area) = match app.sidebar_position {
+        crate::config::SidebarPositionConfig::Left => {
+            let [sidebar_area, main_area] =
+                Layout::horizontal([Constraint::Length(sidebar_w), Constraint::Min(1)]).areas(area);
+            (sidebar_area, main_area)
+        }
+        crate::config::SidebarPositionConfig::Right => {
+            let [main_area, sidebar_area] =
+                Layout::horizontal([Constraint::Min(1), Constraint::Length(sidebar_w)]).areas(area);
+            (sidebar_area, main_area)
+        }
+    };
 
     let (tab_bar_rect, terminal_area) = app
         .active
@@ -245,7 +255,11 @@ fn compute_view_internal(
 
     if !app.sidebar_collapsed {
         app.workspace_scroll = normalized_workspace_scroll(app, sidebar_area, app.workspace_scroll);
-        let (_, detail_area) = expanded_sidebar_sections(sidebar_area, app.sidebar_section_split);
+        let (_, detail_area) = expanded_sidebar_sections(
+            sidebar_area,
+            app.sidebar_section_split,
+            app.sidebar_position,
+        );
         let max_agent_scroll = agent_panel_scroll_metrics(app, detail_area).max_offset_from_bottom;
         app.agent_panel_scroll = app.agent_panel_scroll.min(max_agent_scroll);
     } else {
@@ -1031,6 +1045,35 @@ mod tests {
     }
 
     #[test]
+    fn right_sidebar_places_chrome_and_content_on_right() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.sidebar_position = crate::config::SidebarPositionConfig::Right;
+        app.workspaces = vec![Workspace::test_new("one")];
+        app.active = Some(0);
+        app.selected = 0;
+        app.mode = Mode::Terminal;
+
+        compute_view(&mut app, Rect::new(0, 0, 80, 20));
+
+        assert_eq!(app.view.sidebar_rect, Rect::new(54, 0, 26, 20));
+        assert_eq!(app.view.tab_bar_rect, Rect::new(0, 0, 54, 1));
+        assert_eq!(app.view.terminal_area, Rect::new(0, 1, 54, 19));
+        assert_eq!(app.view.workspace_card_areas[0].rect.x, 55);
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(&app, frame)).unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(54, 5)].symbol(), "│");
+        assert_eq!(buffer[(55, 19)].symbol(), "»");
+
+        let new_button = app.sidebar_new_button_rect();
+        assert_eq!(buffer[(new_button.x + 1, new_button.y)].symbol(), "n");
+        let menu = app.global_launcher_rect();
+        assert_eq!(buffer[(menu.x + 2, menu.y)].symbol(), "m");
+    }
+
+    #[test]
     fn hidden_collapsed_sidebar_uses_full_width_terminal_area() {
         let mut app = crate::app::state::AppState::test_new();
         app.sidebar_collapsed = true;
@@ -1053,26 +1096,47 @@ mod tests {
     }
 
     #[test]
-    fn collapsed_sidebar_keeps_active_workspace_highlight_in_terminal_mode() {
-        let mut app = crate::app::state::AppState::test_new();
-        app.sidebar_collapsed = true;
-        app.workspaces = vec![Workspace::test_new("one"), Workspace::test_new("two")];
-        app.active = Some(1);
-        app.selected = 0;
-        app.mode = Mode::Terminal;
+    fn collapsed_sidebar_tracks_position_and_active_workspace_highlight() {
+        for position in [
+            crate::config::SidebarPositionConfig::Left,
+            crate::config::SidebarPositionConfig::Right,
+        ] {
+            let mut app = crate::app::state::AppState::test_new();
+            app.sidebar_collapsed = true;
+            app.sidebar_position = position;
+            app.workspaces = vec![Workspace::test_new("one"), Workspace::test_new("two")];
+            app.active = Some(1);
+            app.selected = 0;
+            app.mode = Mode::Terminal;
 
-        compute_view(&mut app, Rect::new(0, 0, 80, 20));
+            compute_view(&mut app, Rect::new(0, 0, 80, 20));
 
-        let backend = TestBackend::new(80, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|frame| render(&app, frame)).unwrap();
-        let buffer = terminal.backend().buffer();
+            let backend = TestBackend::new(80, 20);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|frame| render(&app, frame)).unwrap();
+            let buffer = terminal.backend().buffer();
 
-        let (ws_area, _, _) = collapsed_sidebar_sections(app.view.sidebar_rect);
-        let active_row = ws_area.y + 1;
-        let active_style = buffer[(ws_area.x, active_row)].style();
+            let (ws_area, _, _) =
+                collapsed_sidebar_sections(app.view.sidebar_rect, app.sidebar_position);
+            let expected_x = match position {
+                crate::config::SidebarPositionConfig::Left => 0,
+                crate::config::SidebarPositionConfig::Right => 77,
+            };
+            assert_eq!(ws_area.x, expected_x);
 
-        assert_eq!(active_style.bg, Some(app.palette.surface_dim));
+            let active_row = ws_area.y + 1;
+            let active_style = buffer[(ws_area.x, active_row)].style();
+            assert_eq!(active_style.bg, Some(app.palette.surface_dim));
+
+            let divider_x = sidebar_divider_x(app.view.sidebar_rect, position).unwrap();
+            assert_eq!(buffer[(divider_x, 5)].symbol(), "│");
+            let toggle = collapsed_sidebar_toggle_rect(app.view.sidebar_rect, position);
+            let expected_icon = match position {
+                crate::config::SidebarPositionConfig::Left => "»",
+                crate::config::SidebarPositionConfig::Right => "«",
+            };
+            assert_eq!(buffer[(toggle.x, toggle.y)].symbol(), expected_icon);
+        }
     }
 
     #[test]

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -14,6 +14,7 @@ use super::status::{state_dot, state_label, state_label_color};
 use super::text::{display_width, display_width_u16, truncate_end};
 use crate::app::state::{AgentPanelSort, Palette};
 use crate::app::{AppState, Mode};
+use crate::config::SidebarPositionConfig;
 use crate::detect::AgentState;
 use crate::terminal::TerminalRuntimeRegistry;
 
@@ -56,8 +57,29 @@ fn sidebar_section_heights(total_h: u16, split_ratio: f32) -> (u16, u16) {
     (ws_h, detail_h)
 }
 
-pub(crate) fn expanded_sidebar_sections(area: Rect, split_ratio: f32) -> (Rect, Rect) {
-    let content = Rect::new(area.x, area.y, area.width.saturating_sub(1), area.height);
+fn sidebar_content_rect(area: Rect, position: SidebarPositionConfig) -> Rect {
+    let width = area.width.saturating_sub(1);
+    let x = match position {
+        SidebarPositionConfig::Left => area.x,
+        SidebarPositionConfig::Right if area.width > 0 => area.x.saturating_add(1),
+        SidebarPositionConfig::Right => area.x,
+    };
+    Rect::new(x, area.y, width, area.height)
+}
+
+pub(crate) fn sidebar_divider_x(area: Rect, position: SidebarPositionConfig) -> Option<u16> {
+    (area.width > 0).then(|| match position {
+        SidebarPositionConfig::Left => area.x.saturating_add(area.width.saturating_sub(1)),
+        SidebarPositionConfig::Right => area.x,
+    })
+}
+
+pub(crate) fn expanded_sidebar_sections(
+    area: Rect,
+    split_ratio: f32,
+    position: SidebarPositionConfig,
+) -> (Rect, Rect) {
+    let content = sidebar_content_rect(area, position);
     if content.width == 0 || content.height == 0 {
         return (Rect::default(), Rect::default());
     }
@@ -68,8 +90,12 @@ pub(crate) fn expanded_sidebar_sections(area: Rect, split_ratio: f32) -> (Rect, 
     (ws_area, detail_area)
 }
 
-pub(crate) fn sidebar_section_divider_rect(area: Rect, split_ratio: f32) -> Rect {
-    let content = Rect::new(area.x, area.y, area.width.saturating_sub(1), area.height);
+pub(crate) fn sidebar_section_divider_rect(
+    area: Rect,
+    split_ratio: f32,
+    position: SidebarPositionConfig,
+) -> Rect {
+    let content = sidebar_content_rect(area, position);
     if content.width == 0 || content.height < 6 {
         return Rect::default();
     }
@@ -311,7 +337,7 @@ pub(crate) fn next_entry_is_indented_workspace(entries: &[WorkspaceListEntry], i
 }
 
 pub(crate) fn normalized_workspace_scroll(app: &AppState, area: Rect, requested: usize) -> usize {
-    let ws_area = workspace_list_rect(area, app.sidebar_section_split);
+    let ws_area = workspace_list_rect(area, app.sidebar_section_split, app.sidebar_position);
     let body = workspace_list_body_rect(ws_area, false);
     if body.height == 0 {
         return requested;
@@ -435,8 +461,12 @@ fn workspace_list_entries_inner(app: &AppState, force_expanded: bool) -> Vec<Wor
     entries
 }
 
-pub(crate) fn workspace_list_rect(area: Rect, split_ratio: f32) -> Rect {
-    let (ws_area, _) = expanded_sidebar_sections(area, split_ratio);
+pub(crate) fn workspace_list_rect(
+    area: Rect,
+    split_ratio: f32,
+    position: SidebarPositionConfig,
+) -> Rect {
+    let (ws_area, _) = expanded_sidebar_sections(area, split_ratio, position);
     ws_area
 }
 
@@ -659,7 +689,7 @@ pub(crate) fn compute_workspace_list_areas(
     app: &AppState,
     area: Rect,
 ) -> (Vec<crate::app::state::WorkspaceCardArea>, Vec<()>) {
-    let ws_area = workspace_list_rect(area, app.sidebar_section_split);
+    let ws_area = workspace_list_rect(area, app.sidebar_section_split, app.sidebar_position);
     if ws_area == Rect::default() {
         return (Vec::new(), Vec::new());
     }
@@ -725,8 +755,11 @@ pub(crate) fn workspace_group_chevron_rect(card: &crate::app::state::WorkspaceCa
 }
 
 /// Auto-scale sidebar width based on workspace identity + agent summary.
-pub(crate) fn collapsed_sidebar_sections(area: Rect) -> (Rect, Option<u16>, Rect) {
-    let content = Rect::new(area.x, area.y, area.width.saturating_sub(1), area.height);
+pub(crate) fn collapsed_sidebar_sections(
+    area: Rect,
+    position: SidebarPositionConfig,
+) -> (Rect, Option<u16>, Rect) {
+    let content = sidebar_content_rect(area, position);
     if content.width == 0 || content.height == 0 {
         return (Rect::default(), None, Rect::default());
     }
@@ -762,14 +795,16 @@ pub(super) fn render_sidebar_collapsed(app: &AppState, frame: &mut Frame, area: 
     } else {
         Style::default().fg(p.surface_dim)
     };
-    let sep_x = area.x + area.width.saturating_sub(1);
+    let Some(sep_x) = sidebar_divider_x(area, app.sidebar_position) else {
+        return;
+    };
     let buf = frame.buffer_mut();
     for y in area.y..area.y + area.height {
         buf[(sep_x, y)].set_symbol("│");
         buf[(sep_x, y)].set_style(sep_style);
     }
 
-    let (ws_area, divider_y, detail_area) = collapsed_sidebar_sections(area);
+    let (ws_area, divider_y, detail_area) = collapsed_sidebar_sections(area, app.sidebar_position);
     if ws_area == Rect::default() {
         render_sidebar_toggle(app, frame, area, true, p);
         return;
@@ -966,14 +1001,17 @@ pub(super) fn render_sidebar(
         Style::default().fg(p.surface_dim)
     };
 
-    let sep_x = area.x + area.width.saturating_sub(1);
+    let Some(sep_x) = sidebar_divider_x(area, app.sidebar_position) else {
+        return;
+    };
     let buf = frame.buffer_mut();
     for y in area.y..area.y + area.height {
         buf[(sep_x, y)].set_symbol("│");
         buf[(sep_x, y)].set_style(sep_style);
     }
 
-    let (ws_area, detail_area) = expanded_sidebar_sections(area, app.sidebar_section_split);
+    let (ws_area, detail_area) =
+        expanded_sidebar_sections(area, app.sidebar_section_split, app.sidebar_position);
 
     render_workspace_list(app, terminal_runtimes, frame, ws_area, is_navigating);
     render_agent_detail(app, terminal_runtimes, frame, detail_area);
@@ -1519,26 +1557,29 @@ fn render_agent_detail(
     }
 }
 
-pub(crate) fn collapsed_sidebar_toggle_rect(area: Rect) -> Rect {
-    let bottom_y = area.y + area.height.saturating_sub(1);
-    let content_w = area.width.saturating_sub(1);
-    if content_w == 0 || area.height == 0 {
-        return Rect::default();
-    }
-    let x = area.x + content_w / 2;
-    Rect::new(x, bottom_y, 1, 1)
-}
-
-pub(crate) fn expanded_sidebar_toggle_rect(area: Rect) -> Rect {
-    if area.width <= 1 || area.height == 0 {
+pub(crate) fn collapsed_sidebar_toggle_rect(area: Rect, position: SidebarPositionConfig) -> Rect {
+    let content = sidebar_content_rect(area, position);
+    if content.width == 0 || content.height == 0 {
         return Rect::default();
     }
     Rect::new(
-        area.x + area.width.saturating_sub(2),
-        area.y + area.height.saturating_sub(1),
+        content.x + content.width / 2,
+        content.y + content.height.saturating_sub(1),
         1,
         1,
     )
+}
+
+pub(crate) fn expanded_sidebar_toggle_rect(area: Rect, position: SidebarPositionConfig) -> Rect {
+    let content = sidebar_content_rect(area, position);
+    if content.width == 0 || content.height == 0 {
+        return Rect::default();
+    }
+    let x = match position {
+        SidebarPositionConfig::Left => content.x + content.width.saturating_sub(1),
+        SidebarPositionConfig::Right => content.x,
+    };
+    Rect::new(x, content.y + content.height.saturating_sub(1), 1, 1)
 }
 
 fn render_sidebar_toggle(
@@ -1549,14 +1590,17 @@ fn render_sidebar_toggle(
     p: &Palette,
 ) {
     let toggle_area = if collapsed {
-        collapsed_sidebar_toggle_rect(area)
+        collapsed_sidebar_toggle_rect(area, app.sidebar_position)
     } else {
-        expanded_sidebar_toggle_rect(area)
+        expanded_sidebar_toggle_rect(area, app.sidebar_position)
     };
     if toggle_area == Rect::default() {
         return;
     }
-    let icon = if collapsed { "»" } else { "«" };
+    let icon = match (app.sidebar_position, collapsed) {
+        (SidebarPositionConfig::Left, false) | (SidebarPositionConfig::Right, true) => "«",
+        (SidebarPositionConfig::Left, true) | (SidebarPositionConfig::Right, false) => "»",
+    };
     let icon_style = if collapsed && app.global_menu_attention_badge_visible() {
         Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
     } else {
@@ -1611,7 +1655,8 @@ mod tests {
             .draw(|frame| render_sidebar(&app, &TerminalRuntimeRegistry::new(), frame, area))
             .unwrap();
         let buffer = terminal.backend().buffer();
-        let (_, agent_area) = expanded_sidebar_sections(area, app.sidebar_section_split);
+        let (_, agent_area) =
+            expanded_sidebar_sections(area, app.sidebar_section_split, app.sidebar_position);
         let body = agent_panel_body_rect(agent_area, false);
 
         let first = row_text(buffer, body.y, 25);
@@ -1662,7 +1707,8 @@ rows = [[{ token = "workspace", bold = false }, { token = "agent", dim = false }
         terminal
             .draw(|frame| render_sidebar(&app, &TerminalRuntimeRegistry::new(), frame, area))
             .unwrap();
-        let (_, agent_area) = expanded_sidebar_sections(area, app.sidebar_section_split);
+        let (_, agent_area) =
+            expanded_sidebar_sections(area, app.sidebar_section_split, app.sidebar_position);
         let body = agent_panel_body_rect(agent_area, false);
         let buffer = terminal.backend().buffer();
         let workspace = buffer[(find_symbol_x(buffer, body.y, body.width, "o"), body.y)].style();
@@ -1834,7 +1880,8 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
             .draw(|frame| render_sidebar(&app, &TerminalRuntimeRegistry::new(), frame, area))
             .unwrap();
         let buffer = terminal.backend().buffer();
-        let (_, agent_area) = expanded_sidebar_sections(area, app.sidebar_section_split);
+        let (_, agent_area) =
+            expanded_sidebar_sections(area, app.sidebar_section_split, app.sidebar_position);
         let body = agent_panel_body_rect(agent_area, false);
         let first = row_text(buffer, body.y, 17);
 
@@ -1864,7 +1911,8 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         renderer
             .draw(|frame| render_sidebar(&app, &TerminalRuntimeRegistry::new(), frame, area))
             .unwrap();
-        let (_, agent_area) = expanded_sidebar_sections(area, app.sidebar_section_split);
+        let (_, agent_area) =
+            expanded_sidebar_sections(area, app.sidebar_section_split, app.sidebar_position);
         let body = agent_panel_body_rect(agent_area, false);
         let rendered = row_text(renderer.backend().buffer(), body.y, 9);
 
@@ -1940,7 +1988,8 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         app.workspaces = vec![Workspace::test_new("one"), Workspace::test_new("two")];
         app.sidebar_spaces.rows = vec![vec![crate::config::SpaceSidebarToken::Workspace]; 6];
         let area = Rect::new(0, 0, 20, 10);
-        let workspace_area = workspace_list_rect(area, app.sidebar_section_split);
+        let workspace_area =
+            workspace_list_rect(area, app.sidebar_section_split, app.sidebar_position);
         let body = workspace_list_body_rect(workspace_area, false);
 
         let metrics = workspace_list_scroll_metrics(&app, workspace_area);
@@ -1991,7 +2040,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
             .draw(|frame| render_sidebar_toggle(&app, frame, area, false, &app.palette))
             .expect("sidebar toggle should render");
 
-        let toggle = expanded_sidebar_toggle_rect(area);
+        let toggle = expanded_sidebar_toggle_rect(area, app.sidebar_position);
         assert_eq!(
             terminal.backend().buffer()[(toggle.x, toggle.y)].symbol(),
             "«"
@@ -1999,12 +2048,14 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
     }
 
     #[test]
-    fn expanded_sidebar_toggle_sits_inside_sidebar_content() {
-        let area = Rect::new(0, 0, 26, 20);
-        let toggle = expanded_sidebar_toggle_rect(area);
+    fn expanded_sidebar_toggle_tracks_sidebar_position() {
+        let area = Rect::new(40, 0, 26, 20);
 
-        assert_eq!(toggle.x, area.x + area.width - 2);
-        assert_eq!(toggle.y, area.y + area.height - 1);
+        let left = expanded_sidebar_toggle_rect(area, SidebarPositionConfig::Left);
+        let right = expanded_sidebar_toggle_rect(area, SidebarPositionConfig::Right);
+
+        assert_eq!(left, Rect::new(64, 19, 1, 1));
+        assert_eq!(right, Rect::new(41, 19, 1, 1));
     }
 
     #[test]
@@ -2111,7 +2162,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         }
 
         let area = Rect::new(0, 0, 4, 12);
-        let (_, _, detail_area) = collapsed_sidebar_sections(area);
+        let (_, _, detail_area) = collapsed_sidebar_sections(area, app.sidebar_position);
         let mut terminal = Terminal::new(TestBackend::new(area.width, area.height))
             .expect("test terminal should initialize");
 
@@ -2141,7 +2192,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         }
 
         let area = Rect::new(0, 0, 4, 25);
-        let (workspace_area, _, _) = collapsed_sidebar_sections(area);
+        let (workspace_area, _, _) = collapsed_sidebar_sections(area, app.sidebar_position);
         let mut terminal = Terminal::new(TestBackend::new(area.width, area.height))
             .expect("test terminal should initialize");
 
@@ -2182,7 +2233,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         }
 
         let area = Rect::new(0, 0, 4, 25);
-        let (_, _, detail_area) = collapsed_sidebar_sections(area);
+        let (_, _, detail_area) = collapsed_sidebar_sections(area, app.sidebar_position);
         let mut terminal = Terminal::new(TestBackend::new(area.width, area.height))
             .expect("test terminal should initialize");
 
@@ -2226,7 +2277,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         assert_eq!(agent_panel_entries(&app)[0].pane_id, urgent_pane);
 
         let area = Rect::new(0, 0, 4, 16);
-        let (_, _, detail_area) = collapsed_sidebar_sections(area);
+        let (_, _, detail_area) = collapsed_sidebar_sections(area, app.sidebar_position);
         let mut terminal = Terminal::new(TestBackend::new(area.width, area.height))
             .expect("test terminal should initialize");
 
@@ -2343,7 +2394,8 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
 
     #[test]
     fn expanded_sidebar_sections_handle_tiny_heights() {
-        let (ws_area, detail_area) = expanded_sidebar_sections(Rect::new(0, 0, 20, 5), 0.9);
+        let (ws_area, detail_area) =
+            expanded_sidebar_sections(Rect::new(0, 0, 20, 5), 0.9, SidebarPositionConfig::Left);
 
         assert_eq!(ws_area, Rect::new(0, 0, 19, 3));
         assert_eq!(detail_area, Rect::new(0, 3, 19, 2));
@@ -2351,7 +2403,8 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
 
     #[test]
     fn sidebar_section_divider_is_hidden_for_tiny_heights() {
-        let divider = sidebar_section_divider_rect(Rect::new(0, 0, 20, 5), 0.5);
+        let divider =
+            sidebar_section_divider_rect(Rect::new(0, 0, 20, 5), 0.5, SidebarPositionConfig::Left);
 
         assert_eq!(divider, Rect::default());
     }
@@ -2443,7 +2496,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         app.sidebar_spaces.row_gap = 0;
         let area = Rect::new(0, 0, 30, 20);
         app.view.workspace_card_areas = compute_workspace_card_areas(&app, area);
-        let list_area = workspace_list_rect(area, app.sidebar_section_split);
+        let list_area = workspace_list_rect(area, app.sidebar_section_split, app.sidebar_position);
 
         let mut terminal = Terminal::new(TestBackend::new(area.width, area.height)).unwrap();
         terminal
@@ -2484,7 +2537,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         let area = Rect::new(0, 0, 30, 10);
         app.view.workspace_card_areas = compute_workspace_card_areas(&app, area);
         assert_eq!(app.view.workspace_card_areas.len(), 2);
-        let list_area = workspace_list_rect(area, app.sidebar_section_split);
+        let list_area = workspace_list_rect(area, app.sidebar_section_split, app.sidebar_position);
 
         let mut terminal = Terminal::new(TestBackend::new(area.width, area.height)).unwrap();
         terminal
@@ -2576,7 +2629,7 @@ rows = [[{ token = "git_status", fg = "#123456" }]]
         app.sidebar_spaces.row_gap = 0;
         let area = Rect::new(0, 0, 30, 20);
         app.view.workspace_card_areas = compute_workspace_card_areas(&app, area);
-        let list_area = workspace_list_rect(area, app.sidebar_section_split);
+        let list_area = workspace_list_rect(area, app.sidebar_section_split, app.sidebar_position);
         let indicator_row = workspace_drop_indicator_row(
             &app,
             &app.view.workspace_card_areas,

--- a/tests/live_handoff.rs
+++ b/tests/live_handoff.rs
@@ -1214,7 +1214,7 @@ fn live_handoff_accepts_canonical_pane_id_from_child_env() {
 
 #[test]
 fn live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session() {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{symlink, PermissionsExt};
 
     let _lock = test_lock();
     let base = unique_test_dir();
@@ -1224,17 +1224,20 @@ fn live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session() {
     let old_session = base.join("old-session.jsonl");
     let new_session = base.join("new-session.jsonl");
     let started_marker = base.join("agent-started");
-    let fake_pi = base.join("pi");
+    let fake_pi = base.join("launch-pi");
+    let fake_pi_process = base.join("pi");
     fs::create_dir_all(&base).unwrap();
     fs::write(
         &fake_pi,
         format!(
-            "#!/bin/sh\nexport HERDR_AGENT=pi\necho started > {}\nexec /bin/sleep 30\n",
-            started_marker.display()
+            "#!/bin/sh\nexport HERDR_AGENT=pi\necho started > {}\nexec {} 30\n",
+            started_marker.display(),
+            fake_pi_process.display()
         ),
     )
     .unwrap();
     fs::set_permissions(&fake_pi, fs::Permissions::from_mode(0o755)).unwrap();
+    symlink("/bin/sleep", &fake_pi_process).unwrap();
 
     let spawned = spawn_server(&config_home, &runtime_dir, &api_socket);
     wait_for_socket(&api_socket, Duration::from_secs(10));


### PR DESCRIPTION
 Description

 This adds support for placing Herdr’s desktop sidebar on either the left or right side of the window.

 ### What changed

 - Added the new ui.sidebar_position configuration option.
 - Kept the existing left-side layout as the default.
 - Updated layout calculations for:
     - Sidebar and terminal content
     - Dividers and resize handling
     - Collapse/expand controls
     - Workspace and agent panel sections
     - Scrollbars and mouse hit-testing
 - Applied the setting during startup and live configuration reloads.
 - Added documentation and config-reference metadata.
 - Expanded interaction and layout tests to cover both sidebar positions.
 - Improved the live handoff test setup to launch the fake agent through a symlinked process.

 Example:

 ```toml
   [ui]
   sidebar_position = "right"
 ```

 This should make the sidebar easier to use for workflows where the primary terminal content is more naturally read from the left side of the screen,
 while preserving existing behavior for users who prefer the default layout.

 ### Validation

 - Added coverage for sidebar interactions in both left and right positions.
 - Added parsing, startup, reload, resizing, scrolling, and hit-testing coverage.
 - just ci — [run result]
