### PR TITLE
fix(agent): wait for prompt enter submission

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,6 +19,12 @@ use crate::api::schema::{Method, Request};
 
 pub const SOCKET_PATH_ENV_VAR: &str = "HERDR_SOCKET_PATH";
 
+/// Delay between agent.prompt text and the submitting Enter.
+/// `--wait` must not observe prompt effect until this delay has elapsed so Enter
+/// has been handed to the PTY write path.
+pub(crate) const AGENT_PROMPT_SUBMIT_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(300);
+
 pub(crate) fn request_changes_ui(request: &Request) -> bool {
     matches!(
         &request.method,

--- a/src/api/wait.rs
+++ b/src/api/wait.rs
@@ -223,10 +223,31 @@ pub(super) fn prompt_agent(
         return agent_wait_not_running(request_id).map(Some);
     }
 
+    // Composer text alone can bump state_change_seq before delayed Enter is written.
+    // Wait for the Enter delay, then rebaseline so --wait cannot treat pre-Enter
+    // screen updates as prompt effect.
+    std::thread::sleep(crate::api::AGENT_PROMPT_SUBMIT_DELAY);
+    let after_enter = match agent_get(&request_id, &target, api_tx) {
+        Ok(agent) => agent,
+        Err(response) => {
+            return serde_json::to_string(&response)
+                .map(Some)
+                .map_err(std::io::Error::other);
+        }
+    };
+    if !agent_wait_identity_matches(
+        &after_enter,
+        &before_prompt.terminal_id,
+        before_prompt.name.as_deref().filter(|name| *name == target),
+        before_prompt.agent.as_deref(),
+    ) {
+        return agent_wait_not_running(request_id).map(Some);
+    }
+
     let wait_started = std::time::Instant::now();
-    let prompt_state_change_seq = prompted.state_change_seq;
+    let prompt_state_change_seq = after_enter.state_change_seq;
     let until = agent_wait_statuses(wait.until);
-    let mut initial = prompted;
+    let mut initial = after_enter;
     let mut after_state_change_seq = Some(prompt_state_change_seq);
 
     if initial.agent_status != crate::api::schema::AgentStatus::Working {
@@ -782,6 +803,46 @@ fn wait_matched_response(request_id: &str, event: serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn idle_agent_with_seq(state_change_seq: u64) -> crate::api::schema::AgentInfo {
+        serde_json::from_value(serde_json::json!({
+            "terminal_id": "t1",
+            "agent_status": "idle",
+            "workspace_id": "w1",
+            "tab_id": "tab1",
+            "pane_id": "p1",
+            "focused": false,
+            "state_change_seq": state_change_seq,
+            "revision": 0
+        }))
+        .expect("agent info")
+    }
+
+    #[test]
+    fn prompt_wait_rebaseline_rejects_composer_only_seq_bump() {
+        // Typing prompt text into the composer can advance state_change_seq
+        // before delayed Enter. Effect wait must use a post-Enter baseline.
+        let after_composer_text = idle_agent_with_seq(2);
+        let pre_enter_baseline = 1;
+        let post_enter_baseline = 2;
+        assert!(
+            agent_wait_matches(
+                &after_composer_text,
+                &[crate::api::schema::AgentStatus::Idle],
+                Some(pre_enter_baseline)
+            ),
+            "pre-Enter baseline would falsely treat composer text as effect"
+        );
+        assert!(
+            !agent_wait_matches(
+                &after_composer_text,
+                &[crate::api::schema::AgentStatus::Idle],
+                Some(post_enter_baseline)
+            ),
+            "post-Enter rebaseline must require a later lifecycle observation"
+        );
+        assert_eq!(crate::api::AGENT_PROMPT_SUBMIT_DELAY.as_millis(), 300);
+    }
 
     #[test]
     fn agent_wait_probe_only_translates_agent_disappearance() {

--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -1,16 +1,13 @@
-use std::time::Duration;
-
 use bytes::Bytes;
 
 use crate::api::schema::{
     AgentPromptParams, AgentRenameParams, AgentSendKeysParams, AgentStartParams, AgentTarget,
     PaneReadResult, ResponseResult,
 };
+use crate::api::AGENT_PROMPT_SUBMIT_DELAY;
 use crate::app::App;
 
 use super::responses::{encode_error, encode_error_body, encode_success};
-
-const AGENT_PROMPT_SUBMIT_DELAY: Duration = Duration::from_millis(300);
 
 impl App {
     pub(super) fn handle_agent_list(&mut self, id: String) -> String {
@@ -100,10 +97,14 @@ impl App {
         }
         let (text, enter) =
             crate::app::api_helpers::encode_api_submission_parts(runtime, &params.text);
-        if let Err(err) = runtime.try_send_bytes(Bytes::from(text)) {
+        if let Err(err) = runtime.try_send_ordered_submission(
+            Bytes::from(text),
+            Bytes::from(enter),
+            AGENT_PROMPT_SUBMIT_DELAY,
+            None,
+        ) {
             return encode_error(id, "agent_prompt_failed", err.to_string());
         }
-        runtime.send_bytes_after(Bytes::from(enter), AGENT_PROMPT_SUBMIT_DELAY);
         let Some(agent) = self.agent_info(resolved.ws_idx, resolved.pane_id) else {
             return agent_not_found(id, &params.target);
         };
@@ -294,6 +295,7 @@ mod tests {
         detect::{Agent, AgentState},
         workspace::Workspace,
     };
+    use std::time::Duration;
 
     fn app_with_agent() -> App {
         let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -394,6 +396,53 @@ mod tests {
         let error: crate::api::schema::ErrorResponse = serde_json::from_str(&rejected).unwrap();
         assert_eq!(error.error.code, "agent_not_found");
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn agent_prompt_orders_enter_before_intervening_input() {
+        let mut app = app_with_agent();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0].tabs[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_agent_name("reviewer".into());
+        terminal.set_detected_state(Some(Agent::OpenCode), AgentState::Idle);
+        let (runtime, mut rx) =
+            crate::terminal::TerminalRuntime::test_with_channel_and_scrollback_bytes(
+                80, 24, 0, b"", 8,
+            );
+        app.state.insert_test_runtime(pane_id, runtime);
+
+        let _ = app.handle_agent_prompt(
+            "req".into(),
+            AgentPromptParams {
+                target: "reviewer".into(),
+                text: "PROMPT".into(),
+                wait: None,
+            },
+        );
+        app.lookup_runtime_sender(0, pane_id)
+            .unwrap()
+            .try_send_bytes(Bytes::from_static(b"INTERRUPT"))
+            .unwrap();
+
+        assert_eq!(rx.try_recv().unwrap(), Bytes::from_static(b"PROMPT"));
+        assert!(rx.try_recv().is_err(), "interrupt must not precede Enter");
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            Bytes::from_static(b"\r")
+        );
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            Bytes::from_static(b"INTERRUPT")
+        );
     }
 
     #[tokio::test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1,10 +1,12 @@
 use std::cell::Cell;
+use std::collections::VecDeque;
 use std::io;
 use std::path::Path;
 use std::sync::{
     atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering},
     Arc, Mutex,
 };
+use std::time::Duration;
 
 use bytes::Bytes;
 use portable_pty::CommandBuilder;
@@ -984,6 +986,8 @@ pub struct PaneRuntime {
     pane_id: PaneId,
     terminal: Arc<PaneTerminal>,
     io: PaneRuntimeIo,
+    /// Holds intervening user input between prompt text and delayed Enter.
+    ordered: Arc<Mutex<OrderedSubmissionGate>>,
     current_size: Cell<(u16, u16, u32, u32)>,
     child_pid: Arc<AtomicU32>,
     reported_cwd: Arc<Mutex<Option<std::path::PathBuf>>>,
@@ -996,6 +1000,12 @@ pub struct PaneRuntime {
     preserve_processes_on_drop: bool,
     // Task handles for deterministic shutdown
     detect_handle: Option<tokio::task::AbortHandle>,
+}
+
+#[derive(Debug, Default)]
+struct OrderedSubmissionGate {
+    holding: bool,
+    deferred: VecDeque<Bytes>,
 }
 
 enum PaneRuntimeIo {
@@ -1135,28 +1145,6 @@ impl PaneRuntimeIo {
                 if let Some(bytes) = response() {
                     let _ = sender.try_send(bytes);
                 }
-            }
-        }
-    }
-
-    fn send_bytes_after(&self, bytes: Bytes, delay: std::time::Duration) {
-        match self {
-            PaneRuntimeIo::Actor(actor) => {
-                let actor = actor.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(delay).await;
-                    if let Err(err) = actor.write_user_input(bytes).await {
-                        warn!(error = %err, "failed to send delayed PTY input");
-                    }
-                });
-            }
-            #[cfg(test)]
-            PaneRuntimeIo::TestChannel { sender, .. } => {
-                let sender = sender.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(delay).await;
-                    let _ = sender.send(bytes).await;
-                });
             }
         }
     }
@@ -1926,6 +1914,7 @@ impl PaneRuntime {
             pane_id,
             terminal,
             io,
+            ordered: Arc::new(Mutex::new(OrderedSubmissionGate::default())),
             current_size: Cell::new((rows, cols, cell_width_px, cell_height_px)),
             child_pid,
             reported_cwd,
@@ -2443,6 +2432,7 @@ impl PaneRuntime {
             pane_id,
             terminal,
             io,
+            ordered: Arc::new(Mutex::new(OrderedSubmissionGate::default())),
             current_size: Cell::new((rows, cols, 0, 0)),
             child_pid,
             reported_cwd,
@@ -2697,15 +2687,158 @@ impl PaneRuntime {
     }
 
     pub async fn send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::SendError<Bytes>> {
+        {
+            let mut gate = self
+                .ordered
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if gate.holding {
+                gate.deferred.push_back(bytes);
+                return Ok(());
+            }
+        }
         self.io.send_bytes(bytes).await
     }
 
     pub fn try_send_bytes(&self, bytes: Bytes) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        {
+            let mut gate = self
+                .ordered
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if gate.holding {
+                gate.deferred.push_back(bytes);
+                return Ok(());
+            }
+        }
         self.io.try_send_bytes(bytes)
     }
 
-    pub fn send_bytes_after(&self, bytes: Bytes, delay: std::time::Duration) {
-        self.io.send_bytes_after(bytes, delay);
+    /// Queue prompt bytes and a delayed Enter without allowing other user input
+    /// to interleave between them. Deferred inputs flush only after Enter is queued.
+    pub fn try_send_ordered_submission(
+        &self,
+        prompt: Bytes,
+        enter: Bytes,
+        delay: Duration,
+        on_written: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        {
+            let mut gate = self
+                .ordered
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if gate.holding {
+                return Err(mpsc::error::TrySendError::Full(prompt));
+            }
+            gate.holding = true;
+        }
+
+        if let Err(err) = self.io.try_send_bytes(prompt) {
+            let mut gate = self
+                .ordered
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            gate.holding = false;
+            gate.deferred.clear();
+            return Err(err);
+        }
+
+        match &self.io {
+            PaneRuntimeIo::Actor(actor) => {
+                let actor = actor.clone();
+                let ordered = Arc::clone(&self.ordered);
+                tokio::spawn(async move {
+                    tokio::time::sleep(delay).await;
+                    if let Err(err) = actor.write_user_input(enter).await {
+                        warn!(error = %err, "failed to send ordered prompt Enter");
+                    }
+                    let deferred = {
+                        let mut gate = ordered
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        gate.holding = false;
+                        std::mem::take(&mut gate.deferred)
+                    };
+                    for bytes in deferred {
+                        if let Err(err) = actor.write_user_input(bytes).await {
+                            warn!(error = %err, "failed to flush deferred PTY input");
+                            break;
+                        }
+                    }
+                    if let Some(on_written) = on_written {
+                        let _ = on_written.send(());
+                    }
+                });
+            }
+            #[cfg(test)]
+            PaneRuntimeIo::TestChannel { sender, .. } => {
+                let sender = sender.clone();
+                let ordered = Arc::clone(&self.ordered);
+                tokio::spawn(async move {
+                    tokio::time::sleep(delay).await;
+                    let _ = sender.send(enter).await;
+                    let deferred = {
+                        let mut gate = ordered
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        gate.holding = false;
+                        std::mem::take(&mut gate.deferred)
+                    };
+                    for bytes in deferred {
+                        if sender.send(bytes).await.is_err() {
+                            break;
+                        }
+                    }
+                    if let Some(on_written) = on_written {
+                        let _ = on_written.send(());
+                    }
+                });
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)] // retained for callers outside agent.prompt
+    pub fn send_bytes_after(&self, bytes: Bytes, delay: Duration) {
+        let ordered = Arc::clone(&self.ordered);
+        match &self.io {
+            PaneRuntimeIo::Actor(actor) => {
+                let actor = actor.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(delay).await;
+                    {
+                        let mut gate = ordered
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        if gate.holding {
+                            gate.deferred.push_back(bytes);
+                            return;
+                        }
+                    }
+                    if let Err(err) = actor.write_user_input(bytes).await {
+                        warn!(error = %err, "failed to send delayed PTY input");
+                    }
+                });
+            }
+            #[cfg(test)]
+            PaneRuntimeIo::TestChannel { sender, .. } => {
+                let sender = sender.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(delay).await;
+                    {
+                        let mut gate = ordered
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        if gate.holding {
+                            gate.deferred.push_back(bytes);
+                            return;
+                        }
+                    }
+                    let _ = sender.send(bytes).await;
+                });
+            }
+        }
     }
 
     pub async fn send_paste(&self, text: String) -> Result<(), mpsc::error::SendError<Bytes>> {
@@ -2937,6 +3070,7 @@ impl PaneRuntime {
                     sender: tx,
                     resize_tx,
                 },
+                ordered: Arc::new(Mutex::new(OrderedSubmissionGate::default())),
                 current_size: Cell::new((rows, cols, 0, 0)),
                 child_pid: Arc::new(AtomicU32::new(0)),
                 reported_cwd: Arc::new(Mutex::new(None)),
@@ -2957,6 +3091,60 @@ impl PaneRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn ordered_submission_blocks_interleaved_input_until_enter() {
+        let (runtime, mut rx) = PaneRuntime::test_with_channel(80, 24);
+        let (written_tx, written_rx) = tokio::sync::oneshot::channel();
+        runtime
+            .try_send_ordered_submission(
+                Bytes::from_static(b"prompt-bytes"),
+                Bytes::from_static(b"\r"),
+                Duration::from_millis(20),
+                Some(written_tx),
+            )
+            .expect("ordered submission should enqueue");
+        // Interleaved input while gate holds must be deferred, not written early.
+        runtime
+            .try_send_bytes(Bytes::from_static(b"interleaved"))
+            .expect("deferred enqueue should succeed");
+
+        let first = rx.recv().await.expect("prompt bytes");
+        assert_eq!(first.as_ref(), b"prompt-bytes");
+        // Enter has not been written yet; interleaved must not appear first.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(rx.try_recv().is_err(), "no interleaved write before Enter");
+
+        let enter = rx.recv().await.expect("enter bytes");
+        assert_eq!(enter.as_ref(), b"\r");
+        let deferred = rx.recv().await.expect("deferred interleaved bytes");
+        assert_eq!(deferred.as_ref(), b"interleaved");
+        written_rx.await.expect("on_written signal");
+    }
+
+    #[tokio::test]
+    async fn ordered_submission_rejects_second_hold_while_active() {
+        let (runtime, mut rx) = PaneRuntime::test_with_channel(80, 24);
+        runtime
+            .try_send_ordered_submission(
+                Bytes::from_static(b"first"),
+                Bytes::from_static(b"\r"),
+                Duration::from_millis(30),
+                None,
+            )
+            .expect("first ordered submission");
+        let err = runtime
+            .try_send_ordered_submission(
+                Bytes::from_static(b"second"),
+                Bytes::from_static(b"\r"),
+                Duration::from_millis(30),
+                None,
+            )
+            .expect_err("second hold must fail");
+        assert!(matches!(err, mpsc::error::TrySendError::Full(_)));
+        assert_eq!(rx.recv().await.unwrap().as_ref(), b"first");
+        assert_eq!(rx.recv().await.unwrap().as_ref(), b"\r");
+    }
 
     #[test]
     fn pane_launch_env_removes_outer_codex_thread_id() {
@@ -3491,6 +3679,7 @@ mod tests {
                 sender: tx,
                 resize_tx,
             },
+            ordered: Arc::new(Mutex::new(OrderedSubmissionGate::default())),
             current_size: Cell::new((80, 24, 0, 0)),
             child_pid: Arc::new(AtomicU32::new(0)),
             reported_cwd: Arc::new(Mutex::new(None)),
@@ -3522,6 +3711,7 @@ mod tests {
                 sender: tx,
                 resize_tx,
             },
+            ordered: Arc::new(Mutex::new(OrderedSubmissionGate::default())),
             current_size: Cell::new((80, 24, 0, 0)),
             child_pid: Arc::new(AtomicU32::new(0)),
             reported_cwd: Arc::new(Mutex::new(None)),

--- a/src/terminal/runtime.rs
+++ b/src/terminal/runtime.rs
@@ -432,6 +432,18 @@ impl TerminalRuntime {
         self.0.try_send_bytes(bytes)
     }
 
+    pub fn try_send_ordered_submission(
+        &self,
+        prompt: Bytes,
+        enter: Bytes,
+        delay: std::time::Duration,
+        on_written: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), mpsc::error::TrySendError<Bytes>> {
+        self.0
+            .try_send_ordered_submission(prompt, enter, delay, on_written)
+    }
+
+    #[allow(dead_code)] // retained; agent.prompt uses ordered submission
     pub fn send_bytes_after(&self, bytes: Bytes, delay: std::time::Duration) {
         self.0.send_bytes_after(bytes, delay);
     }


### PR DESCRIPTION
## Summary

- `agent.prompt` could return / `--wait` could resolve while prompt text still sat unsubmitted in the composer, because delayed Enter was scheduled separately and composer text alone could advance `state_change_seq`.
- Prompt text and delayed Enter are now one ordered PTY submission: intervening input is deferred until Enter is written.
- `--wait` sleeps through the Enter delay, then rebaselines effect observation on a post-Enter `state_change_seq` so pre-Enter screen updates cannot satisfy the effect gate. Callers without `--wait` still return immediately after enqueue.

refs #2422

## Test plan

- [x] `ordered_submission_*` pane tests (interleave deferred; second hold rejected)
- [x] `agent_prompt_sends_text_then_delays_enter` and `agent_prompt_orders_enter_before_intervening_input`
- [x] `prompt_wait_rebaseline_rejects_composer_only_seq_bump`
- [x] `cargo fmt --check` + `cargo clippy -D warnings`
- [x] all `herdr` binary unit tests (3035)
- [ ] full `just ci` in this environment: PTY-spawned integration tests (`auto_detect_*`, some session/client_mode/multi_client) also fail on clean `master` here; not caused by this patch


Made with [Cursor](https://cursor.com)