### PR TITLE
docs: add Aliyun Model Studio CLI (bailian-cli) to companion tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ herdr
 
 run your agents, split panes, walk away. `ctrl+b q` detaches, `herdr` reattaches. [quick start →](https://herdr.dev/docs/quick-start/)
 
+## companion tools
+
+- [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) (`bailian-cli`) — Official CLI for the Aliyun AI platform. Extends coding agents with image/video generation, knowledge retrieval, app orchestration, and model deployment.
+
 ## docs
 
 everything lives at [herdr.dev/docs](https://herdr.dev/docs/): [quick start](https://herdr.dev/docs/quick-start/) · [concepts](https://herdr.dev/docs/concepts/) · [supported agents](https://herdr.dev/docs/agents/) · [keyboard](https://herdr.dev/docs/keyboard/) · [configuration](https://herdr.dev/docs/configuration/) · [session state](https://herdr.dev/docs/session-state/) · [remote](https://herdr.dev/docs/persistence-remote/) · [integrations](https://herdr.dev/docs/integrations/) · [plugins](https://herdr.dev/docs/plugins/) · [socket api](https://herdr.dev/docs/socket-api/)


### PR DESCRIPTION
## What this PR does

Adds [Aliyun Model Studio CLI](https://github.com/modelstudioai/cli) (`bailian-cli`) to a new **companion tools** section in README.md, before the docs section.

## Why

`bailian-cli` is the official CLI for the Aliyun AI platform (DashScope). It extends coding agents with capabilities they do not provide natively:

- Image/video generation (HappyHorse, WAN models)
- Knowledge retrieval (Bailian knowledge bases)
- App orchestration (deploy and call hosted Agents)
- Model deployment (fine-tune and deploy custom models)

Herdr is the runtime coding agents live on; `bailian-cli` complements it by providing access to Aliyun model capabilities from within agent sessions.

## Changes

- Added a `## companion tools` section before `## docs`
- One bullet point with a concise description
- Documentation only (+5 lines)