### PR TITLE
fix(client): restore host kitty keyboard state on detach

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -414,6 +414,7 @@ fn setup_terminal_with_capabilities(
     Ok(TerminalGuard {
         reset_modify_other_keys: modify_other_keys_mode.is_some(),
         reset_host_color_scheme_reports: host_color_scheme_reports,
+        reset_keyboard_enhancement_flags: enable_client_protocols,
         #[cfg(windows)]
         restore_windows_input_mode: windows_virtual_terminal_input.restore_mode,
     })
@@ -427,6 +428,9 @@ fn should_enable_host_color_scheme_reports(enable_client_protocols: bool) -> boo
 struct TerminalGuard {
     reset_modify_other_keys: bool,
     reset_host_color_scheme_reports: bool,
+    /// Only set when setup pushed a keyboard enhancement stack entry. Direct
+    /// attach never pushes, so it must not pop on teardown either.
+    reset_keyboard_enhancement_flags: bool,
     #[cfg(windows)]
     restore_windows_input_mode: Option<u32>,
 }
@@ -569,6 +573,7 @@ fn set_mouse_capture(enabled: bool) -> io::Result<()> {
 fn restore_terminal_state(
     reset_modify_other_keys: bool,
     reset_host_color_scheme_reports: bool,
+    reset_keyboard_enhancement_flags: bool,
     #[cfg(windows)] restore_windows_input_mode: Option<u32>,
 ) {
     let _ = clear_received_kitty_graphics(&mut io::stdout());
@@ -579,7 +584,9 @@ fn restore_terminal_state(
         let _ = io::stdout().flush();
     }
 
-    let _ = pop_keyboard_enhancement_flags();
+    if reset_keyboard_enhancement_flags {
+        let _ = pop_keyboard_enhancement_flags();
+    }
 
     let _ = execute!(
         io::stdout(),
@@ -650,6 +657,7 @@ impl Drop for TerminalGuard {
         restore_terminal_state(
             self.reset_modify_other_keys,
             self.reset_host_color_scheme_reports,
+            self.reset_keyboard_enhancement_flags,
             #[cfg(windows)]
             self.restore_windows_input_mode,
         );
@@ -1204,6 +1212,7 @@ fn run_client_with_mode(
     // Install a panic hook to restore the terminal on panic (same as monolithic).
     let panic_resets_modify_other_keys = terminal_guard.reset_modify_other_keys;
     let panic_resets_host_color_scheme_reports = terminal_guard.reset_host_color_scheme_reports;
+    let panic_resets_keyboard_enhancement_flags = terminal_guard.reset_keyboard_enhancement_flags;
     #[cfg(windows)]
     let panic_restore_windows_input_mode = terminal_guard.restore_windows_input_mode;
     let original_hook = std::panic::take_hook();
@@ -1211,6 +1220,7 @@ fn run_client_with_mode(
         restore_terminal_state(
             panic_resets_modify_other_keys,
             panic_resets_host_color_scheme_reports,
+            panic_resets_keyboard_enhancement_flags,
             #[cfg(windows)]
             panic_restore_windows_input_mode,
         );

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -415,6 +415,7 @@ fn setup_terminal_with_capabilities(
         reset_modify_other_keys: modify_other_keys_mode.is_some(),
         reset_host_color_scheme_reports: host_color_scheme_reports,
         reset_keyboard_enhancement_flags: enable_client_protocols,
+        restored: Arc::new(AtomicBool::new(false)),
         #[cfg(windows)]
         restore_windows_input_mode: windows_virtual_terminal_input.restore_mode,
     })
@@ -431,6 +432,10 @@ struct TerminalGuard {
     /// Only set when setup pushed a keyboard enhancement stack entry. Direct
     /// attach never pushes, so it must not pop on teardown either.
     reset_keyboard_enhancement_flags: bool,
+    /// Shared with the panic hook. Unwinding runs the hook first and then drops
+    /// this guard, so without a shared latch the teardown path would run twice
+    /// and the second pop would take a stack entry herdr never pushed.
+    restored: Arc<AtomicBool>,
     #[cfg(windows)]
     restore_windows_input_mode: Option<u32>,
 }
@@ -570,12 +575,23 @@ fn set_mouse_capture(enabled: bool) -> io::Result<()> {
     }
 }
 
+/// Returns true for the first caller only, so the terminal is restored once
+/// no matter how many teardown paths fire.
+fn claim_terminal_restore(restored: &AtomicBool) -> bool {
+    !restored.swap(true, Ordering::SeqCst)
+}
+
 fn restore_terminal_state(
+    restored: &AtomicBool,
     reset_modify_other_keys: bool,
     reset_host_color_scheme_reports: bool,
     reset_keyboard_enhancement_flags: bool,
     #[cfg(windows)] restore_windows_input_mode: Option<u32>,
 ) {
+    if !claim_terminal_restore(restored) {
+        return;
+    }
+
     let _ = clear_received_kitty_graphics(&mut io::stdout());
 
     // Reset modifyOtherKeys if we enabled it.
@@ -655,6 +671,7 @@ fn disable_windows_win32_input_mode(writer: &mut impl std::io::Write) -> io::Res
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         restore_terminal_state(
+            &self.restored,
             self.reset_modify_other_keys,
             self.reset_host_color_scheme_reports,
             self.reset_keyboard_enhancement_flags,
@@ -1213,11 +1230,13 @@ fn run_client_with_mode(
     let panic_resets_modify_other_keys = terminal_guard.reset_modify_other_keys;
     let panic_resets_host_color_scheme_reports = terminal_guard.reset_host_color_scheme_reports;
     let panic_resets_keyboard_enhancement_flags = terminal_guard.reset_keyboard_enhancement_flags;
+    let panic_restored = Arc::clone(&terminal_guard.restored);
     #[cfg(windows)]
     let panic_restore_windows_input_mode = terminal_guard.restore_windows_input_mode;
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         restore_terminal_state(
+            &panic_restored,
             panic_resets_modify_other_keys,
             panic_resets_host_color_scheme_reports,
             panic_resets_keyboard_enhancement_flags,
@@ -2304,6 +2323,15 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn terminal_restore_is_claimed_once_across_teardown_paths() {
+        let restored = Arc::new(AtomicBool::new(false));
+        let panic_hook_copy = Arc::clone(&restored);
+
+        assert!(claim_terminal_restore(&panic_hook_copy));
+        assert!(!claim_terminal_restore(&restored));
     }
 
     #[test]

--- a/src/terminal_modes.rs
+++ b/src/terminal_modes.rs
@@ -24,7 +24,11 @@ pub(crate) fn set_host_kitty_keyboard_report_all<W: Write>(
     if report_all_keys {
         flags |= crossterm::event::KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
     }
-    write!(writer, "\x1b[={}u", flags.bits())?;
+    // Mode 1 (set the given flags, reset the rest) is the protocol default, but
+    // it has to be written explicitly: iTerm2 matches the mode parameter against
+    // 1, 2, and 3 with no default arm, so an omitted mode leaves the sequence a
+    // no-op there and the host never follows the focused pane's key reporting.
+    write!(writer, "\x1b[={};1u", flags.bits())?;
     writer.flush()
 }
 
@@ -47,7 +51,7 @@ mod tests {
         set_host_kitty_keyboard_report_all(&mut output, true).unwrap();
         set_host_kitty_keyboard_report_all(&mut output, false).unwrap();
 
-        assert_eq!(output, b"\x1b[=15u\x1b[=7u");
+        assert_eq!(output, b"\x1b[=15;1u\x1b[=7;1u");
     }
 
     #[test]


### PR DESCRIPTION
Detaching from herdr in iTerm2 leaves the terminal emitting CSI-u key events as text, so the shell after `herdr` is unusable until `reset`. Two things go wrong on teardown:

**The host key reporting sequence never applies in iTerm2.** `set_host_kitty_keyboard_report_all` wrote `ESC [ = {flags} u` with the mode parameter omitted. Mode 1 is the protocol default, but iTerm2 matches the parameter against 1, 2 and 3 with no default arm, so the bare form is a no-op there and the host never follows the focused pane's key reporting. Now written as `ESC [ = {flags} ; 1 u`.

**The keyboard enhancement stack is popped without a matching push.** Direct attach goes through `setup_terminal_with_capabilities` with `enable_client_protocols` false and never pushes, but `restore_terminal_state` popped unconditionally. iTerm2 keeps an independent stack per screen buffer and falls back to a shared field when the current stack is empty, so the unbalanced pop leaves enhanced key reporting on after herdr exits. `TerminalGuard` now records whether setup pushed, and only pops when it did.

Verified on Linux with `cargo test`, `cargo fmt --check` and `cargo clippy --all-targets`. The suite is green apart from `generated_workspace_ids_are_short_base32_handles`, which fails identically on unmodified master on this machine.

User-facing behavior change, so it may need a public-doc note — happy to add one if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
