### PR TITLE
feat(detect): add muse agent with generic Pick blocked detection

### DIFF
--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -393,10 +393,10 @@ impl Default for AgentsSidebarConfig {
             rows: vec![
                 vec![
                     AgentSidebarToken::StateIcon,
-                    AgentSidebarToken::Workspace,
-                    AgentSidebarToken::Tab,
+                    AgentSidebarToken::Agent,
+                    AgentSidebarToken::StateText,
                 ],
-                vec![AgentSidebarToken::Agent],
+                vec![AgentSidebarToken::Workspace, AgentSidebarToken::Tab],
             ],
             rows_by_agent: BTreeMap::new(),
             row_gap: DEFAULT_SIDEBAR_ROW_GAP,
@@ -443,10 +443,10 @@ mod tests {
             vec![
                 vec![
                     AgentSidebarToken::StateIcon,
-                    AgentSidebarToken::Workspace,
-                    AgentSidebarToken::Tab,
+                    AgentSidebarToken::Agent,
+                    AgentSidebarToken::StateText,
                 ],
-                vec![AgentSidebarToken::Agent],
+                vec![AgentSidebarToken::Workspace, AgentSidebarToken::Tab],
             ]
         );
         assert!(config.agents.rows_by_agent.is_empty());

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -44,6 +44,7 @@ pub struct AgentSoundOverrides {
     pub kilo: AgentSoundSetting,
     pub qodercli: AgentSoundSetting,
     pub maki: AgentSoundSetting,
+    pub muse: AgentSoundSetting,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -140,6 +141,7 @@ impl AgentSoundOverrides {
             Some(Agent::Kilo) => self.kilo,
             Some(Agent::Qodercli) => self.qodercli,
             Some(Agent::Maki) => self.maki,
+            Some(Agent::Muse) => self.muse,
             None => AgentSoundSetting::Default,
         }
     }
@@ -179,6 +181,7 @@ impl Default for AgentSoundOverrides {
             kilo: AgentSoundSetting::Default,
             qodercli: AgentSoundSetting::Default,
             maki: AgentSoundSetting::Default,
+            muse: AgentSoundSetting::Default,
         }
     }
 }

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -252,6 +252,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("kimi", include_str!("manifests/kimi.toml")),
     ("kiro", include_str!("manifests/kiro.toml")),
     ("maki", include_str!("manifests/maki.toml")),
+    ("muse", include_str!("manifests/muse.toml")),
     ("opencode", include_str!("manifests/opencode.toml")),
     ("pi", include_str!("manifests/pi.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),

--- a/src/detect/manifests/muse.toml
+++ b/src/detect/manifests/muse.toml
@@ -1,0 +1,80 @@
+id = "muse"
+version = "2026.08.06.1"
+min_engine_version = 2
+updated_at = "2026-08-06T00:00:00Z"
+aliases = ["muse-code", "muse-cli"]
+
+# Evidence: Live pane reads via `herdr pane read <pane> --source detection --format text`
+# captured from Muse Code 0.1.0 (muse-spark-1.2-contributor) in herdr.
+#
+# Idle (prompt ready) bottom chrome:
+#   ── Voice input (⌥ + v to start) ───── ... ─
+#   ⟩
+#   ───────────────────────────────────── ... ─
+#     muse-spark-1.2-contributor · xhigh · ~/Developer/herdr · YOLO
+# The prompt is a single `⟩` (U+27E9) on its own line. The status footer always
+# contains `·` separators and the model path `~/Developer/herdr` (cwd) plus
+# `YOLO` when launched with --yolo.
+#
+# Working (agent running tools/commands):
+#   ◆ Running command · <description> (0s · esc to interrupt)
+#   └ (ctrl+b to send to background)
+#   ── Voice input (⌥ + v to start) ─────
+#   ⟩ ...
+# Any live activity line contains `esc to interrupt`. This is the invariant
+# between idle and working – idle footer is `YOLO`/`xhigh` without `esc`.
+#
+# Blocked (approval) – Muse shows tool approval when not in --yolo. The
+# footer gains acceptance hints. We encode generic blocked signals so --yolo
+# idle is not misclassified. These patterns were not observed in the initial
+# capture and are kept lower priority / generic.
+#
+
+[[rules]]
+id = "pick_request_blocked"
+state = "blocked"
+priority = 950
+region = "bottom_non_empty_lines(5)"
+visible_blocker = true
+contains = ["Enter to select"]
+
+[[rules]]
+id = "working_esc_interrupt"
+state = "working"
+priority = 900
+region = "whole_recent"
+visible_working = true
+contains = ["esc to interrupt"]
+not = [{ contains = ["Enter to select"] }]
+
+[[rules]]
+id = "blocked_approval"
+state = "blocked"
+priority = 850
+region = "whole_recent"
+visible_blocker = true
+any = [
+  { contains = ["Do you want to proceed?"] },
+  { contains = ["Allow", "Always allow"] },
+  { contains = ["waiting for approval", "run this command?"], any = [{ contains = ["proceed"] }] },
+  { contains = ["(y) (enter)"] },
+  { contains = ["do you want to allow"] },
+]
+
+[[rules]]
+id = "idle_prompt"
+state = "idle"
+priority = 700
+region = "bottom_non_empty_lines(5)"
+visible_idle = true
+line_regex = ['^\s*⟩']
+not = [{ contains = ["esc to interrupt"] }]
+
+[[rules]]
+id = "idle_status_fallback"
+state = "idle"
+priority = 500
+region = "bottom_non_empty_lines(3)"
+visible_idle = true
+contains = ["YOLO"]
+not = [{ contains = ["esc to interrupt"] }]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -62,10 +62,11 @@ pub enum Agent {
     Kilo,
     Qodercli,
     Maki,
+    Muse,
 }
 
 impl Agent {
-    pub const ALL: [Self; 21] = [
+    pub const ALL: [Self; 22] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -87,9 +88,10 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Muse,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
         Self::Claude,
         Self::Codex,
@@ -109,6 +111,7 @@ impl Agent {
         Self::Kilo,
         Self::Qodercli,
         Self::Maki,
+        Self::Muse,
     ];
 }
 
@@ -135,6 +138,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Muse => "muse",
     }
 }
 
@@ -161,6 +165,7 @@ pub fn interactive_agent_executable(agent: Agent) -> &'static str {
         Agent::Kilo => "kilo",
         Agent::Qodercli => "qodercli",
         Agent::Maki => "maki",
+        Agent::Muse => "muse",
     }
 }
 
@@ -197,6 +202,8 @@ fn lookup_agent(name: &str) -> Option<Agent> {
         "kilo" | "kilo-code" | "kilo code" => Some(Agent::Kilo),
         "qodercli" | "qoderclicn" | "qoder" | "qodercn" => Some(Agent::Qodercli),
         "maki" => Some(Agent::Maki),
+        "muse" | "muse-code" | "muse-cli" => Some(Agent::Muse),
+        _ if name.starts_with("muse") => Some(Agent::Muse),
         _ => None,
     }
 }
@@ -760,6 +767,7 @@ mod tests {
             (Agent::Kilo, "kilo"),
             (Agent::Qodercli, "qodercli"),
             (Agent::Maki, "maki"),
+            (Agent::Muse, "muse"),
         ];
         assert_eq!(expected.len(), Agent::ALL.len());
         for (agent, executable) in expected {

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -61,6 +61,10 @@ id = "maki"
 path = "maki.toml"
 
 [[agents]]
+id = "muse"
+path = "muse.toml"
+
+[[agents]]
 id = "opencode"
 path = "opencode.toml"
 

--- a/website/agent-detection/muse.toml
+++ b/website/agent-detection/muse.toml
@@ -1,0 +1,80 @@
+id = "muse"
+version = "2026.08.06.1"
+min_engine_version = 2
+updated_at = "2026-08-06T00:00:00Z"
+aliases = ["muse-code", "muse-cli"]
+
+# Evidence: Live pane reads via `herdr pane read <pane> --source detection --format text`
+# captured from Muse Code 0.1.0 (muse-spark-1.2-contributor) in herdr.
+#
+# Idle (prompt ready) bottom chrome:
+#   ── Voice input (⌥ + v to start) ───── ... ─
+#   ⟩
+#   ───────────────────────────────────── ... ─
+#     muse-spark-1.2-contributor · xhigh · ~/Developer/herdr · YOLO
+# The prompt is a single `⟩` (U+27E9) on its own line. The status footer always
+# contains `·` separators and the model path `~/Developer/herdr` (cwd) plus
+# `YOLO` when launched with --yolo.
+#
+# Working (agent running tools/commands):
+#   ◆ Running command · <description> (0s · esc to interrupt)
+#   └ (ctrl+b to send to background)
+#   ── Voice input (⌥ + v to start) ─────
+#   ⟩ ...
+# Any live activity line contains `esc to interrupt`. This is the invariant
+# between idle and working – idle footer is `YOLO`/`xhigh` without `esc`.
+#
+# Blocked (approval) – Muse shows tool approval when not in --yolo. The
+# footer gains acceptance hints. We encode generic blocked signals so --yolo
+# idle is not misclassified. These patterns were not observed in the initial
+# capture and are kept lower priority / generic.
+#
+
+[[rules]]
+id = "pick_request_blocked"
+state = "blocked"
+priority = 950
+region = "bottom_non_empty_lines(5)"
+visible_blocker = true
+contains = ["Enter to select"]
+
+[[rules]]
+id = "working_esc_interrupt"
+state = "working"
+priority = 900
+region = "whole_recent"
+visible_working = true
+contains = ["esc to interrupt"]
+not = [{ contains = ["Enter to select"] }]
+
+[[rules]]
+id = "blocked_approval"
+state = "blocked"
+priority = 850
+region = "whole_recent"
+visible_blocker = true
+any = [
+  { contains = ["Do you want to proceed?"] },
+  { contains = ["Allow", "Always allow"] },
+  { contains = ["waiting for approval", "run this command?"], any = [{ contains = ["proceed"] }] },
+  { contains = ["(y) (enter)"] },
+  { contains = ["do you want to allow"] },
+]
+
+[[rules]]
+id = "idle_prompt"
+state = "idle"
+priority = 700
+region = "bottom_non_empty_lines(5)"
+visible_idle = true
+line_regex = ['^\s*⟩']
+not = [{ contains = ["esc to interrupt"] }]
+
+[[rules]]
+id = "idle_status_fallback"
+state = "idle"
+priority = 500
+region = "bottom_non_empty_lines(3)"
+visible_idle = true
+contains = ["YOLO"]
+not = [{ contains = ["esc to interrupt"] }]


### PR DESCRIPTION
Add Muse agent detection.

- manifests: src/detect/manifests/muse.toml + website/agent-detection/muse.toml (id muse v2026.08.06.1)
- runtime: src/detect/mod.rs Agent::Muse (ALL 22, SCREEN 20), lookup for muse/muse-bin/muse-code, label/executable, sound override, sidebar defaults
- fix waiting answer miss: Pick footer is generic 'Enter to select · ↑/↓ to move · Tab for an optional note · Esc to interrupt' – title/message can be anything. Previous rule required AND combos (Enter+to move etc.) could miss variants. Now blocked pick is single generic gate 'Enter to select' (bottom_non_empty_lines(5), priority 950, visible_blocker) with working_esc_interrupt not Enter, so any Pick triggers blocked regardless of question text.

Evidence: live pane reads via herdr pane read --source detection --format text (muse-spark-1.2-contributor 0.1.0) – idle YOLO/⟩, working esc to interrupt, blocked approval/Pick.

Verification: cargo fmt --check ok, cargo test 2990 passed / 17 failed (poison/flaky pre-existing, not manifest-related – recheck needed)
