### PR TITLE
fix: default copy_on_select to false

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Settings and `ui.status_indicators = "symbols"` can now use distinct static shapes for blocked, working, done, idle, and unknown agent states. (#2260)
 - The plugin marketplace now discovers valid manifests at repository roots and subdirectories, groups multiple plugins under each repository, and publishes their versions and exact default-branch commits.
 
+### Changed
+- `ui.copy_on_select` now defaults to `false`. Mouse selections were auto-copying to the clipboard on every drag or double-click, which could clobber other clipboard writers (e.g. system dictation) over OSC 52. `Ctrl+C`, or `Cmd+C` when the host forwards it, still copies and clears the retained selection.
+
 ### Fixed
 - Stable direct installs, self-updates, and remote helper downloads now require and verify the SHA-256 digest published for each GitHub release asset.
 - Configs containing the retired Herdr-written `ui.agent_panel_scope` setting no longer report it as an unknown key after upgrades. (#2292)

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -602,7 +602,7 @@
         {
           "key": "ui.copy_on_select",
           "type": "boolean",
-          "default": "true",
+          "default": "false",
           "description": "Automatically copy text selected by mouse drag or double-click. When disabled, Ctrl+C or a host-forwarded Cmd+C copies and clears the retained selection."
         },
         {

--- a/src/app/input/terminal.rs
+++ b/src/app/input/terminal.rs
@@ -641,6 +641,7 @@ mod tests {
         app.state.selected = 0;
         app.state.mode = Mode::Terminal;
         app.state.view.pane_infos = pane_infos;
+        app.state.copy_on_select = true;
 
         let row = info.inner_rect.y;
         let start_col = info.inner_rect.x + 1;
@@ -662,6 +663,7 @@ mod tests {
     #[tokio::test]
     async fn drag_copy_then_click_does_not_reuse_double_click_candidate() {
         let (mut app, info) = app_with_screen_bytes(b"alpha beta");
+        app.state.copy_on_select = true;
         let row = info.inner_rect.y;
         let start_col = info.inner_rect.x;
         let end_col = info.inner_rect.x + 4;
@@ -693,6 +695,7 @@ mod tests {
     #[tokio::test]
     async fn double_click_selects_and_copies_word() {
         let (mut app, info) = app_with_screen_bytes(b"alpha beta-gamma_delta@omega");
+        app.state.copy_on_select = true;
         let col = info.inner_rect.x + 13;
         let row = info.inner_rect.y;
         double_click(&mut app, col, row);
@@ -768,6 +771,7 @@ mod tests {
     #[tokio::test]
     async fn new_drag_cancels_stale_double_click_highlight_deadline() {
         let (mut app, info) = app_with_screen_bytes(b"alpha beta");
+        app.state.copy_on_select = true;
         let row = info.inner_rect.y;
         let word_col = info.inner_rect.x + 2;
 
@@ -799,6 +803,7 @@ mod tests {
     #[tokio::test]
     async fn ignored_left_down_keeps_double_click_highlight_deadline() {
         let (mut app, info) = app_with_screen_bytes(b"alpha beta");
+        app.state.copy_on_select = true;
         let col = info.inner_rect.x + 2;
         let row = info.inner_rect.y;
 
@@ -830,6 +835,7 @@ mod tests {
     #[tokio::test]
     async fn double_click_uses_display_columns_for_wide_chars() {
         let (mut app, info) = app_with_screen_bytes("echo 你好-world done".as_bytes());
+        app.state.copy_on_select = true;
         let col = info.inner_rect.x + 8;
         let row = info.inner_rect.y;
         double_click(&mut app, col, row);
@@ -842,6 +848,7 @@ mod tests {
     async fn double_click_copies_quoted_path_without_quotes() {
         let line = r#"cat "/tmp/build output/log.txt""#;
         let (mut app, info) = app_with_screen_bytes(line.as_bytes());
+        app.state.copy_on_select = true;
         let col = info.inner_rect.x + line.find("output").expect("path segment") as u16;
         let row = info.inner_rect.y;
         double_click(&mut app, col, row);
@@ -856,6 +863,7 @@ mod tests {
     #[tokio::test]
     async fn double_click_excludes_trailing_punctuation() {
         let (mut app, info) = app_with_screen_bytes(b"done.");
+        app.state.copy_on_select = true;
         let col = info.inner_rect.x + 2;
         let row = info.inner_rect.y;
         double_click(&mut app, col, row);
@@ -1185,6 +1193,7 @@ mod tests {
     #[tokio::test]
     async fn double_click_highlight_clears_after_short_delay() {
         let (mut app, info) = app_with_screen_bytes(b"copied");
+        app.state.copy_on_select = true;
         let col = info.inner_rect.x + 2;
         let row = info.inner_rect.y;
         double_click(&mut app, col, row);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1880,7 +1880,7 @@ impl AppState {
             sidebar_spaces: crate::config::SpacesSidebarConfig::default(),
             next_agent_state_change_seq: 0,
             mouse_capture: true,
-            copy_on_select: true,
+            copy_on_select: false,
             right_click_passthrough_modifiers: None,
             right_click_passthrough: None,
             redraw_on_focus_gained: true,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1043,7 +1043,7 @@ impl Default for UiConfig {
             sidebar_collapsed_mode: SidebarCollapsedModeConfig::Compact,
             mobile_width_threshold: DEFAULT_MOBILE_WIDTH_THRESHOLD,
             mouse_capture: true,
-            copy_on_select: true,
+            copy_on_select: false,
             host_cursor: HostCursorModeConfig::Auto,
             right_click_passthrough_modifier: RightClickPassthroughModifierConfig::default(),
             redraw_on_focus_gained: true,
@@ -1512,16 +1512,16 @@ mouse_capture = false
     }
 
     #[test]
-    fn copy_on_select_default_on_and_parse() {
+    fn copy_on_select_default_off_and_parse() {
         let default_config = Config::default();
-        assert!(default_config.ui.copy_on_select);
+        assert!(!default_config.ui.copy_on_select);
 
         let toml = r#"
 [ui]
-copy_on_select = false
+copy_on_select = true
 "#;
         let config: Config = toml::from_str(toml).unwrap();
-        assert!(!config.ui.copy_on_select);
+        assert!(config.ui.copy_on_select);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,7 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # Automatically copy text selected with the mouse.
 # Set false to retain drag or double-click word selection until Ctrl+C,
 # or Cmd+C when the host forwards it, copies and clears it.
-# copy_on_select = true
+# copy_on_select = false
 
 # Host cursor policy: "auto", "native", or "drawn".
 # "auto" draws Herdr's own cursor on native Windows builds and WSL to avoid ConPTY cursor flicker, and uses the native terminal cursor elsewhere.


### PR DESCRIPTION
## Summary
- Flips the built-in default for `ui.copy_on_select` from `true` to `false`, closing a footgun where auto-copying every mouse selection to the clipboard via OSC 52 races with other clipboard writers over SSH (e.g. dictation tools). This has silently regressed twice via config edits that preserved the explanatory comment but not the boolean.
- Ctrl+C, or Cmd+C when the host forwards it, remains the deliberate-copy path when the setting is off.
- Updates the `copy_on_select_default_on_and_parse` test to `copy_on_select_default_off_and_parse` reflecting the new default, fixes tests that relied on the old default-true behavior by setting `copy_on_select = true` explicitly, and updates the config reference docs and changelog.

## Test plan
- [x] `just check` (fmt, clippy x2 targets, cargo nextest full suite, integration asset tests, plugin marketplace tests, doc/changelog checks) — all green
- [x] `cargo test --bin herdr -- --test-threads=1` — all pass except a pre-existing unrelated flaky test (`generated_workspace_ids_are_short_base32_handles`, order-dependent on generated id length)