### PR TITLE
fix(ci): install Zig from Homebrew for manual macOS builds

### DIFF
--- a/.github/workflows/build-artifacts-manual.yml
+++ b/.github/workflows/build-artifacts-manual.yml
@@ -153,10 +153,19 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           targets: ${{ matrix.target }}
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+      - name: Restore Homebrew Zig cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          version: 0.15.2
+          path: ~/Library/Caches/Homebrew/downloads
+          key: homebrew-zig-0.15-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: |
+            homebrew-zig-0.15-${{ runner.os }}-
+
+      - name: Install patched Zig
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install zig@0.15
+          echo "$(brew --prefix zig@0.15)/bin" >> "$GITHUB_PATH"
+          "$(brew --prefix zig@0.15)/bin/zig" version
 
       - name: Install macOS build tools
         run: brew install cmake ninja


### PR DESCRIPTION
`Build artifacts (manual)` currently fails both macOS jobs before it compiles
anything.

`macos-latest` now runs macOS 26, whose SDK is newer than the libSystem bundled
with the pinned Zig 0.15.2. Linking the vendored libghostty-vt build runner dies
with a wall of undefined libc symbols:

```
error: undefined symbol: _dispatch_semaphore_signal
  note: referenced by .zig-cache/o/.../build_zcu.o:_Build.Watch.FsEvents.eventCallback
error: undefined symbol: __availability_version_check
error: undefined symbol: _abort
...
thread 'main' panicked at build.rs:78:5:
zig build for vendored libghostty-vt failed: exit status: 2
```

`release.yml` already handles this. It gates `mlugg/setup-zig` behind
`if: runner.os != 'macOS'` and installs `zig@0.15` from Homebrew instead
(`Install patched Zig on macOS`). The manual workflow never picked that up, so
it still calls `setup-zig` unconditionally.

This applies the same two steps to the manual workflow's macOS job: the Homebrew
download cache, then the `brew install zig@0.15` that puts a Zig built against
the current SDK on `PATH`. The Linux and Windows jobs are untouched.

## Verification

Both runs are on the same tree; the only difference is this patch.

| Run | Zig source | aarch64 | x86_64 |
| --- | --- | --- | --- |
| before | `setup-zig` 0.15.2 | failed | failed |
| after | `brew zig@0.15` | passed | passed |

The resulting `aarch64-apple-darwin` binary runs on macOS 26 and reports the
expected version, so this is a build-host problem rather than anything wrong
with the vendored source.

Related: #285 covers the same SDK-versus-pinned-Zig mismatch for local macOS
builds. This only fixes CI.
