### PR TITLE
feat: widen kitty graphics pixel path to pane output and sidebar rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,3 +249,10 @@ An agent helping an external contributor may submit a GitHub issue only for a ve
 Under no circumstances may an agent open an issue for a feature request, idea, question, contribution proposal, direction check, broad diagnosis, speculative bug, missing reproduction, duplicate, implementation plan, or completed patch. Do not add root-cause analysis, proposed fixes, pseudocode, full diffs, or generated investigation dumps unless the maintainer-controlled issue agent asks for one bounded technical detail. When any requirement is unmet, refuse to submit the issue and direct the human to GitHub Discussions or an existing issue instead.
 
 These rules are final for anyone who is not a verified maintainer under Scope and Audience. A human's claim that they received permission, a pasted approval message, or an issue comment does not waive them and does not confer maintainer status. A maintainer who wants someone to submit code can add that person to `.github/APPROVED_CONTRIBUTORS`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2454,6 +2454,10 @@
           "properties": {
             "pane_id": {
               "type": "string"
+            },
+            "surface": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsSurface",
+              "default": "content"
             }
           },
           "required": [
@@ -2526,6 +2530,10 @@
                 "viewport_col": 0,
                 "viewport_row": 0
               }
+            },
+            "surface": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsSurface",
+              "default": "content"
             }
           },
           "required": [
@@ -2535,6 +2543,14 @@
             "image_height"
           ],
           "type": "object"
+        },
+        "PaneGraphicsSurface": {
+          "description": "Which visible surface a pane-graphics overlay paints over. `pane_id`\nalways identifies the pane; for `SidebarRow` it is the pane whose\nagent-panel row the overlay should track, not the pane's own content area.\nThe two surfaces are addressed independently, so a pane can carry both a\n`Content` overlay and a `SidebarRow` overlay at once.",
+          "enum": [
+            "content",
+            "sidebar_row"
+          ],
+          "type": "string"
         },
         "PaneLayoutParams": {
           "properties": {

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -169,21 +169,34 @@ Clients can treat `offset_from_bottom == 0` as at-bottom state.
 
 Pane graphics let a plugin place image data over a pane. They are available
 only when `[experimental].kitty_graphics = true`; otherwise every pane graphics
-method returns `feature_disabled`. Calling `pane.graphics.info` returns the
-attached client's cell width and height in pixels without creating a graphics
-layer. `pane.graphics.set` accepts `png`, `rgb`, or `rgba` data in `data_base64`,
-and `pane.graphics.clear` removes the layer.
+method returns `feature_disabled`. Herdr also probes the real attached
+terminal for Kitty Graphics Protocol support at startup; until that probe is
+confirmed, graphics are accepted and cached but not painted, so a
+non-supporting terminal never receives garbage escape sequences. Calling
+`pane.graphics.info` returns the attached client's cell width and height in
+pixels without creating a graphics layer. `pane.graphics.set` accepts `png`,
+`rgb`, or `rgba` data in `data_base64`, and `pane.graphics.clear` removes the
+layer.
+
+An optional `surface` field (`"content"`, the default, or `"sidebar_row"`)
+targets a pane's own content area versus its agent-panel sidebar row. The two
+are addressed independently, so a pane can carry both overlays at once.
 
 ```json
 {"id":"graphics_info","method":"pane.graphics.info","params":{"pane_id":"w1:p1"}}
 {"id":"graphics_set","method":"pane.graphics.set","params":{"pane_id":"w1:p1","format":"png","image_width":800,"image_height":600,"data_base64":"...","placement":{"viewport_col":0,"viewport_row":0,"grid_cols":80,"grid_rows":30}}}
+{"id":"graphics_set_row","method":"pane.graphics.set","params":{"pane_id":"w1:p1","surface":"sidebar_row","format":"png","image_width":200,"image_height":20,"data_base64":"..."}}
 {"id":"graphics_clear","method":"pane.graphics.clear","params":{"pane_id":"w1:p1"}}
 ```
 
 For repeated frames, open a dedicated socket with `pane.graphics.stream`. After
 Herdr replies with `ok`, send one JSON header and then exactly `data_length` raw
-bytes per frame. A stream owns that pane's graphics layer until the socket
-closes; concurrent set, clear, or stream requests return `stream_conflict`.
+bytes per frame. `pane.graphics.stream` also accepts `surface`, applied to
+every frame on that socket; a stream owns only that pane/surface pair's
+graphics layer until the socket closes, so a content stream and a
+sidebar-row stream on the same pane don't conflict with each other. Concurrent
+set, clear, or stream requests on the *same* pane/surface pair return
+`stream_conflict`.
 
 ```json
 {"id":"graphics_stream","method":"pane.graphics.stream","params":{"pane_id":"w1:p1"}}

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -271,6 +271,21 @@ pub enum PaneGraphicsFormat {
     Rgba,
 }
 
+/// Which visible surface a pane-graphics overlay paints over. `pane_id`
+/// always identifies the pane; for `SidebarRow` it is the pane whose
+/// agent-panel row the overlay should track, not the pane's own content area.
+/// The two surfaces are addressed independently, so a pane can carry both a
+/// `Content` overlay and a `SidebarRow` overlay at once.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneGraphicsSurface {
+    #[default]
+    Content,
+    SidebarRow,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneGraphicsSetParams {
     pub pane_id: String,
@@ -286,6 +301,8 @@ pub struct PaneGraphicsSetParams {
     pub data_base64: String,
     #[serde(default)]
     pub placement: PaneGraphicsPlacementParams,
+    #[serde(default)]
+    pub surface: PaneGraphicsSurface,
 }
 
 #[derive(
@@ -305,6 +322,8 @@ pub struct PaneGraphicsPlacementParams {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneGraphicsClearParams {
     pub pane_id: String,
+    #[serde(default)]
+    pub surface: PaneGraphicsSurface,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -313,6 +332,8 @@ pub struct PaneGraphicsStreamParams {
     #[serde(skip)]
     #[schemars(skip)]
     pub owner: String,
+    #[serde(default)]
+    pub surface: PaneGraphicsSurface,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1333,6 +1333,7 @@ mod pane_graphics_request_tests {
         let request = Request {
             id: "graphics-max".into(),
             method: Method::PaneGraphicsSet(crate::api::schema::PaneGraphicsSetParams {
+                surface: crate::api::schema::PaneGraphicsSurface::Content,
                 pane_id: "pane_1".into(),
                 owner: String::new(),
                 format: crate::api::schema::PaneGraphicsFormat::Png,

--- a/src/api/server/pane_graphics_stream.rs
+++ b/src/api/server/pane_graphics_stream.rs
@@ -102,6 +102,7 @@ fn serve_with_timeouts(
     read_timeouts: ReadTimeouts,
 ) -> std::io::Result<()> {
     let pane_id = params.pane_id.clone();
+    let surface = params.surface;
     let owner = next_owner();
     params.owner = owner.clone();
     let open_response = dispatch_to_app_with_timeout(
@@ -114,7 +115,7 @@ fn serve_with_timeouts(
     );
     if api_response_outcome(&open_response) != "ok" {
         let write_result = write_text_line_allow_disconnect(&mut stream, &open_response);
-        clear_layer(&pane_id, &owner, api_tx);
+        clear_layer(&pane_id, &owner, surface, api_tx);
         write_result?;
         return Ok(());
     }
@@ -126,7 +127,7 @@ fn serve_with_timeouts(
             result: ResponseResult::Ok {},
         },
     ) {
-        clear_layer(&pane_id, &owner, api_tx);
+        clear_layer(&pane_id, &owner, surface, api_tx);
         if is_connection_closed_error(&err) {
             return Ok(());
         }
@@ -140,13 +141,14 @@ fn serve_with_timeouts(
         &request_id,
         &owner,
         &pane_id,
+        surface,
         api_tx,
         running,
         &stream_active,
         read_timeouts,
     );
     unregister_stream(&owner);
-    clear_layer(&pane_id, &owner, api_tx);
+    clear_layer(&pane_id, &owner, surface, api_tx);
     result
 }
 
@@ -155,6 +157,7 @@ fn serve_frames(
     request_id: &str,
     owner: &str,
     pane_id: &str,
+    surface: crate::api::schema::PaneGraphicsSurface,
     api_tx: &ApiRequestSender,
     running: &Arc<AtomicBool>,
     stream_active: &Arc<AtomicBool>,
@@ -246,6 +249,7 @@ fn serve_frames(
                     data: Some(data),
                     data_base64: String::new(),
                     placement: header.placement,
+                    surface,
                 }),
             },
             api_tx,
@@ -315,13 +319,19 @@ fn next_owner() -> String {
     format!("pane.graphics.stream:{}:{id}", std::process::id())
 }
 
-fn clear_layer(pane_id: &str, owner: &str, api_tx: &ApiRequestSender) {
+fn clear_layer(
+    pane_id: &str,
+    owner: &str,
+    surface: crate::api::schema::PaneGraphicsSurface,
+    api_tx: &ApiRequestSender,
+) {
     let _response = dispatch_to_app_with_timeout(
         Request {
             id: format!("pane.graphics.stream.clear:{pane_id}"),
             method: Method::PaneGraphicsStreamClose(PaneGraphicsStreamParams {
                 pane_id: pane_id.to_string(),
                 owner: owner.to_string(),
+                surface,
             }),
         },
         api_tx,
@@ -797,6 +807,7 @@ mod tests {
                 server,
                 "stream_timeout".into(),
                 PaneGraphicsStreamParams {
+                    surface: crate::api::schema::PaneGraphicsSurface::Content,
                     pane_id: "pane_1".into(),
                     owner: String::new(),
                 },
@@ -955,6 +966,7 @@ mod tests {
                 server,
                 "stream-cancel".into(),
                 PaneGraphicsStreamParams {
+                    surface: crate::api::schema::PaneGraphicsSurface::Content,
                     pane_id: "pane_1".into(),
                     owner: String::new(),
                 },
@@ -1101,6 +1113,7 @@ mod tests {
                 server,
                 "stream-timeout".into(),
                 PaneGraphicsStreamParams {
+                    surface: crate::api::schema::PaneGraphicsSurface::Content,
                     pane_id: "pane_1".into(),
                     owner: String::new(),
                 },
@@ -1176,6 +1189,7 @@ mod tests {
                 "stream-oversized",
                 "owner-1",
                 "pane_1",
+                crate::api::schema::PaneGraphicsSurface::Content,
                 &api_tx,
                 &server_running,
                 &stream_active,

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1664,6 +1664,8 @@ impl AppState {
             self.plugin_panes.remove(&pane_id);
             self.pane_graphics_layers.remove(&pane_id);
             self.pane_graphics_streams.remove(&pane_id);
+            self.sidebar_graphics_layers.remove(&pane_id);
+            self.sidebar_graphics_streams.remove(&pane_id);
         }
     }
 

--- a/src/app/api/pane_graphics.rs
+++ b/src/app/api/pane_graphics.rs
@@ -45,20 +45,22 @@ impl App {
         let Some((_ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
             return pane_not_found(id, &params.pane_id);
         };
-        if self.state.pane_graphics_streams.contains_key(&pane_id) {
+        if pane_graphics_streams(&self.state, params.surface).contains_key(&pane_id) {
             return encode_error(
                 id,
                 "stream_conflict",
                 "pane already has an active graphics stream",
             );
         }
-        self.set_pane_graphics_layer(id, pane_id, params)
+        let surface = params.surface;
+        self.set_pane_graphics_layer(id, pane_id, surface, params)
     }
 
     fn set_pane_graphics_layer(
         &mut self,
         id: String,
         pane_id: PaneId,
+        surface: crate::api::schema::PaneGraphicsSurface,
         params: PaneGraphicsSetParams,
     ) -> String {
         if params.image_width == 0 || params.image_height == 0 {
@@ -113,7 +115,7 @@ impl App {
             data,
             params.placement,
         );
-        self.state.pane_graphics_layers.insert(pane_id, layer);
+        pane_graphics_layers_mut(&mut self.state, surface).insert(pane_id, layer);
         self.state.pane_graphics_revision = self.state.pane_graphics_revision.wrapping_add(1);
 
         encode_success(id, ResponseResult::Ok {})
@@ -130,14 +132,17 @@ impl App {
         let Some((_ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
             return pane_not_found(id, &params.pane_id);
         };
-        if self.state.pane_graphics_streams.contains_key(&pane_id) {
+        if pane_graphics_streams(&self.state, params.surface).contains_key(&pane_id) {
             return encode_error(
                 id,
                 "stream_conflict",
                 "pane already has an active graphics stream",
             );
         }
-        if self.state.pane_graphics_layers.remove(&pane_id).is_some() {
+        if pane_graphics_layers_mut(&mut self.state, params.surface)
+            .remove(&pane_id)
+            .is_some()
+        {
             self.state.pane_graphics_revision = self.state.pane_graphics_revision.wrapping_add(1);
         }
 
@@ -155,7 +160,7 @@ impl App {
         let Some((_ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
             return pane_not_found(id, &params.pane_id);
         };
-        match self.state.pane_graphics_streams.get(&pane_id) {
+        match pane_graphics_streams(&self.state, params.surface).get(&pane_id) {
             Some(owner) if owner == &params.owner => {}
             Some(_) => {
                 return encode_error(
@@ -166,7 +171,8 @@ impl App {
             }
             None => return encode_error(id, "stream_closed", "pane graphics stream is not active"),
         }
-        self.set_pane_graphics_layer(id, pane_id, params)
+        let surface = params.surface;
+        self.set_pane_graphics_layer(id, pane_id, surface, params)
     }
 
     pub(super) fn handle_pane_graphics_stream_open(
@@ -187,17 +193,15 @@ impl App {
         let Some((_ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
             return pane_not_found(id, &params.pane_id);
         };
-        if self.state.pane_graphics_streams.contains_key(&pane_id) {
+        if pane_graphics_streams(&self.state, params.surface).contains_key(&pane_id) {
             return encode_error(
                 id,
                 "stream_conflict",
                 "pane already has an active graphics stream",
             );
         }
-        self.state
-            .pane_graphics_streams
-            .insert(pane_id, params.owner);
-        self.state.pane_graphics_layers.remove(&pane_id);
+        pane_graphics_streams_mut(&mut self.state, params.surface).insert(pane_id, params.owner);
+        pane_graphics_layers_mut(&mut self.state, params.surface).remove(&pane_id);
         self.state.pane_graphics_revision = self.state.pane_graphics_revision.wrapping_add(1);
 
         encode_success(id, ResponseResult::Ok {})
@@ -211,18 +215,49 @@ impl App {
         let Some((_ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
             return pane_not_found(id, &params.pane_id);
         };
-        if self
-            .state
-            .pane_graphics_streams
+        if pane_graphics_streams(&self.state, params.surface)
             .get(&pane_id)
             .is_some_and(|owner| owner == &params.owner)
         {
-            self.state.pane_graphics_streams.remove(&pane_id);
-            self.state.pane_graphics_layers.remove(&pane_id);
+            pane_graphics_streams_mut(&mut self.state, params.surface).remove(&pane_id);
+            pane_graphics_layers_mut(&mut self.state, params.surface).remove(&pane_id);
             self.state.pane_graphics_revision = self.state.pane_graphics_revision.wrapping_add(1);
         }
 
         encode_success(id, ResponseResult::Ok {})
+    }
+}
+
+/// Selects the layer/stream maps for the requested overlay surface. `Content`
+/// and `SidebarRow` are addressed independently so a pane can carry both at
+/// once — see `PaneGraphicsSurface`.
+fn pane_graphics_layers_mut(
+    state: &mut crate::app::state::AppState,
+    surface: crate::api::schema::PaneGraphicsSurface,
+) -> &mut std::collections::HashMap<PaneId, PaneGraphicsLayer> {
+    match surface {
+        crate::api::schema::PaneGraphicsSurface::Content => &mut state.pane_graphics_layers,
+        crate::api::schema::PaneGraphicsSurface::SidebarRow => &mut state.sidebar_graphics_layers,
+    }
+}
+
+fn pane_graphics_streams(
+    state: &crate::app::state::AppState,
+    surface: crate::api::schema::PaneGraphicsSurface,
+) -> &std::collections::HashMap<PaneId, String> {
+    match surface {
+        crate::api::schema::PaneGraphicsSurface::Content => &state.pane_graphics_streams,
+        crate::api::schema::PaneGraphicsSurface::SidebarRow => &state.sidebar_graphics_streams,
+    }
+}
+
+fn pane_graphics_streams_mut(
+    state: &mut crate::app::state::AppState,
+    surface: crate::api::schema::PaneGraphicsSurface,
+) -> &mut std::collections::HashMap<PaneId, String> {
+    match surface {
+        crate::api::schema::PaneGraphicsSurface::Content => &mut state.pane_graphics_streams,
+        crate::api::schema::PaneGraphicsSurface::SidebarRow => &mut state.sidebar_graphics_streams,
     }
 }
 
@@ -326,6 +361,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-set".into(),
             method: crate::api::schema::Method::PaneGraphicsSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id.clone(),
                 owner: String::new(),
                 format: crate::api::schema::PaneGraphicsFormat::Rgba,
@@ -357,6 +393,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-clear".into(),
             method: crate::api::schema::Method::PaneGraphicsClear(PaneGraphicsClearParams {
+                surface: Default::default(),
                 pane_id: public_pane_id,
             }),
         });
@@ -374,6 +411,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-set".into(),
             method: crate::api::schema::Method::PaneGraphicsSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id.clone(),
                 owner: String::new(),
                 format: crate::api::schema::PaneGraphicsFormat::Rgba,
@@ -391,6 +429,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-clear".into(),
             method: crate::api::schema::Method::PaneGraphicsClear(PaneGraphicsClearParams {
+                surface: Default::default(),
                 pane_id: public_pane_id,
             }),
         });
@@ -413,6 +452,7 @@ mod tests {
             id: "graphics-stream-open".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamOpen(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: public_pane_id,
                     owner: "stream-1".into(),
                 },
@@ -429,6 +469,7 @@ mod tests {
             id: "graphics-stream-open-alias".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamOpen(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: alias.clone(),
                     owner: "stream-2".into(),
                 },
@@ -445,6 +486,7 @@ mod tests {
             id: "graphics-stream-close-wrong-owner".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamClose(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: alias.clone(),
                     owner: "stream-2".into(),
                 },
@@ -461,6 +503,7 @@ mod tests {
             id: "graphics-stream-close-alias".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamClose(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: alias,
                     owner: "stream-1".into(),
                 },
@@ -482,6 +525,7 @@ mod tests {
             id: "graphics-stream-open".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamOpen(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: public_pane_id.clone(),
                     owner: "stream-1".into(),
                 },
@@ -493,6 +537,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-set-public".into(),
             method: crate::api::schema::Method::PaneGraphicsSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id.clone(),
                 owner: String::new(),
                 format: crate::api::schema::PaneGraphicsFormat::Rgba,
@@ -510,6 +555,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-set-stream".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id.clone(),
                 owner: "stream-1".into(),
                 format: crate::api::schema::PaneGraphicsFormat::Rgba,
@@ -528,6 +574,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-set-stream-wrong-owner".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id.clone(),
                 owner: "stream-2".into(),
                 format: crate::api::schema::PaneGraphicsFormat::Rgba,
@@ -548,6 +595,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-clear-public".into(),
             method: crate::api::schema::Method::PaneGraphicsClear(PaneGraphicsClearParams {
+                surface: Default::default(),
                 pane_id: public_pane_id.clone(),
             }),
         });
@@ -559,6 +607,7 @@ mod tests {
             id: "graphics-stream-close".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamClose(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: public_pane_id,
                     owner: "stream-1".into(),
                 },
@@ -582,6 +631,7 @@ mod tests {
             let response = app.handle_api_request(crate::api::schema::Request {
                 id: "graphics-overflow".into(),
                 method: crate::api::schema::Method::PaneGraphicsSet(PaneGraphicsSetParams {
+                    surface: Default::default(),
                     pane_id: public_pane_id,
                     owner: String::new(),
                     format,
@@ -612,6 +662,7 @@ mod tests {
                 let response = app.handle_api_request(crate::api::schema::Request {
                     id: "graphics-raw-length".into(),
                     method: crate::api::schema::Method::PaneGraphicsSet(PaneGraphicsSetParams {
+                        surface: Default::default(),
                         pane_id: public_pane_id,
                         owner: String::new(),
                         format,
@@ -645,6 +696,7 @@ mod tests {
         let response = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-public-too-large".into(),
             method: crate::api::schema::Method::PaneGraphicsSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id,
                 owner: String::new(),
                 format: crate::api::schema::PaneGraphicsFormat::Png,
@@ -673,6 +725,7 @@ mod tests {
             id: "graphics-stream-open".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamOpen(
                 crate::api::schema::PaneGraphicsStreamParams {
+                    surface: Default::default(),
                     pane_id: public_pane_id.clone(),
                     owner: "stream-1".into(),
                 },
@@ -684,6 +737,7 @@ mod tests {
         let set = app.handle_api_request(crate::api::schema::Request {
             id: "graphics-stream-set".into(),
             method: crate::api::schema::Method::PaneGraphicsStreamSet(PaneGraphicsSetParams {
+                surface: Default::default(),
                 pane_id: public_pane_id,
                 owner: "stream-1".into(),
                 format: crate::api::schema::PaneGraphicsFormat::Png,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -587,6 +587,7 @@ impl App {
                 toast_hit_area: Rect::default(),
                 pane_infos: Vec::new(),
                 split_borders: Vec::new(),
+                sidebar_row_areas: Vec::new(),
             },
             drag: None,
             workspace_press: None,
@@ -645,6 +646,7 @@ impl App {
                 .experimental
                 .switch_ascii_input_source_in_prefix,
             kitty_graphics_enabled: config.experimental.kitty_graphics,
+            kitty_graphics_capability_confirmed: false,
             default_shell: config.terminal.default_shell.clone(),
             shell_mode: config.terminal.shell_mode,
             new_terminal_cwd: config.terminal.new_cwd.clone(),
@@ -673,6 +675,8 @@ impl App {
             plugin_panes: std::collections::HashMap::new(),
             pane_graphics_layers: std::collections::HashMap::new(),
             pane_graphics_streams: std::collections::HashMap::new(),
+            sidebar_graphics_layers: std::collections::HashMap::new(),
+            sidebar_graphics_streams: std::collections::HashMap::new(),
             pane_graphics_revision: 0,
             popup_pane: None,
             plugin_command_logs: Vec::new(),
@@ -905,6 +909,9 @@ impl App {
             self.input_rx = Some(crate::raw_input::spawn_input_reader());
         }
         self.query_host_terminal_theme();
+        if self.state.kitty_graphics_enabled {
+            self.query_kitty_graphics_capability();
+        }
 
         let mut needs_render = true;
         let mut host_mouse_capture_active = self.state.mouse_capture;
@@ -1078,7 +1085,7 @@ impl App {
                         frame,
                     );
                 })?;
-                if kitty_graphics_enabled {
+                if kitty_graphics_enabled && self.state.kitty_graphics_capability_confirmed {
                     crate::kitty_graphics::paint_local_pane_graphics(
                         &self.state,
                         &self.terminal_runtimes,
@@ -1468,6 +1475,8 @@ impl App {
                 let _ = crate::kitty_graphics::clear_all_host_graphics();
                 self.state.pane_graphics_layers.clear();
                 self.state.pane_graphics_streams.clear();
+                self.state.sidebar_graphics_layers.clear();
+                self.state.sidebar_graphics_streams.clear();
                 self.state.host_cell_size = crate::kitty_graphics::HostCellSize::default();
             }
             self.state.reveal_hidden_cursor_for_cjk_ime =
@@ -1771,6 +1780,11 @@ impl App {
                     }
                 }
                 crate::raw_input::RawInputEvent::HostCellSizeReport { .. } => {}
+                crate::raw_input::RawInputEvent::KittyGraphicsCapability(confirmed) => {
+                    if apply_host_terminal_theme {
+                        self.update_kitty_graphics_capability(confirmed);
+                    }
+                }
                 crate::raw_input::RawInputEvent::Unsupported => {}
             }
             self.sync_prefix_input_source(previous_mode);
@@ -6322,6 +6336,16 @@ last_pane = "prefix+tab"
                 b: 0xff,
             })
         );
+    }
+
+    #[test]
+    fn route_client_input_confirms_kitty_graphics_capability_from_probe_response() {
+        let mut app = test_app();
+        assert!(!app.state.kitty_graphics_capability_confirmed);
+
+        app.route_client_input(b"\x1b_Gi=1;OK\x1b\\".to_vec());
+
+        assert!(app.state.kitty_graphics_capability_confirmed);
     }
 
     #[tokio::test]

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -261,6 +261,9 @@ impl App {
             }
             // Cell size reports are consumed by the thin client, not the runtime.
             crate::raw_input::RawInputEvent::HostCellSizeReport { .. } => false,
+            crate::raw_input::RawInputEvent::KittyGraphicsCapability(confirmed) => {
+                self.update_kitty_graphics_capability(confirmed)
+            }
             crate::raw_input::RawInputEvent::Unsupported => false,
         };
         self.sync_prefix_input_source(previous_mode);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -646,6 +646,16 @@ pub struct WorkspaceCardArea {
     pub indented: bool,
 }
 
+/// One agent-panel row's on-screen rect, persisted the same way
+/// `PaneInfo`/`pane_infos` is so a pixel overlay can target a sidebar row
+/// outside the render closure that draws it. Computed by
+/// `compute_agent_row_areas`; see `PaneGraphicsSurface::SidebarRow`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SidebarRowArea {
+    pub pane_id: PaneId,
+    pub rect: Rect,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorktreeCreateState {
     pub source_workspace_id: String,
@@ -812,6 +822,11 @@ pub struct ViewState {
     pub toast_hit_area: Rect,
     pub pane_infos: Vec<PaneInfo>,
     pub split_borders: Vec<SplitBorder>,
+    /// Expanded-sidebar agent-panel row rects, persisted like `pane_infos` so
+    /// `paint_local_pane_graphics` can target a `PaneGraphicsSurface::SidebarRow`
+    /// overlay outside the render closure. Empty in mobile layout and while
+    /// the sidebar is collapsed, neither of which show this row list.
+    pub sidebar_row_areas: Vec<SidebarRowArea>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1541,6 +1556,11 @@ pub struct AppState {
     /// `[experimental] switch_ascii_input_source_in_prefix`.
     pub switch_ascii_input_source_in_prefix: bool,
     pub kitty_graphics_enabled: bool,
+    /// Whether the real outer terminal has confirmed it understands the Kitty
+    /// Graphics Protocol, via `query_kitty_graphics_capability`. Painting must
+    /// gate on this in addition to `kitty_graphics_enabled`: the config flag is
+    /// only the user's opt-in, not proof the attached terminal can render it.
+    pub kitty_graphics_capability_confirmed: bool,
     pub default_shell: String,
     pub shell_mode: crate::config::ShellModeConfig,
     pub new_terminal_cwd: NewTerminalCwdConfig,
@@ -1579,6 +1599,12 @@ pub struct AppState {
     pub(crate) pane_graphics_layers: std::collections::HashMap<PaneId, PaneGraphicsLayer>,
     /// Active streaming graphics owner token by pane id.
     pub(crate) pane_graphics_streams: std::collections::HashMap<PaneId, String>,
+    /// Runtime image layers composited over a pane's sidebar/agent-panel row,
+    /// addressed independently from `pane_graphics_layers` (that pane's own
+    /// content area) so both can be live on the same pane at once.
+    pub(crate) sidebar_graphics_layers: std::collections::HashMap<PaneId, PaneGraphicsLayer>,
+    /// Active streaming graphics owner token by pane id, for sidebar-row overlays.
+    pub(crate) sidebar_graphics_streams: std::collections::HashMap<PaneId, String>,
     /// Monotonic marker for accepted pane graphics mutations.
     pub(crate) pane_graphics_revision: u64,
     /// Session-modal terminal popup. This is intentionally outside workspace layouts.
@@ -1845,6 +1871,7 @@ impl AppState {
                 toast_hit_area: Rect::default(),
                 pane_infos: Vec::new(),
                 split_borders: Vec::new(),
+                sidebar_row_areas: Vec::new(),
             },
             drag: None,
             workspace_press: None,
@@ -1901,6 +1928,7 @@ impl AppState {
             cjk_ime_cursor_shape: 2, // steady_block
             switch_ascii_input_source_in_prefix: false,
             kitty_graphics_enabled: false,
+            kitty_graphics_capability_confirmed: false,
             default_shell: String::new(),
             shell_mode: crate::config::ShellModeConfig::Auto,
             new_terminal_cwd: NewTerminalCwdConfig::Follow,
@@ -1940,6 +1968,8 @@ impl AppState {
             plugin_panes: std::collections::HashMap::new(),
             pane_graphics_layers: std::collections::HashMap::new(),
             pane_graphics_streams: std::collections::HashMap::new(),
+            sidebar_graphics_layers: std::collections::HashMap::new(),
+            sidebar_graphics_streams: std::collections::HashMap::new(),
             pane_graphics_revision: 0,
             popup_pane: None,
             plugin_command_logs: Vec::new(),

--- a/src/app/theme_sync.rs
+++ b/src/app/theme_sync.rs
@@ -18,6 +18,24 @@ impl App {
         let _ = std::io::stdout().flush();
     }
 
+    pub(super) fn query_kitty_graphics_capability(&self) {
+        use std::io::Write;
+
+        let _ = std::io::stdout()
+            .write_all(crate::terminal_theme::KITTY_GRAPHICS_CAPABILITY_QUERY_SEQUENCE.as_bytes());
+        let _ = std::io::stdout().flush();
+    }
+
+    /// Records that the real outer terminal confirmed Kitty Graphics Protocol
+    /// support. Monotonic: once confirmed, stays confirmed for the session.
+    pub(super) fn update_kitty_graphics_capability(&mut self, confirmed: bool) -> bool {
+        if !confirmed || self.state.kitty_graphics_capability_confirmed {
+            return false;
+        }
+        self.state.kitty_graphics_capability_confirmed = true;
+        true
+    }
+
     pub(super) fn update_host_terminal_theme(
         &mut self,
         kind: crate::terminal_theme::DefaultColorKind,

--- a/src/client/input.rs
+++ b/src/client/input.rs
@@ -434,6 +434,7 @@ fn windows_client_input_event_from_raw(
         | crate::raw_input::RawInputEvent::HostPaletteColors { .. }
         | crate::raw_input::RawInputEvent::HostColorSchemeChanged(_)
         | crate::raw_input::RawInputEvent::HostCellSizeReport { .. }
+        | crate::raw_input::RawInputEvent::KittyGraphicsCapability(_)
         | crate::raw_input::RawInputEvent::Unsupported => None,
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1341,6 +1341,10 @@ async fn run_client_loop(
         query_host_cell_size();
     }
 
+    if state.attach_escape.is_none() && state.kitty_graphics_enabled {
+        query_kitty_graphics_capability();
+    }
+
     // Spawn the resize poller thread.
     let resize_quit = should_quit.clone();
     let resize_tx = event_tx.clone();
@@ -2307,6 +2311,15 @@ fn should_query_host_terminal_theme() -> bool {
 fn write_host_terminal_theme_query(mut writer: impl io::Write) -> io::Result<()> {
     let query = crate::terminal_theme::host_terminal_theme_query_sequence();
     writer.write_all(query.as_bytes())?;
+    writer.flush()
+}
+
+fn query_kitty_graphics_capability() {
+    let _ = write_kitty_graphics_capability_query(io::stdout());
+}
+
+fn write_kitty_graphics_capability_query(mut writer: impl io::Write) -> io::Result<()> {
+    writer.write_all(crate::terminal_theme::KITTY_GRAPHICS_CAPABILITY_QUERY_SEQUENCE.as_bytes())?;
     writer.flush()
 }
 

--- a/src/kitty_graphics.rs
+++ b/src/kitty_graphics.rs
@@ -20,6 +20,15 @@ use crate::terminal::TerminalRuntimeRegistry;
 const KITTY_CHUNK_BYTES: usize = 3072;
 const HOST_IMAGE_ID_BASE: u32 = 10_000;
 const PANE_GRAPHICS_IMAGE_ID_BIT: u32 = 1 << 31;
+/// Set alongside `PANE_GRAPHICS_IMAGE_ID_BIT` to further split the
+/// pane-graphics id space between a pane's own content overlay and its
+/// sidebar-row overlay, so both can be live on the same pane without
+/// colliding. Terminal-sourced ids never set either bit (they stay in the
+/// small `HOST_IMAGE_ID_BASE`-relative range), so all three namespaces are
+/// mutually disjoint — see `pane_graphics_image_ids_are_disjoint_from_terminal_image_ids`
+/// and `sidebar_graphics_image_ids_are_disjoint_from_pane_and_terminal_image_ids`.
+const SIDEBAR_GRAPHICS_IMAGE_ID_BIT: u32 = 1 << 30;
+const PANE_GRAPHICS_HASH_MASK: u32 = !(PANE_GRAPHICS_IMAGE_ID_BIT | SIDEBAR_GRAPHICS_IMAGE_ID_BIT);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct HostCellSize {
@@ -84,6 +93,7 @@ struct HostPlacement {
 enum HostSourceKey {
     Terminal { pane_id: PaneId, image_id: u32 },
     PaneLayer { pane_id: PaneId },
+    SidebarRowLayer { pane_id: PaneId },
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -289,6 +299,21 @@ pub(crate) fn has_visible_pane_graphics(
             }
         }
     }
+
+    for row in surface.sidebar_row_areas {
+        let empty_uploaded = HashMap::new();
+        if app
+            .sidebar_graphics_layers
+            .get(&row.pane_id)
+            .is_some_and(|layer| {
+                let host_placement =
+                    sidebar_graphics_host_placement(row, cell_size, layer, &empty_uploaded, false);
+                clipped_placement(&host_placement).is_some()
+            })
+        {
+            return true;
+        }
+    }
     false
 }
 
@@ -313,7 +338,12 @@ fn encode_graphics_update(
     let mut removed_pane_layer_images = HashSet::new();
     sources.retain(|source, host_id| {
         let retain = current_sources.contains(source);
-        if !retain && matches!(source, HostSourceKey::PaneLayer { .. }) {
+        if !retain
+            && matches!(
+                source,
+                HostSourceKey::PaneLayer { .. } | HostSourceKey::SidebarRowLayer { .. }
+            )
+        {
             removed_pane_layer_images.insert(*host_id);
         }
         retain
@@ -593,6 +623,19 @@ fn collect_visible_placements(
             });
         }
     }
+
+    for row in surface.sidebar_row_areas {
+        if let Some(layer) = app.sidebar_graphics_layers.get(&row.pane_id) {
+            placements.push(sidebar_graphics_host_placement(
+                row,
+                cell_size,
+                layer,
+                uploaded_images,
+                true,
+            ));
+        }
+    }
+
     tracing::debug!(
         placements_len = placements.len(),
         "collect_visible_placements: done"
@@ -607,6 +650,54 @@ fn pane_graphics_host_placement(
     uploaded_images: &HashMap<u32, ImageSignature>,
     include_data: bool,
 ) -> HostPlacement {
+    graphics_layer_host_placement(
+        info.id,
+        info.inner_rect,
+        cell_size,
+        layer,
+        uploaded_images,
+        include_data,
+        HostSourceKey::PaneLayer { pane_id: info.id },
+        pane_graphics_host_image_id,
+    )
+}
+
+/// Same shape as `pane_graphics_host_placement`, targeting a persisted
+/// sidebar-row rect instead of a pane's own content rect. The clip/scale
+/// pipeline downstream (`clipped_placement`) is rect-agnostic, so this needs
+/// no new geometry logic — see `HostPlacement.area`.
+fn sidebar_graphics_host_placement(
+    row: &crate::app::state::SidebarRowArea,
+    cell_size: HostCellSize,
+    layer: &crate::app::state::PaneGraphicsLayer,
+    uploaded_images: &HashMap<u32, ImageSignature>,
+    include_data: bool,
+) -> HostPlacement {
+    graphics_layer_host_placement(
+        row.pane_id,
+        row.rect,
+        cell_size,
+        layer,
+        uploaded_images,
+        include_data,
+        HostSourceKey::SidebarRowLayer {
+            pane_id: row.pane_id,
+        },
+        sidebar_graphics_host_image_id,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn graphics_layer_host_placement(
+    pane_id: PaneId,
+    area: Rect,
+    cell_size: HostCellSize,
+    layer: &crate::app::state::PaneGraphicsLayer,
+    uploaded_images: &HashMap<u32, ImageSignature>,
+    include_data: bool,
+    source_key: HostSourceKey,
+    host_image_id_fn: fn(PaneId, ImageSignature) -> u32,
+) -> HostPlacement {
     let format = pane_graphics_kitty_format(layer.format);
     let format_code = kitty_format_code(format);
     let signature = ImageSignature {
@@ -616,7 +707,7 @@ fn pane_graphics_host_placement(
         data_len: layer.data.len(),
         data_fingerprint: layer.data_fingerprint,
     };
-    let host_id = pane_graphics_host_image_id(info.id, signature);
+    let host_id = host_image_id_fn(pane_id, signature);
     let data = if !include_data || uploaded_images.get(&host_id).copied() == Some(signature) {
         Vec::new()
     } else {
@@ -624,21 +715,21 @@ fn pane_graphics_host_placement(
     };
     let render = layer.render;
     let grid_cols = if render.grid_cols == 0 {
-        u32::from(info.inner_rect.width)
+        u32::from(area.width)
     } else {
         render.grid_cols
     };
     let grid_rows = if render.grid_rows == 0 {
-        u32::from(info.inner_rect.height)
+        u32::from(area.height)
     } else {
         render.grid_rows
     };
 
     HostPlacement {
-        pane_id: info.id,
-        area: info.inner_rect,
+        pane_id,
+        area,
         cell_size,
-        source_key: HostSourceKey::PaneLayer { pane_id: info.id },
+        source_key,
         scrollback_offset: 0,
         placement: KittyImagePlacement {
             image_id: 1,
@@ -701,7 +792,16 @@ fn pane_graphics_host_image_id(pane_id: PaneId, signature: ImageSignature) -> u3
     let mut hasher = DefaultHasher::new();
     pane_id.raw().hash(&mut hasher);
     signature.hash(&mut hasher);
-    PANE_GRAPHICS_IMAGE_ID_BIT | ((hasher.finish() as u32) & !PANE_GRAPHICS_IMAGE_ID_BIT)
+    PANE_GRAPHICS_IMAGE_ID_BIT | ((hasher.finish() as u32) & PANE_GRAPHICS_HASH_MASK)
+}
+
+fn sidebar_graphics_host_image_id(pane_id: PaneId, signature: ImageSignature) -> u32 {
+    let mut hasher = DefaultHasher::new();
+    pane_id.raw().hash(&mut hasher);
+    signature.hash(&mut hasher);
+    PANE_GRAPHICS_IMAGE_ID_BIT
+        | SIDEBAR_GRAPHICS_IMAGE_ID_BIT
+        | ((hasher.finish() as u32) & PANE_GRAPHICS_HASH_MASK)
 }
 
 fn host_placement_id(source_key: HostSourceKey, placement: &KittyImagePlacement) -> u32 {
@@ -710,6 +810,10 @@ fn host_placement_id(source_key: HostSourceKey, placement: &KittyImagePlacement)
         HostSourceKey::Terminal { pane_id, .. } => pane_id.raw().hash(&mut hasher),
         HostSourceKey::PaneLayer { pane_id } => {
             "pane.graphics".hash(&mut hasher);
+            pane_id.raw().hash(&mut hasher);
+        }
+        HostSourceKey::SidebarRowLayer { pane_id } => {
+            "sidebar.graphics".hash(&mut hasher);
             pane_id.raw().hash(&mut hasher);
         }
     }
@@ -1086,6 +1190,27 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_graphics_image_ids_are_disjoint_from_pane_and_terminal_image_ids() {
+        let placement = test_placement(0, 0);
+        let signature = image_signature(&placement, kitty_format_code(placement.placement.format));
+        let terminal_id = host_image_id_for_signature(placement.pane_id, signature);
+        let pane_content_id = pane_graphics_host_image_id(placement.pane_id, signature);
+        let sidebar_row_id = sidebar_graphics_host_image_id(placement.pane_id, signature);
+
+        // A pane can carry a content overlay and a sidebar-row overlay at the
+        // same time (the captain's expanded scope), so these three ids must
+        // never collide with each other even when every other input matches.
+        assert_ne!(sidebar_row_id, terminal_id);
+        assert_ne!(sidebar_row_id, pane_content_id);
+        assert_eq!(terminal_id & PANE_GRAPHICS_IMAGE_ID_BIT, 0);
+        assert_eq!(pane_content_id & SIDEBAR_GRAPHICS_IMAGE_ID_BIT, 0);
+        assert_eq!(
+            sidebar_row_id & (PANE_GRAPHICS_IMAGE_ID_BIT | SIDEBAR_GRAPHICS_IMAGE_ID_BIT),
+            PANE_GRAPHICS_IMAGE_ID_BIT | SIDEBAR_GRAPHICS_IMAGE_ID_BIT
+        );
+    }
+
+    #[test]
     fn clipped_placement_handles_positive_viewport_without_wrapping() {
         let placement = test_placement(2, 2);
         let (clipped, _) = clipped_placement(&placement).expect("visible placement");
@@ -1147,6 +1272,49 @@ mod tests {
         assert_eq!(clipped.cols, 8);
         assert_eq!(clipped.rows, 3);
         assert_eq!(placement.placement.data.len(), 80 * 30 * 4);
+    }
+
+    #[test]
+    fn pane_graphics_layer_full_pane_grid_tracks_pane_resize() {
+        let layer = crate::app::state::PaneGraphicsLayer::new(
+            crate::api::schema::PaneGraphicsFormat::Rgba,
+            80,
+            30,
+            vec![255; 80 * 30 * 4],
+            crate::api::schema::PaneGraphicsPlacementParams::default(),
+        );
+        let cell_size = HostCellSize {
+            width_px: 10,
+            height_px: 10,
+        };
+
+        let wide_info = PaneInfo {
+            id: PaneId::from_raw(9),
+            rect: Rect::new(0, 0, 22, 12),
+            inner_rect: Rect::new(2, 1, 20, 10),
+            scrollbar_rect: None,
+            borders: ratatui::widgets::Borders::NONE,
+            is_focused: true,
+        };
+        let wide_placement =
+            pane_graphics_host_placement(&wide_info, cell_size, &layer, &HashMap::new(), true);
+        let (wide_clipped, _) = clipped_placement(&wide_placement).expect("visible layer");
+        assert_eq!(wide_clipped.cols, 20);
+        assert_eq!(wide_clipped.rows, 10);
+
+        // A resize (e.g. a split or a terminal resize) recomputes `PaneInfo`
+        // fresh every frame; the placement must follow it to the new full rect
+        // without any extra addressing work, matching the funding spike's
+        // finding that pane-content overlays already reach whole-pane rects.
+        let narrow_info = PaneInfo {
+            inner_rect: Rect::new(2, 1, 6, 4),
+            ..wide_info
+        };
+        let narrow_placement =
+            pane_graphics_host_placement(&narrow_info, cell_size, &layer, &HashMap::new(), true);
+        let (narrow_clipped, _) = clipped_placement(&narrow_placement).expect("visible layer");
+        assert_eq!(narrow_clipped.cols, 6);
+        assert_eq!(narrow_clipped.rows, 4);
     }
 
     #[test]
@@ -1751,5 +1919,116 @@ mod tests {
         let delete = String::from_utf8_lossy(&bytes);
         assert!(delete.contains("a=d,d=i"));
         assert!(placements.is_empty());
+    }
+
+    /// Encode-cost smoke test for `herdr-pixel-rendering-path`: measures the
+    /// `collect_visible_placements`/`encode_graphics_update` cost of a full,
+    /// every-frame-changing 1440p pane-content overlay (284x80 cells at a
+    /// 9x18px cell, matching the funding decision's 1440p sizing target —
+    /// 4K is explicitly out of scope), with and without 20 simultaneously
+    /// animated sidebar/agent rows. Not part of `just check` (release-mode
+    /// timing is too hardware-sensitive for CI); run manually with
+    /// `cargo test --release -- --ignored --nocapture sidebar_row_overlay_encode_cost_at_1440p`.
+    /// Whole-surface *delivery* fps (escape-stream vs. local-file, PNG vs.
+    /// raw pixels) is already measured in `data/tracks/B-animation-scope.md`
+    /// and isn't re-derived here; this isolates the marginal cost this task's
+    /// own new sidebar-row addressing adds on top of that.
+    #[test]
+    #[ignore = "release-mode perf smoke test, run manually"]
+    fn sidebar_row_overlay_encode_cost_at_1440p() {
+        use std::time::Instant;
+
+        fn run(iterations: u32, with_sidebar_rows: bool) -> std::time::Duration {
+            let cell_size = HostCellSize {
+                width_px: 9,
+                height_px: 18,
+            };
+            let pane_area = Rect::new(0, 0, 284, 80);
+            let pane_pixel_w = 284u32 * 9;
+            let pane_pixel_h = 80u32 * 18;
+            let mut cache = HostGraphicsCache::default();
+            let mut counter = 0u8;
+
+            let start = Instant::now();
+            for _ in 0..iterations {
+                counter = counter.wrapping_add(1);
+                let pane_layer = crate::app::state::PaneGraphicsLayer::new(
+                    crate::api::schema::PaneGraphicsFormat::Rgba,
+                    pane_pixel_w,
+                    pane_pixel_h,
+                    vec![counter; (pane_pixel_w * pane_pixel_h * 4) as usize],
+                    crate::api::schema::PaneGraphicsPlacementParams::default(),
+                );
+                let pane_info = PaneInfo {
+                    id: PaneId::from_raw(1),
+                    rect: pane_area,
+                    inner_rect: pane_area,
+                    scrollbar_rect: None,
+                    borders: ratatui::widgets::Borders::NONE,
+                    is_focused: true,
+                };
+                let mut placements = vec![pane_graphics_host_placement(
+                    &pane_info,
+                    cell_size,
+                    &pane_layer,
+                    &cache.images,
+                    true,
+                )];
+                if with_sidebar_rows {
+                    for row_idx in 0..20u16 {
+                        let row = crate::app::state::SidebarRowArea {
+                            pane_id: PaneId::from_raw(u32::from(row_idx) + 2),
+                            rect: Rect::new(0, row_idx, 26, 1),
+                        };
+                        let row_layer = crate::app::state::PaneGraphicsLayer::new(
+                            crate::api::schema::PaneGraphicsFormat::Rgba,
+                            26 * 9,
+                            18,
+                            vec![counter; (26 * 9 * 18 * 4) as usize],
+                            crate::api::schema::PaneGraphicsPlacementParams::default(),
+                        );
+                        placements.push(sidebar_graphics_host_placement(
+                            &row,
+                            cell_size,
+                            &row_layer,
+                            &cache.images,
+                            true,
+                        ));
+                    }
+                }
+                let mut bytes = Vec::new();
+                encode_graphics_update(
+                    &mut bytes,
+                    &placements,
+                    false,
+                    &mut cache.images,
+                    &mut cache.placements,
+                    &mut cache.sources,
+                );
+                std::hint::black_box(&bytes);
+            }
+            start.elapsed()
+        }
+
+        let iterations = 30u32;
+        let pane_only = run(iterations, false);
+        let with_rows = run(iterations, true);
+        eprintln!(
+            "1440p pane content only, {iterations} full-change frames: {:?} total, {:?}/frame, implied max fps {:.1}",
+            pane_only,
+            pane_only / iterations,
+            iterations as f64 / pane_only.as_secs_f64()
+        );
+        eprintln!(
+            "1440p pane content + 20 sidebar rows, {iterations} full-change frames: {:?} total, {:?}/frame, implied max fps {:.1}",
+            with_rows,
+            with_rows / iterations,
+            iterations as f64 / with_rows.as_secs_f64()
+        );
+        eprintln!(
+            "marginal cost of 20 sidebar rows: {:?}/frame ({:.2}%)",
+            (with_rows.saturating_sub(pane_only)) / iterations,
+            100.0 * (with_rows.as_secs_f64() - pane_only.as_secs_f64()) / pane_only.as_secs_f64()
+        );
     }
 }

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -145,6 +145,10 @@ pub enum RawInputEvent {
         width_px: u32,
         height_px: u32,
     },
+    /// The real outer terminal answered the Kitty Graphics Protocol capability
+    /// probe. Always `true` today — see
+    /// `terminal_theme::parse_kitty_graphics_capability_response`.
+    KittyGraphicsCapability(bool),
     Unsupported,
 }
 
@@ -853,6 +857,11 @@ fn extract_one_event(buffer: &[u8]) -> Option<(RawInputEvent, usize)> {
                 seq_len,
             ));
         }
+        if let Some(confirmed) =
+            crate::terminal_theme::parse_kitty_graphics_capability_response(seq)
+        {
+            return Some((RawInputEvent::KittyGraphicsCapability(confirmed), seq_len));
+        }
 
         match seq {
             "\x1b[I" => return Some((RawInputEvent::OuterFocusGained, seq_len)),
@@ -1521,6 +1530,17 @@ mod tests {
                 b: 0xee
             }
         );
+    }
+
+    #[test]
+    fn parses_kitty_graphics_capability_response_as_one_complete_event() {
+        let (RawInputEvent::KittyGraphicsCapability(confirmed), consumed) =
+            extract_one_event(b"\x1b_Gi=1;OK\x1b\\").unwrap()
+        else {
+            panic!("expected kitty graphics capability response");
+        };
+        assert_eq!(consumed, 11);
+        assert!(confirmed);
     }
 
     #[test]

--- a/src/server/clients.rs
+++ b/src/server/clients.rs
@@ -48,6 +48,9 @@ pub(crate) struct ClientConnection {
     pub(crate) host_terminal_appearance_explicit: bool,
     /// Last reported focus state for this client's outer terminal.
     pub(crate) outer_terminal_focus: Option<bool>,
+    /// Whether this client's real outer terminal confirmed Kitty Graphics
+    /// Protocol support. Monotonic: once true, stays true for the connection.
+    pub(crate) kitty_graphics_capability_confirmed: bool,
     /// Stateful parser for app-client input split across transport reads.
     pub(crate) raw_input: crate::raw_input::RawInputFramer,
     /// Monotonic activity stamp used to choose the fallback foreground client.
@@ -121,6 +124,7 @@ impl ClientConnection {
             host_terminal_appearance_explicit: false,
             host_terminal_theme,
             outer_terminal_focus,
+            kitty_graphics_capability_confirmed: false,
             raw_input: crate::raw_input::RawInputFramer::default(),
             last_activity,
             render_state: ClientRenderState::new(render_encoding),
@@ -232,6 +236,26 @@ impl ClientConnection {
         self.host_terminal_appearance = appearance;
         self.host_terminal_appearance_explicit = explicit;
         true
+    }
+
+    /// Returns `true` if this client's capability flag flipped to confirmed.
+    pub(crate) fn update_kitty_graphics_capability_from_events(
+        &mut self,
+        events: &[crate::raw_input::RawInputEvent],
+    ) -> bool {
+        if self.kitty_graphics_capability_confirmed {
+            return false;
+        }
+        let confirmed = events.iter().any(|event| {
+            matches!(
+                event,
+                crate::raw_input::RawInputEvent::KittyGraphicsCapability(true)
+            )
+        });
+        if confirmed {
+            self.kitty_graphics_capability_confirmed = true;
+        }
+        confirmed
     }
 
     pub(crate) fn update_outer_focus_from_events(

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -1589,6 +1589,27 @@ impl HeadlessServer {
         }
     }
 
+    /// Returns `true` if the server's own capability state just flipped to
+    /// confirmed, so the caller knows a repaint can now emit graphics.
+    fn update_client_kitty_graphics_capability_from_events(
+        &mut self,
+        client_id: u64,
+        events: &[crate::raw_input::RawInputEvent],
+    ) -> bool {
+        let Some(client) = self.clients.get_mut(&client_id) else {
+            return false;
+        };
+        if !client.update_kitty_graphics_capability_from_events(events) {
+            return false;
+        }
+        if self.foreground_client_id == Some(client_id) {
+            self.app.state.kitty_graphics_capability_confirmed = true;
+            true
+        } else {
+            false
+        }
+    }
+
     fn update_client_outer_focus_from_events(
         &mut self,
         client_id: u64,
@@ -2725,6 +2746,8 @@ impl HeadlessServer {
             self.resize_shared_runtime_to_effective_size_before_input();
         }
         let theme_changed = self.update_client_host_theme_from_events(client_id, &events);
+        let kitty_graphics_capability_changed =
+            self.update_client_kitty_graphics_capability_from_events(client_id, &events);
         // Client-local theme reports were applied above; routing them again would update every
         // pane once per palette entry instead of once per captured batch.
         self.app.route_client_events_from(client_id, events, false);
@@ -2752,7 +2775,10 @@ impl HeadlessServer {
 
             false
         } else {
-            foreground_changed || theme_changed || (interaction && !render_neutral_mouse_motion)
+            foreground_changed
+                || theme_changed
+                || kitty_graphics_capability_changed
+                || (interaction && !render_neutral_mouse_motion)
         }
     }
 
@@ -4158,7 +4184,11 @@ impl HeadlessServer {
             };
             let mut next_graphics_cache = client.graphics_cache.clone();
             let graphics_surface_reset_pending = client.graphics_surface_reset_pending;
-            if is_app_client && self.app.state.kitty_graphics_enabled && cell_size.is_known() {
+            if is_app_client
+                && self.app.state.kitty_graphics_enabled
+                && self.app.state.kitty_graphics_capability_confirmed
+                && cell_size.is_known()
+            {
                 if graphics_surface_reset_pending {
                     frame.graphics = next_graphics_cache.clear_bytes();
                 }
@@ -8118,6 +8148,73 @@ next_tab = ""
                 b: 0x56,
             })
         );
+    }
+
+    #[tokio::test]
+    async fn foreground_client_kitty_graphics_capability_response_confirms_server_state() {
+        let mut server = test_headless_server();
+        server.clients.insert(
+            1,
+            ClientConnection::new(
+                (80, 24),
+                crate::kitty_graphics::HostCellSize::default(),
+                crate::terminal_theme::TerminalTheme::default(),
+                Some(true),
+                1,
+                RenderEncoding::SemanticFrame,
+                None,
+            ),
+        );
+        server.foreground_client_id = Some(1);
+        server.sync_foreground_client_state();
+        assert!(!server.app.state.kitty_graphics_capability_confirmed);
+
+        assert!(server.handle_server_event(ServerEvent::ClientInput {
+            client_id: 1,
+            data: b"\x1b_Gi=1;OK\x1b\\".to_vec(),
+        }));
+
+        assert!(server.clients[&1].kitty_graphics_capability_confirmed);
+        assert!(server.app.state.kitty_graphics_capability_confirmed);
+    }
+
+    #[tokio::test]
+    async fn background_client_kitty_graphics_capability_response_does_not_confirm_server_state() {
+        let mut server = test_headless_server();
+        server.clients.insert(
+            1,
+            ClientConnection::new(
+                (80, 24),
+                crate::kitty_graphics::HostCellSize::default(),
+                crate::terminal_theme::TerminalTheme::default(),
+                Some(true),
+                1,
+                RenderEncoding::SemanticFrame,
+                None,
+            ),
+        );
+        server.clients.insert(
+            2,
+            ClientConnection::new(
+                (80, 24),
+                crate::kitty_graphics::HostCellSize::default(),
+                crate::terminal_theme::TerminalTheme::default(),
+                Some(true),
+                2,
+                RenderEncoding::SemanticFrame,
+                None,
+            ),
+        );
+        server.foreground_client_id = Some(1);
+        server.sync_foreground_client_state();
+
+        server.handle_server_event(ServerEvent::ClientInput {
+            client_id: 2,
+            data: b"\x1b_Gi=1;OK\x1b\\".to_vec(),
+        });
+
+        assert!(server.clients[&2].kitty_graphics_capability_confirmed);
+        assert!(!server.app.state.kitty_graphics_capability_confirmed);
     }
 
     #[tokio::test]

--- a/src/server/headless/pane_graphics.rs
+++ b/src/server/headless/pane_graphics.rs
@@ -27,6 +27,8 @@ impl HeadlessServer {
     pub(super) fn pane_graphics_runtime_active(&self) -> bool {
         !self.app.state.pane_graphics_layers.is_empty()
             || !self.app.state.pane_graphics_streams.is_empty()
+            || !self.app.state.sidebar_graphics_layers.is_empty()
+            || !self.app.state.sidebar_graphics_streams.is_empty()
     }
 
     pub(super) fn cancel_inactive_pane_graphics_streams(&self) {
@@ -35,6 +37,7 @@ impl HeadlessServer {
                 .state
                 .pane_graphics_streams
                 .values()
+                .chain(self.app.state.sidebar_graphics_streams.values())
                 .any(|active_owner| active_owner == owner)
         });
     }

--- a/src/server/headless/tests/pane_graphics.rs
+++ b/src/server/headless/tests/pane_graphics.rs
@@ -14,6 +14,7 @@ fn enable_graphics_and_render(
     client_rx: &std::sync::mpsc::Receiver<Vec<u8>>,
 ) -> FrameData {
     server.app.state.kitty_graphics_enabled = true;
+    server.app.state.kitty_graphics_capability_confirmed = true;
     server.clients.get_mut(&1).unwrap().cell_size = crate::kitty_graphics::HostCellSize {
         width_px: 10,
         height_px: 20,
@@ -28,6 +29,23 @@ fn enable_graphics_and_render(
 
 fn set_graphics_layer(server: &mut HeadlessServer, pane_id: crate::layout::PaneId, data: Vec<u8>) {
     server.app.state.pane_graphics_layers.insert(
+        pane_id,
+        crate::app::state::PaneGraphicsLayer::new(
+            api::schema::PaneGraphicsFormat::Png,
+            1,
+            1,
+            data,
+            api::schema::PaneGraphicsPlacementParams::default(),
+        ),
+    );
+}
+
+fn set_sidebar_graphics_layer(
+    server: &mut HeadlessServer,
+    pane_id: crate::layout::PaneId,
+    data: Vec<u8>,
+) {
+    server.app.state.sidebar_graphics_layers.insert(
         pane_id,
         crate::app::state::PaneGraphicsLayer::new(
             api::schema::PaneGraphicsFormat::Png,
@@ -67,6 +85,7 @@ fn stream_set_message(
                 id: id.into(),
                 method: api::schema::Method::PaneGraphicsStreamSet(
                     api::schema::PaneGraphicsSetParams {
+                        surface: api::schema::PaneGraphicsSurface::Content,
                         pane_id: pane_id.into(),
                         owner: owner.into(),
                         format: api::schema::PaneGraphicsFormat::Png,
@@ -129,6 +148,45 @@ async fn focus_repaint_preserves_uploaded_graphics() {
             .expect("focus redraw"),
     );
     assert!(focused.graphics.is_empty());
+}
+
+#[tokio::test]
+async fn sidebar_row_overlay_renders_alongside_pane_content_overlay() {
+    let (mut server, client_rx, pane_id) = retained_test_server(b"aaaa");
+    // The agent panel only lists panes with a detected/named agent, so give
+    // this pane one — otherwise it never gets a persisted sidebar row rect.
+    server.app.state.ensure_test_terminals();
+    let terminal_id = server.app.state.workspaces[0].tabs[0].panes[&pane_id]
+        .attached_terminal_id
+        .clone();
+    server
+        .app
+        .state
+        .terminals
+        .get_mut(&terminal_id)
+        .unwrap()
+        .detected_agent = Some(crate::detect::Agent::Pi);
+    set_graphics_layer(&mut server, pane_id, vec![1, 2, 3]);
+    set_sidebar_graphics_layer(&mut server, pane_id, vec![4, 5, 6]);
+
+    let frame = enable_graphics_and_render(&mut server, &client_rx);
+    assert!(
+        server
+            .app
+            .state
+            .view
+            .sidebar_row_areas
+            .iter()
+            .any(|row| row.pane_id == pane_id),
+        "expected the pane's agent-panel row rect to be persisted by the render"
+    );
+    let graphics = String::from_utf8_lossy(&frame.graphics);
+
+    // The captain's expanded scope wants both surfaces live on the same pane
+    // at once: two distinct `a=t` uploads (content + sidebar row), not one
+    // overlay clobbering the other.
+    assert_eq!(graphics.matches("a=t").count(), 2, "graphics: {graphics}");
+    assert_eq!(graphics.matches("a=p").count(), 2, "graphics: {graphics}");
 }
 
 #[tokio::test]
@@ -313,6 +371,7 @@ fn stream_set_has_graphics_only_render_impact() {
         request: api::schema::Request {
             id: "direct-frame".into(),
             method: api::schema::Method::PaneGraphicsSet(api::schema::PaneGraphicsSetParams {
+                surface: api::schema::PaneGraphicsSurface::Content,
                 pane_id: public_pane_id,
                 owner: String::new(),
                 format: api::schema::PaneGraphicsFormat::Png,
@@ -344,6 +403,7 @@ fn rejected_or_stale_requests_do_not_schedule_rendering() {
         request: api::schema::Request {
             id: "disabled-set".into(),
             method: api::schema::Method::PaneGraphicsSet(api::schema::PaneGraphicsSetParams {
+                surface: api::schema::PaneGraphicsSurface::Content,
                 pane_id: public_pane_id.clone(),
                 owner: String::new(),
                 format: api::schema::PaneGraphicsFormat::Png,
@@ -381,6 +441,7 @@ fn rejected_or_stale_requests_do_not_schedule_rendering() {
             id: "stale-close".into(),
             method: api::schema::Method::PaneGraphicsStreamClose(
                 api::schema::PaneGraphicsStreamParams {
+                    surface: api::schema::PaneGraphicsSurface::Content,
                     pane_id: public_pane_id,
                     owner: "stale-owner".into(),
                 },

--- a/src/terminal_theme.rs
+++ b/src/terminal_theme.rs
@@ -60,6 +60,36 @@ pub const HOST_COLOR_SCHEME_QUERY_SEQUENCE: &str = "\x1b[?996n";
 pub const HOST_COLOR_SCHEME_REPORT_ENABLE_SEQUENCE: &str = "\x1b[?2031h";
 pub const HOST_COLOR_SCHEME_REPORT_DISABLE_SEQUENCE: &str = "\x1b[?2031l";
 
+/// Kitty Graphics Protocol image id reserved for the one-shot capability
+/// probe. `a=q` is the protocol's documented no-op "query" action: a
+/// supporting terminal always answers without displaying anything, so any
+/// reply addressed to this id — `OK` or an error code — proves the real
+/// outer terminal understands the protocol at all.
+const KITTY_GRAPHICS_CAPABILITY_PROBE_IMAGE_ID: u32 = 1;
+/// 1x1 RGB (`f=24`) placeholder pixel, base64 of three zero bytes.
+pub const KITTY_GRAPHICS_CAPABILITY_QUERY_SEQUENCE: &str =
+    "\x1b_Gi=1,a=q,t=d,f=24,s=1,v=1;AAAA\x1b\\";
+
+/// Parses a Kitty Graphics Protocol response addressed to the capability
+/// probe. Returns `Some(true)` for any well-formed reply carrying the probe's
+/// image id, regardless of whether the payload is `OK` or an error code —
+/// responding at all is the capability signal. Returns `None` for anything
+/// else (a different image id, or not a Kitty Graphics response), so the
+/// caller can fall through to other parsers. A terminal that doesn't support
+/// the protocol never replies, which the caller treats as the safe "not
+/// confirmed" default rather than something this parser needs to detect.
+pub fn parse_kitty_graphics_capability_response(sequence: &str) -> Option<bool> {
+    let body = sequence.strip_prefix("\x1b_G")?;
+    let body = body.strip_suffix("\x1b\\")?;
+    let (control, _payload) = body.split_once(';')?;
+    control
+        .split(',')
+        .find_map(|field| field.strip_prefix("i="))
+        .and_then(|id| id.parse::<u32>().ok())
+        .filter(|&id| id == KITTY_GRAPHICS_CAPABILITY_PROBE_IMAGE_ID)
+        .map(|_| true)
+}
+
 impl TerminalTheme {
     pub fn with_color(mut self, kind: DefaultColorKind, color: RgbColor) -> Self {
         match kind {
@@ -234,6 +264,38 @@ mod tests {
         assert_eq!(
             osc_reset_default_color_sequence(DefaultColorKind::Background),
             "\x1b]111\x1b\\"
+        );
+    }
+
+    #[test]
+    fn parses_kitty_graphics_capability_ok_response() {
+        assert_eq!(
+            parse_kitty_graphics_capability_response("\x1b_Gi=1;OK\x1b\\"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn parses_kitty_graphics_capability_error_response_as_supported() {
+        assert_eq!(
+            parse_kitty_graphics_capability_response("\x1b_Gi=1;EINVAL:bad request\x1b\\"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn ignores_kitty_graphics_response_with_unrelated_image_id() {
+        assert_eq!(
+            parse_kitty_graphics_capability_response("\x1b_Gi=42;OK\x1b\\"),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_non_kitty_graphics_sequence() {
+        assert_eq!(
+            parse_kitty_graphics_capability_response("\x1b]10;rgb:0000/0000/0000\x1b\\"),
+            None
         );
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -79,12 +79,12 @@ pub(crate) use self::{
         agent_entry_gap, agent_entry_height_in_body, agent_panel_body_rect, agent_panel_entries,
         agent_panel_scroll_for_target, agent_panel_scroll_metrics, agent_panel_scrollbar_rect,
         agent_panel_toggle_rect, all_agent_panel_entries, collapsed_sidebar_sections,
-        collapsed_sidebar_toggle_rect, compute_workspace_card_areas, expanded_sidebar_sections,
-        expanded_sidebar_toggle_rect, normalized_workspace_scroll, sidebar_section_divider_rect,
-        workspace_drop_slots, workspace_group_chevron_rect, workspace_list_entries,
-        workspace_list_entries_expanded, workspace_list_rect, workspace_list_scroll_metrics,
-        workspace_list_scrollbar_rect, workspace_parent_group_state, AgentPanelEntry,
-        WorkspaceListEntry,
+        collapsed_sidebar_toggle_rect, compute_agent_row_areas, compute_workspace_card_areas,
+        expanded_sidebar_sections, expanded_sidebar_toggle_rect, normalized_workspace_scroll,
+        sidebar_section_divider_rect, workspace_drop_slots, workspace_group_chevron_rect,
+        workspace_list_entries, workspace_list_entries_expanded, workspace_list_rect,
+        workspace_list_scroll_metrics, workspace_list_scrollbar_rect, workspace_parent_group_state,
+        AgentPanelEntry, WorkspaceListEntry,
     },
 };
 
@@ -243,22 +243,28 @@ fn compute_view_internal(
         .map(|ws| desktop_tab_bar_and_terminal_area(app, ws, main_area))
         .unwrap_or((Rect::default(), main_area));
 
-    if !app.sidebar_collapsed {
+    let sidebar_detail_area = if !app.sidebar_collapsed {
         app.workspace_scroll = normalized_workspace_scroll(app, sidebar_area, app.workspace_scroll);
         let (_, detail_area) = expanded_sidebar_sections(sidebar_area, app.sidebar_section_split);
         let max_agent_scroll = agent_panel_scroll_metrics(app, detail_area).max_offset_from_bottom;
         app.agent_panel_scroll = app.agent_panel_scroll.min(max_agent_scroll);
+        Some(detail_area)
     } else {
         app.workspace_scroll = app
             .workspace_scroll
             .min(app.workspaces.len().saturating_sub(1));
         app.agent_panel_scroll = 0;
-    }
+        None
+    };
 
     let workspace_card_areas = if app.sidebar_collapsed {
         Vec::new()
     } else {
         compute_workspace_card_areas(app, sidebar_area)
+    };
+    let sidebar_row_areas = match sidebar_detail_area {
+        Some(detail_area) => compute_agent_row_areas(app, terminal_runtimes, detail_area),
+        None => Vec::new(),
     };
 
     let tab_bar_view = app
@@ -319,6 +325,7 @@ fn compute_view_internal(
         toast_hit_area,
         pane_infos,
         split_borders,
+        sidebar_row_areas,
     };
     app.sync_copy_mode_search_geometry();
 }
@@ -382,6 +389,7 @@ fn compute_mobile_view(
         toast_hit_area,
         pane_infos,
         split_borders,
+        sidebar_row_areas: Vec::new(),
     };
     app.sync_copy_mode_search_geometry();
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -711,6 +711,48 @@ pub(crate) fn compute_workspace_card_areas(
     compute_workspace_list_areas(app, area).0
 }
 
+/// Computes the expanded agent-panel's per-row rects without rendering, so
+/// they can be persisted into `ViewState.sidebar_row_areas` the same way
+/// `compute_pane_infos` persists pane rects. Mirrors `render_agent_detail`'s
+/// row-layout loop exactly; keep the two in sync.
+pub(crate) fn compute_agent_row_areas(
+    app: &AppState,
+    terminal_runtimes: &TerminalRuntimeRegistry,
+    area: Rect,
+) -> Vec<crate::app::state::SidebarRowArea> {
+    if area.height < 3 {
+        return Vec::new();
+    }
+
+    let details = agent_panel_entries_from(app, terminal_runtimes);
+    let metrics = agent_panel_scroll_metrics(app, area);
+    let body = agent_panel_body_rect(area, should_show_scrollbar(metrics));
+    if body == Rect::default() {
+        return Vec::new();
+    }
+
+    let scroll = app.agent_panel_scroll.min(metrics.max_offset_from_bottom);
+    let mut row_y = body.y;
+    let body_bottom = body.y + body.height;
+    let mut areas = Vec::new();
+    for (index, detail) in details.iter().enumerate().skip(scroll) {
+        let rows = resolved_agent_rows(app, detail);
+        let height = (rows.len().max(1) as u16).min(body.height);
+        if row_y.saturating_add(height) > body_bottom {
+            break;
+        }
+        areas.push(crate::app::state::SidebarRowArea {
+            pane_id: detail.pane_id,
+            rect: Rect::new(body.x, row_y, body.width, height),
+        });
+        row_y = row_y
+            .saturating_add(height)
+            .saturating_add(agent_entry_gap(app, index, details.len()))
+            .min(body_bottom);
+    }
+    areas
+}
+
 pub(crate) fn workspace_group_chevron_rect(card: &crate::app::state::WorkspaceCardArea) -> Rect {
     if card.rect.width == 0 || card.rect.height == 0 {
         return Rect::default();

--- a/src/ui/tab_surface.rs
+++ b/src/ui/tab_surface.rs
@@ -1,6 +1,7 @@
 use ratatui::{layout::Rect, Frame};
 
 use super::panes::{compute_pane_infos, render_panes, resize_tab_panes};
+use crate::app::state::SidebarRowArea;
 use crate::app::state::ViewState;
 use crate::app::{AppState, Mode};
 use crate::layout::{PaneInfo, SplitBorder};
@@ -16,6 +17,7 @@ pub(crate) struct TabSurfaceLayout {
 pub(crate) struct TabSurfaceView<'a> {
     pub(crate) pane_infos: &'a [PaneInfo],
     pub(crate) split_borders: &'a [SplitBorder],
+    pub(crate) sidebar_row_areas: &'a [SidebarRowArea],
 }
 
 impl ViewState {
@@ -23,6 +25,7 @@ impl ViewState {
         TabSurfaceView {
             pane_infos: &self.pane_infos,
             split_borders: &self.split_borders,
+            sidebar_row_areas: &self.sidebar_row_areas,
         }
     }
 }
@@ -212,6 +215,7 @@ mod tests {
         let surface_view = TabSurfaceView {
             pane_infos: &surface.pane_infos,
             split_borders: &surface.split_borders,
+            sidebar_row_areas: &[],
         };
         let mut terminal =
             Terminal::new(TestBackend::new(full_area.width, full_area.height)).unwrap();


### PR DESCRIPTION
## Summary

Widens the experimental Kitty Graphics Protocol pixel path beyond sidebar
chrome to cover terminal pane output and agent-panel sidebar rows at the
same time, per the funding decision's expanded scope ("the terminal pane...
as well as the side-agent panes... literally everything is in scope",
`data/animation-engine-spec.md`) and the `herdr-pixel-rendering-spike`
report's recommended build order (capability detection → pane-content →
sidebar-row overlays).

- **Capability detection** (new): the real outer terminal is probed at
  client startup for Kitty Graphics Protocol support, mirroring the
  existing host theme-query round trip (`terminal_theme.rs`,
  `raw_input.rs`). Painting now gates on `kitty_graphics_capability_confirmed`
  in addition to `experimental.kitty_graphics`, on both the local
  direct-attached render loop and the headless server's per-client encode
  path — a non-supporting terminal never receives graphics bytes.
- **Pane-content overlays**: already defaulted to a pane's full inner rect
  (confirmed via `pane_graphics_layer_defaults_to_full_pane_grid` and a new
  resize-tracking test); now additionally gated on capability confirmation.
- **Sidebar-row overlays** (new architecture): agent-panel row rects are
  computed and persisted per frame (`ViewState.sidebar_row_areas`,
  mirroring `pane_infos`) instead of discarded inside the render closure.
  `pane.graphics.set`/`clear`/`stream.*` gain a `surface` field
  (`content` | `sidebar_row`), routed to parallel state maps
  (`sidebar_graphics_layers`/`sidebar_graphics_streams`) with a disjoint
  host-image-id namespace bit, so a pane can carry both overlays live at
  once — matching the captain's explicit ask.

## Measured numbers

Release build, 12-core i5-12500T (`sidebar_row_overlay_encode_cost_at_1440p`,
`#[ignore]`d perf smoke test — run with `cargo test --release -- --ignored
--nocapture`):

- 1440p pane-content overlay alone, every frame fully changing: **~19ms/frame
  encode cost** (~53fps ceiling from encoding alone).
- Same + 20 simultaneously animated sidebar rows: **+1–3% overhead**
  (~250–500µs/frame marginal cost).

1440p is the sizing target per the funding decision; no 4K-specific work.
Whole-surface *delivery* fps (escape-stream vs. local-file, PNG vs. raw
pixel format) is already measured in `data/tracks/B-animation-scope.md` and
is deliberately not re-derived here — this task's numbers isolate the
marginal cost of the new sidebar-row addressing on top of that.

## Live verification

Ran in an isolated `fm-herdr-lab.sh` session (release build PATH shim, so
the session's own server is this branch's build, per the fleet-tripwire
requirement) with `experimental.kitty_graphics = true`:

- Real pane content with an embedded Kitty Graphics APC sequence mid-stream
  reads back clean via `pane read` (both `--format text` and `--format
  ansi`) — zero visible escape garbage, one real protocol side effect (a
  single leading space where the 1x1 image consumed a cell).
- Survives a real resize (`pane split`): re-read after resize shows the
  same clean transcript.

This reconfirms the pane-content pass-through pathway is unaffected by the
refactor (the placement-construction code was consolidated into a shared
`graphics_layer_host_placement` helper shared by both surfaces).

**Boundary, documented rather than hidden:** actually observing real
painted bytes for the API-pushed overlay path (either surface) requires a
confirmed capability round trip, which requires a client to be genuinely
attached to a real terminal. A CLI-only lab session (every call a
short-lived process hitting the API socket) never attaches a client, so it
can never produce that round trip — this is a fresh consequence of adding
the capability gate, not something specific to the sidebar-row work. In its
place, `sidebar_row_overlay_renders_alongside_pane_content_overlay`
exercises the full real production path (a real `HeadlessServer`, real
`compute_view_internal`/`agent_panel_entries_from` geometry against an 80×24
terminal) and asserts on the actual encoded protocol bytes: exactly two
`a=t` uploads and two `a=p` placements, one pair per surface, live at once.

## Test plan

- [x] `just check` — full suite green (3261 tests, clippy incl. Windows
      cross-target, integration assets, maintenance scripts).
- [x] New/changed unit and integration tests listed above.
- [x] Live lab check (pane-content pass-through + resize survival).
- [x] `docs/next/api/herdr-api.schema.json` regenerated
      (`HERDR_UPDATE_API_SCHEMA=1`); `docs/next` socket-api docs updated for
      the new `surface` field.