### PR TITLE
fix: detect codex model capacity errors as blocked

### DIFF
--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -734,8 +734,9 @@ fn codex_osc_title_plain_is_idle() {
 }
 
 #[test]
-fn codex_model_capacity_error_is_blocked() {
-    let screen = "⚠ Selected model is at capacity. Please try a different model.\n\n\
+fn codex_wrapped_model_capacity_error_is_blocked() {
+    let screen = "⚠ Selected model is at capacity. Please\n\
+        \x20\x20try a different model.\n\n\
         › Summarize recent commits\n\n\
         gpt-5.6-sol high · /work · Ready\n";
     let result = osc_explain(Agent::Codex, screen, "project", "");
@@ -746,6 +747,23 @@ fn codex_model_capacity_error_is_blocked() {
         Some("model_capacity_blocked")
     );
     assert!(result.visible_blocker);
+}
+
+#[test]
+fn codex_active_spinner_beats_stale_model_capacity_error() {
+    let screen = "⚠ Selected model is at capacity. Please\n\
+        \x20\x20try a different model.\n\n\
+        › Summarize recent commits\n\n\
+        gpt-5.6-sol high · /work · Working\n";
+    let result = osc_explain(Agent::Codex, screen, "⠋ project", "");
+
+    assert_eq!(result.state, AgentState::Working);
+    assert_eq!(
+        result.matched_rule.as_ref().map(|r| r.id.as_str()),
+        Some("osc_title_working")
+    );
+    assert!(result.visible_working);
+    assert!(!result.visible_blocker);
 }
 
 #[test]

--- a/src/detect/manifest/tests.rs
+++ b/src/detect/manifest/tests.rs
@@ -734,6 +734,38 @@ fn codex_osc_title_plain_is_idle() {
 }
 
 #[test]
+fn codex_model_capacity_error_is_blocked() {
+    let screen = "⚠ Selected model is at capacity. Please try a different model.\n\n\
+        › Summarize recent commits\n\n\
+        gpt-5.6-sol high · /work · Ready\n";
+    let result = osc_explain(Agent::Codex, screen, "project", "");
+
+    assert_eq!(result.state, AgentState::Blocked);
+    assert_eq!(
+        result.matched_rule.as_ref().map(|r| r.id.as_str()),
+        Some("model_capacity_blocked")
+    );
+    assert!(result.visible_blocker);
+}
+
+#[test]
+fn codex_stale_model_capacity_error_remains_idle() {
+    let screen = "⚠ Selected model is at capacity. Please try a different model.\n\n\
+        • Explored\n\
+        └ Read Cargo.toml\n\n\
+        › Summarize recent commits\n\n\
+        gpt-5.6-sol high · /work · Ready\n";
+    let result = osc_explain(Agent::Codex, screen, "project", "");
+
+    assert_eq!(result.state, AgentState::Idle);
+    assert_eq!(
+        result.matched_rule.as_ref().map(|r| r.id.as_str()),
+        Some("osc_title_idle")
+    );
+    assert!(result.visible_idle);
+}
+
+#[test]
 fn codex_background_terminal_screen_does_not_override_osc_idle() {
     // Background terminal tasks can be long-lived helpers such as dev servers.
     // They should not make Codex look busy once the foreground turn is idle.

--- a/src/detect/manifests/codex.toml
+++ b/src/detect/manifests/codex.toml
@@ -14,10 +14,10 @@ contains = ["Action Required"]
 [[rules]]
 id = "model_capacity_blocked"
 state = "blocked"
-priority = 1090
-region = "bottom_non_empty_lines(3)"
+priority = 490
+region = "bottom_non_empty_lines(4)"
 visible_blocker = true
-contains = ["Selected model is at capacity. Please try a different model."]
+regex = ['(?m)^⚠ Selected\s+model\s+is\s+at\s+capacity\.\s+Please\s+try\s+a\s+different\s+model\.$']
 
 [[rules]]
 id = "osc_title_working"

--- a/src/detect/manifests/codex.toml
+++ b/src/detect/manifests/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.07.18.1"
+version = "2026.08.05.1"
 min_engine_version = 2
-updated_at = "2026-07-18T00:00:00Z"
+updated_at = "2026-08-05T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -10,6 +10,14 @@ priority = 1100
 region = "osc_title"
 visible_blocker = true
 contains = ["Action Required"]
+
+[[rules]]
+id = "model_capacity_blocked"
+state = "blocked"
+priority = 1090
+region = "bottom_non_empty_lines(3)"
+visible_blocker = true
+contains = ["Selected model is at capacity. Please try a different model."]
 
 [[rules]]
 id = "osc_title_working"

--- a/website/agent-detection/codex.toml
+++ b/website/agent-detection/codex.toml
@@ -14,10 +14,10 @@ contains = ["Action Required"]
 [[rules]]
 id = "model_capacity_blocked"
 state = "blocked"
-priority = 1090
-region = "bottom_non_empty_lines(3)"
+priority = 490
+region = "bottom_non_empty_lines(4)"
 visible_blocker = true
-contains = ["Selected model is at capacity. Please try a different model."]
+regex = ['(?m)^⚠ Selected\s+model\s+is\s+at\s+capacity\.\s+Please\s+try\s+a\s+different\s+model\.$']
 
 [[rules]]
 id = "osc_title_working"

--- a/website/agent-detection/codex.toml
+++ b/website/agent-detection/codex.toml
@@ -1,7 +1,7 @@
 id = "codex"
-version = "2026.07.18.1"
+version = "2026.08.05.1"
 min_engine_version = 2
-updated_at = "2026-07-18T00:00:00Z"
+updated_at = "2026-08-05T00:00:00Z"
 
 [[rules]]
 id = "osc_title_blocked"
@@ -10,6 +10,14 @@ priority = 1100
 region = "osc_title"
 visible_blocker = true
 contains = ["Action Required"]
+
+[[rules]]
+id = "model_capacity_blocked"
+state = "blocked"
+priority = 1090
+region = "bottom_non_empty_lines(3)"
+visible_blocker = true
+contains = ["Selected model is at capacity. Please try a different model."]
 
 [[rules]]
 id = "osc_title_working"


### PR DESCRIPTION
## Summary

- classify Codex model-capacity errors as `blocked`
- limit matching to the bottom three non-empty lines so stale errors remain idle
- publish the updated Codex detection manifest

## Validation

- captured the affected pane with `herdr agent read <pane> --source detection --format text`
- stock Herdr 0.7.5 classified the captured screen as `idle`; the patched bundled manifest classifies it as `blocked`
- `just ci` (Rust 1.96.1, Zig 0.15.2): 3,217 Rust tests, 19 integration asset tests, and 24 plugin marketplace tests passed
- `python3 scripts/agent_detection_manifest_check.py --require-website`
