### PR TITLE
Report agents running inside ssh panes via reverse socket forward

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -808,6 +808,12 @@
             "pane_id": {
               "type": "string"
             },
+            "remote_target": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "revision": {
               "format": "uint64",
               "minimum": 0,
@@ -7379,6 +7385,12 @@
             },
             "pane_id": {
               "type": "string"
+            },
+            "remote_target": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "revision": {
               "format": "uint64",

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -1078,6 +1078,12 @@
           "type": "boolean",
           "default": "true",
           "description": "Add keepalive fallbacks and private connection reuse for `herdr --remote`. Set false to run plain ssh unchanged."
+        },
+        {
+          "key": "remote.agent_reporting",
+          "type": "boolean",
+          "default": "false",
+          "description": "When a pane runs ssh, expose a report-only agent endpoint over the connection and export herdr env on the remote shell so remote agents appear in the sidebar."
         }
       ]
     },

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@ mod wait;
 
 pub use event_hub::EventHub;
 pub(crate) use server::cancel_inactive_pane_graphics_streams;
+pub(crate) use server::{start_remote_report_listener, RemoteReportHandle};
 pub use server::{start_server, start_server_with_capabilities, ServerHandle};
 pub use status::{read_runtime_status_at, RuntimeStatus};
 

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -428,6 +428,8 @@ pub struct PaneInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scroll: Option<PaneScrollInfo>,
     pub revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_target: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -749,6 +749,7 @@ fn worktree_request_and_response_round_trip() {
                 agent_session: None,
                 scroll: None,
                 revision: 0,
+                remote_target: None,
             },
             worktree: WorktreeInfo {
                 path: "/worktrees/herdr/worktree-api".into(),
@@ -1177,6 +1178,7 @@ fn create_response_round_trips_with_root_pane() {
                 agent_session: None,
                 scroll: None,
                 revision: 0,
+                remote_target: None,
             },
         },
     };

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -23,6 +23,9 @@ use crate::ipc::{
 };
 
 mod pane_graphics_stream;
+mod remote_report;
+pub(crate) use remote_report::{start_remote_report_listener, RemoteReportHandle};
+
 pub(crate) use pane_graphics_stream::cancel_inactive_streams as cancel_inactive_pane_graphics_streams;
 
 const SOCKET_PERMISSION_MODE: u32 = 0o600;
@@ -877,6 +880,7 @@ mod tests {
             agent_session: None,
             scroll: None,
             revision: 0,
+            remote_target: None,
         }
     }
 

--- a/src/api/server/remote_report.rs
+++ b/src/api/server/remote_report.rs
@@ -1,0 +1,340 @@
+use std::io;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use interprocess::local_socket::traits::{ListenerExt as _, Stream as _};
+use tracing::{debug, error, info, warn};
+
+use crate::api::schema::{Method, PaneTarget, Request, ResponseResult, SuccessResponse};
+use crate::api::ApiRequestSender;
+use crate::ipc::LocalStream;
+
+use super::{
+    dispatch_to_app_with_timeout, error_response_json, write_text_line_allow_disconnect,
+    APP_RESPONSE_TIMEOUT, STREAM_WRITE_TIMEOUT,
+};
+
+pub(crate) struct RemoteReportHandle {
+    _thread: std::thread::JoinHandle<()>,
+    path: PathBuf,
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for RemoteReportHandle {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Err(err) = std::fs::remove_file(&self.path) {
+            if err.kind() != io::ErrorKind::NotFound {
+                warn!(
+                    path = %self.path.display(),
+                    err = %err,
+                    "failed to remove remote report socket on shutdown"
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn start_remote_report_listener(
+    api_tx: ApiRequestSender,
+) -> io::Result<RemoteReportHandle> {
+    let path = crate::session::remote_report_socket_path();
+    super::prepare_socket_path(&path)?;
+
+    let listener = crate::ipc::bind_local_listener(&path)?;
+    super::restrict_socket_permissions(&path)?;
+    info!(path = %path.display(), "remote report listener listening");
+
+    let running = Arc::new(AtomicBool::new(true));
+    let listener_running = Arc::clone(&running);
+    let thread = std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    let api_tx = api_tx.clone();
+                    let connection_running = Arc::clone(&listener_running);
+                    std::thread::spawn(move || {
+                        if let Err(err) = handle_connection(stream, &api_tx, &connection_running) {
+                            warn!(err = %err, "remote report connection failed");
+                        }
+                    });
+                }
+                Err(err) => {
+                    if listener_running.load(Ordering::Relaxed) {
+                        error!(err = %err, "remote report listener accept failed");
+                    }
+                    break;
+                }
+            }
+        }
+        debug!("remote report listener thread exiting");
+    });
+
+    Ok(RemoteReportHandle {
+        _thread: thread,
+        path,
+        running,
+    })
+}
+
+fn handle_connection(
+    mut stream: LocalStream,
+    api_tx: &ApiRequestSender,
+    running: &Arc<AtomicBool>,
+) -> io::Result<()> {
+    if let Err(err) = stream.set_send_timeout(Some(STREAM_WRITE_TIMEOUT)) {
+        debug!(err = %err, "remote report connection write timeout unavailable");
+    }
+
+    loop {
+        if !running.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        let Some(line) = super::read_initial_request_line(&mut stream)? else {
+            return Ok(());
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let request = match serde_json::from_str::<Request>(line) {
+            Ok(request) => request,
+            Err(err) => {
+                write_text_line_allow_disconnect(
+                    &mut stream,
+                    &error_response_json(
+                        String::new(),
+                        "invalid_request",
+                        format!("invalid request: {err}"),
+                    ),
+                )?;
+                continue;
+            }
+        };
+
+        let response = dispatch_remote_request(request, api_tx);
+        write_text_line_allow_disconnect(&mut stream, &response)?;
+    }
+}
+
+fn dispatch_remote_request(request: Request, api_tx: &ApiRequestSender) -> String {
+    let request_id = request.id.clone();
+
+    if matches!(&request.method, Method::Ping(_)) {
+        return super::handle_request(request, api_tx, None, None);
+    }
+
+    let Some(pane_id) = report_pane_id(&request.method) else {
+        return error_response_json(
+            request_id,
+            "method_not_allowed",
+            "method is not allowed over the remote report socket".into(),
+        );
+    };
+
+    let validation_response = dispatch_to_app_with_timeout(
+        Request {
+            id: format!("remote-report:validate:{request_id}"),
+            method: Method::PaneGet(PaneTarget {
+                pane_id: pane_id.to_owned(),
+            }),
+        },
+        api_tx,
+        Some(APP_RESPONSE_TIMEOUT),
+    );
+    if !pane_response_is_remote(&validation_response) {
+        return error_response_json(
+            request_id,
+            "pane_not_remote",
+            "pane is not a remote (ssh) session".into(),
+        );
+    }
+
+    dispatch_to_app_with_timeout(request, api_tx, Some(APP_RESPONSE_TIMEOUT))
+}
+
+fn report_pane_id(method: &Method) -> Option<&str> {
+    match method {
+        Method::PaneReportAgent(params) => Some(&params.pane_id),
+        Method::PaneReportAgentSession(params) => Some(&params.pane_id),
+        Method::PaneReportMetadata(params) => Some(&params.pane_id),
+        Method::PaneReleaseAgent(params) => Some(&params.pane_id),
+        Method::PaneClearAgentAuthority(params) => Some(&params.pane_id),
+        _ => None,
+    }
+}
+
+fn pane_response_is_remote(response: &str) -> bool {
+    let Ok(response) = serde_json::from_str::<SuccessResponse>(response) else {
+        return false;
+    };
+    matches!(
+        response.result,
+        ResponseResult::PaneInfo { pane } if pane.remote_target.is_some()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::api::schema::{AgentStatus, ErrorResponse, PaneInfo};
+    use crate::api::ApiRequestMessage;
+    use crate::ipc::LocalStream;
+    use interprocess::local_socket::traits::Listener as _;
+    use std::collections::HashMap;
+    use std::io::{BufRead, BufReader, Write};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::mpsc::{self, Sender};
+    use std::thread::JoinHandle;
+    use tokio::sync::mpsc as tokio_mpsc;
+
+    static NEXT_LOCAL_STREAM_ID: AtomicU64 = AtomicU64::new(1);
+
+    fn local_stream_pair(name: &str) -> (LocalStream, LocalStream, PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "herdr-remote-report-{name}-{}-{}.sock",
+            std::process::id(),
+            NEXT_LOCAL_STREAM_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+        let listener = crate::ipc::bind_local_listener(&path).unwrap();
+        let client = crate::ipc::connect_local_stream(&path).unwrap();
+        let server = listener.accept().unwrap();
+        (client, server, path)
+    }
+
+    fn pane_info(remote_target: Option<String>) -> PaneInfo {
+        PaneInfo {
+            pane_id: "pane_1".into(),
+            terminal_id: "terminal_1".into(),
+            workspace_id: "workspace_1".into(),
+            tab_id: "tab_1".into(),
+            focused: true,
+            cwd: None,
+            foreground_cwd: None,
+            label: None,
+            agent: None,
+            title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
+            display_agent: None,
+            agent_status: AgentStatus::Idle,
+            state_labels: HashMap::new(),
+            tokens: HashMap::new(),
+            agent_session: None,
+            scroll: None,
+            revision: 0,
+            remote_target,
+        }
+    }
+
+    fn send_success(message: &ApiRequestMessage, result: ResponseResult) {
+        message
+            .respond_to
+            .send(
+                serde_json::to_string(&SuccessResponse {
+                    id: message.request.id.clone(),
+                    result,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+    }
+
+    fn spawn_api_responder(
+        remote_target: Option<String>,
+        seen_tx: Sender<Request>,
+    ) -> (ApiRequestSender, JoinHandle<()>) {
+        let (api_tx, mut api_rx) = tokio_mpsc::unbounded_channel::<ApiRequestMessage>();
+        let responder = std::thread::spawn(move || {
+            while let Some(message) = api_rx.blocking_recv() {
+                match &message.request.method {
+                    Method::PaneGet(_) => send_success(
+                        &message,
+                        ResponseResult::PaneInfo {
+                            pane: pane_info(remote_target.clone()),
+                        },
+                    ),
+                    Method::PaneReportAgent(_)
+                    | Method::PaneReportAgentSession(_)
+                    | Method::PaneReportMetadata(_)
+                    | Method::PaneReleaseAgent(_)
+                    | Method::PaneClearAgentAuthority(_) => {
+                        seen_tx.send(message.request.clone()).unwrap();
+                        send_success(&message, ResponseResult::Ok {});
+                    }
+                    other => panic!("unexpected request: {other:?}"),
+                }
+            }
+        });
+        (api_tx, responder)
+    }
+
+    fn run_request(raw_request: &str, remote_target: Option<&str>) -> (String, Vec<Request>) {
+        let (seen_tx, seen_rx) = mpsc::channel();
+        let (api_tx, responder) = spawn_api_responder(remote_target.map(str::to_owned), seen_tx);
+        let (mut client, server, path) = local_stream_pair("request");
+        let running = Arc::new(AtomicBool::new(true));
+        let server_running = Arc::clone(&running);
+        let server_thread =
+            std::thread::spawn(move || handle_connection(server, &api_tx, &server_running));
+
+        client.write_all(raw_request.as_bytes()).unwrap();
+        client.write_all(b"\n").unwrap();
+        client.flush().unwrap();
+        let mut reader = BufReader::new(&mut client);
+        let mut response = String::new();
+        reader.read_line(&mut response).unwrap();
+        drop(reader);
+        drop(client);
+        running.store(false, Ordering::Relaxed);
+        assert!(server_thread.join().unwrap().is_ok());
+        assert!(responder.join().is_ok());
+        let _ = std::fs::remove_file(path);
+        (response, seen_rx.try_iter().collect())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_report_forwards_allowed_request_verbatim_for_remote_pane() {
+        let raw_request = r#"{"id":"report_1","method":"pane.report_agent","params":{"pane_id":"pane_1","source":"herdr:omp","agent":"omp","state":"working"}}"#;
+        let (response, seen) = run_request(raw_request, Some("localhost"));
+        let response: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(response.result, ResponseResult::Ok {});
+        assert_eq!(seen, vec![serde_json::from_str(raw_request).unwrap()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_report_rejects_non_remote_pane() {
+        let raw_request = r#"{"id":"report_2","method":"pane.report_agent","params":{"pane_id":"pane_1","source":"herdr:omp","agent":"omp","state":"working"}}"#;
+        let (response, seen) = run_request(raw_request, None);
+        let response: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(response.error.code, "pane_not_remote");
+        assert!(seen.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_report_rejects_pane_send_text_without_dispatching() {
+        let raw_request = r#"{"id":"send_1","method":"pane.send_text","params":{"pane_id":"pane_1","text":"uname\n"}}"#;
+        let (response, seen) = run_request(raw_request, Some("localhost"));
+        let response: ErrorResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(response.error.code, "method_not_allowed");
+        assert!(seen.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_report_forwards_ping() {
+        let raw_request = r#"{"id":"ping_1","method":"ping","params":{}}"#;
+        let (response, seen) = run_request(raw_request, None);
+        let response: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert!(matches!(response.result, ResponseResult::Pong { .. }));
+        assert!(seen.is_empty());
+    }
+}

--- a/src/api/subscriptions.rs
+++ b/src/api/subscriptions.rs
@@ -673,6 +673,7 @@ mod tests {
             agent_session: None,
             scroll,
             revision: 0,
+            remote_target: None,
         }
     }
 

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1790,6 +1790,44 @@ pub(crate) struct PaneZoomOutcome {
 }
 
 impl AppState {
+    /// Toggle-off path for `[remote] agent_reporting`: every pane currently
+    /// marked as an SSH session reverts as if the session had ended — the
+    /// remote-reported authority releases and live transport state clears.
+    /// Detection loops never re-probe a stable ssh foreground on their own,
+    /// so this runs eagerly from the config-apply path.
+    pub(crate) fn release_all_remote_transports(&mut self) -> Vec<PaneStateUpdate> {
+        let pane_ids: Vec<PaneId> = self
+            .workspaces
+            .iter()
+            .flat_map(|workspace| workspace.panes.keys().copied().collect::<Vec<PaneId>>())
+            .collect();
+        let mut updates = Vec::new();
+        for pane_id in pane_ids {
+            let is_remote = self
+                .workspaces
+                .iter()
+                .find_map(|workspace| workspace.pane_state(pane_id))
+                .and_then(|pane| self.terminals.get(&pane.attached_terminal_id))
+                .is_some_and(|terminal| terminal.remote_transport.is_some());
+            if !is_remote {
+                continue;
+            }
+            // Release before clearing the transport, matching the
+            // RemoteTransportChanged None-transition: full-lifecycle
+            // authorities are only releasable while still marked remote.
+            updates.extend(self.update_terminal_state(pane_id, |terminal| {
+                terminal.remote_env_injected_at = None;
+                terminal.release_remote_hook_authority()
+            }));
+            updates.extend(self.update_terminal_state(pane_id, |terminal| {
+                terminal
+                    .set_remote_transport(None)
+                    .then_some(TerminalStateMutation::default())
+            }));
+        }
+        updates
+    }
+
     #[cfg(test)]
     pub fn navigate_pane(&mut self, direction: NavDirection) {
         let Some(ws_idx) = self.active else {
@@ -2665,6 +2703,72 @@ fn is_trailing_token_wrapper(ch: char) -> bool {
 // ---------------------------------------------------------------------------
 
 impl AppState {
+    pub(crate) fn remote_transport_for_pane(
+        &self,
+        pane_id: PaneId,
+    ) -> Option<crate::detect::RemoteTransport> {
+        let terminal_id = self.workspaces.iter().find_map(|workspace| {
+            workspace
+                .pane_state(pane_id)
+                .map(|pane| pane.attached_terminal_id.clone())
+        })?;
+        self.terminals
+            .get(&terminal_id)?
+            .remote_transport()
+            .cloned()
+    }
+
+    pub(crate) fn remote_env_injection_line(
+        &self,
+        pane_id: PaneId,
+        remote_socket_path: &str,
+        now: Instant,
+    ) -> Option<String> {
+        let workspace = self
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.pane_state(pane_id).is_some())?;
+        let pane = workspace.pane_state(pane_id)?;
+        let terminal = self.terminals.get(&pane.attached_terminal_id)?;
+        if terminal.remote_transport().is_none() || terminal.hook_authority_remote {
+            return None;
+        }
+        if terminal.remote_env_injected_at.is_some_and(|injected_at| {
+            now.saturating_duration_since(injected_at) < std::time::Duration::from_secs(30)
+        }) {
+            return None;
+        }
+        let pane_number = workspace.public_pane_number(pane_id)?;
+        let public_pane_id =
+            crate::workspace::public_pane_id_for_number(&workspace.id, pane_number);
+
+        // The leading space dodges shell history when the remote shell sets
+        // histignorespace. Plain bytes, without bracketed-paste markers, let
+        // readline execute the line.
+        // POSIX export covers sh/bash/zsh/ash and fish's compatibility builtin;
+        // csh/tcsh rejects the line harmlessly.
+        Some(format!(
+            " export HERDR_ENV=1 HERDR_PANE_ID={} HERDR_SOCKET_PATH={}\n",
+            crate::remote::shell_quote(&public_pane_id),
+            crate::remote::shell_quote(remote_socket_path),
+        ))
+    }
+
+    pub(crate) fn mark_remote_env_injected(&mut self, pane_id: PaneId, now: Instant) {
+        let Some(terminal_id) = self.workspaces.iter().find_map(|workspace| {
+            workspace
+                .pane_state(pane_id)
+                .map(|pane| pane.attached_terminal_id.clone())
+        }) else {
+            return;
+        };
+        if let Some(terminal) = self.terminals.get_mut(&terminal_id) {
+            terminal.remote_env_injected_at = Some(now);
+        }
+    }
+}
+
+impl AppState {
     pub fn apply_workspace_git_statuses(
         &mut self,
         terminal_runtimes: &crate::terminal::TerminalRuntimeRegistry,
@@ -2795,6 +2899,45 @@ impl AppState {
                 })
                 .into_iter()
                 .collect(),
+            AppEvent::RemoteTransportChanged { pane_id, transport } => {
+                let pane_exists = self
+                    .workspaces
+                    .iter()
+                    .any(|workspace| workspace.pane_state(pane_id).is_some());
+                let ssh_session_ended = transport.is_none();
+                let transport_for_forward = transport.clone();
+                let mut updates: Vec<PaneStateUpdate> = Vec::new();
+                if ssh_session_ended {
+                    // Release the remote-reported authority BEFORE dropping
+                    // the transport: full-lifecycle authorities are only
+                    // effective (and thus releasable) while the pane is still
+                    // marked remote. A hook authority reported over the
+                    // forward belongs to a process on the remote host whose
+                    // report stream is now dead — release it so the pane
+                    // leaves the agents section. Collateral: a local agent
+                    // backgrounded with ctrl+z while the user ssh's reports
+                    // "while remote" and is released here; it re-registers on
+                    // its next lifecycle event or foreground return.
+                    let release_update = self.update_terminal_state(pane_id, |terminal| {
+                        terminal.remote_env_injected_at = None;
+                        terminal.release_remote_hook_authority()
+                    });
+                    updates.extend(release_update);
+                }
+                updates.extend(self.update_terminal_state(pane_id, |terminal| {
+                    terminal
+                        .set_remote_transport(transport)
+                        .then_some(TerminalStateMutation::default())
+                }));
+                if pane_exists {
+                    match transport_for_forward {
+                        Some(transport) => self.remote_forwards.claim(pane_id, transport),
+                        None => self.remote_forwards.release(pane_id),
+                    }
+                }
+                updates
+            }
+            AppEvent::RemoteTransportPromptReady { .. } => Vec::new(),
             AppEvent::HookStateReported {
                 pane_id,
                 source,
@@ -3298,6 +3441,8 @@ impl AppState {
     }
 
     fn handle_pane_died(&mut self, pane_id: PaneId) {
+        // PaneDied is the common cleanup event for explicit closes and PTY exits.
+        self.remote_forwards.release(pane_id);
         self.pending_agent_notifications.remove(&pane_id);
         self.remove_plugin_pane_records([pane_id]);
         let ws_idx = self
@@ -3399,6 +3544,92 @@ mod tests {
             state.mode = Mode::Terminal;
         }
         state
+    }
+
+    fn app_with_remote_pane() -> (AppState, PaneId) {
+        let mut state = app_with_workspaces(&["remote"]);
+        let pane_id = state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = state.workspaces[0]
+            .pane_state(pane_id)
+            .expect("test pane exists")
+            .attached_terminal_id
+            .clone();
+        state
+            .terminals
+            .get_mut(&terminal_id)
+            .expect("test terminal exists")
+            .set_remote_transport(Some(crate::detect::RemoteTransport {
+                dest: "host".into(),
+                port: None,
+                config_path: None,
+                identity_file: None,
+            }));
+        (state, pane_id)
+    }
+
+    #[test]
+    fn remote_env_injection_line_quotes_socket_path() {
+        let (state, pane_id) = app_with_remote_pane();
+        let now = std::time::Instant::now();
+        let workspace = &state.workspaces[0];
+        let pane_number = workspace.public_pane_number(pane_id).unwrap();
+        let public_pane_id =
+            crate::workspace::public_pane_id_for_number(&workspace.id, pane_number);
+        let socket_path = "/home/remote user/.herdr/agent-report.sock";
+
+        assert_eq!(
+            state
+                .remote_transport_for_pane(pane_id)
+                .map(|transport| transport.dest),
+            Some("host".to_string())
+        );
+        assert_eq!(
+            state.remote_env_injection_line(pane_id, socket_path, now),
+            Some(format!(
+                " export HERDR_ENV=1 HERDR_PANE_ID={} HERDR_SOCKET_PATH={}\n",
+                crate::remote::shell_quote(&public_pane_id),
+                crate::remote::shell_quote(socket_path),
+            ))
+        );
+    }
+
+    #[test]
+    fn remote_env_injection_line_rejects_all_ineligible_states() {
+        let now = std::time::Instant::now();
+        let socket_path = "/tmp/agent-report.sock";
+
+        let no_transport = app_with_workspaces(&["local"]);
+        let local_pane = no_transport.workspaces[0].tabs[0].root_pane;
+        assert!(no_transport
+            .remote_env_injection_line(local_pane, socket_path, now)
+            .is_none());
+
+        let (mut remote, remote_pane) = app_with_remote_pane();
+        let terminal_id = remote.workspaces[0]
+            .pane_state(remote_pane)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+        {
+            let terminal = remote.terminals.get_mut(&terminal_id).unwrap();
+            terminal.hook_authority_remote = true;
+        }
+        assert!(remote
+            .remote_env_injection_line(remote_pane, socket_path, now)
+            .is_none());
+
+        {
+            let terminal = remote.terminals.get_mut(&terminal_id).unwrap();
+            terminal.hook_authority_remote = false;
+            terminal.remote_env_injected_at = Some(now - std::time::Duration::from_secs(1));
+        }
+        assert!(remote
+            .remote_env_injection_line(remote_pane, socket_path, now)
+            .is_none());
+
+        assert!(remote
+            .remote_env_injection_line(PaneId::from_raw(0), socket_path, now)
+            .is_none());
     }
 
     fn insert_test_pane_graphics_layer(state: &mut AppState, pane_id: PaneId) {
@@ -5174,6 +5405,215 @@ mod tests {
         assert!(state.pending_agent_notifications.is_empty());
         assert!(state.drain_due_agent_notifications(deadline).is_empty());
         assert!(state.toast.is_none());
+    }
+
+    #[test]
+    fn remote_hook_authority_is_released_when_ssh_session_ends() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0]
+            .panes
+            .get(&pane_id)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+
+        state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:hermes".into(),
+            agent_label: "hermes".into(),
+            state: AgentState::Working,
+            message: None,
+            seq: None,
+            session_ref: None,
+        });
+        assert!(
+            !state
+                .terminals
+                .get(&terminal_id)
+                .unwrap()
+                .hook_authority_remote
+        );
+
+        state.handle_app_event(AppEvent::RemoteTransportChanged {
+            pane_id,
+            transport: Some(crate::detect::RemoteTransport {
+                dest: "host".into(),
+                port: None,
+                config_path: None,
+                identity_file: None,
+            }),
+        });
+        state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:hermes".into(),
+            agent_label: "hermes".into(),
+            state: AgentState::Idle,
+            message: None,
+            seq: None,
+            session_ref: None,
+        });
+        let terminal = state.terminals.get(&terminal_id).unwrap();
+        assert!(terminal.hook_authority_remote);
+        assert!(terminal.hook_authority.is_some());
+
+        state.handle_app_event(AppEvent::RemoteTransportChanged {
+            pane_id,
+            transport: None,
+        });
+        let terminal = state.terminals.get(&terminal_id).unwrap();
+        assert!(!terminal.hook_authority_remote);
+        assert!(terminal.hook_authority.is_none());
+        assert!(terminal.remote_env_injected_at.is_none());
+        assert_eq!(terminal.effective_agent_label(), None);
+    }
+
+    #[test]
+    fn local_hook_authority_survives_ssh_session_end() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0]
+            .panes
+            .get(&pane_id)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+
+        // Authority reported before any SSH session is local, and an SSH
+        // session ending must not release it.
+        state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "custom:hermes".into(),
+            agent_label: "hermes".into(),
+            state: AgentState::Working,
+            message: None,
+            seq: None,
+            session_ref: None,
+        });
+        state.handle_app_event(AppEvent::RemoteTransportChanged {
+            pane_id,
+            transport: None,
+        });
+        let terminal = state.terminals.get(&terminal_id).unwrap();
+        assert!(terminal.hook_authority.is_some());
+        assert!(!terminal.hook_authority_remote);
+        assert_eq!(terminal.effective_agent_label(), Some("hermes"));
+    }
+
+    #[test]
+    fn full_lifecycle_remote_report_is_effective_and_released_on_ssh_exit() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0]
+            .panes
+            .get(&pane_id)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+
+        // Without a transport, a process-less full-lifecycle report is
+        // ignored (no local process evidence anchors it).
+        state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "herdr:omp".into(),
+            agent_label: "omp".into(),
+            state: AgentState::Working,
+            message: None,
+            seq: None,
+            session_ref: None,
+        });
+        assert!(state
+            .terminals
+            .get(&terminal_id)
+            .unwrap()
+            .hook_authority
+            .is_none());
+
+        // Over an SSH session the report proxy is the evidence: the authority
+        // is accepted and effective with no locally detected process.
+        state.handle_app_event(AppEvent::RemoteTransportChanged {
+            pane_id,
+            transport: Some(crate::detect::RemoteTransport {
+                dest: "host".into(),
+                port: None,
+                config_path: None,
+                identity_file: None,
+            }),
+        });
+        state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "herdr:omp".into(),
+            agent_label: "omp".into(),
+            state: AgentState::Working,
+            message: None,
+            seq: None,
+            session_ref: None,
+        });
+        let terminal = state.terminals.get(&terminal_id).unwrap();
+        assert!(terminal.hook_authority_remote);
+        assert_eq!(terminal.effective_agent_label(), Some("omp"));
+        assert_eq!(terminal.state, AgentState::Working);
+
+        // SSH exit releases it even though the effectiveness gate depends on
+        // the transport; release must run before the transport clears.
+        state.handle_app_event(AppEvent::RemoteTransportChanged {
+            pane_id,
+            transport: None,
+        });
+        let terminal = state.terminals.get(&terminal_id).unwrap();
+        assert!(terminal.hook_authority.is_none());
+        assert!(!terminal.hook_authority_remote);
+        assert_eq!(terminal.effective_agent_label(), None);
+    }
+
+    #[test]
+    fn release_all_remote_transports_clears_remote_state() {
+        let mut state = app_with_workspaces(&["ws"]);
+        let pane_id = *state.workspaces[0].panes.keys().next().unwrap();
+        let terminal_id = state.workspaces[0]
+            .panes
+            .get(&pane_id)
+            .unwrap()
+            .attached_terminal_id
+            .clone();
+
+        state.handle_app_event(AppEvent::RemoteTransportChanged {
+            pane_id,
+            transport: Some(crate::detect::RemoteTransport {
+                dest: "host".into(),
+                port: None,
+                config_path: None,
+                identity_file: None,
+            }),
+        });
+        state.handle_app_event(AppEvent::HookStateReported {
+            pane_id,
+            source: "herdr:omp".into(),
+            agent_label: "omp".into(),
+            state: AgentState::Working,
+            message: None,
+            seq: None,
+            session_ref: None,
+        });
+        assert_eq!(
+            state
+                .terminals
+                .get(&terminal_id)
+                .unwrap()
+                .effective_agent_label(),
+            Some("omp")
+        );
+
+        let updates = state.release_all_remote_transports();
+        assert!(!updates.is_empty());
+        let terminal = state.terminals.get(&terminal_id).unwrap();
+        assert!(terminal.remote_transport.is_none());
+        assert!(terminal.hook_authority.is_none());
+        assert!(!terminal.hook_authority_remote);
+        assert_eq!(terminal.effective_agent_label(), None);
+
+        // Idempotent: nothing remote left to release.
+        assert!(state.release_all_remote_transports().is_empty());
     }
 
     #[test]

--- a/src/app/agent_resume.rs
+++ b/src/app/agent_resume.rs
@@ -316,29 +316,13 @@ fn stable_terminal_inner_rect(pane_inner: Rect) -> Rect {
 
 fn shell_command_from_argv(argv: &[String]) -> Option<String> {
     let mut parts = argv.iter();
-    let first = shell_quote(parts.next()?);
+    let first = crate::remote::shell_quote(parts.next()?);
     let mut command = first;
     for part in parts {
         command.push(' ');
-        command.push_str(&shell_quote(part));
+        command.push_str(&crate::remote::shell_quote(part));
     }
     Some(command)
-}
-
-fn shell_quote(value: &str) -> String {
-    if value.is_empty() {
-        return "''".to_string();
-    }
-    if value.bytes().all(|byte| {
-        byte.is_ascii_alphanumeric()
-            || matches!(
-                byte,
-                b'_' | b'-' | b'.' | b'/' | b':' | b'@' | b'%' | b'+' | b'='
-            )
-    }) {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -254,6 +254,11 @@ impl App {
         } else {
             None
         };
+        let remote_prompt_ready = if let AppEvent::RemoteTransportPromptReady { pane_id } = &ev {
+            Some(*pane_id)
+        } else {
+            None
+        };
 
         let update_ready = if let AppEvent::UpdateReady {
             version,
@@ -288,6 +293,9 @@ impl App {
                     }
                 }
             }
+        }
+        if let Some(pane_id) = remote_prompt_ready {
+            self.maybe_inject_remote_env(pane_id);
         }
         self.sync_full_lifecycle_authority_detection_pauses();
         if terminal_cwd_reported {
@@ -359,7 +367,7 @@ impl App {
         }
     }
 
-    fn reset_all_agent_detection_runtimes(&self) {
+    pub(super) fn reset_all_agent_detection_runtimes(&self) {
         for runtime in self.terminal_runtimes.values() {
             runtime.reset_agent_detection();
         }
@@ -408,7 +416,7 @@ impl App {
         }
     }
 
-    fn sync_full_lifecycle_authority_detection_pauses(&self) {
+    pub(super) fn sync_full_lifecycle_authority_detection_pauses(&self) {
         for workspace in &self.state.workspaces {
             for tab in &workspace.tabs {
                 for pane in tab.panes.values() {

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use bytes::Bytes;
 
 use crate::api::schema::{
@@ -1467,6 +1469,53 @@ impl App {
 
         encode_success(id, ResponseResult::Ok {})
     }
+    fn try_send_pane_bytes(
+        &self,
+        ws_idx: usize,
+        pane_id: PaneId,
+        bytes: Bytes,
+    ) -> Option<Result<(), tokio::sync::mpsc::error::TrySendError<Bytes>>> {
+        let runtime = self.lookup_runtime_sender(ws_idx, pane_id)?;
+        Some(runtime.try_send_bytes(bytes))
+    }
+
+    pub(super) fn maybe_inject_remote_env(&mut self, pane_id: PaneId) {
+        if !crate::config::remote_agent_reporting_enabled() {
+            return;
+        }
+        let Some((ws_idx, _)) = self.find_pane(pane_id) else {
+            return;
+        };
+        let Some(transport) = self.state.remote_transport_for_pane(pane_id) else {
+            return;
+        };
+        let Some(remote_socket_path) = self
+            .state
+            .remote_forwards
+            .remote_socket_path_for(&transport)
+        else {
+            return;
+        };
+        let Some(line) =
+            self.state
+                .remote_env_injection_line(pane_id, &remote_socket_path, Instant::now())
+        else {
+            return;
+        };
+        let Some(send_result) =
+            self.try_send_pane_bytes(ws_idx, pane_id, Bytes::from(line.into_bytes()))
+        else {
+            return;
+        };
+        match send_result {
+            Ok(()) => self.state.mark_remote_env_injected(pane_id, Instant::now()),
+            Err(err) => tracing::warn!(
+                pane = pane_id.raw(),
+                err = %err,
+                "failed to inject remote environment"
+            ),
+        }
+    }
 
     pub(super) fn handle_pane_send_text(
         &mut self,
@@ -1476,10 +1525,11 @@ impl App {
         let Some((ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
             return pane_not_found(id, &params.pane_id);
         };
-        let Some(runtime) = self.lookup_runtime_sender(ws_idx, pane_id) else {
+        let Some(send_result) = self.try_send_pane_bytes(ws_idx, pane_id, Bytes::from(params.text))
+        else {
             return pane_not_found(id, &params.pane_id);
         };
-        if let Err(err) = runtime.try_send_bytes(Bytes::from(params.text)) {
+        if let Err(err) = send_result {
             return encode_error(id, "pane_send_failed", err.to_string());
         }
 

--- a/src/app/config_io.rs
+++ b/src/app/config_io.rs
@@ -76,6 +76,14 @@ impl App {
         }
     }
 
+    pub(super) fn save_remote_agent_reporting(&mut self, enabled: bool) {
+        if self.update_config_file("remote agent reporting", |content| {
+            crate::config::upsert_section_bool(content, "remote", "agent_reporting", enabled)
+        }) {
+            self.apply_config_from_disk(false);
+        }
+    }
+
     pub(super) fn save_toast_delivery(&mut self, delivery: crate::config::ToastDelivery) {
         let value = match delivery {
             crate::config::ToastDelivery::Off => "\"off\"",

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -466,6 +466,10 @@ impl App {
             agent_session: terminal_agent_session_info(terminal),
             scroll,
             revision: terminal.revision,
+            remote_target: terminal
+                .remote_transport
+                .as_ref()
+                .map(|transport| transport.dest.clone()),
         })
     }
 

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -403,6 +403,9 @@ impl App {
                             self.save_status_indicators(style)
                         }
                         SettingsAction::SaveSound(enabled) => self.save_sound(enabled),
+                        SettingsAction::SaveRemoteAgentReporting(enabled) => {
+                            self.save_remote_agent_reporting(enabled)
+                        }
                         SettingsAction::SaveToastDelivery(delivery) => {
                             self.save_toast_delivery(delivery)
                         }

--- a/src/app/input/settings.rs
+++ b/src/app/input/settings.rs
@@ -16,6 +16,7 @@ pub(super) enum SettingsAction {
     SaveTheme(String),
     SaveStatusIndicators(StatusIndicatorStyle),
     SaveSound(bool),
+    SaveRemoteAgentReporting(bool),
     SaveToastDelivery(ToastDelivery),
     SaveAgentBorderLabels(bool),
     InstallRecommendedIntegrations,
@@ -29,6 +30,9 @@ impl App {
                 SettingsAction::SaveTheme(name) => self.save_theme(&name),
                 SettingsAction::SaveStatusIndicators(style) => self.save_status_indicators(style),
                 SettingsAction::SaveSound(enabled) => self.save_sound(enabled),
+                SettingsAction::SaveRemoteAgentReporting(enabled) => {
+                    self.save_remote_agent_reporting(enabled)
+                }
                 SettingsAction::SaveToastDelivery(delivery) => self.save_toast_delivery(delivery),
                 SettingsAction::SaveAgentBorderLabels(enabled) => {
                     self.save_agent_border_labels(enabled)
@@ -166,8 +170,8 @@ pub(super) fn update_settings_state(state: &mut AppState, key: KeyEvent) -> Opti
                 state.settings.list.selected = status_indicator_index(state.status_indicators);
             }
             KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h') => {
-                state.settings.section = SettingsSection::Integrations;
-                state.settings.list.selected = 0;
+                state.settings.section = SettingsSection::Remote;
+                state.settings.list.selected = usize::from(!state.remote_agent_reporting());
             }
             _ => match super::modal::modal_action_from_key(&key, super::modal::SETTINGS_ACTIONS) {
                 Some(super::modal::ModalAction::Apply) => return apply_settings(state),
@@ -279,14 +283,38 @@ pub(super) fn update_settings_state(state: &mut AppState, key: KeyEvent) -> Opti
                 state.settings.list.selected = usize::from(!state.agent_border_labels_enabled());
             }
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
-                state.settings.section = SettingsSection::Theme;
-                state.settings.list.selected = current_theme_index(&state.theme_name);
+                state.settings.section = SettingsSection::Remote;
+                state.settings.list.selected = usize::from(!state.remote_agent_reporting());
             }
             _ => match super::modal::modal_action_from_key(&key, super::modal::SETTINGS_ACTIONS) {
                 Some(super::modal::ModalAction::Apply) => return apply_settings(state),
                 Some(super::modal::ModalAction::Close) => cancel_settings(state),
                 _ => {}
             },
+        },
+        SettingsSection::Remote => match key.code {
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                state.settings.list.selected = 1 - state.settings.list.selected.min(1);
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                let enabled = state.settings.list.selected == 0;
+                return Some(SettingsAction::SaveRemoteAgentReporting(enabled));
+            }
+            KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h') => {
+                state.settings.section = SettingsSection::Integrations;
+                state.settings.list.selected = 0;
+            }
+            KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
+                state.settings.section = SettingsSection::Theme;
+                state.settings.list.selected = current_theme_index(&state.theme_name);
+            }
+            _ => {
+                if let Some(super::modal::ModalAction::Close) =
+                    super::modal::modal_action_from_key(&key, super::modal::SETTINGS_ACTIONS)
+                {
+                    cancel_settings(state);
+                }
+            }
         },
     }
 
@@ -309,6 +337,7 @@ pub(crate) fn open_settings_at(state: &mut AppState, section: SettingsSection) {
         SettingsSection::Toast => toast_delivery_index(state.toast_delivery()),
         SettingsSection::PaneLabels => usize::from(!state.agent_border_labels_enabled()),
         SettingsSection::Integrations => 0,
+        SettingsSection::Remote => usize::from(!state.remote_agent_reporting()),
     };
     state.mode = Mode::Settings;
 }
@@ -378,7 +407,7 @@ impl AppState {
                 let idx = scroll + (row - area.y) as usize;
                 (idx < THEME_NAMES.len()).then_some(idx)
             }
-            SettingsSection::Indicators | SettingsSection::Sound => {
+            SettingsSection::Indicators | SettingsSection::Sound | SettingsSection::Remote => {
                 let list_y = area.y + 3;
                 if row >= list_y && row < list_y + 2 {
                     Some((row - list_y) as usize)
@@ -421,6 +450,7 @@ impl AppState {
                         SettingsSection::PaneLabels => {
                             usize::from(!self.agent_border_labels_enabled())
                         }
+                        SettingsSection::Remote => usize::from(!self.remote_agent_reporting()),
                         SettingsSection::Integrations => 0,
                     });
                     return None;
@@ -448,6 +478,10 @@ impl AppState {
                             Some(SettingsAction::SaveAgentBorderLabels(enabled))
                         }
                         SettingsSection::Integrations => None,
+                        SettingsSection::Remote => {
+                            let enabled = idx == 0;
+                            Some(SettingsAction::SaveRemoteAgentReporting(enabled))
+                        }
                     };
                 }
 
@@ -555,7 +589,23 @@ mod tests {
     }
 
     #[test]
-    fn settings_tab_cycle_wraps_after_integrations() {
+    fn settings_remote_toggle_returns_save_action() {
+        let mut state = state_with_workspaces(&["test"]);
+        open_settings_at(&mut state, SettingsSection::Remote);
+        state.settings.list.selected = 0;
+
+        let action = update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()),
+        );
+
+        assert_eq!(action, Some(SettingsAction::SaveRemoteAgentReporting(true)));
+        assert!(!state.remote_agent_reporting());
+        assert_eq!(state.mode, Mode::Settings);
+    }
+
+    #[test]
+    fn settings_tab_cycle_wraps_after_remote() {
         let mut state = state_with_workspaces(&["test"]);
         open_settings_at(&mut state, SettingsSection::PaneLabels);
 
@@ -569,7 +619,19 @@ mod tests {
             &mut state,
             KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()),
         );
+        assert_eq!(state.settings.section, SettingsSection::Remote);
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()),
+        );
         assert_eq!(state.settings.section, SettingsSection::Theme);
+
+        update_settings_state(
+            &mut state,
+            KeyEvent::new(KeyCode::BackTab, KeyModifiers::empty()),
+        );
+        assert_eq!(state.settings.section, SettingsSection::Remote);
 
         update_settings_state(
             &mut state,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,6 +17,7 @@ mod git_refresh;
 mod ids;
 mod input;
 mod popup;
+pub(crate) mod remote_forward;
 mod runtime;
 mod runtime_mutations;
 mod session;
@@ -651,6 +652,8 @@ impl App {
             pane_scrollback_limit_bytes: config.advanced.scrollback_limit_bytes,
             accent: crate::config::parse_color(&config.ui.accent),
             sound: config.ui.sound.clone(),
+            remote_agent_reporting: config.remote.agent_reporting,
+            remote_forwards: crate::app::remote_forward::RemoteForwardManager::new(),
             local_sound_playback: true,
             toast_config: config.ui.toast.clone(),
             keybinds: config.keybinds(),
@@ -1376,9 +1379,31 @@ impl App {
         invalid_sections: &[String],
         notify_success: bool,
     ) -> crate::config::ConfigReloadReport {
+        let was_remote_agent_reporting = crate::config::remote_agent_reporting_enabled();
         let mut diagnostics = load_diagnostics.to_vec();
         let invalid_section =
             |section: &str| invalid_sections.iter().any(|invalid| invalid == section);
+
+        // Process-global so pane detection tasks observe the toggle without
+        // config threading; updated on every load, even when sections fail.
+        crate::config::set_remote_agent_reporting_enabled(config.remote.agent_reporting);
+        if was_remote_agent_reporting && !config.remote.agent_reporting {
+            // Detection loops never re-probe a stable ssh foreground on their
+            // own, so toggle-off clears remote state eagerly instead of
+            // waiting for the next foreground change.
+            let updates = self.state.release_all_remote_transports();
+            for update in &updates {
+                self.emit_pane_state_update(update);
+            }
+            self.sync_full_lifecycle_authority_detection_pauses();
+            self.state.remote_forwards.shutdown();
+        }
+        if !was_remote_agent_reporting && config.remote.agent_reporting {
+            // Force re-probes so ssh foregrounds claim their forwards and
+            // prompts re-emit without waiting for a foreground change.
+            self.reset_all_agent_detection_runtimes();
+        }
+        self.state.remote_agent_reporting = config.remote.agent_reporting;
 
         if !invalid_section("keys") {
             match config.live_keybinds_with_diagnostics() {

--- a/src/app/remote_forward.rs
+++ b/src/app/remote_forward.rs
@@ -1,0 +1,1008 @@
+//! SSH reverse-forward lifecycle for remote agent reporting.
+
+use crate::detect::RemoteTransport;
+#[cfg(not(unix))]
+use crate::layout::PaneId;
+
+#[cfg(unix)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TransportKey {
+    dest: String,
+    port: Option<String>,
+    config_path: Option<String>,
+    identity_file: Option<String>,
+}
+
+#[cfg(unix)]
+impl From<&RemoteTransport> for TransportKey {
+    fn from(transport: &RemoteTransport) -> Self {
+        Self {
+            dest: transport.dest.clone(),
+            port: transport.port.clone(),
+            config_path: transport.config_path.clone(),
+            identity_file: transport.identity_file.clone(),
+        }
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::{RemoteTransport, TransportKey};
+    use crate::layout::PaneId;
+    use std::collections::HashMap;
+    use std::io::{self, BufRead, Read};
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command as ProcessCommand, Stdio};
+    use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+    use std::sync::{Arc, Mutex, MutexGuard};
+    use std::thread::JoinHandle;
+    use std::time::{Duration, Instant};
+
+    const CLAIM_DEBOUNCE: Duration = Duration::from_secs(1);
+    const PREP_TIMEOUT: Duration = Duration::from_secs(15);
+    const WORKER_TICK: Duration = Duration::from_secs(1);
+    const RETRY_BACKOFF: [Duration; 4] = [
+        Duration::from_secs(2),
+        Duration::from_secs(5),
+        Duration::from_secs(15),
+        Duration::from_secs(60),
+    ];
+
+    trait ChildProcess: Send {
+        fn try_wait(&mut self) -> io::Result<Option<bool>>;
+        fn kill(&mut self) -> io::Result<()>;
+        fn wait(&mut self) -> io::Result<()>;
+    }
+
+    trait ProcessRunner: Send {
+        fn prepare(&mut self, argv: &[String], timeout: Duration) -> io::Result<String>;
+        fn spawn_forward(&mut self, argv: &[String]) -> io::Result<Box<dyn ChildProcess>>;
+    }
+
+    struct SystemChild {
+        child: Child,
+    }
+
+    impl ChildProcess for SystemChild {
+        fn try_wait(&mut self) -> io::Result<Option<bool>> {
+            self.child
+                .try_wait()
+                .map(|status| status.map(|value| value.success()))
+        }
+
+        fn kill(&mut self) -> io::Result<()> {
+            self.child.kill()
+        }
+
+        fn wait(&mut self) -> io::Result<()> {
+            self.child.wait().map(|_| ())
+        }
+    }
+
+    struct SystemRunner;
+
+    /// Test runner that never reaches a real ssh: preparation fails
+    /// immediately, so no forward child is ever spawned from unit tests.
+    #[cfg(test)]
+    struct FailingRunner;
+
+    #[cfg(test)]
+    impl ProcessRunner for FailingRunner {
+        fn prepare(&mut self, _argv: &[String], _timeout: Duration) -> io::Result<String> {
+            Err(io::Error::other("test runner never runs ssh preparation"))
+        }
+
+        fn spawn_forward(&mut self, _argv: &[String]) -> io::Result<Box<dyn ChildProcess>> {
+            Err(io::Error::other("test runner never spawns ssh"))
+        }
+    }
+
+    impl ProcessRunner for SystemRunner {
+        fn prepare(&mut self, argv: &[String], timeout: Duration) -> io::Result<String> {
+            let Some(program) = argv.first() else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "empty ssh preparation argv",
+                ));
+            };
+            let mut command = ProcessCommand::new(program);
+            command
+                .args(argv.iter().skip(1))
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut child = command.spawn()?;
+            if let Some(stderr) = child.stderr.take() {
+                drain_stderr(stderr, "ssh preparation");
+            }
+
+            let started = Instant::now();
+            loop {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        let mut stdout = child.stdout.take().ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "ssh preparation did not provide stdout",
+                            )
+                        })?;
+                        let mut output = Vec::new();
+                        stdout.read_to_end(&mut output)?;
+                        if !status.success() {
+                            return Err(io::Error::other(format!(
+                                "ssh preparation exited with {status}"
+                            )));
+                        }
+                        let home = String::from_utf8_lossy(&output).trim().to_string();
+                        if home.is_empty() {
+                            return Err(io::Error::other(
+                                "ssh preparation returned an empty remote home",
+                            ));
+                        }
+                        return Ok(home);
+                    }
+                    Ok(None) if started.elapsed() >= timeout => {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "ssh preparation timed out",
+                        ));
+                    }
+                    Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                    Err(err) => {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(err);
+                    }
+                }
+            }
+        }
+
+        fn spawn_forward(&mut self, argv: &[String]) -> io::Result<Box<dyn ChildProcess>> {
+            let Some(program) = argv.first() else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "empty ssh forward argv",
+                ));
+            };
+            let mut command = ProcessCommand::new(program);
+            command
+                .args(argv.iter().skip(1))
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped());
+            let mut child = command.spawn()?;
+            if let Some(stderr) = child.stderr.take() {
+                drain_stderr(stderr, "ssh reverse forward");
+            }
+            Ok(Box::new(SystemChild { child }))
+        }
+    }
+
+    fn drain_stderr<R>(reader: R, context: &'static str)
+    where
+        R: Read + Send + 'static,
+    {
+        std::thread::spawn(move || {
+            let reader = std::io::BufReader::new(reader);
+            for line in reader.lines() {
+                match line {
+                    Ok(line) => tracing::warn!(context, %line, "ssh process reported stderr"),
+                    Err(err) => tracing::debug!(context, %err, "ssh stderr reader stopped"),
+                }
+            }
+        });
+    }
+
+    #[derive(Debug)]
+    enum WorkerCommand {
+        Claim(PaneId, RemoteTransport),
+        Release(PaneId),
+        Reset,
+        Terminate,
+    }
+
+    struct ForwardState {
+        transport: RemoteTransport,
+        pane_count: usize,
+        remote_socket_path: Option<String>,
+        child: Option<Box<dyn ChildProcess>>,
+        next_action: Instant,
+        backoff_index: usize,
+    }
+
+    struct WorkerState {
+        pane_keys: HashMap<PaneId, TransportKey>,
+        forwards: HashMap<TransportKey, ForwardState>,
+    }
+
+    impl WorkerState {
+        fn new() -> Self {
+            Self {
+                pane_keys: HashMap::new(),
+                forwards: HashMap::new(),
+            }
+        }
+
+        fn claim(
+            &mut self,
+            pane: PaneId,
+            transport: RemoteTransport,
+            now: Instant,
+        ) -> Option<TransportKey> {
+            let key = TransportKey::from(&transport);
+            if self.pane_keys.get(&pane) == Some(&key) {
+                return None;
+            }
+            let released = if let Some(previous_key) = self.pane_keys.insert(pane, key.clone()) {
+                self.release_key(&previous_key).then_some(previous_key)
+            } else {
+                None
+            };
+            let state = self.forwards.entry(key).or_insert_with(|| ForwardState {
+                transport,
+                pane_count: 0,
+                remote_socket_path: None,
+                child: None,
+                next_action: now + CLAIM_DEBOUNCE,
+                backoff_index: 0,
+            });
+            state.pane_count += 1;
+            released
+        }
+
+        fn release(&mut self, pane: PaneId) -> Option<TransportKey> {
+            let key = self.pane_keys.remove(&pane)?;
+            self.release_key(&key).then_some(key)
+        }
+
+        fn release_key(&mut self, key: &TransportKey) -> bool {
+            let remove = if let Some(state) = self.forwards.get_mut(key) {
+                state.pane_count = state.pane_count.saturating_sub(1);
+                state.pane_count == 0
+            } else {
+                false
+            };
+            if remove {
+                if let Some(mut state) = self.forwards.remove(key) {
+                    stop_child(&mut state.child);
+                }
+            }
+            remove
+        }
+
+        fn reset(&mut self) {
+            for state in self.forwards.values_mut() {
+                stop_child(&mut state.child);
+            }
+            self.forwards.clear();
+            self.pane_keys.clear();
+        }
+
+        fn tick(
+            &mut self,
+            now: Instant,
+            runner: &mut dyn ProcessRunner,
+            prepared: &Arc<Mutex<HashMap<TransportKey, String>>>,
+            socket_name: &str,
+        ) {
+            let keys = self.forwards.keys().cloned().collect::<Vec<_>>();
+            for key in keys {
+                if !self.forwards.contains_key(&key) {
+                    continue;
+                }
+                self.reap_child(&key, now);
+                self.start_if_due(&key, now, runner, prepared, socket_name);
+            }
+        }
+
+        fn reap_child(&mut self, key: &TransportKey, now: Instant) {
+            let result = self
+                .forwards
+                .get_mut(key)
+                .and_then(|state| state.child.as_mut().map(|child| child.try_wait()));
+            let Some(result) = result else {
+                return;
+            };
+            match result {
+                Ok(None) => {}
+                Ok(Some(success)) => {
+                    tracing::warn!(
+                        destination = %key.dest,
+                        success,
+                        "ssh reverse forward exited"
+                    );
+                    self.schedule_retry(key, now);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        destination = %key.dest,
+                        error = %err,
+                        "failed to reap ssh reverse forward"
+                    );
+                    self.schedule_retry(key, now);
+                }
+            }
+        }
+
+        fn schedule_retry(&mut self, key: &TransportKey, now: Instant) {
+            let Some(state) = self.forwards.get_mut(key) else {
+                return;
+            };
+            stop_child(&mut state.child);
+            let index = state.backoff_index.min(RETRY_BACKOFF.len() - 1);
+            state.next_action = now + RETRY_BACKOFF[index];
+            state.backoff_index = (index + 1).min(RETRY_BACKOFF.len() - 1);
+        }
+
+        fn start_if_due(
+            &mut self,
+            key: &TransportKey,
+            now: Instant,
+            runner: &mut dyn ProcessRunner,
+            prepared: &Arc<Mutex<HashMap<TransportKey, String>>>,
+            socket_name: &str,
+        ) {
+            let Some(state) = self.forwards.get(key) else {
+                return;
+            };
+            if state.pane_count == 0 || state.child.is_some() || state.next_action > now {
+                return;
+            }
+            let transport = state.transport.clone();
+            let mut remote_socket_path = state.remote_socket_path.clone();
+
+            if remote_socket_path.is_none() {
+                let argv = build_prep_argv(&transport, socket_name);
+                match runner.prepare(&argv, PREP_TIMEOUT) {
+                    Ok(remote_home) => {
+                        let path = remote_socket_path_for_home(&remote_home, socket_name);
+                        remote_socket_path = Some(path.clone());
+                        if let Some(state) = self.forwards.get_mut(key) {
+                            state.remote_socket_path = Some(path.clone());
+                        }
+                        lock(prepared).insert(key.clone(), path);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            destination = %transport.dest,
+                            error = %err,
+                            "ssh reverse-forward preparation failed"
+                        );
+                        self.schedule_retry(key, now);
+                        return;
+                    }
+                }
+            }
+
+            let Some(remote_socket_path) = remote_socket_path else {
+                self.schedule_retry(key, now);
+                return;
+            };
+            let argv = build_forward_argv(
+                &transport,
+                &remote_socket_path,
+                &crate::session::remote_report_socket_path(),
+            );
+            match runner.spawn_forward(&argv) {
+                Ok(child) => {
+                    if let Some(state) = self.forwards.get_mut(key) {
+                        state.child = Some(child);
+                        state.next_action = now;
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        destination = %transport.dest,
+                        error = %err,
+                        "ssh reverse-forward spawn failed"
+                    );
+                    self.schedule_retry(key, now);
+                }
+            }
+        }
+    }
+
+    fn stop_child(child: &mut Option<Box<dyn ChildProcess>>) {
+        if let Some(mut child) = child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+        match mutex.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn worker_loop(
+        rx: Receiver<WorkerCommand>,
+        prepared: Arc<Mutex<HashMap<TransportKey, String>>>,
+        mut runner: Box<dyn ProcessRunner>,
+        socket_name: String,
+    ) {
+        let mut state = WorkerState::new();
+        loop {
+            match rx.recv_timeout(WORKER_TICK) {
+                Ok(WorkerCommand::Claim(pane, transport)) => {
+                    if let Some(key) = state.claim(pane, transport, Instant::now()) {
+                        lock(&prepared).remove(&key);
+                    }
+                }
+                Ok(WorkerCommand::Release(pane)) => {
+                    if let Some(key) = state.release(pane) {
+                        lock(&prepared).remove(&key);
+                    }
+                }
+                Ok(WorkerCommand::Reset) => {
+                    state.reset();
+                    lock(&prepared).clear();
+                }
+                Ok(WorkerCommand::Terminate) => {
+                    state.reset();
+                    lock(&prepared).clear();
+                    break;
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => {
+                    state.reset();
+                    lock(&prepared).clear();
+                    break;
+                }
+            }
+            state.tick(Instant::now(), runner.as_mut(), &prepared, &socket_name);
+        }
+    }
+
+    pub(crate) struct RemoteForwardManager {
+        control: Mutex<Control>,
+        prepared: Arc<Mutex<HashMap<TransportKey, String>>>,
+        runner: Mutex<Option<Box<dyn ProcessRunner>>>,
+    }
+
+    struct Control {
+        command_tx: Option<Sender<WorkerCommand>>,
+        worker: Option<JoinHandle<()>>,
+    }
+
+    impl RemoteForwardManager {
+        pub(crate) fn new() -> Self {
+            Self::with_runner(Box::new(SystemRunner))
+        }
+
+        #[cfg(test)]
+        pub(crate) fn for_test() -> Self {
+            Self::with_runner(Box::new(FailingRunner))
+        }
+
+        fn with_runner(runner: Box<dyn ProcessRunner>) -> Self {
+            Self {
+                control: Mutex::new(Control {
+                    command_tx: None,
+                    worker: None,
+                }),
+                prepared: Arc::new(Mutex::new(HashMap::new())),
+                runner: Mutex::new(Some(runner)),
+            }
+        }
+
+        fn ensure_worker(&self) -> Option<Sender<WorkerCommand>> {
+            let mut control = lock(&self.control);
+            if let Some(command_tx) = control.command_tx.as_ref() {
+                return Some(command_tx.clone());
+            }
+            let runner = match lock(&self.runner).take() {
+                Some(runner) => runner,
+                None => Box::new(SystemRunner),
+            };
+            let (command_tx, command_rx) = mpsc::channel();
+            let prepared = Arc::clone(&self.prepared);
+            let socket_name = remote_socket_name();
+            let worker =
+                std::thread::spawn(move || worker_loop(command_rx, prepared, runner, socket_name));
+            control.worker = Some(worker);
+            control.command_tx = Some(command_tx.clone());
+            Some(command_tx)
+        }
+
+        pub(crate) fn claim(&self, pane: PaneId, transport: RemoteTransport) {
+            let Some(command_tx) = self.ensure_worker() else {
+                return;
+            };
+            if let Err(err) = command_tx.send(WorkerCommand::Claim(pane, transport)) {
+                tracing::debug!(%err, "remote forward worker is unavailable");
+            }
+        }
+
+        pub(crate) fn release(&self, pane: PaneId) {
+            let command_tx = lock(&self.control).command_tx.clone();
+            let Some(command_tx) = command_tx else {
+                return;
+            };
+            if let Err(err) = command_tx.send(WorkerCommand::Release(pane)) {
+                tracing::debug!(%err, "remote forward worker is unavailable");
+            }
+        }
+
+        pub(crate) fn remote_socket_path_for(&self, transport: &RemoteTransport) -> Option<String> {
+            lock(&self.prepared)
+                .get(&TransportKey::from(transport))
+                .cloned()
+        }
+
+        pub(crate) fn shutdown(&self) {
+            lock(&self.prepared).clear();
+            let command_tx = lock(&self.control).command_tx.clone();
+            if let Some(command_tx) = command_tx {
+                if let Err(err) = command_tx.send(WorkerCommand::Reset) {
+                    tracing::debug!(%err, "remote forward worker is unavailable");
+                }
+            }
+        }
+    }
+
+    impl Drop for RemoteForwardManager {
+        fn drop(&mut self) {
+            self.shutdown();
+            let (command_tx, worker) = {
+                let mut control = lock(&self.control);
+                (control.command_tx.take(), control.worker.take())
+            };
+            if let Some(command_tx) = command_tx {
+                let _ = command_tx.send(WorkerCommand::Terminate);
+            }
+            if let Some(worker) = worker {
+                if worker.join().is_err() {
+                    tracing::warn!("remote forward worker thread panicked");
+                }
+            }
+        }
+    }
+
+    fn ssh_option_args(transport: &RemoteTransport) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(port) = &transport.port {
+            args.extend(["-p".to_string(), port.clone()]);
+        }
+        if let Some(config_path) = &transport.config_path {
+            args.extend(["-F".to_string(), config_path.clone()]);
+        }
+        if let Some(identity_file) = &transport.identity_file {
+            args.extend(["-i".to_string(), identity_file.clone()]);
+        }
+        args
+    }
+
+    fn build_prep_argv(transport: &RemoteTransport, socket_name: &str) -> Vec<String> {
+        let mut argv = vec![
+            "ssh".to_string(),
+            "-T".to_string(),
+            "-o".to_string(),
+            "BatchMode=yes".to_string(),
+            "-o".to_string(),
+            "ConnectTimeout=8".to_string(),
+            // Do not allow a user's multiplexing config to turn this into a mux slave.
+            "-o".to_string(),
+            "ControlMaster=no".to_string(),
+            "-o".to_string(),
+            "ControlPath=none".to_string(),
+        ];
+        argv.extend(ssh_option_args(transport));
+        argv.push(transport.dest.clone());
+        argv.push(format!(
+            "h=$HOME; mkdir -p \"$h/.herdr\" && rm -f \"$h/.herdr/{socket_name}\" && printf %s \"$h\""
+        ));
+        argv
+    }
+
+    fn build_forward_argv(
+        transport: &RemoteTransport,
+        remote_socket_path: &str,
+        local_socket_path: &Path,
+    ) -> Vec<String> {
+        let mut argv = vec![
+            "ssh".to_string(),
+            "-N".to_string(),
+            "-T".to_string(),
+            "-o".to_string(),
+            "BatchMode=yes".to_string(),
+            "-o".to_string(),
+            "ExitOnForwardFailure=yes".to_string(),
+            "-o".to_string(),
+            "ServerAliveInterval=15".to_string(),
+            "-o".to_string(),
+            "ServerAliveCountMax=3".to_string(),
+            "-o".to_string(),
+            "ConnectTimeout=8".to_string(),
+            // Do not allow a user's multiplexing config to turn this into a mux slave.
+            "-o".to_string(),
+            "ControlMaster=no".to_string(),
+            "-o".to_string(),
+            "ControlPath=none".to_string(),
+        ];
+        argv.extend(ssh_option_args(transport));
+        argv.extend([
+            "-R".to_string(),
+            format!("{}:{}", remote_socket_path, local_socket_path.display()),
+            transport.dest.clone(),
+        ]);
+        argv
+    }
+
+    fn remote_socket_path_for_home(remote_home: &str, socket_name: &str) -> String {
+        format!("{}/.herdr/{socket_name}", remote_home.trim_end_matches('/'))
+    }
+
+    fn absolute_path(path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            return path.to_path_buf();
+        }
+        match std::env::current_dir() {
+            Ok(current_dir) => current_dir.join(path),
+            Err(_) => path.to_path_buf(),
+        }
+    }
+
+    fn remote_socket_name_for_path(path: &Path) -> String {
+        use std::hash::{Hash, Hasher};
+        let absolute = absolute_path(path);
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        absolute.to_string_lossy().hash(&mut hasher);
+        let digest = format!("{:016x}", hasher.finish());
+        let hash8 = digest.chars().take(8).collect::<String>();
+        format!("agent-report-{hash8}.sock")
+    }
+
+    fn remote_socket_name() -> String {
+        remote_socket_name_for_path(&crate::api::socket_path())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::collections::VecDeque;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        fn transport(
+            dest: &str,
+            port: Option<&str>,
+            config_path: Option<&str>,
+            identity_file: Option<&str>,
+        ) -> RemoteTransport {
+            RemoteTransport {
+                dest: dest.to_string(),
+                port: port.map(str::to_string),
+                config_path: config_path.map(str::to_string),
+                identity_file: identity_file.map(str::to_string),
+            }
+        }
+
+        #[test]
+        fn prep_argv_covers_transport_option_combinations() {
+            let script = "h=$HOME; mkdir -p \"$h/.herdr\" && rm -f \"$h/.herdr/agent-report-test.sock\" && printf %s \"$h\"";
+            let cases = [
+                (
+                    transport("host", None, None, None),
+                    vec![
+                        "ssh",
+                        "-T",
+                        "-o",
+                        "BatchMode=yes",
+                        "-o",
+                        "ConnectTimeout=8",
+                        "-o",
+                        "ControlMaster=no",
+                        "-o",
+                        "ControlPath=none",
+                        "host",
+                        script,
+                    ],
+                ),
+                (
+                    transport("host", Some("2222"), None, None),
+                    vec![
+                        "ssh",
+                        "-T",
+                        "-o",
+                        "BatchMode=yes",
+                        "-o",
+                        "ConnectTimeout=8",
+                        "-o",
+                        "ControlMaster=no",
+                        "-o",
+                        "ControlPath=none",
+                        "-p",
+                        "2222",
+                        "host",
+                        script,
+                    ],
+                ),
+                (
+                    transport("host", None, Some("cfg"), None),
+                    vec![
+                        "ssh",
+                        "-T",
+                        "-o",
+                        "BatchMode=yes",
+                        "-o",
+                        "ConnectTimeout=8",
+                        "-o",
+                        "ControlMaster=no",
+                        "-o",
+                        "ControlPath=none",
+                        "-F",
+                        "cfg",
+                        "host",
+                        script,
+                    ],
+                ),
+                (
+                    transport("host", None, None, Some("id")),
+                    vec![
+                        "ssh",
+                        "-T",
+                        "-o",
+                        "BatchMode=yes",
+                        "-o",
+                        "ConnectTimeout=8",
+                        "-o",
+                        "ControlMaster=no",
+                        "-o",
+                        "ControlPath=none",
+                        "-i",
+                        "id",
+                        "host",
+                        script,
+                    ],
+                ),
+                (
+                    transport("user@host", Some("2200"), Some("cfg"), Some("id")),
+                    vec![
+                        "ssh",
+                        "-T",
+                        "-o",
+                        "BatchMode=yes",
+                        "-o",
+                        "ConnectTimeout=8",
+                        "-o",
+                        "ControlMaster=no",
+                        "-o",
+                        "ControlPath=none",
+                        "-p",
+                        "2200",
+                        "-F",
+                        "cfg",
+                        "-i",
+                        "id",
+                        "user@host",
+                        script,
+                    ],
+                ),
+            ];
+            for (transport, expected) in cases {
+                assert_eq!(
+                    build_prep_argv(&transport, "agent-report-test.sock"),
+                    expected
+                        .iter()
+                        .map(|arg| (*arg).to_string())
+                        .collect::<Vec<_>>()
+                );
+            }
+        }
+
+        #[test]
+        fn forward_argv_uses_the_report_socket_and_all_options() {
+            let transport = transport("user@host", Some("2200"), Some("cfg"), Some("id"));
+            let argv = build_forward_argv(
+                &transport,
+                "/home/user/.herdr/agent-report-test.sock",
+                Path::new("/tmp/herdr/agent-report.sock"),
+            );
+            assert_eq!(argv[0], "ssh");
+            assert!(argv.windows(2).any(|pair| {
+                pair[0] == "-R"
+                    && pair[1]
+                        == "/home/user/.herdr/agent-report-test.sock:/tmp/herdr/agent-report.sock"
+            }));
+            assert!(argv
+                .windows(2)
+                .any(|pair| pair[0] == "-p" && pair[1] == "2200"));
+            assert!(argv
+                .windows(2)
+                .any(|pair| pair[0] == "-F" && pair[1] == "cfg"));
+            assert!(argv
+                .windows(2)
+                .any(|pair| pair[0] == "-i" && pair[1] == "id"));
+            assert!(argv
+                .windows(2)
+                .any(|pair| pair[0] == "-o" && pair[1] == "ControlMaster=no"));
+            assert!(argv
+                .windows(2)
+                .any(|pair| pair[0] == "-o" && pair[1] == "ControlPath=none"));
+            assert_eq!(argv.last().map(String::as_str), Some("user@host"));
+        }
+
+        #[test]
+        fn socket_name_is_deterministic_and_session_specific() {
+            let first = remote_socket_name_for_path(Path::new("/tmp/herdr/a/herdr.sock"));
+            let second = remote_socket_name_for_path(Path::new("/tmp/herdr/a/herdr.sock"));
+            let third = remote_socket_name_for_path(Path::new("/tmp/herdr/b/herdr.sock"));
+            assert_eq!(first, second);
+            assert_ne!(first, third);
+            assert!(first.starts_with("agent-report-"));
+            assert!(first.ends_with(".sock"));
+        }
+
+        struct StubChild {
+            polls: VecDeque<io::Result<Option<bool>>>,
+            kills: Arc<AtomicUsize>,
+        }
+
+        impl ChildProcess for StubChild {
+            fn try_wait(&mut self) -> io::Result<Option<bool>> {
+                self.polls.pop_front().unwrap_or(Ok(None))
+            }
+
+            fn kill(&mut self) -> io::Result<()> {
+                self.kills.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+
+            fn wait(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        struct StubRunner {
+            preparations: usize,
+            forwards: usize,
+            kills: Arc<AtomicUsize>,
+            child_polls: VecDeque<VecDeque<io::Result<Option<bool>>>>,
+        }
+
+        impl ProcessRunner for StubRunner {
+            fn prepare(&mut self, _argv: &[String], _timeout: Duration) -> io::Result<String> {
+                self.preparations += 1;
+                Ok("/home/test".to_string())
+            }
+
+            fn spawn_forward(&mut self, _argv: &[String]) -> io::Result<Box<dyn ChildProcess>> {
+                self.forwards += 1;
+                Ok(Box::new(StubChild {
+                    polls: self.child_polls.pop_front().unwrap_or_default(),
+                    kills: Arc::clone(&self.kills),
+                }))
+            }
+        }
+
+        fn pane(raw: u32) -> PaneId {
+            PaneId::from_raw(raw)
+        }
+
+        #[test]
+        fn claim_release_refcounts_and_stops_only_on_last_release() {
+            let kills = Arc::new(AtomicUsize::new(0));
+            let mut runner = StubRunner {
+                preparations: 0,
+                forwards: 0,
+                kills: Arc::clone(&kills),
+                child_polls: VecDeque::new(),
+            };
+            let mut state = WorkerState::new();
+            let prepared = Arc::new(Mutex::new(HashMap::new()));
+            let transport = transport("host", None, None, None);
+            let start = Instant::now();
+            state.claim(pane(1), transport.clone(), start);
+            state.claim(pane(2), transport, start);
+            state.tick(
+                start + CLAIM_DEBOUNCE,
+                &mut runner,
+                &prepared,
+                "agent-report-test.sock",
+            );
+            assert_eq!(runner.preparations, 1);
+            assert_eq!(runner.forwards, 1);
+            assert_eq!(state.forwards.len(), 1);
+            assert_eq!(
+                state.forwards.values().next().map(|item| item.pane_count),
+                Some(2)
+            );
+
+            state.release(pane(1));
+            assert_eq!(kills.load(Ordering::Relaxed), 0);
+            assert_eq!(
+                state.forwards.values().next().map(|item| item.pane_count),
+                Some(1)
+            );
+            state.release(pane(2));
+            assert_eq!(kills.load(Ordering::Relaxed), 1);
+            assert!(state.forwards.is_empty());
+        }
+
+        #[test]
+        fn child_exit_uses_increasing_capped_backoff() {
+            assert_eq!(RETRY_BACKOFF[0], Duration::from_secs(2));
+            assert_eq!(RETRY_BACKOFF[1], Duration::from_secs(5));
+            assert_eq!(RETRY_BACKOFF[2], Duration::from_secs(15));
+            assert_eq!(RETRY_BACKOFF[3], Duration::from_secs(60));
+
+            let kills = Arc::new(AtomicUsize::new(0));
+            let mut runner = StubRunner {
+                preparations: 0,
+                forwards: 0,
+                kills,
+                child_polls: VecDeque::from([
+                    VecDeque::from([Ok(Some(false))]),
+                    VecDeque::from([Ok(Some(false))]),
+                ]),
+            };
+            let mut state = WorkerState::new();
+            let prepared = Arc::new(Mutex::new(HashMap::new()));
+            let transport = transport("host", None, None, None);
+            let key = TransportKey::from(&transport);
+            let start = Instant::now();
+            state.claim(pane(1), transport, start);
+
+            let first_due = start + CLAIM_DEBOUNCE;
+            state.tick(first_due, &mut runner, &prepared, "agent-report-test.sock");
+            let after_first_exit = first_due + Duration::from_secs(1);
+            state.tick(
+                after_first_exit,
+                &mut runner,
+                &prepared,
+                "agent-report-test.sock",
+            );
+            assert_eq!(
+                state.forwards.get(&key).map(|item| item.next_action),
+                Some(after_first_exit + RETRY_BACKOFF[0])
+            );
+
+            let second_due = after_first_exit + RETRY_BACKOFF[0];
+            state.tick(second_due, &mut runner, &prepared, "agent-report-test.sock");
+            let after_second_exit = second_due + Duration::from_secs(1);
+            state.tick(
+                after_second_exit,
+                &mut runner,
+                &prepared,
+                "agent-report-test.sock",
+            );
+            assert_eq!(
+                state.forwards.get(&key).map(|item| item.next_action),
+                Some(after_second_exit + RETRY_BACKOFF[1])
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) use unix::RemoteForwardManager;
+
+#[cfg(not(unix))]
+pub(crate) struct RemoteForwardManager;
+
+#[cfg(not(unix))]
+impl RemoteForwardManager {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self::new()
+    }
+
+    // The local report endpoint is an AF_UNIX path, which cannot be reached through
+    // Windows' named-pipe IPC; remote forwarding is intentionally inert there.
+    pub(crate) fn claim(&self, _pane: PaneId, _transport: RemoteTransport) {}
+
+    pub(crate) fn release(&self, _pane: PaneId) {}
+
+    pub(crate) fn remote_socket_path_for(&self, _transport: &RemoteTransport) -> Option<String> {
+        None
+    }
+
+    pub(crate) fn shutdown(&self) {}
+}

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1019,6 +1019,7 @@ pub enum SettingsSection {
     Toast,
     PaneLabels,
     Integrations,
+    Remote,
 }
 
 impl SettingsSection {
@@ -1029,6 +1030,7 @@ impl SettingsSection {
         Self::Toast,
         Self::PaneLabels,
         Self::Integrations,
+        Self::Remote,
     ];
 
     pub fn label(self) -> &'static str {
@@ -1039,6 +1041,7 @@ impl SettingsSection {
             Self::Toast => "toasts",
             Self::PaneLabels => "pane labels",
             Self::Integrations => "integrations",
+            Self::Remote => "remote",
         }
     }
 }
@@ -1548,6 +1551,10 @@ pub struct AppState {
     #[allow(dead_code)] // kept for backward compat; palette.accent is the source of truth
     pub accent: Color,
     pub sound: SoundConfig,
+    pub remote_agent_reporting: bool,
+    /// Owns SSH reverse-forward children for remote agent reporting; lazy,
+    /// spawns no worker thread until the first ssh claim.
+    pub remote_forwards: crate::app::remote_forward::RemoteForwardManager,
     pub local_sound_playback: bool,
     pub toast_config: ToastConfig,
     pub keybinds: Keybinds,
@@ -1613,6 +1620,10 @@ impl AppState {
         self.sound.enabled
     }
 
+    pub fn remote_agent_reporting(&self) -> bool {
+        self.remote_agent_reporting
+    }
+
     pub fn toast_delivery(&self) -> ToastDelivery {
         self.toast_config.delivery
     }
@@ -1649,7 +1660,10 @@ impl AppState {
     }
 
     pub(crate) fn settings_section_has_badge(&self, section: SettingsSection) -> bool {
-        section == SettingsSection::Integrations && self.integration_updates_available()
+        match section {
+            SettingsSection::Integrations => self.integration_updates_available(),
+            _ => false,
+        }
     }
 
     pub(crate) fn focused_pane_requests_mouse_capture_from(
@@ -1910,6 +1924,8 @@ impl AppState {
                 enabled: false,
                 ..SoundConfig::default()
             },
+            remote_agent_reporting: false,
+            remote_forwards: crate::app::remote_forward::RemoteForwardManager::for_test(),
             local_sound_playback: false,
             toast_config: ToastConfig::default(),
             keybinds: Keybinds::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub use self::{
 
 pub(crate) use self::io::upsert_top_level_bool;
 pub(crate) use self::keybinds::parse_key_combo;
+pub(crate) use self::model::{remote_agent_reporting_enabled, set_remote_agent_reporting_enabled};
 
 pub const CONFIG_PATH_ENV_VAR: &str = "HERDR_CONFIG_PATH";
 pub const DEFAULT_SCROLLBACK_LIMIT_BYTES: usize = 10_000_000;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeSet, num::NonZeroUsize};
+use std::{
+    collections::BTreeSet,
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crossterm::event::KeyModifiers;
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -907,14 +911,32 @@ pub struct RemoteConfig {
     /// Add keepalive fallbacks and private connection reuse for `herdr --remote`.
     /// Set false to run plain ssh unchanged. Default: true.
     pub manage_ssh_config: bool,
+    /// When a pane runs ssh, expose a report-only agent endpoint over the
+    /// connection and export herdr env on the remote shell so remote agents
+    /// appear in the sidebar. Default: false.
+    pub agent_reporting: bool,
 }
 
 impl Default for RemoteConfig {
     fn default() -> Self {
         Self {
             manage_ssh_config: true,
+            agent_reporting: false,
         }
     }
+}
+
+static REMOTE_AGENT_REPORTING_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Process-global view of `[remote] agent_reporting`, refreshed on every
+/// config load so pane detection tasks read it without threading config
+/// through spawn constructors.
+pub(crate) fn remote_agent_reporting_enabled() -> bool {
+    REMOTE_AGENT_REPORTING_ENABLED.load(Ordering::Relaxed)
+}
+
+pub(crate) fn set_remote_agent_reporting_enabled(enabled: bool) {
+    REMOTE_AGENT_REPORTING_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -207,6 +207,96 @@ pub fn identify_agent(process_name: &str) -> Option<Agent> {
     parse_agent_label(process_name)
 }
 
+/// The connection details for an SSH-family foreground transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteTransport {
+    /// The `[user@]host` token from the SSH invocation.
+    pub dest: String,
+    /// The value supplied to `-p`, if present.
+    pub port: Option<String>,
+    /// The value supplied to `-F`, if present.
+    pub config_path: Option<String>,
+    /// The value supplied to `-i`, if present.
+    pub identity_file: Option<String>,
+}
+
+/// Detect an SSH-family client as the foreground process-group leader.
+pub fn remote_transport_in_job(job: &crate::platform::ForegroundJob) -> Option<RemoteTransport> {
+    let leader = job
+        .processes
+        .iter()
+        .find(|process| process.pid == job.process_group_id)?;
+    let executable = leader.argv0.as_deref().unwrap_or(&leader.name);
+    let executable_name = path_basename(executable).to_lowercase();
+    let executable = executable_name
+        .strip_suffix(".exe")
+        .unwrap_or(executable_name.as_str());
+    if !matches!(executable, "ssh" | "autossh") {
+        return None;
+    }
+    parse_ssh_invocation(leader.argv.as_deref()?)
+}
+
+fn parse_ssh_invocation(argv: &[String]) -> Option<RemoteTransport> {
+    const OPTIONS_WITH_ARGUMENTS: &str = "BbcDEFIiJLlmOopQRSWw";
+    let mut port = None;
+    let mut config_path = None;
+    let mut identity_file = None;
+    let mut options_ended = false;
+    let mut index = 1;
+
+    while let Some(argument) = argv.get(index) {
+        index += 1;
+        if options_ended {
+            return Some(RemoteTransport {
+                dest: argument.clone(),
+                port,
+                config_path,
+                identity_file,
+            });
+        }
+        if argument == "--" {
+            options_ended = true;
+            continue;
+        }
+        if !argument.starts_with('-') || argument == "-" {
+            return Some(RemoteTransport {
+                dest: argument.clone(),
+                port,
+                config_path,
+                identity_file,
+            });
+        }
+
+        let option_bytes = argument.as_bytes();
+        let mut option_offset = 1;
+        while option_offset < option_bytes.len() {
+            let option = option_bytes[option_offset] as char;
+            option_offset += 1;
+            if !OPTIONS_WITH_ARGUMENTS.contains(option) {
+                continue;
+            }
+
+            let value = if option_offset < option_bytes.len() {
+                argument[option_offset..].to_string()
+            } else {
+                argv.get(index)?.clone()
+            };
+            if option_offset == option_bytes.len() {
+                index += 1;
+            }
+            match option {
+                'p' => port = Some(value),
+                'F' => config_path = Some(value),
+                'i' => identity_file = Some(value),
+                _ => {}
+            }
+            break;
+        }
+    }
+    None
+}
+
 pub fn identify_agent_in_job(job: &crate::platform::ForegroundJob) -> Option<(Agent, String)> {
     if let Some(process) = job
         .processes
@@ -810,6 +900,86 @@ mod tests {
         assert_eq!(identify_agent("CLAUDE"), Some(Agent::Claude));
         assert_eq!(identify_agent("Codex"), Some(Agent::Codex));
         assert_eq!(identify_agent("Devin"), Some(Agent::Devin));
+    }
+
+    #[test]
+    fn remote_transport_in_job_parses_ssh_invocations() {
+        let expected = |dest: &str,
+                        port: Option<&str>,
+                        config_path: Option<&str>,
+                        identity_file: Option<&str>| {
+            Some(RemoteTransport {
+                dest: dest.to_string(),
+                port: port.map(str::to_string),
+                config_path: config_path.map(str::to_string),
+                identity_file: identity_file.map(str::to_string),
+            })
+        };
+        let cases = [
+            (
+                &["autossh", "host"][..],
+                "autossh",
+                expected("host", None, None, None),
+            ),
+            (
+                &["SSH.EXE", "host"][..],
+                "SSH.EXE",
+                expected("host", None, None, None),
+            ),
+            (
+                &["ssh", "--", "-host"][..],
+                "ssh",
+                expected("-host", None, None, None),
+            ),
+            (
+                &["ssh", "-p", "2222", "u@h"][..],
+                "ssh",
+                expected("u@h", Some("2222"), None, None),
+            ),
+            (
+                &["ssh", "-tt", "host"][..],
+                "ssh",
+                expected("host", None, None, None),
+            ),
+            (
+                &["ssh", "-vAL", "8080:x:80", "host"][..],
+                "ssh",
+                expected("host", None, None, None),
+            ),
+            (
+                &["ssh", "-p2222", "-Fconfig", "-ikey", "host"][..],
+                "ssh",
+                expected("host", Some("2222"), Some("config"), Some("key")),
+            ),
+            (
+                &["ssh", "-oProxyCommand=none", "host"][..],
+                "ssh",
+                expected("host", None, None, None),
+            ),
+            (&["ssh"][..], "ssh", None),
+            (&["mosh", "host"][..], "mosh", None),
+        ];
+
+        for (argv, name, expected) in cases {
+            let job = crate::platform::ForegroundJob {
+                process_group_id: 42,
+                processes: vec![foreground_process(42, name, argv)],
+            };
+            assert_eq!(remote_transport_in_job(&job), expected);
+        }
+    }
+
+    #[test]
+    fn remote_transport_in_job_ignores_non_leader_ssh_processes() {
+        let job = crate::platform::ForegroundJob {
+            process_group_id: 42,
+            processes: vec![
+                foreground_process(42, "codex", &["codex"]),
+                foreground_process(43, "ssh", &["ssh", "host"]),
+            ],
+        };
+
+        assert_eq!(remote_transport_in_job(&job), None);
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -66,6 +66,17 @@ pub enum AppEvent {
         process_exited: bool,
         observed_at: Instant,
     },
+    /// The foreground process's SSH transport changed.
+    // Constructed only by the unix pane detection tasks; remote agent
+    // reporting is inert on Windows (the report endpoint is an AF_UNIX path).
+    #[cfg_attr(windows, allow(dead_code))]
+    RemoteTransportChanged {
+        pane_id: crate::layout::PaneId,
+        transport: Option<crate::detect::RemoteTransport>,
+    },
+    /// A remote shell prompt is ready for environment injection.
+    #[cfg_attr(windows, allow(dead_code))]
+    RemoteTransportPromptReady { pane_id: crate::layout::PaneId },
     /// Hook-authoritative agent state was reported for a pane.
     HookStateReported {
         pane_id: PaneId,

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -40,6 +40,9 @@ use self::agent_detection::{
     DetectionScreenReadInput, PendingIdleConfirmation, ScreenDetectionPublishInput,
     AGENT_PENDING_IDLE_RECHECK, AGENT_STARTUP_GRACE_WINDOW,
 };
+// Consumed only by the unix detection loops that emit remote prompt events.
+#[cfg(unix)]
+use self::agent_detection::remote_shell_prompt_ready;
 use self::terminal::{GhosttyPaneTerminal, PaneTerminal};
 pub(crate) use self::terminal::{
     TerminalDirtyPatch, TerminalDirtyPatchOutcome, TerminalReadSnapshot, TerminalTextMatch,
@@ -492,6 +495,9 @@ struct ProcessProbeResult {
     foreground_is_pane_shell: bool,
     agent: Option<Agent>,
     process_name: Option<String>,
+    // Read only by the unix detection loops that emit RemoteTransportChanged.
+    #[cfg_attr(windows, allow(dead_code))]
+    remote_transport: Option<crate::detect::RemoteTransport>,
 }
 
 fn agent_hint_for_foreground_job_members(
@@ -537,6 +543,7 @@ fn process_probe_result(
         foreground_is_pane_shell: job.processes.iter().any(|process| process.pid == pid),
         agent: Some(agent),
         process_name: Some(process_name),
+        remote_transport: None,
     }
 }
 
@@ -568,6 +575,15 @@ fn probe_foreground_process_from_jobs(
         if let Some((agent, process_name)) = crate::detect::identify_agent_in_job(job) {
             return process_probe_result(job, pid, agent, process_name);
         }
+        if let Some(remote_transport) = crate::detect::remote_transport_in_job(job) {
+            return ProcessProbeResult {
+                process_group_id: Some(job.process_group_id),
+                foreground_is_pane_shell: job.processes.iter().any(|process| process.pid == pid),
+                agent: None,
+                process_name: None,
+                remote_transport: Some(remote_transport),
+            };
+        }
     }
 
     let foreground_job = foreground_job();
@@ -593,11 +609,16 @@ fn probe_foreground_process_from_jobs(
         }
 
         let identified = crate::detect::identify_agent_in_job(job);
+        let remote_transport = identified
+            .is_none()
+            .then(|| crate::detect::remote_transport_in_job(job))
+            .flatten();
         return ProcessProbeResult {
             process_group_id: Some(job.process_group_id),
             foreground_is_pane_shell: job.processes.iter().any(|process| process.pid == pid),
             agent: identified.as_ref().map(|(agent, _)| *agent),
             process_name: identified.map(|(_, process_name)| process_name),
+            remote_transport,
         };
     }
 
@@ -606,6 +627,7 @@ fn probe_foreground_process_from_jobs(
         foreground_is_pane_shell: false,
         agent: None,
         process_name: None,
+        remote_transport: None,
     }
 }
 
@@ -645,6 +667,9 @@ fn spawn_basic_detection_task(
         let mut last_visible_working = false;
         let mut last_visible_signal_refresh = None;
         let mut last_process_check = std::time::Instant::now();
+        let mut last_remote_transport: Option<crate::detect::RemoteTransport> = None;
+        let mut remote_transport_since: Option<std::time::Instant> = None;
+        let mut last_prompt_emit: Option<std::time::Instant> = None;
         let mut last_foreground_pgid = None;
         let mut has_process_probe = false;
         let mut acquisition_started_at = None;
@@ -683,6 +708,9 @@ fn spawn_basic_detection_task(
                     last_detection_text.clear();
                     last_screen_scan_detection_content_seq = None;
                     agent_startup_grace_until = None;
+                    last_remote_transport = None;
+                    remote_transport_since = None;
+                    last_prompt_emit = None;
                     pending_idle.clear();
                 }
             }
@@ -729,6 +757,29 @@ fn spawn_basic_detection_task(
                 let had_process_probe = has_process_probe;
                 has_process_probe = true;
                 let probe = probe_foreground_process(pid, foreground_pgid);
+                let effective_remote_transport = if crate::config::remote_agent_reporting_enabled()
+                {
+                    probe.remote_transport.clone()
+                } else {
+                    None
+                };
+                if effective_remote_transport != last_remote_transport {
+                    if let Err(err) = state_events
+                        .send(AppEvent::RemoteTransportChanged {
+                            pane_id,
+                            transport: effective_remote_transport.clone(),
+                        })
+                        .await
+                    {
+                        warn!(
+                            pane = pane_id.raw(),
+                            err = %err,
+                            "failed to deliver RemoteTransportChanged event"
+                        );
+                    }
+                    remote_transport_since = effective_remote_transport.as_ref().map(|_| now);
+                    last_remote_transport = effective_remote_transport;
+                }
                 let process_group_id = probe.process_group_id;
                 let tracked_process_group_id =
                     process_group_for_change_tracking(foreground_pgid, process_group_id);
@@ -862,6 +913,37 @@ fn spawn_basic_detection_task(
                 &mut acquisition_started_at,
                 &mut last_content_change_at,
             );
+            if last_remote_transport.is_some()
+                && crate::config::remote_agent_reporting_enabled()
+                && remote_transport_since.is_some_and(|since| {
+                    now.duration_since(since) >= std::time::Duration::from_millis(1200)
+                })
+                && last_content_change_at.is_some_and(|last_change| {
+                    now.duration_since(last_change) >= std::time::Duration::from_millis(600)
+                })
+                && remote_shell_prompt_ready(
+                    &content,
+                    terminal.cursor_state(),
+                    terminal
+                        .scroll_metrics()
+                        .is_some_and(|metrics| metrics.offset_from_bottom > 0),
+                )
+                && last_prompt_emit.is_none_or(|last_emit| {
+                    now.duration_since(last_emit) >= std::time::Duration::from_secs(30)
+                })
+            {
+                if let Err(err) = state_events
+                    .send(AppEvent::RemoteTransportPromptReady { pane_id })
+                    .await
+                {
+                    warn!(
+                        pane = pane_id.raw(),
+                        err = %err,
+                        "failed to deliver RemoteTransportPromptReady event"
+                    );
+                }
+                last_prompt_emit = Some(now);
+            }
 
             let osc_title = terminal.agent_osc_title();
             let osc_progress = terminal.agent_osc_progress();
@@ -2101,6 +2183,14 @@ impl PaneRuntime {
                 let mut state = AgentState::Idle;
                 let mut last_visible_idle = initial_state.detected_agent.is_some();
                 let mut last_process_check = Instant::now();
+                #[cfg(unix)]
+                let mut last_remote_transport: Option<
+                    crate::detect::RemoteTransport,
+                > = None;
+                #[cfg(unix)]
+                let mut remote_transport_since: Option<Instant> = None;
+                #[cfg(unix)]
+                let mut last_prompt_emit: Option<Instant> = None;
                 let mut last_foreground_pgid = None;
                 let mut has_process_probe = false;
                 let mut acquisition_started_at = None;
@@ -2153,6 +2243,12 @@ impl PaneRuntime {
                             last_detection_text.clear();
                             last_screen_scan_detection_content_seq = None;
                             agent_startup_grace_until = None;
+                            #[cfg(unix)]
+                            {
+                                last_remote_transport = None;
+                                remote_transport_since = None;
+                                last_prompt_emit = None;
+                            }
                             pending_idle.clear();
                         }
                     }
@@ -2200,6 +2296,33 @@ impl PaneRuntime {
                         has_process_probe = true;
                         if pid > 0 {
                             let probe = probe_foreground_process(pid, foreground_pgid);
+                            #[cfg(unix)]
+                            {
+                                let effective_remote_transport =
+                                    if crate::config::remote_agent_reporting_enabled() {
+                                        probe.remote_transport.clone()
+                                    } else {
+                                        None
+                                    };
+                                if effective_remote_transport != last_remote_transport {
+                                    if let Err(err) = state_events
+                                        .send(AppEvent::RemoteTransportChanged {
+                                            pane_id,
+                                            transport: effective_remote_transport.clone(),
+                                        })
+                                        .await
+                                    {
+                                        warn!(
+                                            pane = pane_id.raw(),
+                                            err = %err,
+                                            "failed to deliver RemoteTransportChanged event"
+                                        );
+                                    }
+                                    remote_transport_since =
+                                        effective_remote_transport.as_ref().map(|_| now);
+                                    last_remote_transport = effective_remote_transport;
+                                }
+                            }
                             let process_name = probe.process_name;
                             let process_group_id = probe.process_group_id;
                             let tracked_process_group_id = process_group_for_change_tracking(
@@ -2371,6 +2494,38 @@ impl PaneRuntime {
                         &mut acquisition_started_at,
                         &mut last_content_change_at,
                     );
+                    #[cfg(unix)]
+                    if last_remote_transport.is_some()
+                        && crate::config::remote_agent_reporting_enabled()
+                        && remote_transport_since.is_some_and(|since| {
+                            now.duration_since(since) >= Duration::from_millis(1200)
+                        })
+                        && last_content_change_at.is_some_and(|last_change| {
+                            now.duration_since(last_change) >= Duration::from_millis(600)
+                        })
+                        && remote_shell_prompt_ready(
+                            &content,
+                            terminal.cursor_state(),
+                            terminal
+                                .scroll_metrics()
+                                .is_some_and(|metrics| metrics.offset_from_bottom > 0),
+                        )
+                        && last_prompt_emit.is_none_or(|last_emit| {
+                            now.duration_since(last_emit) >= Duration::from_secs(30)
+                        })
+                    {
+                        if let Err(err) = state_events
+                            .send(AppEvent::RemoteTransportPromptReady { pane_id })
+                            .await
+                        {
+                            warn!(
+                                pane = pane_id.raw(),
+                                err = %err,
+                                "failed to deliver RemoteTransportPromptReady event"
+                            );
+                        }
+                        last_prompt_emit = Some(now);
+                    }
 
                     let osc_title = terminal.agent_osc_title();
                     let osc_progress = terminal.agent_osc_progress();

--- a/src/pane/agent_detection.rs
+++ b/src/pane/agent_detection.rs
@@ -1,6 +1,36 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use super::TerminalCursorState;
 use crate::detect::{Agent, AgentDetection, AgentState};
+
+// Called only by the unix pane detection loops; the remote report endpoint is
+// an AF_UNIX path, so Windows never emits prompt-ready events.
+#[cfg_attr(windows, allow(dead_code))]
+pub(super) fn remote_shell_prompt_ready(
+    content: &str,
+    cursor: Option<TerminalCursorState>,
+    scrolled_away_from_bottom: bool,
+) -> bool {
+    let Some(cursor) = cursor.filter(|cursor| cursor.visible) else {
+        return false;
+    };
+    if scrolled_away_from_bottom {
+        return false;
+    }
+
+    let Some(line) = content.lines().nth(cursor.y as usize) else {
+        return false;
+    };
+    let prompt = line.trim_end();
+    let Some(last) = prompt.chars().last() else {
+        return false;
+    };
+    if !matches!(last, '#' | '$' | '%' | '>' | '❯') {
+        return false;
+    }
+
+    cursor.x as usize >= prompt.chars().count()
+}
 
 pub(super) const AGENT_PENDING_IDLE_RECHECK: std::time::Duration =
     std::time::Duration::from_millis(100);
@@ -552,5 +582,62 @@ mod tests {
         mark_detection_content_changed(&seq);
 
         assert_eq!(seq.load(Ordering::Relaxed), 1);
+    }
+
+    fn cursor(x: u16, y: u16, visible: bool) -> TerminalCursorState {
+        TerminalCursorState {
+            x,
+            y,
+            visible,
+            shape: 0,
+        }
+    }
+
+    #[test]
+    fn remote_shell_prompt_ready_matrix() {
+        for (prompt, x) in [("$", 1), ("#", 1), ("%", 1), (">", 1), ("❯", 1)] {
+            assert!(remote_shell_prompt_ready(
+                &format!("output\n{prompt}"),
+                Some(cursor(x, 1, true)),
+                false,
+            ));
+        }
+
+        assert!(!remote_shell_prompt_ready(
+            "$ echo ready",
+            Some(cursor(12, 0, true)),
+            false,
+        ));
+        assert!(!remote_shell_prompt_ready(
+            "password:",
+            Some(cursor(9, 0, true)),
+            false,
+        ));
+        assert!(!remote_shell_prompt_ready(
+            "The authenticity of host cannot be established (yes/no)",
+            Some(cursor(56, 0, true)),
+            false,
+        ));
+        assert!(!remote_shell_prompt_ready(
+            "$",
+            Some(cursor(1, 0, false)),
+            false,
+        ));
+        assert!(!remote_shell_prompt_ready("$", None, false));
+        assert!(!remote_shell_prompt_ready(
+            "$",
+            Some(cursor(1, 0, true)),
+            true,
+        ));
+        assert!(!remote_shell_prompt_ready(
+            "$",
+            Some(cursor(1, 1, true)),
+            false,
+        ));
+        assert!(!remote_shell_prompt_ready(
+            "  $",
+            Some(cursor(2, 0, true)),
+            false,
+        ));
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -37,7 +37,7 @@ fn ssh_check_command(target: &str) -> String {
     format!("ssh {}", shell_quote(target))
 }
 
-fn shell_quote(value: &str) -> String {
+pub(crate) fn shell_quote(value: &str) -> String {
     if !value.is_empty()
         && value.chars().all(|ch| {
             ch.is_ascii_alphanumeric()

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -296,6 +296,8 @@ pub struct HeadlessServer {
     // Kept on every platform so dropping HeadlessServer owns API server shutdown.
     #[cfg_attr(windows, allow(dead_code))]
     api_server: Option<api::ServerHandle>,
+    #[cfg_attr(windows, allow(dead_code))]
+    remote_report_server: Option<api::RemoteReportHandle>,
     #[cfg(unix)]
     client_listener: LocalListener,
     client_socket_path: PathBuf,
@@ -467,6 +469,7 @@ impl HeadlessServer {
         config_diagnostics: &[String],
         api_tx: Option<api::ApiRequestSender>,
         api_server: Option<api::ServerHandle>,
+        remote_report_server: Option<api::RemoteReportHandle>,
     ) -> io::Result<Self> {
         let client_path = client_socket_path();
         prepare_socket_path(&client_path)?;
@@ -497,6 +500,7 @@ impl HeadlessServer {
             #[cfg(unix)]
             api_tx,
             api_server,
+            remote_report_server,
             #[cfg(unix)]
             client_listener: listener,
             client_socket_path: client_path,
@@ -1298,6 +1302,8 @@ impl HeadlessServer {
         } else {
             let _ = std::fs::remove_file(crate::api::socket_path());
         }
+        self.remote_report_server.take();
+
         let _ = remove_socket_file_if_owned(&self.client_socket_path, &self.client_socket_identity);
         if let Err(err) = crate::server::handoff::wait_ready(&mut stream) {
             crate::server::handoff::cleanup_failed_import_child(&mut import_child);
@@ -1378,7 +1384,9 @@ impl HeadlessServer {
             .api_tx
             .clone()
             .ok_or_else(|| io::Error::other("cannot restore api socket without api sender"))?;
-        let api_server = api::start_server(api_tx, self.app.event_hub.clone())?;
+        self.remote_report_server.take();
+        let api_server = api::start_server(api_tx.clone(), self.app.event_hub.clone())?;
+        let remote_report_server = api::start_remote_report_listener(api_tx)?;
 
         let client_path = client_socket_path();
         prepare_socket_path(&client_path)?;
@@ -1387,6 +1395,7 @@ impl HeadlessServer {
         let client_socket_identity = socket_file_identity(&client_path)?;
         listener.set_nonblocking(ListenerNonblockingMode::Accept)?;
 
+        self.remote_report_server = Some(remote_report_server);
         self.api_server = Some(api_server);
         self.client_listener = listener;
         self.client_socket_path = client_path;
@@ -4683,6 +4692,7 @@ pub fn run_server() -> io::Result<()> {
     }
 
     let loaded_config = config::Config::load();
+    config::set_remote_agent_reporting_enabled(loaded_config.config.remote.agent_reporting);
     let (api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
     let event_hub = api::EventHub::default();
 
@@ -4696,6 +4706,7 @@ pub fn run_server() -> io::Result<()> {
         }
         Err(err) => return Err(err),
     };
+    let _remote_report_server = api::start_remote_report_listener(api_tx.clone())?;
 
     let no_session = false; // Server always does session persistence.
 
@@ -4730,6 +4741,7 @@ pub fn run_server() -> io::Result<()> {
             &loaded_config.diagnostics,
             Some(api_tx.clone()),
             Some(_api_server),
+            Some(_remote_report_server),
         ) {
             Ok(server) => server,
             Err(err) if err.kind() == io::ErrorKind::AddrInUse => {
@@ -4789,6 +4801,7 @@ fn take_startup_cwd() -> Option<PathBuf> {
 #[cfg(unix)]
 fn run_handoff_import_server(socket_path: &Path, token: &str) -> io::Result<()> {
     let loaded_config = config::Config::load();
+    config::set_remote_agent_reporting_enabled(loaded_config.config.remote.agent_reporting);
     let mut received = crate::server::handoff::receive(socket_path, token)?;
     crate::server::handoff::log_import_result(received.manifest.panes.len());
 
@@ -4833,11 +4846,14 @@ fn run_handoff_import_server(socket_path: &Path, token: &str) -> io::Result<()> 
         wait_for_old_public_sockets_to_close(Duration::from_secs(5))?;
 
         let api_server = api::start_server(api_tx.clone(), event_hub.clone())?;
+        let remote_report_server = api::start_remote_report_listener(api_tx.clone())?;
+
         let mut server = HeadlessServer::new(
             app,
             &loaded_config.diagnostics,
             Some(api_tx.clone()),
             Some(api_server),
+            Some(remote_report_server),
         )?;
         crate::server::handoff::report_ready(&mut received.stream)?;
         crate::server::handoff::wait_committed(&mut received.stream)?;
@@ -4994,6 +5010,7 @@ mod tests {
             #[cfg(unix)]
             api_tx: None,
             api_server: None,
+            remote_report_server: None,
             #[cfg(unix)]
             client_listener: listener,
             client_socket_path: socket_path,

--- a/src/session.rs
+++ b/src/session.rs
@@ -180,6 +180,10 @@ pub fn active_api_socket_path() -> PathBuf {
     api_socket_path_for(active_name().as_deref())
 }
 
+pub fn remote_report_socket_path() -> PathBuf {
+    data_dir_for(active_name().as_deref()).join("agent-report.sock")
+}
+
 pub fn client_socket_path_for(name: Option<&str>) -> PathBuf {
     data_dir_for(name).join("herdr-client.sock")
 }

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 // remains only for session-only/custom hook paths and fallback detection.
 // Process-exit updates clear matching hook authority before recomputing state.
 
-use crate::detect::{Agent, AgentState};
+use crate::detect::{Agent, AgentState, RemoteTransport};
 use crate::terminal::TerminalId;
 
 #[path = "metadata.rs"]
@@ -124,6 +124,14 @@ pub struct TerminalState {
     fallback_visible_blocker: bool,
     fallback_observed_at: Option<Instant>,
     pub hook_authority: Option<HookAuthority>,
+    pub remote_transport: Option<RemoteTransport>,
+    /// True when the current hook authority arrived while this pane was an
+    /// SSH session, i.e. the reporting agent runs on the remote host. Live
+    /// process state; never persisted.
+    pub hook_authority_remote: bool,
+    /// When the env-injection line was last typed into the remote shell.
+    /// Live process state; never persisted.
+    pub remote_env_injected_at: Option<Instant>,
     pub agent_metadata: HashMap<String, AgentMetadata>,
     pub metadata_tokens: crate::metadata_tokens::MetadataTokens,
     pub persisted_agent_session: Option<crate::agent_resume::PersistedAgentSession>,
@@ -157,6 +165,9 @@ impl TerminalState {
             fallback_visible_blocker: false,
             fallback_observed_at: None,
             hook_authority: None,
+            remote_transport: None,
+            hook_authority_remote: false,
+            remote_env_injected_at: None,
             agent_metadata: HashMap::new(),
             metadata_tokens: crate::metadata_tokens::MetadataTokens::default(),
             persisted_agent_session: None,
@@ -185,6 +196,18 @@ impl TerminalState {
         self.terminal_title
             .as_deref()
             .and_then(super::stripped_terminal_title)
+    }
+
+    pub fn set_remote_transport(&mut self, transport: Option<RemoteTransport>) -> bool {
+        if self.remote_transport == transport {
+            return false;
+        }
+        self.remote_transport = transport;
+        true
+    }
+
+    pub fn remote_transport(&self) -> Option<&RemoteTransport> {
+        self.remote_transport.as_ref()
     }
 
     pub(crate) fn set_terminal_title(&mut self, title: Option<String>) -> TerminalTitleChange {
@@ -462,6 +485,7 @@ impl TerminalState {
             if let Some(source) = cleared_hook_source {
                 self.hook_report_sequences.remove(&source);
                 self.hook_authority = None;
+                self.hook_authority_remote = false;
             }
             if !newer_custom_authority
                 && self
@@ -535,6 +559,7 @@ impl TerminalState {
                 FullLifecycleHookSuppressionReason::HookClear,
             );
             self.hook_authority = None;
+            self.hook_authority_remote = false;
             self.persisted_agent_session = durable_session;
         }
         if agent_released {
@@ -689,6 +714,9 @@ impl TerminalState {
             }
         }
         self.persisted_agent_session = None;
+        // Provenance: an authority assigned while the pane is an SSH session
+        // belongs to a remote host's process and is released if ssh exits.
+        let reported_while_remote = self.remote_transport.is_some();
         self.hook_authority = Some(HookAuthority {
             source,
             agent_label,
@@ -697,6 +725,7 @@ impl TerminalState {
             reported_at: now,
             session_ref,
         });
+        self.hook_authority_remote = reported_while_remote;
         let current_session = self.current_session_identity_for_persistence();
         Some(TerminalStateMutation {
             effective_state_change: self.recompute_effective_state(
@@ -832,6 +861,15 @@ impl TerminalState {
         reported_at: Instant,
     ) -> FullLifecycleHookReportRoute {
         if !crate::detect::full_lifecycle_hook_authority(source, agent_label) {
+            return FullLifecycleHookReportRoute::Accept {
+                reanchor_sequence: false,
+            };
+        }
+        // While the pane is an SSH session, full-lifecycle reports arrive
+        // through the remote report proxy, which only forwards for panes with
+        // a live transport — the forward itself is the process evidence, so
+        // local process/session anchoring does not apply.
+        if self.remote_transport.is_some() {
             return FullLifecycleHookReportRoute::Accept {
                 reanchor_sequence: false,
             };
@@ -1121,6 +1159,7 @@ impl TerminalState {
             });
             if let Some(pending) = pending {
                 self.hook_report_sequences.insert(source, pending.seq);
+                self.hook_authority_remote = self.remote_transport.is_some();
                 self.hook_authority = Some(pending.authority);
             }
         }
@@ -1481,11 +1520,13 @@ impl TerminalState {
                 replaced_hook_session,
             );
             self.hook_authority = None;
+            self.hook_authority_remote = false;
         } else if foreground_takeover_allowed {
             self.suppress_current_full_lifecycle_hook_authority(
                 FullLifecycleHookSuppressionReason::HookClear,
             );
             self.hook_authority = None;
+            self.hook_authority_remote = false;
         }
         self.reconcile_agent_name_owner(&agent_label, Some(&session_ref));
         self.persisted_agent_session = Some(crate::agent_resume::PersistedAgentSession {
@@ -1610,6 +1651,7 @@ impl TerminalState {
             FullLifecycleHookSuppressionReason::HookClear,
         );
         self.hook_authority = None;
+        self.hook_authority_remote = false;
         self.persisted_agent_session = None;
         Some(TerminalStateMutation {
             effective_state_change: self.recompute_effective_state(
@@ -1672,6 +1714,7 @@ impl TerminalState {
             self.clear_agent_name();
         }
         self.hook_authority = None;
+        self.hook_authority_remote = false;
         if !preserve_foreign_persisted_session {
             self.persisted_agent_session = None;
         }
@@ -1689,8 +1732,30 @@ impl TerminalState {
         })
     }
 
+    /// Release a hook authority that was reported through this pane's SSH
+    /// reverse forward, because the SSH session ended and the report stream
+    /// is dead. This is a local lifecycle event, not a hook report, so it
+    /// bypasses per-source sequence ordering; the release itself reuses the
+    /// hook-release mutation so downstream behavior matches agent exit.
+    pub fn release_remote_hook_authority(&mut self) -> Option<TerminalStateMutation> {
+        if !self.hook_authority_remote {
+            return None;
+        }
+        self.hook_authority_remote = false;
+        let (source, agent_label) = match self.hook_authority.as_ref() {
+            Some(authority) => (authority.source.clone(), authority.agent_label.clone()),
+            None => return None,
+        };
+        self.hook_report_sequences.remove(&source);
+        self.release_agent_with_mutation(&source, &agent_label, None)
+    }
+
     fn hook_authority_is_effective(&self, authority: &HookAuthority) -> bool {
         !crate::detect::full_lifecycle_hook_authority(&authority.source, &authority.agent_label)
+            // A full-lifecycle authority accepted over the SSH report proxy is
+            // effective without a locally detected process; the remote process
+            // can never appear in local process tables.
+            || self.remote_transport.is_some()
             || crate::detect::parse_agent_label(&authority.agent_label).is_none_or(|agent| {
                 self.detected_agent == Some(agent) && self.recent_agent_process_exit.is_none()
             })
@@ -1934,6 +1999,7 @@ impl TerminalState {
         self.fallback_visible_blocker = false;
         self.fallback_observed_at = None;
         self.hook_authority = None;
+        self.hook_authority_remote = false;
         self.persisted_agent_session = None;
         self.agent_metadata.clear();
         self.metadata_report_agents.clear();

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -165,6 +165,17 @@ pub(super) fn render_settings_overlay(app: &AppState, frame: &mut Frame, area: R
         SettingsSection::Integrations => {
             render_settings_integrations(app, frame, content_area);
         }
+        SettingsSection::Remote => {
+            render_settings_toggle(
+                frame,
+                content_area,
+                p,
+                "remote agent reporting",
+                "when a pane runs ssh, expose an agent-report endpoint over the connection and export herdr env on the remote shell",
+                app.remote_agent_reporting(),
+                app.settings.list.selected,
+            );
+        }
     }
 
     if let Some(footer_area) = stack.footer {
@@ -224,6 +235,7 @@ pub(crate) fn settings_show_primary_action(app: &AppState) -> bool {
             .integration_recommendations
             .iter()
             .any(crate::integration::IntegrationRecommendation::needs_install),
+        crate::app::state::SettingsSection::Remote => false,
         _ => true,
     }
 }


### PR DESCRIPTION
# Show agents running inside SSH panes in the sidebar

Closes the gap described in #1170: when a user runs `ssh <host>` in a herdr pane and starts a coding agent on the remote host, the agent never appears in herdr's agents sidebar. Agent identity today requires either local process evidence (the pane's foreground job) or a hook report over the local API unix socket — and neither crosses an SSH boundary. The remote host runs no herdr server, so the pane looks like a plain shell forever.

## What

When a pane's foreground job leader is an SSH client, herdr now (opt-in, default off):

1. **Exposes a report-only API endpoint on the remote host through an SSH reverse socket forward** (`ssh -N -R`), and
2. **Injects `HERDR_ENV` / `HERDR_PANE_ID` / `HERDR_SOCKET_PATH` into the remote shell** by typing an export line when a clean shell prompt is detected.

Remote agent harnesses — anything honoring herdr's existing env-var reporting contract (the same `HERDR_*` variables local panes get at launch) — then report through the forwarded socket, and the pane appears in the agents sidebar with live status, exactly as if the agent were local. No changes are required on the remote host beyond what local agents already need (the harness's herdr hook), and no `ssh_config`/`sshd` changes are required (no `SendEnv`/`AcceptEnv` dependency).

The feature is opt-in via a new config key, toggleable from within herdr's settings panel (a new "remote" section):

```toml
[remote]
agent_reporting = true
```

<img width="629" height="401" alt="image" src="https://github.com/user-attachments/assets/793b04c6-a42e-4ec3-92da-e66018448582" />


## Why this shape

**Transport-only, no parallel identity mechanism.** The alternative — teaching herdr to identify remote agents from screen contents — would mean duplicating every agent's detection rules onto a fuzzy, remote-unaware signal, and keeping two identity systems consistent forever. Instead, the remote case reuses the *existing* report contract verbatim: `pane.report_agent`, `pane.report_agent_session`, `pane.report_metadata`, `pane.release_agent`, and `pane.clear_agent_authority` over a unix socket. Every consumer that already honors the env contract works unchanged, and every future harness that implements it gets remote support for free.

**A narrow, enforceable security boundary.** The forwarded endpoint is *not* the full API socket. A dedicated proxy listener accepts only the five report methods plus `ping`; each report is validated per request against the pane's live state (`pane.remote_target` must be set, i.e. the pane must currently be an SSH session), and everything else — `pane.send_text`, `pane.read`, anything — is rejected with `method_not_allowed`. The local socket is `0600` in the session dir; the remote socket lives under `~/.herdr/agent-report-<hash8>.sock` (hash of the local session's API socket path), so two herdr sessions SSHing into one shared remote host never collide, and a real herdr install on the remote is never touched. A compromised or hostile remote host can report agent state for a pane that is currently SSH'd there — and nothing else.

**Evidence by construction, not heuristics, for authority.** Hook reports normally anchor to a locally detected process to reject stale reports. A report arriving over the proxy already carries stronger evidence: the transport is live *right now*. So while a pane is remote, full-lifecycle hook authorities (omp, pi, and friends) are accepted and effective without local process presence, and each authority records whether it arrived while remote (`hook_authority_remote`). When the SSH session ends, exactly those remote-provenanced authorities are released — the pane drops out of the sidebar — while purely local authorities are untouched.

## How it works, end to end

```
local pane:  $ ssh dev-host
                  │ foreground leader = ssh
                  ▼
detect:      remote_transport_in_job()  ── leader-only getopt parse (dest/-p/-F/-i)
                  │ AppEvent::RemoteTransportChanged
                  ▼
forward mgr: ssh -T BatchMode prep (mkdir ~/.herdr, rm stale socket, capture $HOME)
             ssh -N -R <remote sock>:<session>/agent-report.sock   (kept alive, backoff 2/5/15/60s)
                  │ ControlMaster=no ControlPath=none — never a mux slave that
                  │ would silently drop our forward
                  ▼
prompt watch: clean prompt detected (ends with `# $ % > ❯`, cursor at end,
              not scrolled, content stable, ≥30s rate limit)
                  ▼
inject:      types ` export HERDR_ENV=1 HERDR_PANE_ID=… HERDR_SOCKET_PATH=…`
             (leading space dodges histignorespace; plain bytes so readline runs it)
                  ▼
remote agent → hook → forwarded socket → proxy validates pane is remote
             → existing report path → sidebar entry with live status
```

Key implementation points:

- `src/detect/mod.rs` — `RemoteTransport` + `remote_transport_in_job`: leader-only (an `ssh` child under a local agent, e.g. `git push`, is *not* a remote session), getopt-accurate argv parsing (`-p2222` attached forms, clusters like `-tt`, `-oProxyCommand=…`, `--`).
- `src/pane.rs` — both detection loops (normal panes and the handoff/basic path) diff-track the transport and emit change/prompt events; the feature is gated `#[cfg(unix)]` at this boundary because the endpoint is an AF_UNIX path.
- `src/api/server/remote_report.rs` — the report-only proxy listener (started alongside the API server on startup, handoff import, and handoff restore; old handle dropped before rebinding).
- `src/app/remote_forward.rs` — the forward manager: lazy worker thread (never blocks the app loop), per-`(dest, port, config, identity)` refcounting across panes, 1s claim debounce, child reaping with capped restart backoff, no-op stub on non-unix.
- `src/terminal/state.rs` — `hook_authority_remote` provenance set/cleared at every authority transition site; `release_remote_hook_authority()` releases via the same mutation a hook release uses, bypassing per-source sequence ordering (a local lifecycle event, not a report).
- Settings panel: new "remote" section with an immediate toggle, persisted via `upsert_section_bool`; toggle-off eagerly releases all remote transports and kills forwards; toggle-on resets detection so SSH foregrounds re-probe, re-claim, and re-inject without waiting for a foreground change.
- API: `PaneInfo.remote_target: Option<String>` (additive, `skip_serializing_if` — no protocol bump); schema artifact regenerated; config reference updated.

## Testing

**Live end-to-end** against a real remote Linux host over SSH (key auth, host alias in `~/.ssh/config`), driving a throwaway named herdr session entirely through its API:

1. `ssh <host>` in a pane → within ~2s `pane.get` reports `"remote_target": "<host>"`; the forward child process is visible locally with exactly the specified argv (`-N -T BatchMode ExitOnForwardFailure ServerAlive ControlMaster=no ControlPath=none -R <remote sock>:<local sock>`).
2. The remote shell's default themed prompt (right-side status segment) correctly does **not** match the prompt heuristic — no injection into an ambiguous prompt. Starting a plain shell (`bash --norc`) produces a clean prompt and the ` export HERDR_ENV=1 HERDR_PANE_ID=… HERDR_SOCKET_PATH=…` line appears and executes; `test -S "$HERDR_SOCKET_PATH"` confirms the forward is bound on the remote.
3. A synthetic `pane.report_agent` (`herdr:omp`, `working`) sent from the remote shell through the forwarded socket → `agent list` shows the pane as `omp/working` with `screen_detection_skipped: true`; a follow-up `idle` report flips it. This is the primary new-behavior proof: **report → sidebar entry**.
4. Through the same socket: `pane.send_text` → `method_not_allowed` (and nothing reaches the pane); a report naming a non-SSH pane → `pane_not_remote` (and no sidebar entry appears).
5. A real agent harness running on the remote host — with the same bundled herdr hook herdr installs locally — registered itself as `omp/idle` on launch and reported its remote session path via `pane.report_agent_session`, so `agent resume` targets a valid path while the pane remains on that host.
6. Exiting the SSH session: within ~2s the pane disappears from `agent list`, `remote_target` clears, and the forward child process is gone.
7. Toggling the setting off mid-session kills the forward and clears remote state immediately; toggling back on restarts the forward and produces a fresh injection at the next clean prompt.
8. Control run with the setting left at its default (off): an SSH pane never gains `remote_target`, no forward processes spawn, no injection occurs — existing behavior is unchanged.

All throwaway sessions, panes, and sockets were torn down afterward; the remote `~/.herdr` directory was removed.

## Limitations (deliberate)

- **Opt-in, default off.** Remote reporting types into shells and opens a (narrow) endpoint on remote hosts; users choose that explicitly.
- **Key/agent auth only.** Hosts that need interactive auth can never establish the `BatchMode` forward; prep fails, backoff engages, no injection happens. The pane behaves exactly as before — the failure mode is "feature inert", never a broken terminal.
- **Conservative prompt detection.** Exotic/right-aligned prompts (and `ssh host -t <fullscreen-app>` with no shell) never match, so no injection. Better silent than typing into a fullscreen app; the 30s re-emit gives later clean prompts another chance.
- **No remote screen identification.** Identity comes only from reports; agents without herdr hooks (locally installed hook assets) don't appear. This is the descoped half of the problem and can be added later without touching the transport.
- **Remote hooks are the remote's responsibility.** The harness's herdr hook must exist on the remote host, same as local agents need locally. (Copying the bundled hook file over is sufficient; automating that is a future integration decision, not transport work.)
- **Shell coverage:** POSIX `export a=1 b=2` covers sh/bash/zsh/ash and fish's compat builtin; csh/tcsh reject the line harmlessly.
- **Accepted collateral:** a *local* agent backgrounded with ctrl+z while the user SSHs from the same pane reports "while remote" and is released on SSH exit; it re-registers on its next lifecycle event or foreground return.
- **Pane moved to another workspace mid-SSH:** the remote's `HERDR_PANE_ID` goes stale, reports are rejected as not-found, and the next prompt-ready emit (≤30s) re-injects the fresh id. Self-healing by design.

## Why this narrow scope is directionally correct

- **One contract, many consumers.** Everything flows through the five report methods herdr already exposes. No consumer-specific code exists in this change; omp, pi, claude-family hooks, and any future harness that honors `HERDR_ENV`/`HERDR_PANE_ID`/`HERDR_SOCKET_PATH` are supported uniformly.
- **The transport is the hard part, and it's done generically.** Prep, forwarding, refcounts, backoff, and the authz proxy know nothing about any specific agent. Future remote features (richer session metadata, remote pane titles, remote-aware resume UX) build on the same channel instead of inventing new ones.
- **Provenance is now recorded, not inferred.** `hook_authority_remote` gives future policy work (remote badges in the sidebar, remote-specific release rules, cross-host session resume) a reliable signal to build on.
- **The boundary is small enough to be auditable.** ~1,200 lines including tests, one new config key, one additive API field, two new modules, and a proxy whose entire authorization model fits on one screen.

Docs for the new config key land in the `docs/next` pass separately; this PR updates only the test-enforced reference data and generated schema.
