### PR TITLE
feat: add Muse support

### DIFF
--- a/src/detect/manifests/muse.toml
+++ b/src/detect/manifests/muse.toml
@@ -1,0 +1,80 @@
+id = "muse"
+version = "2026.08.05.1"
+min_engine_version = 2
+updated_at = "2026-08-05T00:00:00Z"
+aliases = ["muse-code", "muse_code"]
+
+# Muse — Muse Spark by Meta (https://dev.meta.ai)
+# Binary: muse (installed via https://dev.meta.ai/install.sh -> ~/.local/bin/muse)
+# Launcher: https://api.meta.ai/muse-launcher.sh
+# Detection is screen-manifest based (no lifecycle hook authority yet).
+# Rules derived from conservative patterns similar to codex/cursor; refine with
+# `herdr agent read <pane> --source detection --format text/ansi` and
+# `herdr agent explain <pane> --json` per AGENTS.md.
+
+[[rules]]
+id = "osc_title_blocked"
+state = "blocked"
+priority = 1100
+region = "osc_title"
+visible_blocker = true
+contains = ["Action Required"]
+
+[[rules]]
+id = "osc_title_working"
+state = "working"
+priority = 1050
+region = "osc_title"
+visible_working = true
+regex = ['(?:^| )[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏](?: |$)']
+
+[[rules]]
+id = "permission_prompt_blocked"
+state = "blocked"
+priority = 900
+region = "whole_recent"
+visible_blocker = true
+any = [
+  { contains = ["do you want to proceed?"] },
+  { contains = ["allow this command?"] },
+  { contains = ["approve"] },
+  { contains = ["[y/n]"] },
+  { contains = ["yes (y)"] },
+]
+
+[[rules]]
+id = "question_prompt_blocked"
+state = "blocked"
+priority = 850
+region = "whole_recent"
+visible_blocker = true
+any = [
+  { contains = ["press enter to confirm or esc to cancel"] },
+  { contains = ["enter to submit"] },
+  { contains = ["esc to cancel"] },
+]
+
+[[rules]]
+id = "working_indicator"
+state = "working"
+priority = 500
+region = "bottom_non_empty_lines(5)"
+visible_working = true
+any = [
+  { contains = ["esc to interrupt"] },
+  { contains = ["ctrl+c to interrupt"] },
+  { line_regex = ['(?i)working'] },
+  { regex = ['[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]'] },
+]
+
+[[rules]]
+id = "osc_title_idle"
+state = "idle"
+priority = 100
+region = "osc_title"
+visible_idle = true
+regex = ['\\S']
+not = [
+  { regex = ['(?:^| )[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏](?: |$)'] },
+  { contains = ["Action Required"] },
+]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -62,10 +62,11 @@ pub enum Agent {
     Kilo,
     Qodercli,
     Maki,
+    Muse,
 }
 
 impl Agent {
-    pub const ALL: [Self; 21] = [
+    pub const ALL: [Self; 22] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -87,9 +88,10 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Muse,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -109,6 +111,7 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Muse,
     ];
 }
 
@@ -135,6 +138,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Muse => "muse",
     }
 }
 
@@ -161,6 +165,7 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Muse => "muse",
     }
 }
 
@@ -197,6 +202,7 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "maki" => Some(Agent::Maki),
+        "muse" | "muse-code" | "muse_code" => Some(Agent::Muse),
         _ => None,
     }
 }


### PR DESCRIPTION
Adds support for Muse (Muse Spark by Meta, https://dev.meta.ai).

## Summary
- Registers `Agent::Muse` in `src/detect/mod.rs` (ALL 21->22, SCREEN_MANIFEST_AGENTS 19->20, agent_label, interactive_agent_executable, lookup for muse/muse-code/muse_code)
- Adds bundled screen manifest `src/detect/manifests/muse.toml` with idle/working/blocked rules (OSC title + bottom-buffer hints)
- Binary is `muse` installed via `curl -fsSL https://dev.meta.ai/install.sh | bash` (launcher https://api.meta.ai/muse-launcher.sh). Aliases: muse-code, muse_code.

## Pattern
Mirrors existing agents (claude.toml, codex.toml, cursor.toml). Rules are conservative and handle blocked (permission/question prompts), working (spinner/esc to interrupt), idle. Refine with live captures: `herdr agent read <pane> --source detection --format text --format ansi` and `herdr agent explain <pane> --json` per AGENTS.md.

## Testing
- `cargo check` (verifying build)
- To validate: `just check` / `just test`

Note: Contributor is not yet in .github/APPROVED_CONTRIBUTORS; opening as draft for maintainer review per CONTRIBUTING.md. If approved, maintainer can add to approved list or reopen.

Replaces need for HERDR_AGENT=muse workaround.
