### PR TITLE
feat(agents): add Prime Agent integration (session restore, kind, manifest, docs)

### DIFF
--- a/docs/next/website/src/content/docs/agents.mdx
+++ b/docs/next/website/src/content/docs/agents.mdx
@@ -14,6 +14,7 @@ Automatic detection works out of the box for common coding agents. The important
 | Agent | State authority | Integration role |
 | --- | --- | --- |
 | Pi | lifecycle hooks when installed; otherwise screen manifest | state and session |
+| Prime Agent | built-in lifecycle reporter when active; otherwise screen manifest | state and session |
 | OMP | lifecycle hooks when installed | state and session |
 | GitHub Copilot CLI | screen manifest | session |
 | Devin CLI | screen manifest | session |

--- a/docs/next/website/src/content/docs/integrations.mdx
+++ b/docs/next/website/src/content/docs/integrations.mdx
@@ -87,7 +87,7 @@ You can include `--agent-session-id` or `--agent-session-path` with `report-agen
 
 Use `HERDR_BIN_PATH` and the CLI wrappers for portable integrations. Code that needs direct IPC can send the equivalent `pane.report_agent`, `pane.report_agent_session`, and `pane.release_agent` requests described in the [Socket API](/docs/socket-api/#agent-state-reporting).
 
-[Prime Agent's built-in Herdr reporter](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts) is a real-world example. It activates only inside Herdr, maps agent events to `working`, `idle`, and `blocked`, preserves report ordering across sessions, and releases authority on exit.
+[Prime Agent's built-in Herdr reporter](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts) is a real-world example. It activates only inside Herdr, maps agent events to `working`, `idle`, and `blocked`, preserves report ordering across sessions, and releases authority on exit. Prime Agent also ships native session restore — see [Prime Agent](#prime-agent).
 
 Some integrations report native agent session references. Herdr uses official session references to resume Claude Code, Codex, Devin CLI, Droid, Kimi Code CLI, Qoder CLI, Cursor Agent CLI, Grok CLI, GitHub Copilot CLI, Pi, OMP, Hermes Agent, OpenCode, Kilo Code CLI, MastraCode, and Antigravity CLI panes after a Herdr server restart unless `[session] resume_agents_on_restore = false` disables it.
 
@@ -314,6 +314,34 @@ The hook reports session identity through Grok's `SessionStart` hook while Grok 
 Herdr uses `~/.grok` by default, or `GROK_HOME` when set. The Grok config directory must already exist. Grok merges every `hooks/*.json` file in that directory, so install writes a self-contained `hooks/herdr.json` with the Herdr `SessionStart` entry next to the `hooks/herdr-agent-state.sh` script, and never edits other hook files. Uninstall removes exactly those two Herdr-owned files.
 
 After Grok emits a session start event, Herdr can use the reported session id to resume the pane with `grok --resume <id>`.
+
+## Prime Agent
+
+Prime Agent is a coding agent CLI with an IPython-backed tool runtime. It
+integrates with Herdr through a built-in reporter that ships with the agent
+itself, so there is no `herdr integration install prime-agent` step: any
+supported Prime Agent version reports when it runs inside a Herdr pane.
+
+- **Lifecycle state** — the built-in reporter (`dist/core/extensions/builtin/herdr-agent-state.js`)
+  activates only when `HERDR_ENV=1` and maps agent events to `working`,
+  `idle`, and `blocked`. When the reporter is actively reporting for the
+  pane, it authors lifecycle state; otherwise Herdr falls back to the
+  prime-agent screen manifest. The reporter preserves report ordering
+  across sessions with a per-source sequence, debounces idle transitions,
+  and releases authority on exit.
+- **Session identity and restore** — the reporter sends the pane's native
+  session reference (`~/.prime/agent/sessions/<uuid>.jsonl`, reported as a
+  session path under the `herdr:pi` source with the `prime-agent` agent
+  label). Herdr persists that reference and, after a server restart with
+  `[session] resume_agents_on_restore = true` (the default), resumes the
+  pane with `prime-agent --resume <path|id>`.
+- **Agent control** — Prime Agent is a supported `agent start` kind, so
+  scripts and other agents can launch it in a pane with
+  `herdr agent start reviewer --kind prime-agent --pane <pane-id>`.
+
+Restore requires a Prime Agent version that ships the built-in reporter
+(reporter source `herdr:pi` / agent label `prime-agent`) and a Herdr build
+that registers that source as official (this version).
 
 ## Custom status labels
 

--- a/src/agent_resume.rs
+++ b/src/agent_resume.rs
@@ -60,7 +60,7 @@ pub fn session_ref_from_report(
         return None;
     }
 
-    if agent == "pi" || agent == "omp" {
+    if agent == "pi" || agent == "omp" || agent == "prime-agent" {
         return _agent_session_path
             .and_then(AgentSessionRef::path)
             .or_else(|| agent_session_id.and_then(AgentSessionRef::id));
@@ -102,7 +102,9 @@ pub fn session_ref_from_snapshot(
         return None;
     }
     let session_ref = match (agent, kind) {
-        ("pi" | "omp", AgentSessionRefKind::Path) => AgentSessionRef::path(value)?,
+        ("pi" | "omp" | "prime-agent", AgentSessionRefKind::Path) => {
+            AgentSessionRef::path(value)?
+        }
         (_, AgentSessionRefKind::Id) => AgentSessionRef::id(value)?,
         _ => return None,
     };
@@ -155,6 +157,16 @@ pub fn plan(source: &str, agent: &str, session_ref: &AgentSessionRef) -> Option<
             // omp resume is `-r, --resume=<value>` (ID prefix or path); it has no
             // `--session` flag, unlike pi.
             vec!["omp".into(), format!("--resume={}", session_ref.value)]
+        }
+        ("herdr:pi", "prime-agent", AgentSessionRefKind::Path | AgentSessionRefKind::Id) => {
+            // prime-agent resume is `-r, --resume=<path|id>`. The session
+            // reference reported by prime-agent's built-in herdr reporter is
+            // the conversation log path (~/.prime/agent/sessions/<uuid>.jsonl).
+            vec![
+                "prime-agent".into(),
+                "--resume".into(),
+                session_ref.value.clone(),
+            ]
         }
         ("herdr:hermes", "hermes", AgentSessionRefKind::Id) => {
             vec![
@@ -226,6 +238,7 @@ pub(crate) fn is_official_agent_source(source: &str, agent: &str) -> bool {
             | ("herdr:omp", "omp")
             | ("herdr:mastracode", "mastracode")
             | ("herdr:pi", "pi")
+            | ("herdr:pi", "prime-agent")
             | ("herdr:hermes", "hermes")
             | ("herdr:opencode", "opencode")
             | ("herdr:qodercli", "qodercli")
@@ -257,6 +270,43 @@ mod tests {
             .join(name)
             .display()
             .to_string()
+    }
+
+    #[test]
+    fn prime_agent_session_refs_are_official_and_path_round_trip() {
+        let path = absolute_test_path("prime-agent-session.jsonl");
+        let reported = session_ref_from_report(
+            "herdr:pi",
+            "prime-agent",
+            Some("019fdc98-0000-0000-0000-000000000000".into()),
+            Some(path.clone()),
+        )
+        .unwrap();
+        assert_eq!(reported.kind, AgentSessionRefKind::Path);
+        assert_eq!(reported.value, path);
+
+        let snapshot = session_ref_from_snapshot(
+            "herdr:pi",
+            "prime-agent",
+            AgentSessionRefKind::Path,
+            &path,
+        )
+        .unwrap();
+        assert_eq!(snapshot.source, "herdr:pi");
+        assert_eq!(snapshot.agent, "prime-agent");
+        assert_eq!(snapshot.session_ref.kind, AgentSessionRefKind::Path);
+        assert_eq!(snapshot.session_ref.value, path);
+
+        assert!(is_official_agent_source("herdr:pi", "prime-agent"));
+        // id-only reports still work (fall back from path to id)
+        let id_only = session_ref_from_report(
+            "herdr:pi",
+            "prime-agent",
+            Some("019fdc98-0000-0000-0000-000000000000".into()),
+            None,
+        )
+        .unwrap();
+        assert_eq!(id_only.kind, AgentSessionRefKind::Id);
     }
 
     #[test]
@@ -364,6 +414,27 @@ mod tests {
             .unwrap()
             .argv,
             vec!["omp", format!("--resume={omp_session}").as_str()]
+        );
+        let prime_agent_session = absolute_test_path("prime-agent-session.jsonl");
+        assert_eq!(
+            plan(
+                "herdr:pi",
+                "prime-agent",
+                &AgentSessionRef::path(&prime_agent_session).unwrap()
+            )
+            .unwrap()
+            .argv,
+            vec!["prime-agent", "--resume", prime_agent_session.as_str()]
+        );
+        assert_eq!(
+            plan(
+                "herdr:pi",
+                "prime-agent",
+                &AgentSessionRef::id("prime-agent-id").unwrap()
+            )
+            .unwrap()
+            .argv,
+            vec!["prime-agent", "--resume", "prime-agent-id"]
         );
         assert_eq!(
             plan(

--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -602,6 +602,7 @@ rows = [[{ token = "git_status", fg = "#ff00aa" }], [{ token = "$jj", bold = tru
     fn accepts_every_canonical_agent_override_key() {
         let agents = [
             Agent::Pi,
+            Agent::PrimeAgent,
             Agent::Claude,
             Agent::Codex,
             Agent::Gemini,

--- a/src/config/sound.rs
+++ b/src/config/sound.rs
@@ -120,6 +120,7 @@ impl AgentSoundOverrides {
     pub fn for_agent(&self, agent: Option<Agent>) -> AgentSoundSetting {
         match agent {
             Some(Agent::Pi) => self.pi,
+            Some(Agent::PrimeAgent) => AgentSoundSetting::Default,
             Some(Agent::Claude) => self.claude,
             Some(Agent::Codex) => self.codex,
             Some(Agent::Gemini) => self.gemini,

--- a/src/detect/manifest.rs
+++ b/src/detect/manifest.rs
@@ -254,6 +254,7 @@ const BUNDLED_MANIFESTS: &[(&str, &str)] = &[
     ("maki", include_str!("manifests/maki.toml")),
     ("opencode", include_str!("manifests/opencode.toml")),
     ("pi", include_str!("manifests/pi.toml")),
+    ("prime-agent", include_str!("manifests/prime-agent.toml")),
     ("qodercli", include_str!("manifests/qodercli.toml")),
     ("copilot", include_str!("manifests/github-copilot.toml")),
 ];

--- a/src/detect/manifests/prime-agent.toml
+++ b/src/detect/manifests/prime-agent.toml
@@ -1,0 +1,18 @@
+id = "prime-agent"
+version = "2026.08.07.1"
+min_engine_version = 2
+updated_at = "2026-08-07T00:00:00Z"
+aliases = ["herdr:pi"]
+
+# prime-agent's built-in herdr reporter (source herdr:pi, agent label
+# prime-agent) authors lifecycle state authoritatively on panes where it is
+# active. These rules are a screen-manifest fallback only: prime-agent panes
+# that cannot report (older builds, wrapped launches) still get a best-effort
+# idle classification from the interactive prompt marker below.
+[[rules]]
+id = "idle_prompt"
+state = "idle"
+priority = 100
+region = "whole_recent"
+visible_idle = true
+contains = ["Try \"explain how"]

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -42,6 +42,7 @@ pub struct AgentDetection {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Agent {
     Pi,
+    PrimeAgent,
     Claude,
     Codex,
     Gemini,
@@ -65,8 +66,9 @@ pub enum Agent {
 }
 
 impl Agent {
-    pub const ALL: [Self; 21] = [
+    pub const ALL: [Self; 22] = [
         Self::Pi,
+        Self::PrimeAgent,
         Self::Claude,
         Self::Codex,
         Self::Gemini,
@@ -89,8 +91,9 @@ impl Agent {
         Self::Maki,
     ];
 
-    pub const SCREEN_MANIFEST_AGENTS: [Self; 19] = [
+    pub const SCREEN_MANIFEST_AGENTS: [Self; 20] = [
         Self::Pi,
+        Self::PrimeAgent,
         Self::Claude,
         Self::Codex,
         Self::Gemini,
@@ -115,6 +118,7 @@ impl Agent {
 pub fn agent_label(agent: Agent) -> &'static str {
     match agent {
         Agent::Pi => "pi",
+        Agent::PrimeAgent => "prime-agent",
         Agent::Claude => "claude",
         Agent::Codex => "codex",
         Agent::Gemini => "gemini",
@@ -141,6 +145,7 @@ pub fn agent_label(agent: Agent) -> &'static str {
 pub fn interactive_agent_executable(agent: Agent) -> &'static str {
     match agent {
         Agent::Pi => "pi",
+        Agent::PrimeAgent => "prime-agent",
         Agent::Claude => "claude",
         Agent::Codex => "codex",
         Agent::Gemini => "gemini",
@@ -177,6 +182,7 @@ pub(crate) fn parse_canonical_agent_label(label: &str) -> Option<Agent> {
 fn lookup_agent(name: &str) -> Option<Agent> {
     match name {
         "pi" => Some(Agent::Pi),
+        "prime-agent" | "prime agent" => Some(Agent::PrimeAgent),
         "claude" | "claude-code" => Some(Agent::Claude),
         "codex" => Some(Agent::Codex),
         "gemini" => Some(Agent::Gemini),
@@ -740,6 +746,7 @@ mod tests {
     fn every_agent_has_a_canonical_interactive_executable() {
         let expected = [
             (Agent::Pi, "pi"),
+            (Agent::PrimeAgent, "prime-agent"),
             (Agent::Claude, "claude"),
             (Agent::Codex, "codex"),
             (Agent::Gemini, "gemini"),

--- a/website/agent-detection/index.toml
+++ b/website/agent-detection/index.toml
@@ -69,6 +69,10 @@ id = "pi"
 path = "pi.toml"
 
 [[agents]]
+id = "prime-agent"
+path = "prime-agent.toml"
+
+[[agents]]
 id = "qodercli"
 path = "qodercli.toml"
 

--- a/website/agent-detection/prime-agent.toml
+++ b/website/agent-detection/prime-agent.toml
@@ -1,0 +1,18 @@
+id = "prime-agent"
+version = "2026.08.07.1"
+min_engine_version = 2
+updated_at = "2026-08-07T00:00:00Z"
+aliases = ["herdr:pi"]
+
+# prime-agent's built-in herdr reporter (source herdr:pi, agent label
+# prime-agent) authors lifecycle state authoritatively on panes where it is
+# active. These rules are a screen-manifest fallback only: prime-agent panes
+# that cannot report (older builds, wrapped launches) still get a best-effort
+# idle classification from the interactive prompt marker below.
+[[rules]]
+id = "idle_prompt"
+state = "idle"
+priority = 100
+region = "whole_recent"
+visible_idle = true
+contains = ["Try \"explain how"]

--- a/website/assets/agent-icons/prime-agent.svg
+++ b/website/assets/agent-icons/prime-agent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 17V7l8 5 8-5v10l-8-5-8 5z"/></svg>


### PR DESCRIPTION
## Summary

Adds native **Prime Agent** support to Herdr: session identity persistence and
automatic resume after a server restart, an `agent start --kind prime-agent`
kind, a screen-manifest fallback, icons, and docs.

Prime Agent (https://herdr.dev/docs/integrations/) already ships a **built-in
Herdr reporter** (`dist/core/extensions/builtin/herdr-agent-state.js`, source
`herdr:pi`, agent label `prime-agent`) that reports `working`/`idle`/`blocked`
and the pane's native session reference. What was missing on the Herdr side
was registering that source as **official** so session references get
persisted and panes can be auto-resumed after `herdr server` restarts —
exactly what Claude Code, Codex, Hermes Agent, etc. already get.

## Changes

### Session restore (`src/agent_resume.rs`)
- Register `("herdr:pi", "prime-agent")` in `is_official_agent_source` so
  prime-agent session references are persisted instead of dropped.
- `session_ref_from_report` / `session_ref_from_snapshot`: accept
  `AgentSessionRefKind::Path` for prime-agent (the built-in reporter sends
  the conversation log path `~/.prime/agent/sessions/<uuid>.jsonl`).
- `plan()`: resume a restored pane with `prime-agent --resume <path|id>`
  (`-r, --resume` is prime-agent's native resume flag; it accepts a session
  path or id).
- Tests: planner arms for path and id refs, and an official-source
  round-trip test for reported and snapshot refs.

### Agent kind (`src/detect/mod.rs`)
- Add `Agent::PrimeAgent` (label `prime-agent`) to the enum, `ALL`, and
  `SCREEN_MANIFEST_AGENTS`. This makes `herdr agent start <name> --kind
  prime-agent --pane <id>` work, lets foreground process-name detection
  recognize prime-agent panes, and gives hook-report ownership checks a
  canonical label to compare against.
- `interactive_agent_executable`: `prime-agent`.

### Screen detection (`src/detect/manifests/prime-agent.toml`,
`website/agent-detection/`)
- Minimal fallback manifest: an `idle` rule matching prime-agent's
  interactive prompt marker (`Try "explain how ...`). Lifecycle state on
  panes with an active built-in reporter is still authoritative from hook
  reports; the manifest only covers panes that cannot report (older builds,
  wrapped launches).
- Registered in `BUNDLED_MANIFESTS` and the published
  `website/agent-detection/index.toml`; `scripts/agent_detection_manifest_check.py`
  passes.

### Config plumbing
- `src/config/sound.rs`: `Agent::PrimeAgent` uses the default sound.
- `src/config/sidebar.rs`: canonical sidebar override key accepted.
- `website/assets/agent-icons/prime-agent.svg`: agent icon.

### Docs
- `docs/.../integrations.mdx`: new **Prime Agent** section (built-in
  reporter, lifecycle + session restore, `agent start --kind prime-agent`),
  and a pointer from the "Integrate your own agent" reference example.
- `docs/.../agents.mdx`: Prime Agent row in the supported-agents table.

## Why no `herdr integration install prime-agent`?

Prime Agent ships its reporter inside the agent itself (it is a no-op
outside Herdr), so there is no hook file for Herdr to install — the same
model Herdr's docs already point at as the reference custom integration.
This PR is the Herdr-side half: official source registration, restore
planning, and the agent kind/manifest plumbing.

## Testing

- `cargo test --bin herdr agent_resume` — 23 passed (incl. new prime-agent
  planner + round-trip tests).
- `cargo test --bin herdr detect` — 174 passed (incl. bundled manifest
  parse/validate with the new manifest).
- `cargo test --bin herdr config::sidebar`, `config::sound` — passed.
- Full binary suite: 3028 passed; the 5 failures are pre-existing
  environment-dependent socket/update-count tests that also fail on a clean
  `master` checkout in this environment.
- End-to-end (isolated server, separate `XDG_CONFIG_HOME` +
  `HERDR_SOCKET_PATH`, live server untouched):
  1. `pane.report_agent` (source `herdr:pi`, agent `prime-agent`,
     `agent_session_path=<real session>`) → session ref persisted in
     `session.json`.
  2. Server killed and restarted with the patched binary.
  3. The restored pane auto-launched `prime-agent`; the pane's TUI booted
     with the status bar showing `agents/resume`.
- `scripts/agent_detection_manifest_check.py` → `agent detection manifests ok`.
