### PR TITLE
feat: option to open a workspace in the launch directory

### DIFF
--- a/docs/next/website/src/content/docs/session-state.mdx
+++ b/docs/next/website/src/content/docs/session-state.mdx
@@ -28,6 +28,13 @@ herdr
 
 This is the strongest persistence path because the original processes never stop.
 
+By default, reattaching restores the previous layout. To instead land in the directory where you ran `herdr` — focusing that workspace when one exists, or opening a new one there — enable:
+
+```toml
+[session]
+open_workspace_in_launch_directory = true
+```
+
 ## Snapshot restore
 
 If the Herdr server stops and starts again, the original pane processes are gone. Herdr restores the saved session shape: workspaces, tabs, panes, cwd, layout, and focus.

--- a/docs/next/website/src/data/config-reference.json
+++ b/docs/next/website/src/data/config-reference.json
@@ -1060,6 +1060,12 @@
           "type": "boolean",
           "default": "true",
           "description": "Resume supported AI-agent panes into their native conversation sessions when restoring a Herdr session."
+        },
+        {
+          "key": "session.open_workspace_in_launch_directory",
+          "type": "boolean",
+          "default": "false",
+          "description": "When you run `herdr` from a directory, focus the workspace for that directory, or open a new workspace there when the restored session has none. Off by default so attaching restores the previous layout."
         }
       ]
     },

--- a/src/app/creation.rs
+++ b/src/app/creation.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::api::schema::{EventData, EventEnvelope, EventKind};
 #[cfg(test)]
@@ -272,6 +272,41 @@ impl App {
         }
         self.schedule_session_save();
         Ok(idx)
+    }
+
+    /// Focus the workspace whose resolved identity matches `launch_cwd`, or
+    /// create a new workspace there when none does. Returns true when a new
+    /// workspace was created.
+    ///
+    /// Used when a full app client attaches: running `herdr` from a directory
+    /// should land in (or open) a terminal pane in that directory, even when
+    /// the persistent session already has other workspaces.
+    pub(crate) fn ensure_workspace_for_launch_cwd(&mut self, launch_cwd: &Path) -> bool {
+        if self.state.mode == Mode::Onboarding {
+            return false;
+        }
+        let canonical_launch = crate::worktree::canonical_or_original(launch_cwd);
+        if let Some(idx) = self.state.workspaces.iter().position(|ws| {
+            ws.resolved_identity_cwd_from(&self.state.terminals, &self.terminal_runtimes)
+                .is_some_and(|cwd| crate::worktree::canonical_or_original(&cwd) == canonical_launch)
+        }) {
+            if self.state.active != Some(idx) {
+                self.state.switch_workspace(idx);
+                self.state.mode = Mode::Terminal;
+            }
+            return false;
+        }
+        match self.create_workspace_with_launch_env(canonical_launch.clone(), true, Vec::new()) {
+            Ok(_) => true,
+            Err(err) => {
+                tracing::warn!(
+                    cwd = %canonical_launch.display(),
+                    err = %err,
+                    "failed to create workspace for launch directory"
+                );
+                false
+            }
+        }
     }
 
     pub(super) fn collect_panes_for_workspace(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -654,6 +654,7 @@ impl App {
             default_shell: config.terminal.default_shell.clone(),
             shell_mode: config.terminal.shell_mode,
             new_terminal_cwd: config.terminal.new_cwd.clone(),
+            open_workspace_in_launch_directory: config.session.open_workspace_in_launch_directory,
             pane_scrollback_limit_bytes: config.advanced.scrollback_limit_bytes,
             accent: crate::config::parse_color(&config.ui.accent),
             sound: config.ui.sound.clone(),
@@ -1539,6 +1540,11 @@ impl App {
             self.state.default_shell = config.terminal.default_shell.clone();
             self.state.shell_mode = config.terminal.shell_mode;
             self.state.new_terminal_cwd = config.terminal.new_cwd.clone();
+        }
+
+        if !invalid_section("session") {
+            self.state.open_workspace_in_launch_directory =
+                config.session.open_workspace_in_launch_directory;
         }
 
         if !invalid_section("worktrees") {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1451,6 +1451,9 @@ pub struct AppState {
     pub default_shell: String,
     pub shell_mode: crate::config::ShellModeConfig,
     pub new_terminal_cwd: NewTerminalCwdConfig,
+    /// Open or focus a workspace for the directory a client launched `herdr`
+    /// from, instead of only restoring the previous layout.
+    pub open_workspace_in_launch_directory: bool,
     pub pane_scrollback_limit_bytes: usize,
     #[allow(dead_code)] // kept for backward compat; palette.accent is the source of truth
     pub accent: Color,
@@ -1808,6 +1811,7 @@ impl AppState {
             default_shell: String::new(),
             shell_mode: crate::config::ShellModeConfig::Auto,
             new_terminal_cwd: NewTerminalCwdConfig::Follow,
+            open_workspace_in_launch_directory: false,
             pane_scrollback_limit_bytes: crate::config::DEFAULT_SCROLLBACK_LIMIT_BYTES,
             accent: Color::Cyan,
             sound: SoundConfig {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -817,6 +817,15 @@ fn do_handshake(
         .map_err(ClientError::ConnectionFailed)?;
 
     // Send Hello.
+    let launch_cwd = if direct_attach_requested
+        || std::env::var_os(crate::remote::REATTACH_COMMAND_ENV_VAR).is_some()
+    {
+        // Direct attaches are not app launches; remote attaches must not
+        // interpret the local launch directory on the remote server.
+        None
+    } else {
+        std::env::current_dir().ok()
+    };
     let hello = ClientMessage::Hello {
         version: PROTOCOL_VERSION,
         cols,
@@ -831,6 +840,7 @@ fn do_handshake(
             cell_width_px,
             cell_height_px,
         ),
+        launch_cwd,
     };
     protocol::write_message(stream, &hello)
         .map_err(|e| ClientError::ConnectionFailed(io::Error::other(e.to_string())))?;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -271,12 +271,18 @@ pub struct SessionConfig {
     /// Resume supported AI-agent panes into their native conversation sessions
     /// when restoring a Herdr session. Default: true.
     pub resume_agents_on_restore: bool,
+    /// When a full app client runs `herdr` from a directory, focus the
+    /// workspace for that directory, or open a new workspace there when the
+    /// restored session has none. Off by default so attaching restores the
+    /// previous layout.
+    pub open_workspace_in_launch_directory: bool,
 }
 
 impl Default for SessionConfig {
     fn default() -> Self {
         Self {
             resume_agents_on_restore: true,
+            open_workspace_in_launch_directory: false,
         }
     }
 }
@@ -1255,6 +1261,19 @@ resume_agents_on_restore = false
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert!(!config.session.resume_agents_on_restore);
+    }
+
+    #[test]
+    fn open_workspace_in_launch_directory_defaults_off_and_parses() {
+        let default_config = Config::default();
+        assert!(!default_config.session.open_workspace_in_launch_directory);
+
+        let toml = r#"
+[session]
+open_workspace_in_launch_directory = true
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.session.open_workspace_in_launch_directory);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,11 @@ const DEFAULT_CONFIG: &str = r##"# herdr configuration
 # a Herdr server restart. Requires official integrations that report session refs.
 # resume_agents_on_restore = true
 
+# When you run `herdr` from a directory, focus the workspace for that directory,
+# or open a new workspace there when the restored session has none. Off by
+# default so attaching restores the previous layout.
+# open_workspace_in_launch_directory = false
+
 [remote]
 # Whether herdr manages the ssh config used for `herdr --remote`.
 # When true (default), herdr runs remote ssh through a generated config that

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -359,6 +360,11 @@ pub enum ClientMessage {
         keybindings: ClientKeybindings,
         /// Whether this connection will render the full app or attach directly to a pane terminal.
         launch_mode: ClientLaunchMode,
+        /// Directory the client was launched from, for full app clients.
+        /// The server opens a terminal pane there when it does not already
+        /// have a workspace for it. None for direct terminal attaches and
+        /// remote attaches (the local path is meaningless on the server).
+        launch_cwd: Option<PathBuf>,
     },
 
     /// Raw input bytes read from the client's stdin.
@@ -1042,6 +1048,7 @@ mod tests {
             requested_encoding: RenderEncoding::SemanticFrame,
             keybindings: ClientKeybindings::Server,
             launch_mode: ClientLaunchMode::App,
+            launch_cwd: None,
         };
         let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
         let (decoded, _): (ClientMessage, _) =
@@ -1079,6 +1086,7 @@ mod tests {
                 requested_encoding: RenderEncoding::SemanticFrame,
                 keybindings: ClientKeybindings::Server,
                 launch_mode: ClientLaunchMode::App,
+                launch_cwd: None,
             }),
             0
         );
@@ -1660,6 +1668,7 @@ mod tests {
             requested_encoding: RenderEncoding::SemanticFrame,
             keybindings: ClientKeybindings::Server,
             launch_mode: ClientLaunchMode::App,
+            launch_cwd: None,
         };
         let mut buf = Vec::new();
         write_message(&mut buf, &msg).unwrap();
@@ -1734,6 +1743,7 @@ mod tests {
                     requested_encoding: RenderEncoding::SemanticFrame,
                     keybindings: ClientKeybindings::Server,
                     launch_mode: ClientLaunchMode::App,
+                    launch_cwd: None,
                 },
                 1 => ClientMessage::Input {
                     data: vec![(i % 256) as u8; (i as usize % 50) + 1],
@@ -2170,6 +2180,7 @@ mod tests {
             requested_encoding: RenderEncoding::SemanticFrame,
             keybindings: ClientKeybindings::Server,
             launch_mode: ClientLaunchMode::App,
+            launch_cwd: None,
         };
         let mut buf = Vec::new();
         write_message(&mut buf, &msg).unwrap();
@@ -2206,6 +2217,7 @@ mod tests {
                 requested_encoding: RenderEncoding::SemanticFrame,
                 keybindings: ClientKeybindings::Server,
                 launch_mode: ClientLaunchMode::App,
+                launch_cwd: None,
             },
             ClientMessage::Input {
                 data: b"hello world".to_vec(),

--- a/src/server/autodetect.rs
+++ b/src/server/autodetect.rs
@@ -28,10 +28,6 @@ const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// Timeout for checking the stable JSON API before attaching to the binary protocol socket.
 const STATUS_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Private daemon-start hint used to seed a fresh headless server from the
-/// directory where the user ran `herdr`.
-pub(crate) const STARTUP_CWD_ENV_VAR: &str = "HERDR_STARTUP_CWD";
-
 // ---------------------------------------------------------------------------
 // Server detection
 // ---------------------------------------------------------------------------
@@ -126,6 +122,7 @@ fn client_protocol_accepts_hello(socket_path: &Path) -> io::Result<bool> {
         requested_encoding: crate::protocol::RenderEncoding::SemanticFrame,
         keybindings: crate::protocol::ClientKeybindings::Server,
         launch_mode: crate::protocol::ClientLaunchMode::App,
+        launch_cwd: None,
     };
 
     match crate::protocol::write_message(&mut stream, &hello) {
@@ -216,15 +213,6 @@ fn build_server_daemon_command(exe: PathBuf) -> Command {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
     crate::platform::detach_server_daemon_command(&mut command);
-
-    match std::env::current_dir() {
-        Ok(cwd) => {
-            command.env(STARTUP_CWD_ENV_VAR, cwd);
-        }
-        Err(_) => {
-            command.env_remove(STARTUP_CWD_ENV_VAR);
-        }
-    }
 
     if crate::session::explicit_session_requested() {
         command
@@ -366,18 +354,6 @@ mod tests {
         crate::session::clear_explicit_session_for_test();
     }
 
-    #[test]
-    fn server_daemon_command_passes_current_dir_as_startup_cwd() {
-        let expected = std::env::current_dir().unwrap();
-        let command = build_server_daemon_command(PathBuf::from("/tmp/herdr-test"));
-        let envs: Vec<_> = command.get_envs().collect();
-
-        assert!(envs.iter().any(|(key, value)| {
-            *key == OsStr::new(STARTUP_CWD_ENV_VAR) && value == &Some(expected.as_os_str())
-        }));
-    }
-
-    #[cfg(target_os = "linux")]
     #[test]
     fn server_daemon_detach_creates_new_session() {
         let mut command = Command::new("sh");

--- a/src/server/client_transport.rs
+++ b/src/server/client_transport.rs
@@ -6,6 +6,7 @@
 
 use std::collections::VecDeque;
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{SendError, TrySendError};
 use std::sync::{Arc, Condvar, Mutex};
@@ -316,6 +317,7 @@ pub(crate) enum ServerEvent {
         keybindings: Option<Box<crate::config::LiveKeybindConfig>>,
         direct_attach_requested: bool,
         direct_graphics: bool,
+        launch_cwd: Option<PathBuf>,
         writer: ClientWriter,
     },
     /// A client sent an input message.
@@ -559,6 +561,7 @@ pub(crate) fn handle_client_handshake(
         keybindings,
         direct_attach_requested,
         direct_graphics,
+        launch_cwd,
     ) = match hello {
         ClientMessage::Hello {
             version,
@@ -569,6 +572,7 @@ pub(crate) fn handle_client_handshake(
             requested_encoding,
             keybindings,
             launch_mode,
+            launch_cwd,
         } => {
             // Version check.
             match protocol::check_client_version(version) {
@@ -609,6 +613,7 @@ pub(crate) fn handle_client_handshake(
                 keybindings,
                 launch_mode == ClientLaunchMode::TerminalAttach,
                 launch_mode == ClientLaunchMode::AppDirectGraphics,
+                launch_cwd,
             )
         }
         _ => {
@@ -664,6 +669,7 @@ pub(crate) fn handle_client_handshake(
         keybindings,
         direct_attach_requested,
         direct_graphics,
+        launch_cwd,
         writer,
     });
 
@@ -1298,6 +1304,7 @@ new_tab = "ctrl+notakey"
                 requested_encoding: RenderEncoding::TerminalAnsi,
                 keybindings: ClientKeybindings::Server,
                 launch_mode: ClientLaunchMode::App,
+                launch_cwd: None,
             },
         )
         .expect("write hello");
@@ -1331,6 +1338,7 @@ new_tab = "ctrl+notakey"
                 keybindings,
                 direct_attach_requested,
                 direct_graphics,
+                launch_cwd,
                 writer,
             } => {
                 assert_eq!(client_id, 42);
@@ -1340,6 +1348,7 @@ new_tab = "ctrl+notakey"
                 assert!(keybindings.is_none());
                 assert!(!direct_attach_requested);
                 assert!(!direct_graphics);
+                assert_eq!(launch_cwd, None);
                 drop(writer);
             }
             other => panic!("expected ClientConnected, got {other:?}"),
@@ -1375,6 +1384,7 @@ new_tab = "ctrl+notakey"
                 requested_encoding: RenderEncoding::TerminalAnsi,
                 keybindings: ClientKeybindings::Server,
                 launch_mode: ClientLaunchMode::TerminalAttach,
+                launch_cwd: None,
             },
         )
         .expect("write hello");

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -2808,6 +2808,7 @@ impl HeadlessServer {
                 render_encoding,
                 direct_attach_requested,
                 direct_graphics,
+                launch_cwd,
             } => {
                 if self.handoff_in_progress {
                     if let Ok(message) =
@@ -2856,6 +2857,16 @@ impl HeadlessServer {
                 }
                 if first_app_client {
                     self.app.mark_git_status_refresh_due(Instant::now());
+                }
+                if !direct_attach_requested && self.app.state.open_workspace_in_launch_directory {
+                    if let Some(launch_cwd) = launch_cwd {
+                        if self.app.ensure_workspace_for_launch_cwd(&launch_cwd) {
+                            info!(
+                                cwd = %launch_cwd.display(),
+                                "opened a terminal pane in the client launch directory"
+                            );
+                        }
+                    }
                 }
                 self.sync_foreground_client_state();
                 self.resize_shared_runtime_to_effective_size();
@@ -4836,7 +4847,6 @@ pub fn run_server() -> io::Result<()> {
             api_rx,
             event_hub,
         );
-        seed_startup_workspace_if_empty(&mut app);
 
         // The server runs headless — disable local notification side effects.
         // Sound and terminal notifications are forwarded to connected clients
@@ -4877,36 +4887,6 @@ pub fn run_server() -> io::Result<()> {
     rt.shutdown_timeout(Duration::from_millis(100));
     crate::logging::shutdown("server");
     result
-}
-
-fn seed_startup_workspace_if_empty(app: &mut app::App) {
-    let Some(cwd) = take_startup_cwd() else {
-        return;
-    };
-
-    if !app.state.workspaces.is_empty() {
-        info!(
-            cwd = %cwd.display(),
-            "restored session already has workspaces; ignoring startup cwd"
-        );
-        return;
-    }
-
-    match app.create_workspace_with_options(cwd.clone(), true) {
-        Ok(_) => {
-            info!(cwd = %cwd.display(), "created startup workspace");
-        }
-        Err(err) => {
-            warn!(cwd = %cwd.display(), err = %err, "failed to create startup workspace");
-            app.state.mode = app::Mode::Navigate;
-        }
-    }
-}
-
-fn take_startup_cwd() -> Option<PathBuf> {
-    let cwd = std::env::var_os(crate::server::autodetect::STARTUP_CWD_ENV_VAR)?;
-    std::env::remove_var(crate::server::autodetect::STARTUP_CWD_ENV_VAR);
-    (!cwd.is_empty()).then(|| PathBuf::from(cwd))
 }
 
 #[cfg(unix)]
@@ -5571,6 +5551,7 @@ mod tests {
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: true,
+            launch_cwd: None,
             writer: writer_a,
         }));
         assert!(server.clients[&1].direct_graphics);
@@ -5588,6 +5569,7 @@ mod tests {
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_b,
         }));
         assert!(!server.direct_graphics_available());
@@ -5618,6 +5600,7 @@ new_tab = "prefix+t"
             keybindings: Some(Box::new(local_keybindings)),
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_a,
         }));
         assert_eq!(
@@ -5643,6 +5626,7 @@ new_tab = "prefix+t"
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_b,
         }));
         assert_eq!(
@@ -5657,6 +5641,128 @@ new_tab = "prefix+t"
             .bindings
             .iter()
             .any(|binding| binding.label == "prefix+c"));
+    }
+
+    #[tokio::test]
+    async fn client_attach_with_launch_cwd_creates_workspace_there() {
+        let mut server = test_headless_server();
+        server.app.state.mode = crate::app::Mode::Navigate;
+        server.app.state.open_workspace_in_launch_directory = true;
+        let launch_dir =
+            std::env::temp_dir().join(format!("hh-launch-cwd-create-{}", std::process::id()));
+        let _ = fs::create_dir_all(&launch_dir);
+        let (writer, _control, _render) = test_client_writer();
+
+        assert!(server.handle_server_event(ServerEvent::ClientConnected {
+            client_id: 1,
+            cols: 80,
+            rows: 24,
+            cell_width_px: 0,
+            cell_height_px: 0,
+            render_encoding: RenderEncoding::SemanticFrame,
+            keybindings: None,
+            direct_attach_requested: false,
+            direct_graphics: false,
+            launch_cwd: Some(launch_dir.clone()),
+            writer,
+        }));
+
+        assert_eq!(server.app.state.workspaces.len(), 1);
+        assert_eq!(server.app.state.active, Some(0));
+        assert_eq!(server.app.state.mode, crate::app::Mode::Terminal);
+        let identity = server.app.state.workspaces[0].identity_cwd.clone();
+        assert_eq!(
+            crate::worktree::canonical_or_original(&identity),
+            crate::worktree::canonical_or_original(&launch_dir)
+        );
+    }
+
+    #[test]
+    fn client_attach_with_matching_launch_cwd_focuses_existing_workspace() {
+        let mut server = test_headless_server();
+        server.app.state.mode = crate::app::Mode::Navigate;
+        server.app.state.open_workspace_in_launch_directory = true;
+        let first_dir =
+            std::env::temp_dir().join(format!("hh-launch-cwd-first-{}", std::process::id()));
+        let second_dir =
+            std::env::temp_dir().join(format!("hh-launch-cwd-second-{}", std::process::id()));
+        let _ = fs::create_dir_all(&first_dir);
+        let _ = fs::create_dir_all(&second_dir);
+        let mut first = crate::workspace::Workspace::test_new("first");
+        first.identity_cwd = first_dir.clone();
+        let mut second = crate::workspace::Workspace::test_new("second");
+        second.identity_cwd = second_dir.clone();
+        server.app.state.workspaces = vec![first, second];
+        server.app.state.active = Some(0);
+        let (writer, _control, _render) = test_client_writer();
+
+        assert!(server.handle_server_event(ServerEvent::ClientConnected {
+            client_id: 1,
+            cols: 80,
+            rows: 24,
+            cell_width_px: 0,
+            cell_height_px: 0,
+            render_encoding: RenderEncoding::SemanticFrame,
+            keybindings: None,
+            direct_attach_requested: false,
+            direct_graphics: false,
+            launch_cwd: Some(second_dir),
+            writer,
+        }));
+
+        // No new workspace; the matching one is focused.
+        assert_eq!(server.app.state.workspaces.len(), 2);
+        assert_eq!(server.app.state.active, Some(1));
+        assert_eq!(server.app.state.mode, crate::app::Mode::Terminal);
+    }
+
+    #[test]
+    fn client_attach_with_launch_cwd_skipped_when_config_off() {
+        let mut server = test_headless_server();
+        server.app.state.mode = crate::app::Mode::Navigate;
+        let launch_dir =
+            std::env::temp_dir().join(format!("hh-launch-cwd-disabled-{}", std::process::id()));
+        let _ = fs::create_dir_all(&launch_dir);
+        let (writer, _control, _render) = test_client_writer();
+
+        assert!(server.handle_server_event(ServerEvent::ClientConnected {
+            client_id: 1,
+            cols: 80,
+            rows: 24,
+            cell_width_px: 0,
+            cell_height_px: 0,
+            render_encoding: RenderEncoding::SemanticFrame,
+            keybindings: None,
+            direct_attach_requested: false,
+            direct_graphics: false,
+            launch_cwd: Some(launch_dir),
+            writer,
+        }));
+
+        assert!(server.app.state.workspaces.is_empty());
+    }
+
+    #[test]
+    fn client_attach_without_launch_cwd_does_not_create_workspace() {
+        let mut server = test_headless_server();
+        let (writer, _control, _render) = test_client_writer();
+
+        assert!(server.handle_server_event(ServerEvent::ClientConnected {
+            client_id: 1,
+            cols: 80,
+            rows: 24,
+            cell_width_px: 0,
+            cell_height_px: 0,
+            render_encoding: RenderEncoding::SemanticFrame,
+            keybindings: None,
+            direct_attach_requested: false,
+            direct_graphics: false,
+            launch_cwd: None,
+            writer,
+        }));
+
+        assert!(server.app.state.workspaces.is_empty());
+        assert_eq!(server.app.state.active, None);
     }
 
     #[test]
@@ -5684,6 +5790,7 @@ new_tab = "prefix+t"
             keybindings: Some(Box::new(local_keybindings)),
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_a,
         }));
         assert_eq!(server.app.state.config_diagnostic, without_keybindings);
@@ -5698,6 +5805,7 @@ new_tab = "prefix+t"
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_b,
         }));
         assert_eq!(
@@ -5742,6 +5850,7 @@ next_tab = ""
             keybindings: Some(Box::new(local_keybindings)),
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
         server.app.state.mode = crate::app::Mode::Settings;
@@ -5818,6 +5927,7 @@ next_tab = ""
             keybindings: Some(Box::new(local_config.live_keybinds().unwrap())),
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_a,
         }));
         server.app.state.mode = crate::app::Mode::Settings;
@@ -5839,6 +5949,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer: writer_b,
         }));
         assert_eq!(
@@ -5874,6 +5985,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: true,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
         assert!(server.clients.contains_key(&7));
@@ -5940,6 +6052,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: true,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
         control_rx
@@ -6353,6 +6466,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
 
@@ -6388,6 +6502,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: true,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
 
@@ -6422,6 +6537,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: false,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
         assert!(server.has_app_client());
@@ -6523,6 +6639,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: true,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
         assert!(
@@ -8548,6 +8665,7 @@ next_tab = ""
             keybindings: None,
             direct_attach_requested: true,
             direct_graphics: false,
+            launch_cwd: None,
             writer,
         }));
         assert!(

--- a/src/server/headless/tests/pane_graphics.rs
+++ b/src/server/headless/tests/pane_graphics.rs
@@ -254,6 +254,7 @@ fn direct_eligibility_is_installed_with_the_client_connection() {
         keybindings: None,
         direct_attach_requested: false,
         direct_graphics: true,
+        launch_cwd: None,
         writer,
     }));
 


### PR DESCRIPTION

Adds `[session] open_workspace_in_launch_directory` (default `false`).

When enabled, running `herdr` from a directory focuses the workspace for
that directory, or opens a new workspace there when the restored session
has none — instead of always restoring the previous layout. This makes
"open a terminal in the project I'm in" work for a long-running
persistent session.

Implementation summary:

- The full-app client sends its launch directory in the `Hello` handshake
  (`launch_cwd`). Direct terminal attaches and remote attaches send
  `None` — the local launch directory is meaningless on a remote server.
- On `ClientConnected`, the server runs `ensure_workspace_for_launch_cwd`:
  canonicalized match against each workspace's resolved identity cwd →
  focus it; otherwise create a workspace there (one tab, one shell pane)
  and focus it. Gated on the config flag.
- The `HERDR_STARTUP_CWD` daemon-seed hack is removed. It only seeded a
  startup workspace when the restored session was empty, and only when a
  fresh server was spawned. The handshake cwd covers the daemon-spawn path
  too, including non-empty restored sessions.

Tests:

- `open_workspace_in_launch_directory_defaults_off_and_parses`
- `client_attach_with_launch_cwd_creates_workspace_there`
- `client_attach_with_matching_launch_cwd_focuses_existing_workspace`
- `client_attach_with_launch_cwd_skipped_when_config_off`
- `client_attach_without_launch_cwd_does_not_create_workspace`

Docs updated under `docs/next/` (config reference + session-state).

Not covered: an option to always open a *new* pane even when the workspace
exists; the current behavior focuses the existing workspace to avoid
accumulating panes per attach. Happy to adjust based on maintainer input.

---

Refs: https://github.com/herdrdev/herdr/discussions/2508#discussioncomment-17940988
