### PR TITLE
fix: harden panic, security, and data-loss paths

### DIFF
--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -68,7 +68,7 @@ impl App {
         };
         let shell_config = crate::pane::PaneShellConfig::new(&default_shell, self.state.shell_mode);
         let split_result = match params.ratio {
-            Some(ratio) => ws.split_pane_with_ratio(
+            Some(ratio) if ratio.is_finite() => ws.split_pane_with_ratio(
                 target_pane_id,
                 direction,
                 ratio,
@@ -82,7 +82,7 @@ impl App {
                 extra_env,
                 params.focus,
             ),
-            None => ws.split_pane(
+            Some(_) | None => ws.split_pane(
                 target_pane_id,
                 direction,
                 rows,

--- a/src/app/config_io.rs
+++ b/src/app/config_io.rs
@@ -24,11 +24,21 @@ impl App {
 
         let content = std::fs::read_to_string(&path).unwrap_or_default();
         let new_content = update(&content);
-        if let Err(err) = std::fs::write(&path, new_content) {
+        let tmp_path = path.with_extension("toml.tmp");
+        if let Err(err) = std::fs::write(&tmp_path, &new_content) {
             crate::logging::config_write_failed(&path, error_context, &err.to_string());
             self.state.config_diagnostic = Some(format!("failed to save {error_context}: {err}"));
             self.config_diagnostic_deadline =
                 Some(std::time::Instant::now() + std::time::Duration::from_secs(5));
+            let _ = std::fs::remove_file(&tmp_path);
+            return false;
+        }
+        if let Err(err) = std::fs::rename(&tmp_path, &path) {
+            crate::logging::config_write_failed(&path, error_context, &err.to_string());
+            self.state.config_diagnostic = Some(format!("failed to save {error_context}: {err}"));
+            self.config_diagnostic_deadline =
+                Some(std::time::Instant::now() + std::time::Duration::from_secs(5));
+            let _ = std::fs::remove_file(&tmp_path);
             return false;
         }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -208,7 +208,10 @@ impl TileLayout {
         }
         let target = self.focus;
         let ids = self.pane_ids();
-        let pos = ids.iter().position(|id| *id == target).unwrap();
+        let Some(pos) = ids.iter().position(|id| *id == target) else {
+            self.focus = ids.first().copied().unwrap_or(target);
+            return false;
+        };
         let ordered = if pos + 1 < ids.len() {
             ids[pos + 1]
         } else {

--- a/src/pane/terminal.rs
+++ b/src/pane/terminal.rs
@@ -763,8 +763,11 @@ impl RetainedTextBuffer {
             let start_span = &line.spans[start_index];
             let end_span = &line.spans[end_index];
             start_span.byte_start <= end_span.byte_end
-                && text_fingerprint(&line.text[start_span.byte_start..end_span.byte_end])
-                    == text_match.source_fingerprint
+                && line
+                    .text
+                    .get(start_span.byte_start..end_span.byte_end)
+                    .map(text_fingerprint)
+                    == Some(text_match.source_fingerprint)
         })
     }
 

--- a/src/plugin_command.rs
+++ b/src/plugin_command.rs
@@ -16,6 +16,14 @@ fn program_for_cwd(program: &str, cwd: &Path) -> OsString {
     let has_separator = program.contains('/') || (cfg!(windows) && program.contains('\\'));
     if path.is_relative() && has_separator {
         let relative = path.strip_prefix(Path::new(".")).unwrap_or(path);
+        // Reject parent-directory traversal so a plugin manifest cannot
+        // escape the plugin root via command[0] = "../bin/evil".
+        if relative
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return program.into();
+        }
         cwd.join(relative).into_os_string()
     } else {
         path.as_os_str().to_os_string()

--- a/src/server/handoff.rs
+++ b/src/server/handoff.rs
@@ -262,7 +262,7 @@ pub(crate) fn receive(socket_path: &Path, token: &str) -> io::Result<ReceivedHan
     }
     stream.write_all(b"validated\n")?;
     stream.flush()?;
-    let fds = recv_fds(&stream, manifest.panes.len())?;
+    let fds = recv_fds(&stream, manifest.panes.len().min(MAX_FDS_PER_HANDOFF))?;
     Ok(ReceivedHandoff {
         manifest,
         fds,


### PR DESCRIPTION
Six focused hardening fixes found by an adversarial code review of v0.8.0. Each is a small, single-file change addressing a distinct failure mode. All existing tests pass (`cargo test --locked`, 2994 passed, 0 failed).

## Changes

**1. `src/layout.rs:211` — close_focused panic on stale focus**

`close_focused()` called `.unwrap()` on `ids.iter().position(|id| *id == target)`, assuming `self.focus` is always in the pane tree. A restored or stale layout where focus no longer resolves would panic. Changed to `let-else` with a graceful fallback to the first pane.

**2. `src/pane/terminal.rs:766` — copy-mode search byte-slice OOB**

`contains_match` took a raw `&line.text[start_span.byte_start..end_span.byte_end]` slice from byte offsets. If spans are inconsistent with `line.text.len()` (multi-width char drift), this panics with string slice index out of bounds. Changed to `.get(start..end).map(text_fingerprint)` which returns `None` on OOB.

**3. `src/plugin_command.rs:14-23` — plugin program path traversal**

`program_for_cwd` joined relative program paths onto `cwd` (plugin root) without rejecting `..` components. A plugin manifest with `command[0] = "../bin/evil"` could escape the plugin root. Added a `ParentDir` component check.

**4. `src/app/config_io.rs:25-27` — non-atomic config write**

`update_config_file` did a plain `std::fs::write` directly to `config.toml`. A crash mid-write truncates the config — and startup `Config::load()` silently replaces the entire config with defaults on any parse error. Changed to temp+rename (atomic), matching `persist/io.rs`.

**5. `src/server/handoff.rs:265` — import-side fd count not clamped**

`recv_fds` was called with `manifest.panes.len()` (peer-controlled) without clamping to `MAX_FDS_PER_HANDOFF` (64). The export side caps at line 172 but the import side did not. Added `.min(MAX_FDS_PER_HANDOFF)`.

**6. `src/app/api/panes.rs:70-84` — pane.split accepts non-finite ratio**

`handle_pane_split` passed `params.ratio` straight to `split_pane_with_ratio` with no `is_finite()` check, unlike `layouts.rs:226` and `layouts.rs:588` which both validate. Added `is_finite()` guard so non-finite ratios fall through to the default split.

## Verification

```
cargo fmt --check   # clean
cargo test --locked # 2994 passed, 0 failed
```