### PR TITLE
fix: deflake terminal metadata and hook authority tests

### DIFF
--- a/src/terminal/metadata.rs
+++ b/src/terminal/metadata.rs
@@ -861,7 +861,7 @@ mod tests {
             clear_title: false,
             clear_display_agent: false,
             clear_state_labels: false,
-            ttl: Some(Duration::from_millis(1)),
+            ttl: Some(Duration::from_secs(5)),
             seq: None,
         });
         let old_deadline = terminal.next_agent_metadata_expiry().unwrap();

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -2701,14 +2701,23 @@ mod tests {
         let now = Instant::now();
         let mut terminal = test_terminal();
         let session_path = test_session_path("pi.jsonl");
-        terminal.set_detected_state(Some(Agent::Pi), AgentState::Working);
-        terminal.set_hook_authority_with_session_ref(
+        terminal.set_detected_state_with_screen_signals_at(
+            Some(Agent::Pi),
+            AgentState::Working,
+            false,
+            false,
+            false,
+            false,
+            now,
+        );
+        terminal.set_hook_authority_at(
             "herdr:pi".into(),
             "pi".into(),
             AgentState::Working,
             None,
             crate::agent_resume::AgentSessionRef::path(session_path.clone()),
             Some(20),
+            now,
         );
 
         terminal.set_detected_state_with_screen_signals_at(
@@ -2720,13 +2729,14 @@ mod tests {
             true,
             now + Duration::from_millis(1),
         );
-        let late = terminal.set_hook_authority_with_session_ref(
+        let late = terminal.set_hook_authority_at(
             "herdr:pi".into(),
             "pi".into(),
             AgentState::Working,
             None,
             crate::agent_resume::AgentSessionRef::path(session_path),
             Some(21),
+            now + Duration::from_millis(2),
         );
 
         assert!(late.is_none());


### PR DESCRIPTION
Two tests trip under full-suite parallel load and pass in isolation. Test-only diff, no production changes.

`metadata_clear_only_without_ttl_does_not_extend_old_ttl` sets metadata with a 1ms ttl, then asserts the expiry deadline is unchanged after a clear-only report. The test never waits for expiry — it drives it explicitly through `expire_agent_metadata_at(old_deadline, old_deadline)` — so the 1ms value only creates a race: under load more than 1ms elapses before the second report, the metadata legitimately expires, and the assertion sees `None`. Raising the ttl to 5s removes the race; every assertion, including the expiry tail, exercises the same paths.

`late_full_lifecycle_hook_with_same_session_after_process_exit_does_not_reacquire_authority` mixed clocks: hook authority was stamped with a real `Instant::now()` through the convenience wrappers, while the process-exit signal used a synthetic `now + 1ms` captured at test start. Under load the real timestamp lands after the synthetic exit, defeating `hook_authority_not_newer_than` — the exact freshness check the test exists to exercise — so no release suppression is recorded and the late hook reacquires authority. The test now threads explicit increasing timestamps (`now`, `now + 1ms`, `now + 2ms`) through the `set_detected_state_with_screen_signals_at` / `set_hook_authority_at` variants that already exist.

Both fixes verified with `cargo nextest` against current master: 2/2 pass, `cargo fmt --check` clean.

https://claude.ai/code/session_01XKQ9xB2v4AYjwwvA3aXzsH
