### PR TITLE
docs(skill): handle first-run trust prompt after agent start

### DIFF
--- a/skills/herdr/SKILL.md
+++ b/skills/herdr/SKILL.md
@@ -119,6 +119,16 @@ herdr agent start reviewer --kind codex --pane <returned-pane-id> -- <agent-args
 
 `agent start` returns only after Herdr detects the expected agent in the same pane and considers it ready for interactive input. It defaults to a 30-second startup timeout.
 
+A freshly launched agent may pause on a first-run prompt before it accepts input. In an untrusted directory, Codex asks "Do you trust the contents of this directory?" and waits for Enter; other agents may show onboarding or login screens. If the agent is not yet promptable, read the pane and answer the prompt:
+
+```bash
+herdr agent read <name> --source recent-unwrapped --lines 60
+herdr agent send-keys <name> enter
+```
+
+Answer "Yes, continue" for the directory trust check only when the user has asked for work in that directory; otherwise stop and ask. After answering a first-run prompt, confirm the agent is idle before sending work.
+
+
 Submit work through the agent surface:
 
 ```bash


### PR DESCRIPTION
﻿## Summary

When a coding agent is started in a directory it has not trusted yet, it pauses on a first-run prompt before accepting input. For Codex, that prompt is "Do you trust the contents of this directory?" and it waits for Enter; other agents may show onboarding or login screens.

`herdr agent start` can return `interactive_ready: true` while this prompt is still pending. If a driver immediately sends the work prompt, it can race the agent's startup and the first characters can be dropped as the shell interprets them.

This change documents how a driving agent should handle that case: read the pane, detect the first-run prompt, and answer it with `agent send-keys` before submitting work. It also keeps the consent boundary intact by only accepting the trust prompt when the user asked for work in that directory.

## Changes

- `skills/herdr/SKILL.md` — added a short paragraph after the `agent start` step describing how to detect and answer a first-run trust/onboarding prompt before prompting the agent.

## Why not auto-accept

Auto-answering the directory trust prompt from the CLI would bypass a security consent boundary and should not be automated globally. The guidance keeps the decision with the user while giving the agent a concrete procedure.

## Verification

- Validated the JSON/socket flow manually: started Codex in a fresh untrusted temp directory via `herdr agent start`, observed the trust prompt in `herdr pane read`, answered it with `herdr agent send-keys enter`, then confirmed the agent accepted a prompt and returned results.
- Reproduced the original failure mode (prompt text raced startup and leading characters were dropped as a bogus shell command).
