### PR TITLE
fix(input): keep pending url clicks across host focus loss

### DIFF
--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -350,7 +350,7 @@ impl App {
     }
 
     pub(crate) fn release_input_source_headless(&mut self, source_id: crate::app::InputSourceId) {
-        self.pending_url_click_sources.remove(&source_id);
+        // Pending URL clicks survive this call; see clear_input_source.
         for pressed in self.take_pressed_keys_for_source(source_id) {
             let release = pressed
                 .key
@@ -360,7 +360,7 @@ impl App {
     }
 
     pub(crate) async fn release_input_source(&mut self, source_id: crate::app::InputSourceId) {
-        self.pending_url_click_sources.remove(&source_id);
+        // Pending URL clicks survive this call; see clear_input_source.
         for pressed in self.take_pressed_keys_for_source(source_id) {
             let release = pressed
                 .key
@@ -921,6 +921,61 @@ mod tests {
         assert!(
             input_rx.try_recv().is_err(),
             "handled URL click must not leave an unmatched release for the pane"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn outer_focus_loss_does_not_forward_pending_url_click_release_to_pane() {
+        let line = "see https://github.com/herdrdev/herdr/issues/1761";
+        let col = line.find("github").expect("url host") as u16;
+        let (mut app, info) = app_with_screen_bytes(b"");
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let screen = format!("\x1b[?1049h\x1b[?1000h\x1b[?1006h{line}");
+        let (runtime, mut input_rx) =
+            crate::terminal::TerminalRuntime::test_with_channel_and_scrollback_bytes(
+                info.inner_rect.width,
+                info.inner_rect.height,
+                0,
+                screen.as_bytes(),
+                4,
+            );
+        app.state.insert_test_runtime(pane_id, runtime);
+        install_test_link_handler(&mut app);
+        let url_x = info.inner_rect.x + col;
+
+        app.handle_mouse_from_input_source(
+            41,
+            modified_mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                url_x,
+                info.inner_rect.y,
+                KeyModifiers::CONTROL,
+            ),
+        );
+        assert_eq!(app.state.plugin_command_logs.len(), 1);
+
+        // Opening the URL raises the browser, so the host terminal loses focus
+        // while the button is still down.
+        app.route_client_events_from(
+            41,
+            vec![crate::raw_input::RawInputEvent::OuterFocusLost],
+            false,
+        );
+
+        app.handle_mouse_from_input_source(
+            41,
+            modified_mouse(
+                MouseEventKind::Up(MouseButton::Left),
+                url_x,
+                info.inner_rect.y,
+                KeyModifiers::empty(),
+            ),
+        );
+
+        assert!(
+            input_rx.try_recv().is_err(),
+            "focus loss must not clear a pending URL click, so its release must stay out of the pane"
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1778,6 +1778,11 @@ impl App {
     }
 
     pub(crate) fn clear_input_source(&mut self, source_id: InputSourceId) {
+        // Call this only when the input source is gone for good. A pending URL
+        // click has to outlive a plain focus change, because opening the URL
+        // raises the browser and costs the host terminal its focus before the
+        // mouse release arrives.
+        self.pending_url_click_sources.remove(&source_id);
         self.release_input_source_headless(source_id);
     }
 

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -2710,7 +2710,8 @@ impl HeadlessServer {
                 .iter()
                 .any(|event| matches!(event, crate::raw_input::RawInputEvent::OuterFocusLost))
             {
-                self.app.clear_input_source(client_id);
+                // Focus loss is not a teardown, so the pending URL click stays.
+                self.app.release_input_source_headless(client_id);
             }
         }
         let events = events_for_app_routing(events, source_was_foreground, source_is_full_app);


### PR DESCRIPTION
## Problem

Ctrl+clicking an OSC 8 link in a mouse-reporting pane opens two browser tabs
when the button is still down by the time the browser takes focus.
Instrumenting `open` shows both invocations for one click:

```
time          process that called `open`
11:46:23.036  herdr server
11:46:24.335  claude, the agent in the pane
```

Releasing quickly opens one tab, which is why the #1761 fix looked complete.

## Cause

`handle_modified_url_click` inserts the source into
`pending_url_click_sources` so the matching release is consumed instead of
forwarded to the pane. Opening the URL raises the browser, the host terminal
loses focus, and the resulting `OuterFocusLost` ran
`release_input_source_headless`, whose first line cleared the set while the
button was still down. The release then reached the pane and the agent opened
the same URL again.

## Fix

- keep `pending_url_click_sources` across `release_input_source(_headless)`;
  a focus change is not a teardown and the release still arrives
- clear the set in `clear_input_source` instead, whose only production caller
  is `remove_client`
- call `release_input_source_headless` directly on the headless server's
  focus-loss path
- the async `release_input_source` (only reachable with `--no-session`)
  carried the same line and gets the same fix

## Verification

- new test `outer_focus_loss_does_not_forward_pending_url_click_release_to_pane`
  drives the real routing path (Ctrl+press on the link, `OuterFocusLost`
  through `route_client_events_from`, then the release) and asserts nothing
  reaches the pane; it fails with the old clearing line in
  `release_input_source_headless` put back
- `just ci 'all() - test(pane_spawn_cwd_fallback_in_server) - test(live_handoff_keeps_unmanaged_agent_name_bound_to_saved_session) - test(multi_client_client_crash_sigkill_does_not_affect_server)'` (3,034 tests passed; the excluded three fail identically on a clean master checkout on this machine)
- maintenance Python suite (93 passed)

refs #2290
