### PR TITLE
fix: make Windows installer swaps atomic

### DIFF
--- a/scripts/windows_install_conpty_package_test.ps1
+++ b/scripts/windows_install_conpty_package_test.ps1
@@ -133,7 +133,8 @@ try {
         }
     }
 
-    $releaseDir = Get-ChildItem -LiteralPath (Join-Path $herdrHome "packages\standalone\releases") -Directory |
+    $releasesDir = Join-Path $herdrHome "packages\standalone\releases"
+    $releaseDir = Get-ChildItem -LiteralPath $releasesDir -Directory |
         Where-Object { -not $_.Name.StartsWith(".staging.") } |
         Select-Object -First 1
     if ($null -eq $releaseDir) {
@@ -164,6 +165,53 @@ try {
     }
 
     $manifest | Out-File -LiteralPath $manifestPath -Encoding utf8
+    $stagedConpty = Join-Path $releasesDir ".staging.$($releaseDir.Name).$PID\conpty\conpty.dll"
+    $lockState = @{ Handle = $null }
+    $lockStagedFile = {
+        if ($null -eq $lockState.Handle) {
+            $lockState.Handle = [System.IO.File]::Open(
+                $stagedConpty,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::Read
+            )
+        }
+    }.GetNewClosure()
+    $swapBreakpoint = Set-PSBreakpoint -Script $installerPath -Variable "backupDir" -Mode Write -Action $lockStagedFile
+    try {
+        $swapFailed = $false
+        try {
+            & "$PSScriptRoot\..\website\install.ps1" `
+                -ManifestUrl $manifestUrl `
+                -InstallDir $installDir `
+                -ExpectedBuildId "installer-test"
+        } catch {
+            $swapFailed = $true
+        }
+        if ($null -eq $lockState.Handle) {
+            throw "installer did not acquire the staged file handle before the swap"
+        }
+        if (-not $swapFailed) {
+            throw "installer unexpectedly activated a release with a locked staged file"
+        }
+        if (-not (Test-Path -LiteralPath (Join-Path $releaseDir.FullName "herdr.exe") -PathType Leaf)) {
+            throw "failed activation did not restore the prior release"
+        }
+        if (@(Get-ChildItem -LiteralPath $releasesDir -Force -Directory -Filter ".backup.$($releaseDir.Name).*").Count -ne 0) {
+            throw "failed activation stranded a release backup"
+        }
+        foreach ($junction in @($installDir, (Join-Path $herdrHome "packages\standalone\current"))) {
+            if (-not (Test-Path -LiteralPath (Join-Path $junction "herdr.exe") -PathType Leaf)) {
+                throw "failed activation left an invalid installer junction at $junction"
+            }
+        }
+    } finally {
+        Remove-PSBreakpoint -Breakpoint $swapBreakpoint
+        if ($null -ne $lockState.Handle) {
+            $lockState.Handle.Dispose()
+        }
+    }
+
     & "$PSScriptRoot\..\website\install.ps1" `
         -ManifestUrl $manifestUrl `
         -InstallDir $installDir `

--- a/website/install.ps1
+++ b/website/install.ps1
@@ -632,14 +632,15 @@ try {
             $backupDir = $null
             if (Test-Path -LiteralPath $releaseDir) {
                 $backupDir = Join-Path $releasesDir ".backup.$releaseName.$([System.Guid]::NewGuid().ToString('N'))"
-                Move-Item -LiteralPath $releaseDir -Destination $backupDir
+                [System.IO.Directory]::Move($releaseDir, $backupDir)
             }
             try {
-                Move-Item -LiteralPath $stagingDir -Destination $releaseDir
+                [System.IO.Directory]::Move($stagingDir, $releaseDir)
             } catch {
                 if ($null -ne $backupDir -and -not (Test-Path -LiteralPath $releaseDir)) {
-                    Move-Item -LiteralPath $backupDir -Destination $releaseDir
+                    [System.IO.Directory]::Move($backupDir, $releaseDir)
                 }
+                Write-WarningStep "Windows could not activate the downloaded release. Another process may have a package file open, such as antivirus or indexing. No incomplete release was activated. Run herdr update again."
                 throw
             }
             if ($null -ne $backupDir) {


### PR DESCRIPTION
## Problem

While looking into #2356, I could reproduce the half-swapped update with the exact 0.7.5 and 0.8.0 preview packages.

Windows handles open files differently from POSIX. A file can only be renamed or deleted when every open handle allows delete sharing. That means a short-lived antivirus, indexer, or process handle on the staged package can block the installer swap.

PowerShell's `Move-Item` does not fail atomically for this directory move. It creates the destination directory first, then fails when it reaches the locked file. The installer therefore leaves the full payload in `.staging.*` and an empty versioned release directory.

The rollback only restores the backup when the release directory does not exist. Since the empty directory exists, it skips rollback. Repeated attempts explain the empty `.backup.*` directories from the report while both junctions stay on the old version.

## Fix

Use `System.IO.Directory.Move` for the three release transaction moves:

- current release to backup
- staging to current release
- backup back to current release on failure

These paths are siblings on the same volume, so this uses one native directory rename. Under the same forced file handle it fails before creating the destination, which lets the existing rollback restore the previous release cleanly.

This intentionally does not add retries or new cleanup behavior. If Windows keeps the file locked, the update still reports the failure with a suggestion to be tried, but it no longer leaves the install half-swapped.

## Validation

- reproduced the original state with a real Windows handle that allowed reads but not delete sharing
- added the same handle contention to the existing Windows PowerShell 5.1 installer test
- verified the old `Move-Item` path fails the regression by stranding a backup
- verified the atomic move restores the prior release and the next unlocked attempt succeeds
- `CARGO_BUILD_JOBS=2 just check`

Refs #2356