### PR TITLE
Add PID-reuse-safe conditional pane close

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocol": 20,
+  "protocol": 21,
   "schema_version": 1,
   "schemas": {
     "error_response": {
@@ -2449,6 +2449,25 @@
           ],
           "type": "object"
         },
+        "PaneCloseIfParams": {
+          "properties": {
+            "observation": {
+              "$ref": "#/schemas/request/$defs/PaneProcessObservation"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "request_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "request_id",
+            "observation"
+          ],
+          "type": "object"
+        },
         "PaneCurrentParams": {
           "properties": {
             "caller_pane_id": {
@@ -2768,6 +2787,69 @@
               ]
             }
           },
+          "type": "object"
+        },
+        "PaneProcessObservation": {
+          "properties": {
+            "fingerprint_version": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "foreground_process_generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "foreground_process_group_id": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "process_fingerprint": {
+              "type": "string"
+            },
+            "process_generation": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "shell_generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "shell_pid": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "terminal_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "fingerprint_version",
+            "pane_id",
+            "terminal_id",
+            "revision",
+            "process_generation",
+            "process_fingerprint"
+          ],
           "type": "object"
         },
         "PaneReadParams": {
@@ -5287,6 +5369,22 @@
         {
           "properties": {
             "method": {
+              "const": "pane.close_if",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneCloseIfParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
               "const": "layout.export",
               "type": "string"
             },
@@ -6426,6 +6524,32 @@
           ],
           "type": "string"
         },
+        "BuildIdentity": {
+          "properties": {
+            "executable_sha256": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "release_manifest_digest": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_commit": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
         "ClientWindowTitleReason": {
           "enum": [
             "set",
@@ -6433,6 +6557,19 @@
             "no_foreground_client"
           ],
           "type": "string"
+        },
+        "ConditionalMutations": {
+          "properties": {
+            "pane_close": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "pane_close"
+          ],
+          "type": "object"
         },
         "ConfigReloadStatus": {
           "enum": [
@@ -7418,6 +7555,89 @@
           ],
           "type": "string"
         },
+        "PaneCloseIfOutcome": {
+          "oneOf": [
+            {
+              "properties": {
+                "receipt": {
+                  "$ref": "#/schemas/success_response/$defs/PaneCloseReceipt"
+                },
+                "type": {
+                  "const": "closed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "receipt"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "current": {
+                  "$ref": "#/schemas/success_response/$defs/PaneProcessObservation"
+                },
+                "type": {
+                  "const": "precondition_failed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "current"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "not_found",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "unsupported",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "PaneCloseReceipt": {
+          "properties": {
+            "observation": {
+              "$ref": "#/schemas/success_response/$defs/PaneProcessObservation"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "request_id": {
+              "type": "string"
+            },
+            "terminal_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "request_id",
+            "pane_id",
+            "terminal_id",
+            "observation"
+          ],
+          "type": "object"
+        },
         "PaneDirection": {
           "enum": [
             "left",
@@ -7874,8 +8094,16 @@
               },
               "type": "array"
             },
+            "observation": {
+              "$ref": "#/schemas/success_response/$defs/PaneProcessObservation"
+            },
             "pane_id": {
               "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
             },
             "shell_pid": {
               "format": "uint32",
@@ -7885,6 +8113,9 @@
                 "null"
               ]
             },
+            "terminal_id": {
+              "type": "string"
+            },
             "tty": {
               "type": [
                 "string",
@@ -7893,7 +8124,10 @@
             }
           },
           "required": [
-            "pane_id"
+            "pane_id",
+            "terminal_id",
+            "revision",
+            "observation"
           ],
           "type": "object"
         },
@@ -7926,6 +8160,9 @@
                 "null"
               ]
             },
+            "generation": {
+              "type": "string"
+            },
             "name": {
               "type": "string"
             },
@@ -7937,7 +8174,71 @@
           },
           "required": [
             "pid",
+            "generation",
             "name"
+          ],
+          "type": "object"
+        },
+        "PaneProcessObservation": {
+          "properties": {
+            "fingerprint_version": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "foreground_process_generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "foreground_process_group_id": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "process_fingerprint": {
+              "type": "string"
+            },
+            "process_generation": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "shell_generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "shell_pid": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "terminal_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "fingerprint_version",
+            "pane_id",
+            "terminal_id",
+            "revision",
+            "process_generation",
+            "process_fingerprint"
           ],
           "type": "object"
         },
@@ -8733,16 +9034,23 @@
           "oneOf": [
             {
               "properties": {
+                "build_identity": {
+                  "$ref": "#/schemas/success_response/$defs/BuildIdentity",
+                  "default": {
+                    "executable_sha256": null,
+                    "release_manifest_digest": null,
+                    "source_commit": null
+                  }
+                },
                 "capabilities": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/schemas/success_response/$defs/ServerCapabilities"
+                  "$ref": "#/schemas/success_response/$defs/ServerCapabilities",
+                  "default": {
+                    "conditional_mutations": {
+                      "pane_close": 0
                     },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "default": null
+                    "detached_server_daemon": false,
+                    "live_handoff": false
+                  }
                 },
                 "protocol": {
                   "format": "uint32",
@@ -9251,6 +9559,22 @@
               "required": [
                 "type",
                 "process_info"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "outcome": {
+                  "$ref": "#/schemas/success_response/$defs/PaneCloseIfOutcome"
+                },
+                "type": {
+                  "const": "pane_close_if",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "outcome"
               ],
               "type": "object"
             },
@@ -9918,6 +10242,12 @@
         },
         "ServerCapabilities": {
           "properties": {
+            "conditional_mutations": {
+              "$ref": "#/schemas/success_response/$defs/ConditionalMutations",
+              "default": {
+                "pane_close": 0
+              }
+            },
             "detached_server_daemon": {
               "default": false,
               "type": "boolean"

--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -254,6 +254,16 @@
             },
             {
               "properties": {
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": {
                   "const": "worktree_created",
                   "type": "string"
@@ -300,6 +310,16 @@
               "properties": {
                 "forced": {
                   "type": "boolean"
+                },
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "type": {
                   "const": "worktree_removed",
@@ -1200,6 +1220,33 @@
             "is_prunable",
             "is_linked_worktree",
             "label"
+          ],
+          "type": "object"
+        },
+        "WorktreeMutationReceipt": {
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "checkout_path": {
+              "type": "string"
+            },
+            "head_oid": {
+              "type": "string"
+            },
+            "operation": {
+              "type": "string"
+            },
+            "repo_common_dir": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "repo_common_dir",
+            "checkout_path",
+            "branch",
+            "head_oid"
           ],
           "type": "object"
         }
@@ -4343,6 +4390,16 @@
                 "null"
               ]
             },
+            "permit": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/WorktreeExactPermit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "workspace_id": {
               "type": [
                 "string",
@@ -4350,6 +4407,29 @@
               ]
             }
           },
+          "type": "object"
+        },
+        "WorktreeExactPermit": {
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "checkout_path": {
+              "type": "string"
+            },
+            "head_oid": {
+              "type": "string"
+            },
+            "repo_common_dir": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repo_common_dir",
+            "checkout_path",
+            "branch",
+            "head_oid"
+          ],
           "type": "object"
         },
         "WorktreeListParams": {
@@ -4413,6 +4493,16 @@
             "force": {
               "default": false,
               "type": "boolean"
+            },
+            "permit": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/WorktreeExactPermit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "workspace_id": {
               "type": "string"
@@ -6527,6 +6617,16 @@
             },
             {
               "properties": {
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": {
                   "const": "worktree_created",
                   "type": "string"
@@ -6573,6 +6673,16 @@
               "properties": {
                 "forced": {
                   "type": "boolean"
+                },
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "type": {
                   "const": "worktree_removed",
@@ -8754,6 +8864,16 @@
             },
             {
               "properties": {
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "root_pane": {
                   "$ref": "#/schemas/success_response/$defs/PaneInfo"
                 },
@@ -8819,6 +8939,16 @@
                 },
                 "path": {
                   "type": "string"
+                },
+                "receipt": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorktreeMutationReceipt"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "type": {
                   "const": "worktree_removed",
@@ -10049,6 +10179,33 @@
             "is_prunable",
             "is_linked_worktree",
             "label"
+          ],
+          "type": "object"
+        },
+        "WorktreeMutationReceipt": {
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "checkout_path": {
+              "type": "string"
+            },
+            "head_oid": {
+              "type": "string"
+            },
+            "operation": {
+              "type": "string"
+            },
+            "repo_common_dir": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "repo_common_dir",
+            "checkout_path",
+            "branch",
+            "head_oid"
           ],
           "type": "object"
         },

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -84,10 +84,12 @@ impl ApiClient {
                 version,
                 protocol,
                 capabilities,
+                build_identity,
             } => Ok(crate::api::RuntimeStatus {
                 version: Some(version),
                 protocol: Some(protocol),
-                capabilities,
+                capabilities: Some(capabilities),
+                build_identity: Some(build_identity),
             }),
             result => Err(ApiClientError::UnexpectedResult(format!("{result:?}"))),
         }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -70,6 +70,7 @@ pub(crate) fn request_changes_ui(request: &Request) -> bool {
             | Method::PaneClearAgentAuthority(_)
             | Method::PaneReleaseAgent(_)
             | Method::PaneClose(_)
+            | Method::PaneCloseIf(_)
             | Method::PopupClose(_)
             | Method::PluginUnlink(_)
             | Method::PluginDisable(_)

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -139,6 +139,8 @@ pub enum Method {
     PaneLayout(PaneLayoutParams),
     #[serde(rename = "pane.process_info")]
     PaneProcessInfo(PaneProcessInfoParams),
+    #[serde(rename = "pane.close_if")]
+    PaneCloseIf(PaneCloseIfParams),
     #[serde(rename = "layout.export")]
     LayoutExport(LayoutExportParams),
     #[serde(rename = "layout.apply")]

--- a/src/api/schema/events.rs
+++ b/src/api/schema/events.rs
@@ -455,6 +455,8 @@ pub enum EventData {
     WorktreeCreated {
         workspace: WorkspaceInfo,
         worktree: WorktreeInfo,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     WorktreeOpened {
         workspace: WorkspaceInfo,
@@ -467,6 +469,8 @@ pub enum EventData {
         workspace: Option<WorkspaceInfo>,
         worktree: WorktreeInfo,
         forced: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     TabCreated {
         tab: TabInfo,

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -131,6 +131,12 @@ pub struct PaneProcessInfoParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
 }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneCloseIfParams {
+    pub pane_id: String,
+    pub request_id: String,
+    pub observation: PaneProcessObservation,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct LayoutExportParams {
@@ -488,6 +494,9 @@ pub struct PaneScrollInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneProcessInfo {
     pub pane_id: String,
+    pub terminal_id: String,
+    pub revision: u64,
+    pub observation: PaneProcessObservation,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shell_pid: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -499,8 +508,44 @@ pub struct PaneProcessInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneProcessObservation {
+    pub fingerprint_version: u32,
+    pub pane_id: String,
+    pub terminal_id: String,
+    pub revision: u64,
+    pub process_generation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell_generation: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_process_group_id: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_process_generation: Option<String>,
+    pub process_fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneCloseReceipt {
+    pub request_id: String,
+    pub pane_id: String,
+    pub terminal_id: String,
+    pub observation: PaneProcessObservation,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PaneCloseIfOutcome {
+    Closed { receipt: PaneCloseReceipt },
+    PreconditionFailed { current: PaneProcessObservation },
+    NotFound {},
+    Unsupported {},
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneProcessInfoProcess {
     pub pid: u32,
+    pub generation: String,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub argv0: Option<String>,

--- a/src/api/schema/response.rs
+++ b/src/api/schema/response.rs
@@ -71,6 +71,8 @@ pub enum ResponseResult {
         tab: TabInfo,
         root_pane: PaneInfo,
         worktree: WorktreeInfo,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     WorktreeOpened {
         workspace: WorkspaceInfo,
@@ -83,6 +85,8 @@ pub enum ResponseResult {
         workspace_id: String,
         path: String,
         forced: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        receipt: Option<super::worktrees::WorktreeMutationReceipt>,
     },
     TabInfo {
         tab: TabInfo,

--- a/src/api/schema/response.rs
+++ b/src/api/schema/response.rs
@@ -7,9 +7,9 @@ use super::integrations::{
     IntegrationInstallResult, IntegrationTarget, IntegrationUninstallResult,
 };
 use super::panes::{
-    LayoutDescription, PaneEdgesResult, PaneFocusDirectionResult, PaneInfo, PaneLayoutSnapshot,
-    PaneMoveResult, PaneNeighborResult, PaneProcessInfo, PaneReadResult, PaneResizeResult,
-    PaneSwapResult, PaneZoomResult,
+    LayoutDescription, PaneCloseIfOutcome, PaneEdgesResult, PaneFocusDirectionResult, PaneInfo,
+    PaneLayoutSnapshot, PaneMoveResult, PaneNeighborResult, PaneProcessInfo, PaneReadResult,
+    PaneResizeResult, PaneSwapResult, PaneZoomResult,
 };
 use super::plugins::{
     InstalledPluginInfo, PluginActionInfo, PluginCommandLogInfo, PluginInvocationContext,
@@ -46,7 +46,9 @@ pub enum ResponseResult {
         version: String,
         protocol: u32,
         #[serde(default)]
-        capabilities: Option<ServerCapabilities>,
+        capabilities: ServerCapabilities,
+        #[serde(default)]
+        build_identity: super::server::BuildIdentity,
     },
     SessionSnapshot {
         snapshot: Box<SessionSnapshot>,
@@ -141,6 +143,9 @@ pub enum ResponseResult {
     },
     PaneProcessInfo {
         process_info: PaneProcessInfo,
+    },
+    PaneCloseIf {
+        outcome: PaneCloseIfOutcome,
     },
     LayoutExport {
         layout: LayoutDescription,

--- a/src/api/schema/server.rs
+++ b/src/api/schema/server.rs
@@ -13,9 +13,26 @@ pub struct ServerLiveHandoffParams {
     pub expected_version: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct ServerCapabilities {
     pub live_handoff: bool,
     #[serde(default)]
     pub detached_server_daemon: bool,
+    #[serde(default)]
+    pub conditional_mutations: ConditionalMutations,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct ConditionalMutations {
+    pub pane_close: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct BuildIdentity {
+    #[serde(default)]
+    pub source_commit: Option<String>,
+    #[serde(default)]
+    pub executable_sha256: Option<String>,
+    #[serde(default)]
+    pub release_manifest_digest: Option<String>,
 }

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -760,6 +760,7 @@ fn worktree_request_and_response_round_trip() {
                 open_workspace_id: Some("w_1".into()),
                 label: "herdr".into(),
             },
+            receipt: None,
         },
     };
     let json = serde_json::to_string(&response).unwrap();
@@ -822,6 +823,7 @@ fn worktree_lifecycle_events_round_trip() {
             event: EventKind::WorktreeCreated,
             data: EventData::WorktreeCreated {
                 workspace: workspace.clone(),
+                receipt: None,
                 worktree: worktree.clone(),
             },
         },
@@ -843,6 +845,7 @@ fn worktree_lifecycle_events_round_trip() {
                     ..worktree.clone()
                 },
                 forced: false,
+                receipt: None,
             },
         },
         EventEnvelope {

--- a/src/api/schema/tests.rs
+++ b/src/api/schema/tests.rs
@@ -454,6 +454,34 @@ fn pane_process_info_request_round_trips() {
 }
 
 #[test]
+fn pane_close_if_request_requires_correlation_and_exact_observation() {
+    let observation = PaneProcessObservation {
+        fingerprint_version: 1,
+        pane_id: "w1-1".into(),
+        terminal_id: "term-1".into(),
+        revision: 9,
+        process_generation: "a".repeat(64),
+        shell_pid: Some(42),
+        shell_generation: Some("b".repeat(64)),
+        foreground_process_group_id: Some(42),
+        foreground_process_generation: Some("c".repeat(64)),
+        process_fingerprint: "d".repeat(64),
+    };
+    let request = Request {
+        id: "req_close_if".into(),
+        method: Method::PaneCloseIf(PaneCloseIfParams {
+            pane_id: "w1-1".into(),
+            request_id: "attempt-1".into(),
+            observation,
+        }),
+    };
+    let json = serde_json::to_value(&request).unwrap();
+    assert_eq!(json["params"]["request_id"], "attempt-1");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, request);
+}
+
+#[test]
 fn event_envelope_round_trips() {
     let events = [
         EventEnvelope {
@@ -637,10 +665,12 @@ fn success_response_round_trips() {
         result: ResponseResult::Pong {
             version: "0.1.2".into(),
             protocol: 6,
-            capabilities: Some(ServerCapabilities {
+            capabilities: ServerCapabilities {
                 live_handoff: true,
                 detached_server_daemon: true,
-            }),
+                conditional_mutations: ConditionalMutations { pane_close: 0 },
+            },
+            build_identity: BuildIdentity::default(),
         },
     };
 

--- a/src/api/schema/worktrees.rs
+++ b/src/api/schema/worktrees.rs
@@ -8,6 +8,23 @@ pub struct WorktreeListParams {
     pub cwd: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorktreeExactPermit {
+    pub repo_common_dir: String,
+    pub checkout_path: String,
+    pub branch: String,
+    pub head_oid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorktreeMutationReceipt {
+    pub operation: String,
+    pub repo_common_dir: String,
+    pub checkout_path: String,
+    pub branch: String,
+    pub head_oid: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct WorktreeCreateParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -24,6 +41,8 @@ pub struct WorktreeCreateParams {
     pub label: Option<String>,
     #[serde(default)]
     pub focus: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permit: Option<WorktreeExactPermit>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
@@ -47,6 +66,8 @@ pub struct WorktreeRemoveParams {
     pub workspace_id: String,
     #[serde(default)]
     pub force: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permit: Option<WorktreeExactPermit>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -66,6 +66,9 @@ pub fn start_server(
         Some(ServerCapabilities {
             live_handoff: crate::platform::capabilities().live_handoff,
             detached_server_daemon: crate::platform::current_process_is_detached_server_daemon(),
+            conditional_mutations: crate::api::schema::ConditionalMutations {
+                pane_close: u32::from(crate::platform::capabilities().pane_close_if),
+            },
         }),
     )
 }
@@ -324,7 +327,12 @@ fn handle_request(
             result: ResponseResult::Pong {
                 version: crate::build_info::version(),
                 protocol: crate::protocol::PROTOCOL_VERSION,
-                capabilities,
+                capabilities: capabilities.unwrap_or_default(),
+                build_identity: crate::api::schema::BuildIdentity {
+                    source_commit: crate::build_info::source_commit().map(str::to_string),
+                    executable_sha256: crate::build_info::executable_sha256(),
+                    release_manifest_digest: crate::build_info::release_manifest_digest(),
+                },
             },
         })
         .unwrap_or_else(|_| {
@@ -383,6 +391,7 @@ fn api_method_name(method: &Method) -> &'static str {
         Method::PaneSwap(_) => "pane.swap",
         Method::PaneMove(_) => "pane.move",
         Method::PaneZoom(_) => "pane.zoom",
+        Method::PaneCloseIf(_) => "pane.close_if",
         Method::PaneLayout(_) => "pane.layout",
         Method::PaneProcessInfo(_) => "pane.process_info",
         Method::LayoutExport(_) => "layout.export",
@@ -1037,6 +1046,7 @@ mod tests {
             Some(ServerCapabilities {
                 live_handoff: true,
                 detached_server_daemon: true,
+                conditional_mutations: crate::api::schema::ConditionalMutations { pane_close: 1 },
             }),
             None,
         );
@@ -1044,6 +1054,38 @@ mod tests {
         let parsed: SuccessResponse = serde_json::from_str(&response).unwrap();
         assert_eq!(parsed.id, "req_1");
         assert!(matches!(parsed.result, ResponseResult::Pong { .. }));
+    }
+
+    #[test]
+    fn ping_exposes_versioned_capability_and_build_identity_keys() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let response = handle_request(
+            Request {
+                id: "req_identity".into(),
+                method: Method::Ping(crate::api::schema::PingParams::default()),
+            },
+            &tx,
+            Some(ServerCapabilities {
+                live_handoff: false,
+                detached_server_daemon: false,
+                conditional_mutations: crate::api::schema::ConditionalMutations { pane_close: 1 },
+            }),
+            None,
+        );
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value["result"]["capabilities"]["conditional_mutations"]["pane_close"],
+            1
+        );
+        assert!(value["result"]["build_identity"]
+            .get("source_commit")
+            .is_some());
+        assert!(value["result"]["build_identity"]
+            .get("executable_sha256")
+            .is_some());
+        assert!(value["result"]["build_identity"]
+            .get("release_manifest_digest")
+            .is_some());
     }
 
     #[test]

--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -9,6 +9,7 @@ pub struct RuntimeStatus {
     pub version: Option<String>,
     pub protocol: Option<u32>,
     pub capabilities: Option<crate::api::schema::ServerCapabilities>,
+    pub build_identity: Option<crate::api::schema::BuildIdentity>,
 }
 
 pub fn read_runtime_status_at(
@@ -48,10 +49,12 @@ pub fn read_runtime_status_at(
             version,
             protocol,
             capabilities,
+            build_identity,
         } => Ok(Some(RuntimeStatus {
             version: Some(version),
             protocol: Some(protocol),
-            capabilities,
+            capabilities: Some(capabilities),
+            build_identity: Some(build_identity),
         })),
         result => Err(io::Error::other(format!(
             "server status request returned unexpected result: {result:?}"

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -1065,6 +1065,9 @@ impl App {
             Method::PaneProcessInfo(params) => {
                 return self.handle_pane_process_info(request.id, params);
             }
+            Method::PaneCloseIf(params) => {
+                return self.handle_pane_close_if(request.id, params);
+            }
             Method::LayoutExport(params) => return self.handle_layout_export(request.id, params),
             Method::LayoutApply(params) => return self.handle_layout_apply(request.id, params),
             Method::LayoutSetSplitRatio(params) => {

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -2,42 +2,18 @@ use bytes::Bytes;
 use sha2::{Digest, Sha256};
 
 use crate::api::schema::{
-1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
+    EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
     PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
     PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
     PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
     PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
     PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
     PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
-    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
-    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
-    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
-    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
-    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
-2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
-    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
-    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
-    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
-    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
-    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
-3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
-    PaneMoveParams,
-4:     build_info::initialize();
-    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
-        Ok(args) => args,
-        Err(err) => {
-            eprintln!("error: {err}");
-            eprintln!("run 'herdr --help' for usage");
-            std::process::exit(2);
-        }
-    };
-5: /// Return the native process creation-time generation for PID-reuse resistance.
-pub fn process_generation(pid: u32) -> Option<String> {
-    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
-    process_creation_time(process.0).map(|value| value.to_string())
-}
-
-fn select_pane_foreground_job_from_snapshot(
+    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams, PaneReportAgentSessionParams,
+    PaneReportMetadataParams, PaneResizeParams, PaneResizeReason, PaneResizeResult,
+    PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams, PaneSplitParams, PaneSwapParams,
+    PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode, PaneZoomParams, PaneZoomReason,
+    PaneZoomResult, ResponseResult,
 };
 use crate::app::actions::{PaneZoomCommand, PaneZoomNoopReason};
 use crate::app::App;

--- a/src/app/api/panes.rs
+++ b/src/app/api/panes.rs
@@ -1,18 +1,43 @@
 use bytes::Bytes;
+use sha2::{Digest, Sha256};
 
 use crate::api::schema::{
-    EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCurrentParams,
-    PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
+1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
+    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
     PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
     PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
     PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
     PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
-    PaneProcessInfoProcess, PaneReadParams, PaneReadResult, PaneReleaseAgentParams,
-    PaneRenameParams, PaneReportAgentParams, PaneReportAgentSessionParams,
-    PaneReportMetadataParams, PaneResizeParams, PaneResizeReason, PaneResizeResult,
-    PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams, PaneSplitParams, PaneSwapParams,
-    PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode, PaneZoomParams, PaneZoomReason,
-    PaneZoomResult, ResponseResult,
+    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
+    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
+    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
+    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
+    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
+    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
+2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
+    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
+    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
+    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
+    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
+    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
+3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
+    PaneMoveParams,
+4:     build_info::initialize();
+    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("error: {err}");
+            eprintln!("run 'herdr --help' for usage");
+            std::process::exit(2);
+        }
+    };
+5: /// Return the native process creation-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    process_creation_time(process.0).map(|value| value.to_string())
+}
+
+fn select_pane_foreground_job_from_snapshot(
 };
 use crate::app::actions::{PaneZoomCommand, PaneZoomNoopReason};
 use crate::app::App;
@@ -27,6 +52,232 @@ use super::super::api_helpers::{
 #[cfg(test)]
 use super::super::api_helpers::{METADATA_SOURCE_MAX_CHARS, METADATA_TTL_MAX_MS};
 use super::responses::{encode_error, encode_success};
+
+const PANE_PROCESS_OBSERVATION_VERSION: u32 = 1;
+const MAX_PROCESS_EVIDENCE: usize = 64;
+const MAX_PROCESS_FIELD_BYTES: usize = 4096;
+
+fn digest_bytes(bytes: impl AsRef<[u8]>) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+
+fn generation_digest(raw: Option<&str>) -> String {
+    let mut bytes = Vec::new();
+    hash_field_bytes(&mut bytes, raw.unwrap_or_default());
+    digest_bytes(bytes)
+}
+
+fn hash_field_bytes(output: &mut Vec<u8>, field: &str) {
+    output.extend_from_slice(&(field.len() as u64).to_le_bytes());
+    output.extend_from_slice(field.as_bytes());
+}
+
+fn process_generation_digest(processes: &[PaneProcessInfoProcess]) -> String {
+    let mut bytes = Vec::new();
+    let mut sorted = processes.iter().collect::<Vec<_>>();
+    sorted.sort_by_key(|process| process.pid);
+    bytes.extend_from_slice(&(sorted.len() as u64).to_le_bytes());
+    for process in sorted {
+        bytes.extend_from_slice(&process.pid.to_le_bytes());
+        hash_field_bytes(&mut bytes, &process.generation);
+    }
+    digest_bytes(bytes)
+}
+
+/// Version 1 canonical bytes are length-prefixed UTF-8 fields (u64 little-endian)
+/// and fixed-width little-endian integer fields. Every raw process field,
+/// optional identity, process ordering key, and generation is covered.
+pub(crate) fn canonical_process_fingerprint(
+    pane_id: &str,
+    terminal_id: &str,
+    revision: u64,
+    shell_pid: Option<u32>,
+    shell_generation: Option<&str>,
+    foreground_process_group_id: Option<u32>,
+    foreground_process_generation: Option<&str>,
+    processes: &[PaneProcessInfoProcess],
+) -> String {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&PANE_PROCESS_OBSERVATION_VERSION.to_le_bytes());
+    hash_field_bytes(&mut bytes, pane_id);
+    hash_field_bytes(&mut bytes, terminal_id);
+    bytes.extend_from_slice(&revision.to_le_bytes());
+    hash_optional_pid_bytes(&mut bytes, shell_pid);
+    hash_field_bytes(&mut bytes, shell_generation.unwrap_or_default());
+    hash_optional_pid_bytes(&mut bytes, foreground_process_group_id);
+    hash_field_bytes(
+        &mut bytes,
+        foreground_process_generation.unwrap_or_default(),
+    );
+    let mut sorted = processes.iter().collect::<Vec<_>>();
+    sorted.sort_by_key(|process| process.pid);
+    bytes.extend_from_slice(&(sorted.len() as u64).to_le_bytes());
+    for process in sorted {
+        bytes.extend_from_slice(&process.pid.to_le_bytes());
+        hash_field_bytes(&mut bytes, &process.generation);
+        hash_field_bytes(&mut bytes, &process.name);
+        hash_field_bytes(&mut bytes, process.argv0.as_deref().unwrap_or_default());
+        let argv = process.argv.as_deref().unwrap_or_default();
+        bytes.extend_from_slice(&(argv.len() as u64).to_le_bytes());
+        for item in argv {
+            hash_field_bytes(&mut bytes, item);
+        }
+        hash_field_bytes(&mut bytes, process.cmdline.as_deref().unwrap_or_default());
+        hash_field_bytes(&mut bytes, process.cwd.as_deref().unwrap_or_default());
+    }
+    digest_bytes(bytes)
+}
+
+fn hash_optional_pid_bytes(output: &mut Vec<u8>, value: Option<u32>) {
+    output.push(u8::from(value.is_some()));
+    if let Some(value) = value {
+        output.extend_from_slice(&value.to_le_bytes());
+    }
+}
+
+fn pane_process_observation(
+    pane_id: &str,
+    terminal_id: &str,
+    revision: u64,
+    shell_pid: Option<u32>,
+    foreground_process_group_id: Option<u32>,
+    processes: &[PaneProcessInfoProcess],
+) -> (PaneProcessObservation, bool) {
+    let shell_generation_raw = shell_pid.and_then(crate::platform::process_generation);
+    let foreground_generation_raw =
+        foreground_process_group_id.and_then(crate::platform::process_generation);
+    let shell_generation = shell_generation_raw
+        .as_deref()
+        .map(|raw| generation_digest(Some(raw)));
+    let foreground_generation = foreground_generation_raw
+        .as_deref()
+        .map(|raw| generation_digest(Some(raw)));
+    let process_generation = process_generation_digest(processes);
+    let process_fingerprint = canonical_process_fingerprint(
+        pane_id,
+        terminal_id,
+        revision,
+        shell_pid,
+        shell_generation.as_deref(),
+        foreground_process_group_id,
+        foreground_generation.as_deref(),
+        processes,
+    );
+    let supported = shell_pid.is_none_or(|_| shell_generation_raw.is_some())
+        && foreground_process_group_id.is_none_or(|_| foreground_generation_raw.is_some())
+        && processes
+            .iter()
+            .all(|process| process.generation.len() == 64);
+    (
+        PaneProcessObservation {
+            fingerprint_version: PANE_PROCESS_OBSERVATION_VERSION,
+            pane_id: pane_id.to_string(),
+            terminal_id: terminal_id.to_string(),
+            revision,
+            process_generation,
+            shell_pid,
+            shell_generation,
+            foreground_process_group_id,
+            foreground_process_generation: foreground_generation,
+            process_fingerprint,
+        },
+        supported,
+    )
+}
+
+impl App {
+    fn current_pane_process_info(
+        &self,
+        ws_idx: usize,
+        pane_id: PaneId,
+    ) -> Option<(PaneProcessInfo, bool)> {
+        let (runtime, _workspace_id) = self.lookup_runtime(ws_idx, pane_id)?;
+        let public_pane_id = self.public_pane_id(ws_idx, pane_id)?;
+        let terminal_id = self
+            .state
+            .terminal_id_for_pane(ws_idx, pane_id)?
+            .to_string();
+        let revision = self.pane_info(ws_idx, pane_id)?.revision;
+        let shell_pid = runtime.child_pid();
+        let foreground_job = shell_pid.and_then(crate::detect::foreground_job);
+        let foreground_process_group_id = foreground_job.as_ref().map(|job| job.process_group_id);
+        let mut supported = shell_pid.is_none() || foreground_job.is_some();
+        let foreground_processes = foreground_job
+            .map(|job| {
+                if job.processes.len() > MAX_PROCESS_EVIDENCE {
+                    supported = false;
+                    return Vec::new();
+                }
+                job.processes
+                    .into_iter()
+                    .filter_map(|process| {
+                        let generation = crate::platform::process_generation(process.pid);
+                        let cwd = crate::platform::process_cwd(process.pid)
+                            .map(|cwd| cwd.display().to_string());
+                        let fields_ok = process.name.len() <= MAX_PROCESS_FIELD_BYTES
+                            && process
+                                .argv0
+                                .as_ref()
+                                .is_none_or(|v| v.len() <= MAX_PROCESS_FIELD_BYTES)
+                            && process.argv.as_ref().is_none_or(|argv| {
+                                argv.iter().all(|v| v.len() <= MAX_PROCESS_FIELD_BYTES)
+                            })
+                            && process
+                                .cmdline
+                                .as_ref()
+                                .is_none_or(|v| v.len() <= MAX_PROCESS_FIELD_BYTES)
+                            && cwd
+                                .as_ref()
+                                .is_none_or(|v| v.len() <= MAX_PROCESS_FIELD_BYTES);
+                        if !fields_ok {
+                            supported = false;
+                            return None;
+                        }
+                        if generation.is_none() {
+                            supported = false;
+                        }
+                        Some(PaneProcessInfoProcess {
+                            pid: process.pid,
+                            generation: generation_digest(generation.as_deref()),
+                            name: process.name,
+                            argv0: process.argv0,
+                            argv: process.argv,
+                            cmdline: process.cmdline,
+                            cwd,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let (observation, generation_supported) = pane_process_observation(
+            &public_pane_id,
+            &terminal_id,
+            revision,
+            shell_pid,
+            foreground_process_group_id,
+            &foreground_processes,
+        );
+        Some((
+            PaneProcessInfo {
+                pane_id: public_pane_id,
+                terminal_id,
+                revision,
+                observation,
+                shell_pid,
+                foreground_process_group_id,
+                tty: None,
+                foreground_processes,
+            },
+            supported && generation_supported && crate::platform::capabilities().pane_close_if,
+        ))
+    }
+}
 
 impl App {
     pub(super) fn handle_pane_split(&mut self, id: String, params: PaneSplitParams) -> String {
@@ -208,44 +459,106 @@ impl App {
         let Some((ws_idx, pane_id)) = self.resolve_optional_pane(params.pane_id.as_deref()) else {
             return encode_error(id, "pane_not_found", "pane not found");
         };
-        let Some((runtime, _workspace_id)) = self.lookup_runtime(ws_idx, pane_id) else {
+        let Some((process_info, _supported)) = self.current_pane_process_info(ws_idx, pane_id)
+        else {
             return encode_error(id, "pane_not_found", "pane not found");
         };
-        let Some(public_pane_id) = self.public_pane_id(ws_idx, pane_id) else {
-            return encode_error(id, "pane_not_found", "pane not found");
-        };
-        let shell_pid = runtime.child_pid();
-        let foreground_job = shell_pid.and_then(crate::detect::foreground_job);
-        let foreground_process_group_id = foreground_job.as_ref().map(|job| job.process_group_id);
-        let foreground_processes = foreground_job
-            .map(|job| {
-                job.processes
-                    .into_iter()
-                    .map(|process| PaneProcessInfoProcess {
-                        pid: process.pid,
-                        name: process.name,
-                        argv0: process.argv0,
-                        argv: process.argv,
-                        cmdline: process.cmdline,
-                        cwd: crate::platform::process_cwd(process.pid)
-                            .map(|cwd| cwd.display().to_string()),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        encode_success(id, ResponseResult::PaneProcessInfo { process_info })
+    }
 
-        encode_success(
-            id,
-            ResponseResult::PaneProcessInfo {
-                process_info: PaneProcessInfo {
-                    pane_id: public_pane_id,
-                    shell_pid,
-                    foreground_process_group_id,
-                    tty: None,
-                    foreground_processes,
+    pub(super) fn handle_pane_close_if(
+        &mut self,
+        id: String,
+        params: crate::api::schema::PaneCloseIfParams,
+    ) -> String {
+        if params.pane_id.len() > 256 {
+            return encode_success(
+                id,
+                ResponseResult::PaneCloseIf {
+                    outcome: PaneCloseIfOutcome::NotFound {},
                 },
+            );
+        }
+        let Some((ws_idx, pane_id)) = self.parse_pane_id(&params.pane_id) else {
+            return encode_success(
+                id,
+                ResponseResult::PaneCloseIf {
+                    outcome: PaneCloseIfOutcome::NotFound {},
+                },
+            );
+        };
+        let Some((process_info, supported)) = self.current_pane_process_info(ws_idx, pane_id)
+        else {
+            return encode_success(
+                id,
+                ResponseResult::PaneCloseIf {
+                    outcome: PaneCloseIfOutcome::NotFound {},
+                },
+            );
+        };
+        if !supported {
+            return encode_success(
+                id,
+                ResponseResult::PaneCloseIf {
+                    outcome: PaneCloseIfOutcome::Unsupported {},
+                },
+            );
+        }
+        let valid_digest = |value: &str| {
+            value.len() == 64
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        };
+        let observation_valid = !params.request_id.is_empty()
+            && params.request_id.len() <= 256
+            && params.observation.fingerprint_version == PANE_PROCESS_OBSERVATION_VERSION
+            && params.observation.pane_id.len() <= 256
+            && params.observation.terminal_id.len() <= 256
+            && valid_digest(&params.observation.process_generation)
+            && valid_digest(&params.observation.process_fingerprint)
+            && params
+                .observation
+                .shell_generation
+                .as_deref()
+                .is_none_or(valid_digest)
+            && params
+                .observation
+                .foreground_process_generation
+                .as_deref()
+                .is_none_or(valid_digest)
+            && params.observation == process_info.observation;
+        if !observation_valid {
+            return encode_success(
+                id,
+                ResponseResult::PaneCloseIf {
+                    outcome: PaneCloseIfOutcome::PreconditionFailed {
+                        current: process_info.observation,
+                    },
+                },
+            );
+        }
+
+        let receipt = crate::api::schema::PaneCloseReceipt {
+            request_id: params.request_id.clone(),
+            pane_id: process_info.pane_id.clone(),
+            terminal_id: process_info.observation.terminal_id.clone(),
+            observation: process_info.observation.clone(),
+        };
+        match self.close_pane(
+            id.clone(),
+            &crate::api::schema::PaneTarget {
+                pane_id: params.pane_id,
             },
-        )
+        ) {
+            Ok(()) => encode_success(
+                id,
+                ResponseResult::PaneCloseIf {
+                    outcome: PaneCloseIfOutcome::Closed { receipt },
+                },
+            ),
+            Err(response) => response,
+        }
     }
 
     pub(super) fn handle_pane_neighbor(
@@ -1908,6 +2221,68 @@ mod tests {
         workspace::Workspace,
     };
 
+    #[test]
+    fn canonical_process_fingerprint_v1_vector_is_stable() {
+        let process = PaneProcessInfoProcess {
+            pid: 42,
+            generation: "gen".into(),
+            name: "sh".into(),
+            argv0: Some("sh".into()),
+            argv: Some(vec!["-c".into(), "echo".into()]),
+            cmdline: Some("sh -c echo".into()),
+            cwd: Some("/tmp".into()),
+        };
+        assert_eq!(
+            canonical_process_fingerprint(
+                "pane",
+                "term",
+                7,
+                Some(42),
+                Some("shell"),
+                Some(43),
+                Some("fg"),
+                &[process],
+            ),
+            "ed20b7d3f9b23ee99174237c2e9596c0ff6b87b97666816489d05a75b8a4e977"
+        );
+    }
+
+    #[test]
+    fn process_generation_replacement_changes_fingerprint() {
+        let base = PaneProcessInfoProcess {
+            pid: 7,
+            generation: "a".repeat(64),
+            name: "worker".into(),
+            argv0: Some("worker".into()),
+            argv: Some(vec!["worker".into()]),
+            cmdline: Some("worker".into()),
+            cwd: Some("/checkout".into()),
+        };
+        let mut replacement = base.clone();
+        replacement.generation = "b".repeat(64);
+        let first = canonical_process_fingerprint(
+            "pane",
+            "term",
+            1,
+            Some(1),
+            Some("shell"),
+            Some(7),
+            Some("group"),
+            &[base],
+        );
+        let second = canonical_process_fingerprint(
+            "pane",
+            "term",
+            1,
+            Some(1),
+            Some("shell"),
+            Some(7),
+            Some("group"),
+            &[replacement],
+        );
+        assert_ne!(first, second);
+    }
+
     fn app_with_test_workspace() -> (App, String) {
         let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut app = App::new(
@@ -2288,6 +2663,221 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn pane_process_observation_for(app: &mut App, pane_id: String) -> PaneProcessObservation {
+        let (ws_idx, internal_pane_id) = app.parse_pane_id(&pane_id).unwrap();
+        let terminal_id = app
+            .state
+            .terminal_id_for_pane(ws_idx, internal_pane_id)
+            .unwrap()
+            .clone();
+        app.terminal_runtimes.insert(
+            terminal_id,
+            crate::terminal::TerminalRuntime::test_with_screen_bytes(80, 24, b""),
+        );
+
+        let response = app.handle_pane_process_info(
+            "observe".into(),
+            PaneProcessInfoParams {
+                pane_id: Some(pane_id),
+            },
+        );
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        let ResponseResult::PaneProcessInfo { process_info } = success.result else {
+            panic!("expected pane process info response");
+        };
+        process_info.observation
+    }
+
+    #[tokio::test]
+    async fn api_pane_close_if_exact_match_echoes_receipt_and_removes_pane() {
+        let (mut app, _) = app_with_test_workspace();
+        let target_pane = app.state.workspaces[0].tabs[0].root_pane;
+        let _other_pane =
+            app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let public_pane_id = app.public_pane_id(0, target_pane).unwrap();
+        let observation = pane_process_observation_for(&mut app, public_pane_id.clone());
+
+        let response = app.handle_pane_close_if(
+            "close-if-request".into(),
+            crate::api::schema::PaneCloseIfParams {
+                pane_id: public_pane_id.clone(),
+                request_id: "close-if-attempt".into(),
+                observation: observation.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "close-if-request");
+        let ResponseResult::PaneCloseIf {
+            outcome: PaneCloseIfOutcome::Closed { receipt },
+        } = success.result
+        else {
+            panic!("expected pane close_if closed response");
+        };
+        assert_eq!(receipt.request_id, "close-if-attempt");
+        assert_eq!(receipt.pane_id, public_pane_id);
+        assert_eq!(receipt.terminal_id, observation.terminal_id);
+        assert_eq!(receipt.observation, observation);
+        assert!(app.pane_info(0, target_pane).is_none());
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(target_pane)
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn api_pane_close_if_stale_observations_fail_with_current_without_mutation() {
+        let (mut app, _) = app_with_test_workspace();
+        let target_pane = app.state.workspaces[0].tabs[0].root_pane;
+        let _other_pane =
+            app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let public_pane_id = app.public_pane_id(0, target_pane).unwrap();
+        let current = pane_process_observation_for(&mut app, public_pane_id.clone());
+
+        for mismatch in 0..4 {
+            let mut stale = current.clone();
+            match mismatch {
+                0 => stale.terminal_id = "stale-terminal".into(),
+                1 => stale.revision = stale.revision.saturating_add(1),
+                2 => stale.process_generation = "f".repeat(64),
+                3 => stale.process_fingerprint = "e".repeat(64),
+                _ => unreachable!(),
+            }
+
+            let response = app.handle_pane_close_if(
+                format!("stale-{mismatch}"),
+                crate::api::schema::PaneCloseIfParams {
+                    pane_id: public_pane_id.clone(),
+                    request_id: format!("stale-request-{mismatch}"),
+                    observation: stale,
+                },
+            );
+
+            let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+            assert_eq!(success.id, format!("stale-{mismatch}"));
+            let ResponseResult::PaneCloseIf {
+                outcome: PaneCloseIfOutcome::PreconditionFailed { current: observed },
+            } = success.result
+            else {
+                panic!("expected pane close_if precondition failure for mismatch {mismatch}");
+            };
+            assert_eq!(observed, current);
+            assert!(app.pane_info(0, target_pane).is_some());
+            assert!(app.state.workspaces[0]
+                .find_tab_index_for_pane(target_pane)
+                .is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn api_pane_close_if_empty_request_id_fails_without_mutation() {
+        let (mut app, _) = app_with_test_workspace();
+        let target_pane = app.state.workspaces[0].tabs[0].root_pane;
+        let _other_pane =
+            app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let public_pane_id = app.public_pane_id(0, target_pane).unwrap();
+        let observation = pane_process_observation_for(&mut app, public_pane_id.clone());
+
+        let response = app.handle_pane_close_if(
+            "empty-request-id".into(),
+            crate::api::schema::PaneCloseIfParams {
+                pane_id: public_pane_id,
+                request_id: String::new(),
+                observation: observation.clone(),
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        let ResponseResult::PaneCloseIf {
+            outcome: PaneCloseIfOutcome::PreconditionFailed { current },
+        } = success.result
+        else {
+            panic!("expected pane close_if precondition failure");
+        };
+        assert_eq!(current, observation);
+        assert!(app.pane_info(0, target_pane).is_some());
+        assert!(app.state.workspaces[0]
+            .find_tab_index_for_pane(target_pane)
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn api_pane_close_if_missing_pane_reports_not_found_without_mutation() {
+        let (mut app, _) = app_with_test_workspace();
+        let target_pane = app.state.workspaces[0].tabs[0].root_pane;
+        let public_pane_id = app.public_pane_id(0, target_pane).unwrap();
+        let observation = pane_process_observation_for(&mut app, public_pane_id);
+
+        let response = app.handle_pane_close_if(
+            "missing-close-if".into(),
+            crate::api::schema::PaneCloseIfParams {
+                pane_id: "not-a-pane".into(),
+                request_id: "missing-request".into(),
+                observation,
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "missing-close-if");
+        assert!(matches!(
+            success.result,
+            ResponseResult::PaneCloseIf {
+                outcome: PaneCloseIfOutcome::NotFound {}
+            }
+        ));
+        assert!(app.pane_info(0, target_pane).is_some());
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[tokio::test]
+    async fn api_pane_close_if_unsupported_reports_outcome_without_mutation() {
+        let (mut app, public_pane_id) = app_with_test_workspace();
+        let target_pane = app.state.workspaces[0].tabs[0].root_pane;
+        let observation = pane_process_observation_for(&mut app, public_pane_id.clone());
+
+        let response = app.handle_pane_close_if(
+            "unsupported-close-if".into(),
+            crate::api::schema::PaneCloseIfParams {
+                pane_id: public_pane_id,
+                request_id: "unsupported-request".into(),
+                observation,
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert!(matches!(
+            success.result,
+            ResponseResult::PaneCloseIf {
+                outcome: PaneCloseIfOutcome::Unsupported {}
+            }
+        ));
+        assert!(app.pane_info(0, target_pane).is_some());
+    }
+
+    #[tokio::test]
+    async fn api_pane_close_legacy_still_closes_target_pane() {
+        let (mut app, _) = app_with_test_workspace();
+        let target_pane = app.state.workspaces[0].tabs[0].root_pane;
+        let _other_pane =
+            app.state.workspaces[0].test_split(ratatui::layout::Direction::Horizontal);
+        app.state.ensure_test_terminals();
+        let public_pane_id = app.public_pane_id(0, target_pane).unwrap();
+
+        let response = app.handle_pane_close(
+            "legacy-close".into(),
+            PaneTarget {
+                pane_id: public_pane_id,
+            },
+        );
+
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert_eq!(success.id, "legacy-close");
+        assert_eq!(success.result, ResponseResult::Ok {});
+        assert!(app.pane_info(0, target_pane).is_none());
     }
 
     #[test]

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -2251,6 +2251,7 @@ command = ["sh", "-c", "printf %s ${{HERDR_PANE_ID-unset}} > '{}'; sleep 1"]
                     open_workspace_id: Some(workspace.workspace_id),
                     label: "feature".into(),
                 },
+                receipt: None,
             },
         });
         assert_eq!(app.state.plugin_command_logs.len(), logs_before);
@@ -2526,6 +2527,7 @@ command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > {}"]
                     open_workspace_id: Some(target_workspace.workspace_id.clone()),
                     label: "feature".into(),
                 },
+                receipt: None,
             },
         });
 
@@ -2664,6 +2666,7 @@ command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > {}"]
                     workspace: Some(workspace.clone()),
                     worktree: worktree.clone(),
                     forced: true,
+                    receipt: None,
                 },
             },
             "worktree.removed",
@@ -2685,6 +2688,7 @@ command = ["sh", "-c", "printf '%s' \"$HERDR_PLUGIN_CONTEXT_JSON\" > {}"]
                     workspace: Some(workspace),
                     worktree,
                     forced: true,
+                    receipt: None,
                 },
             },
             "worktree.removed",

--- a/src/app/api/worktrees.rs
+++ b/src/app/api/worktrees.rs
@@ -602,11 +602,21 @@ impl App {
     }
 
     pub(crate) fn emit_worktree_created_event(&mut self, ws_idx: usize, worktree: WorktreeInfo) {
+        self.emit_worktree_created_event_with_receipt(ws_idx, worktree, None);
+    }
+
+    pub(crate) fn emit_worktree_created_event_with_receipt(
+        &mut self,
+        ws_idx: usize,
+        worktree: WorktreeInfo,
+        receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
+    ) {
         self.emit_event(EventEnvelope {
             event: EventKind::WorktreeCreated,
             data: EventData::WorktreeCreated {
                 workspace: self.workspace_info(ws_idx),
                 worktree,
+                receipt,
             },
         });
     }
@@ -642,6 +652,23 @@ impl App {
         worktree: WorktreeInfo,
         forced: bool,
     ) {
+        self.emit_worktree_removed_event_with_receipt(
+            workspace_id,
+            workspace,
+            worktree,
+            forced,
+            None,
+        );
+    }
+
+    pub(crate) fn emit_worktree_removed_event_with_receipt(
+        &mut self,
+        workspace_id: String,
+        workspace: Option<crate::api::schema::WorkspaceInfo>,
+        worktree: WorktreeInfo,
+        forced: bool,
+        receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
+    ) {
         self.emit_event(EventEnvelope {
             event: EventKind::WorktreeRemoved,
             data: EventData::WorktreeRemoved {
@@ -649,6 +676,7 @@ impl App {
                 workspace,
                 worktree,
                 forced,
+                receipt,
             },
         });
     }
@@ -898,6 +926,7 @@ mod tests {
             tab,
             root_pane,
             worktree,
+            ..
         } = success.result
         else {
             panic!("expected worktree_created response");
@@ -927,6 +956,7 @@ mod tests {
                 EventData::WorktreeCreated {
                     workspace: event_workspace,
                     worktree: event_worktree,
+                    ..
                 } if event_workspace.workspace_id == workspace.workspace_id
                     && event_worktree.branch.as_deref() == Some("worktree/api-create")
                     && event_worktree.is_linked_worktree
@@ -1191,10 +1221,13 @@ mod tests {
                 source_repo_root: repo.clone(),
                 repo_key: "repo-key".into(),
                 repo_name: "herdr".into(),
+                branch: "worktree/test".into(),
+                permit: None,
                 label: None,
                 focus: false,
                 respond_to,
             }),
+            receipt: None,
             result: Ok(()),
         });
 
@@ -1767,6 +1800,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
         );
@@ -1782,6 +1816,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id,
                     force: true,
+                    permit: None,
                 }),
             },
         );
@@ -1838,6 +1873,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
         );
@@ -1869,6 +1905,7 @@ mod tests {
                     workspace: Some(workspace),
                     worktree,
                     forced,
+                    ..
                 } if workspace_id == &child_id
                     && workspace.workspace_id == child_id
                     && worktree.branch.as_deref() == Some("worktree/api-remove-event")
@@ -1923,6 +1960,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
             respond_to,
@@ -1996,6 +2034,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id.clone(),
                     force: false,
+                    permit: None,
                 }),
             },
             first_tx,
@@ -2006,6 +2045,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id,
                     force: false,
+                    permit: None,
                 }),
             },
             second_tx,
@@ -2065,6 +2105,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: first_id,
                     force: true,
+                    permit: None,
                 }),
             },
             first_tx,
@@ -2075,6 +2116,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: second_id,
                     force: true,
+                    permit: None,
                 }),
             },
             second_tx,
@@ -2110,6 +2152,7 @@ mod tests {
                     path: Some(checkout.display().to_string()),
                     label: None,
                     focus: false,
+                    permit: None,
                 }),
             },
             respond_to,
@@ -2164,6 +2207,7 @@ mod tests {
                 method: crate::api::schema::Method::WorktreeRemove(WorktreeRemoveParams {
                     workspace_id: child_id,
                     force: false,
+                    permit: None,
                 }),
             },
             respond_to,
@@ -2220,9 +2264,11 @@ mod tests {
                 id: "req".into(),
                 operation_id: 7,
                 checkout_key: crate::worktree::canonical_or_original(&checkout),
+                permit: None,
                 respond_to,
             }),
             result: Ok(()),
+            receipt: None,
         });
 
         let response = response_rx

--- a/src/app/api/worktrees/deferred.rs
+++ b/src/app/api/worktrees/deferred.rs
@@ -3,13 +3,92 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::schema::{
     EventData, EventEnvelope, EventKind, Request, ResponseResult, WorktreeCreateParams,
-    WorktreeRemoveParams,
+    WorktreeExactPermit, WorktreeMutationReceipt, WorktreeRemoveParams,
 };
 use crate::app::App;
 use crate::events::{ApiWorktreeAddRequest, ApiWorktreeRemoveRequest, AppEvent};
 
 use super::super::responses::{encode_error, encode_success};
 use super::{absolute_user_path, WorktreeSource};
+
+fn validate_permit(permit: &WorktreeExactPermit) -> Result<(), (&'static str, &'static str)> {
+    if permit.repo_common_dir.trim().is_empty()
+        || permit.checkout_path.trim().is_empty()
+        || permit.branch.trim().is_empty()
+        || permit.head_oid.trim().is_empty()
+    {
+        return Err(("incomplete_permit", "all exact permit fields are required"));
+    }
+    if !Path::new(&permit.repo_common_dir).is_absolute()
+        || !Path::new(&permit.checkout_path).is_absolute()
+    {
+        return Err(("invalid_permit", "permit paths must be absolute"));
+    }
+    if !matches!(permit.head_oid.len(), 40 | 64)
+        || !permit.head_oid.chars().all(|ch| ch.is_ascii_hexdigit())
+    {
+        return Err((
+            "invalid_permit",
+            "permit head_oid must be a full hexadecimal object ID",
+        ));
+    }
+    Ok(())
+}
+
+fn oid_matches(actual: &str, permitted: &str) -> bool {
+    actual.eq_ignore_ascii_case(permitted)
+}
+
+fn identity_matches(
+    identity: &crate::worktree::WorktreeIdentity,
+    permit: &WorktreeExactPermit,
+) -> bool {
+    crate::worktree::canonical_or_original(Path::new(&permit.repo_common_dir))
+        == identity.repo_common_dir
+        && crate::worktree::canonical_or_original(Path::new(&permit.checkout_path))
+            == identity.checkout_path
+        && identity.branch.as_deref() == Some(permit.branch.as_str())
+        && oid_matches(&identity.head_oid, &permit.head_oid)
+}
+
+fn receipt_from_identity(
+    operation: &str,
+    identity: &crate::worktree::WorktreeIdentity,
+) -> Result<WorktreeMutationReceipt, &'static str> {
+    let Some(branch) = identity.branch.clone() else {
+        return Err("identity mismatch: worktree is detached");
+    };
+    Ok(WorktreeMutationReceipt {
+        operation: operation.to_string(),
+        repo_common_dir: identity.repo_common_dir.display().to_string(),
+        checkout_path: identity.checkout_path.display().to_string(),
+        branch,
+        head_oid: identity.head_oid.clone(),
+    })
+}
+
+fn rollback_invalid_managed_create(
+    source_checkout_path: &Path,
+    checkout_path: &Path,
+    permit: &WorktreeExactPermit,
+    mismatch: &str,
+) -> String {
+    let cleanup =
+        crate::worktree::build_worktree_remove_command(source_checkout_path, checkout_path, false);
+    let cleanup_result = crate::worktree::run_worktree_command(&cleanup).and_then(|()| {
+        crate::worktree::delete_local_branch_if_matches(
+            source_checkout_path,
+            &permit.branch,
+            &permit.head_oid,
+        )
+    });
+    match cleanup_result {
+        Ok(()) => format!("identity mismatch: {mismatch}"),
+        Err(cleanup_error) => {
+            format!("identity mismatch: {mismatch}; managed cleanup failed: {cleanup_error}")
+        }
+    }
+}
 
 impl App {
     pub(crate) fn handle_deferred_worktree_api_request(
@@ -97,8 +176,27 @@ impl App {
         params: WorktreeCreateParams,
         respond_to: std::sync::mpsc::Sender<String>,
     ) {
+        let managed_permit = params.permit.clone();
+        if let Some(permit) = managed_permit.as_ref() {
+            if let Err((code, message)) = validate_permit(permit) {
+                Self::send_api_response(respond_to, encode_error(id, code, message));
+                return;
+            }
+            if params.path.is_none() || params.branch.is_none() || params.base.is_none() {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "incomplete_permit",
+                        "managed create requires explicit path, branch, and base",
+                    ),
+                );
+                return;
+            }
+        }
         let branch = params
             .branch
+            .clone()
             .unwrap_or_else(|| {
                 let seed = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -115,7 +213,7 @@ impl App {
             );
             return;
         }
-        let base = params.base.unwrap_or_else(|| "HEAD".into());
+        let base = params.base.clone().unwrap_or_else(|| "HEAD".into());
         let source = match self.resolve_worktree_source(params.workspace_id, params.cwd) {
             Ok(source) => source,
             Err(err) => {
@@ -123,6 +221,55 @@ impl App {
                 return;
             }
         };
+        if let Some(permit) = managed_permit.as_ref() {
+            let identity =
+                match crate::worktree::read_worktree_identity(&source.source_checkout_path) {
+                    Ok(identity) => identity,
+                    Err(message) => {
+                        Self::send_api_response(
+                            respond_to,
+                            encode_error(id, "identity_mismatch", message),
+                        );
+                        return;
+                    }
+                };
+            if crate::worktree::canonical_or_original(Path::new(&permit.repo_common_dir))
+                != identity.repo_common_dir
+                || branch != permit.branch
+            {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "live source identity does not match permit",
+                    ),
+                );
+                return;
+            }
+            let resolved_base =
+                match crate::worktree::resolve_git_revision(&source.source_checkout_path, &base) {
+                    Ok(oid) => oid,
+                    Err(message) => {
+                        Self::send_api_response(
+                            respond_to,
+                            encode_error(id, "identity_mismatch", message),
+                        );
+                        return;
+                    }
+                };
+            if !oid_matches(&resolved_base, &permit.head_oid) {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "resolved base does not match permit head_oid",
+                    ),
+                );
+                return;
+            }
+        }
         let checkout_path = match params.path {
             Some(path) => match absolute_user_path(&path) {
                 Ok(path) => path,
@@ -137,6 +284,21 @@ impl App {
                 &branch,
             ),
         };
+        if let Some(permit) = managed_permit.as_ref() {
+            if crate::worktree::canonical_or_original(Path::new(&permit.checkout_path))
+                != crate::worktree::canonical_or_original(&checkout_path)
+            {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "checkout path does not match permit",
+                    ),
+                );
+                return;
+            }
+        }
         let checkout_key = crate::worktree::canonical_or_original(&checkout_path);
         if self
             .pending_api_worktree_creates
@@ -180,6 +342,8 @@ impl App {
             source_repo_root: source.source_repo_root,
             repo_key: source.repo_key,
             repo_name: source.repo_name,
+            branch,
+            permit: managed_permit,
             label: params.label,
             focus: params.focus,
             respond_to,
@@ -188,23 +352,69 @@ impl App {
         let source_checkout_path = api_request.source_checkout_path.clone();
         let event_tx = self.event_tx.clone();
         std::thread::spawn(move || {
-            let result = if let Some(parent_dir) = parent_dir {
-                std::fs::create_dir_all(&parent_dir).map_err(|err| err.to_string())
+            let (result, receipt) = if let Some(permit) = api_request.permit.as_ref() {
+                let result = if let Some(parent_dir) = parent_dir {
+                    std::fs::create_dir_all(&parent_dir).map_err(|err| err.to_string())
+                } else {
+                    Ok(())
+                }
+                .and_then(|()| {
+                    let command = crate::worktree::build_worktree_add_new_branch_command(
+                        &source_checkout_path,
+                        &path,
+                        &api_request.branch,
+                        &permit.head_oid,
+                    );
+                    crate::worktree::run_worktree_command(&command)
+                })
+                .and_then(|()| {
+                    let identity = match crate::worktree::read_worktree_identity(&path) {
+                        Ok(identity) => identity,
+                        Err(message) => {
+                            return Err(rollback_invalid_managed_create(
+                                &source_checkout_path,
+                                &path,
+                                permit,
+                                &message,
+                            ));
+                        }
+                    };
+                    if !identity_matches(&identity, permit) {
+                        return Err(rollback_invalid_managed_create(
+                            &source_checkout_path,
+                            &path,
+                            permit,
+                            "created worktree does not match permit",
+                        ));
+                    }
+                    receipt_from_identity("create", &identity)
+                        .map_err(|message| message.to_string())
+                });
+                match result {
+                    Ok(receipt) => (Ok(()), Some(receipt)),
+                    Err(message) => (Err(message), None),
+                }
             } else {
-                Ok(())
-            }
-            .and_then(|()| {
-                crate::worktree::run_worktree_add_command(
-                    &source_checkout_path,
-                    &path,
-                    &branch,
-                    &base,
-                )
-            });
+                let result = if let Some(parent_dir) = parent_dir {
+                    std::fs::create_dir_all(&parent_dir).map_err(|err| err.to_string())
+                } else {
+                    Ok(())
+                }
+                .and_then(|()| {
+                    crate::worktree::run_worktree_add_command(
+                        &source_checkout_path,
+                        &path,
+                        &api_request.branch,
+                        &base,
+                    )
+                });
+                (result, None)
+            };
             let _ = event_tx.blocking_send(AppEvent::WorktreeAddFinished(Box::new(
                 crate::events::WorktreeAddResult {
                     path,
                     api_request: Some(api_request),
+                    receipt,
                     result,
                 },
             )));
@@ -254,6 +464,37 @@ impl App {
                 ),
             );
             return;
+        }
+        let managed_permit = params.permit.clone();
+        if let Some(permit) = managed_permit.as_ref() {
+            if let Err((code, message)) = validate_permit(permit) {
+                Self::send_api_response(respond_to, encode_error(id, code, message));
+                return;
+            }
+            if params.force {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "forbidden_force",
+                        "force is forbidden for managed worktree removal",
+                    ),
+                );
+                return;
+            }
+            if crate::worktree::canonical_or_original(Path::new(&permit.checkout_path))
+                != crate::worktree::canonical_or_original(&space.checkout_path)
+            {
+                Self::send_api_response(
+                    respond_to,
+                    encode_error(
+                        id,
+                        "identity_mismatch",
+                        "checkout path does not match permit",
+                    ),
+                );
+                return;
+            }
         }
 
         #[cfg(windows)]
@@ -307,15 +548,11 @@ impl App {
             .insert(checkout_key.clone(), operation_id);
         let workspace_snapshot = self.workspace_info(ws_idx);
         let worktree = self.worktree_info_for_membership(&space, None);
-        let command = crate::worktree::build_worktree_remove_command(
-            &space.repo_root,
-            &space.checkout_path,
-            params.force,
-        );
         let api_request = ApiWorktreeRemoveRequest {
             id,
             operation_id,
             checkout_key,
+            permit: managed_permit.clone(),
             respond_to,
         };
         let repo_root = space.repo_root;
@@ -323,9 +560,42 @@ impl App {
         let force = params.force;
         let event_tx = self.event_tx.clone();
         std::thread::spawn(move || {
-            let result = crate::worktree::run_worktree_remove_command_with_recovery(
-                &command, &repo_root, &path, force,
-            );
+            let (result, receipt) = if let Some(permit) = api_request.permit.as_ref() {
+                match crate::worktree::read_worktree_identity(&path) {
+                    Ok(identity) if identity_matches(&identity, permit) => {
+                        let receipt = receipt_from_identity("remove", &identity)
+                            .map_err(|message| message.to_string());
+                        let command = crate::worktree::build_worktree_remove_command(
+                            &repo_root, &path, false,
+                        );
+                        let result = receipt.and_then(|receipt| {
+                            crate::worktree::run_worktree_command(&command)?;
+                            if crate::worktree::worktree_list_contains_path(&repo_root, &path)? {
+                                return Err("worktree removal did not clear Git inventory".into());
+                            }
+                            Ok(receipt)
+                        });
+                        match result {
+                            Ok(receipt) => (Ok(()), Some(receipt)),
+                            Err(message) => (Err(message), None),
+                        }
+                    }
+                    Ok(_) => (
+                        Err("identity mismatch: live worktree does not match permit".into()),
+                        None,
+                    ),
+                    Err(message) => (Err(format!("identity mismatch: {message}")), None),
+                }
+            } else {
+                let command =
+                    crate::worktree::build_worktree_remove_command(&repo_root, &path, force);
+                (
+                    crate::worktree::run_worktree_remove_command_with_recovery(
+                        &command, &repo_root, &path, force,
+                    ),
+                    None,
+                )
+            };
             let _ = event_tx.blocking_send(AppEvent::WorktreeRemoveFinished(Box::new(
                 crate::events::WorktreeRemoveResult {
                     workspace_id: workspace_internal_id,
@@ -333,6 +603,7 @@ impl App {
                     workspace: Some(Box::new(workspace_snapshot)),
                     worktree: Some(Box::new(worktree)),
                     forced: force,
+                    receipt,
                     api_request: Some(api_request),
                     result,
                 },
@@ -372,9 +643,22 @@ impl App {
                     create.error = Some(err.clone());
                 }
             }
+            let code = if api.permit.is_some() && err.starts_with("identity mismatch") {
+                "identity_mismatch"
+            } else {
+                "worktree_create_failed"
+            };
+            Self::send_api_response(api.respond_to, encode_error(api.id, code, err));
+            return;
+        }
+        if api.permit.is_some() && result.receipt.is_none() {
             Self::send_api_response(
                 api.respond_to,
-                encode_error(api.id, "worktree_create_failed", err),
+                encode_error(
+                    api.id,
+                    "identity_mismatch",
+                    "managed create completed without an exact receipt",
+                ),
             );
             return;
         }
@@ -448,12 +732,13 @@ impl App {
                 encode_error(
                     api.id,
                     "worktree_open_failed",
-                    "created worktree but failed to record workspace membership",
+                    "created workspace has no linked worktree identity",
                 ),
             );
             return;
         };
-        self.emit_worktree_created_event(ws_idx, worktree.clone());
+        let receipt = result.receipt.clone();
+        self.emit_worktree_created_event_with_receipt(ws_idx, worktree.clone(), receipt.clone());
         let tab_idx = self.state.workspaces[ws_idx].active_tab;
         let response = encode_success(
             api.id,
@@ -466,6 +751,7 @@ impl App {
                     .root_pane_info(ws_idx, tab_idx)
                     .expect("created worktree workspace should have an active root pane"),
                 worktree,
+                receipt,
             },
         );
         Self::send_api_response(api.respond_to, response);
@@ -503,12 +789,13 @@ impl App {
             .remove(&api.checkout_key);
 
         if let Err(message) = result.result {
-            let code =
-                if !result.forced && crate::worktree::is_dirty_worktree_remove_error(&message) {
-                    "dirty_worktree_requires_force"
-                } else {
-                    "worktree_remove_failed"
-                };
+            let code = if api.permit.is_some() && message.starts_with("identity mismatch") {
+                "identity_mismatch"
+            } else if !result.forced && crate::worktree::is_dirty_worktree_remove_error(&message) {
+                "dirty_worktree_requires_force"
+            } else {
+                "worktree_remove_failed"
+            };
             if let Some(remove) = &mut self.state.worktree_remove {
                 if remove.workspace_id == result.workspace_id && remove.path == result.path {
                     remove.removing = false;
@@ -575,11 +862,24 @@ impl App {
             );
             return;
         };
-        self.emit_worktree_removed_event(
+        if api.permit.is_some() && result.receipt.is_none() {
+            Self::send_api_response(
+                api.respond_to,
+                encode_error(
+                    api.id,
+                    "identity_mismatch",
+                    "managed remove completed without an exact receipt",
+                ),
+            );
+            return;
+        }
+        let receipt = result.receipt.clone();
+        self.emit_worktree_removed_event_with_receipt(
             workspace_id.clone(),
             workspace_snapshot,
             worktree,
             result.forced,
+            receipt.clone(),
         );
         if self.state.worktree_remove.as_ref().is_some_and(|remove| {
             remove.workspace_id == result.workspace_id && remove.path == result.path
@@ -597,8 +897,59 @@ impl App {
                 workspace_id,
                 path: result.path.display().to_string(),
                 forced: result.forced,
+                receipt,
             },
         );
         Self::send_api_response(api.respond_to, response);
+    }
+}
+
+#[cfg(test)]
+mod permit_tests {
+    use super::*;
+    use std::path::Path;
+
+    fn permit() -> WorktreeExactPermit {
+        WorktreeExactPermit {
+            repo_common_dir: "/repo/.git".into(),
+            checkout_path: "/repo/worktree".into(),
+            branch: "feature".into(),
+            head_oid: "0123456789abcdef0123456789abcdef01234567".into(),
+        }
+    }
+
+    #[test]
+    fn incomplete_permit_is_rejected() {
+        let mut permit = permit();
+        permit.branch.clear();
+        assert_eq!(
+            validate_permit(&permit),
+            Err(("incomplete_permit", "all exact permit fields are required"))
+        );
+    }
+
+    #[test]
+    fn identity_mismatch_is_fail_closed() {
+        let identity = crate::worktree::WorktreeIdentity {
+            repo_common_dir: Path::new("/repo/.git").to_path_buf(),
+            checkout_path: Path::new("/repo/worktree").to_path_buf(),
+            branch: Some("other".into()),
+            head_oid: "0123456789abcdef0123456789abcdef01234567".into(),
+        };
+        assert!(!identity_matches(&identity, &permit()));
+    }
+
+    #[test]
+    fn receipt_uses_git_identity_and_operation() {
+        let identity = crate::worktree::WorktreeIdentity {
+            repo_common_dir: Path::new("/repo/.git").to_path_buf(),
+            checkout_path: Path::new("/repo/worktree").to_path_buf(),
+            branch: Some("feature".into()),
+            head_oid: "0123456789abcdef0123456789abcdef01234567".into(),
+        };
+        let receipt = receipt_from_identity("remove", &identity).unwrap();
+        assert_eq!(receipt.operation, "remove");
+        assert_eq!(receipt.branch, "feature");
+        assert_eq!(receipt.head_oid, identity.head_oid);
     }
 }

--- a/src/app/worktrees.rs
+++ b/src/app/worktrees.rs
@@ -557,6 +557,7 @@ impl App {
                 WorktreeAddResult {
                     path,
                     api_request: None,
+                    receipt: None,
                     result,
                 },
             )));
@@ -599,6 +600,7 @@ impl App {
                 base: Some("HEAD".into()),
                 focus: true,
                 label: None,
+                permit: None,
             },
         );
         if let Some(message) = immediate_api_error_message(immediate_response.as_deref()) {
@@ -700,6 +702,7 @@ impl App {
                     workspace: workspace_snapshot,
                     worktree: worktree_snapshot,
                     forced: force,
+                    receipt: None,
                     api_request: None,
                     result,
                 },
@@ -767,6 +770,7 @@ impl App {
             crate::api::schema::WorktreeRemoveParams {
                 workspace_id,
                 force,
+                permit: None,
             },
         );
         if let Some(message) = immediate_api_error_message(immediate_response.as_deref()) {
@@ -1767,6 +1771,7 @@ mod tests {
         app.handle_worktree_add_finished(WorktreeAddResult {
             path: checkout.clone(),
             api_request: None,
+            receipt: None,
             result: Ok(()),
         });
 
@@ -1806,6 +1811,7 @@ mod tests {
         let crate::api::schema::EventData::WorktreeCreated {
             workspace,
             worktree,
+            ..
         } = &worktree_created.data
         else {
             panic!("unexpected event data");
@@ -1862,6 +1868,7 @@ mod tests {
         app.handle_worktree_add_finished(WorktreeAddResult {
             path: checkout.clone(),
             api_request: None,
+            receipt: None,
             result: Ok(()),
         });
 
@@ -2121,6 +2128,7 @@ mod tests {
             worktree: None,
             forced: false,
             api_request: None,
+            receipt: None,
             result: Err(
                 "fatal: '/w/herdr/dirty' contains modified or untracked files, use --force to delete it"
                     .into(),
@@ -2153,6 +2161,7 @@ mod tests {
             worktree: None,
             forced: false,
             api_request: None,
+            receipt: None,
             result: Err("fatal: '/w/herdr/missing' is not a working tree".into()),
         });
 
@@ -2214,6 +2223,7 @@ mod tests {
             workspace: None,
             worktree: None,
             forced: false,
+            receipt: None,
             api_request: None,
             result: Ok(()),
         });
@@ -2267,6 +2277,7 @@ mod tests {
             workspace: Some(Box::new(workspace_snapshot.clone())),
             worktree: Some(Box::new(worktree_snapshot)),
             forced: true,
+            receipt: None,
             api_request: None,
             result: Ok(()),
         });
@@ -2283,6 +2294,7 @@ mod tests {
                     workspace: Some(workspace),
                     worktree,
                     forced,
+                    ..
                 } if workspace_id == &workspace_snapshot.workspace_id
                     && workspace.workspace_id == workspace_snapshot.workspace_id
                     && worktree.branch.as_deref() == Some("worktree/issue")

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,5 +1,15 @@
 //! Build identity helpers.
 
+use std::sync::OnceLock;
+
+static EXECUTABLE_SHA256: OnceLock<Option<String>> = OnceLock::new();
+static RELEASE_MANIFEST_DIGEST: OnceLock<Option<String>> = OnceLock::new();
+
+pub fn initialize() {
+    let _ = EXECUTABLE_SHA256.get_or_init(compute_executable_sha256);
+    let _ = RELEASE_MANIFEST_DIGEST.get_or_init(read_release_manifest_digest);
+}
+
 pub const BASE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn channel() -> &'static str {
@@ -18,6 +28,51 @@ pub fn version() -> String {
             None => format!("{BASE_VERSION}-{channel}"),
         },
     }
+}
+
+pub fn source_commit() -> Option<&'static str> {
+    non_empty(option_env!("HERDR_BUILD_COMMIT"))
+}
+
+pub fn release_manifest_digest() -> Option<String> {
+    RELEASE_MANIFEST_DIGEST
+        .get_or_init(read_release_manifest_digest)
+        .clone()
+}
+
+pub fn executable_sha256() -> Option<String> {
+    EXECUTABLE_SHA256
+        .get_or_init(compute_executable_sha256)
+        .clone()
+}
+
+fn read_release_manifest_digest() -> Option<String> {
+    validated_sha256(std::env::var("HERDR_RELEASE_MANIFEST_DIGEST").ok())
+}
+
+fn compute_executable_sha256() -> Option<String> {
+    let path = std::env::current_exe().ok()?;
+    let bytes = std::fs::read(path).ok()?;
+    Some(hex_digest(&bytes))
+}
+
+fn validated_sha256(value: Option<String>) -> Option<String> {
+    let value = value?;
+    (value.len() == 64
+        && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && value.bytes().all(|byte| !byte.is_ascii_uppercase()))
+    .then_some(value)
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
 }
 
 pub fn is_preview() -> bool {

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -31,6 +31,7 @@ pub(super) fn run_pane_command(args: &[String]) -> std::io::Result<i32> {
         "input" => pane_input(&args[1..]),
         "split" => pane_split(&args[1..]),
         "swap" => pane_swap(&args[1..]),
+        "move" => pane_move(&args[1..]),
         "close" => pane_close(&args[1..]),
         "close-if" => pane_close_if(&args[1..]),
         "send-text" => pane_send_text(&args[1..]),

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1,43 +1,12 @@
 use crate::api::schema::{
-1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
-    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
-    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
-    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
-    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
-    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
-    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
-    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
-    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
-    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
-    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
-    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
-2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
+    Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
     PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
     PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
     PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
     PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
-    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
-3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
-    PaneMoveParams,
-4:     build_info::initialize();
-    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
-        Ok(args) => args,
-        Err(err) => {
-            eprintln!("error: {err}");
-            eprintln!("run 'herdr --help' for usage");
-            std::process::exit(2);
-        }
-    };
-5: /// Return the native process creation-time generation for PID-reuse resistance.
-pub fn process_generation(pid: u32) -> Option<String> {
-    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
-    process_creation_time(process.0).map(|value| value.to_string())
-}
-
-fn select_pane_foreground_job_from_snapshot(
-    PaneSendKeysParams, PaneSendTextParams, PaneSplitParams, PaneSwapParams, PaneTarget,
-    PaneWaitForOutputParams, PaneZoomMode, PaneZoomParams, ReadFormat, ReadSource, Request,
-    SplitDirection,
+    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams, PaneSendKeysParams,
+    PaneSendTextParams, PaneSplitParams, PaneSwapParams, PaneTarget, PaneWaitForOutputParams,
+    PaneZoomMode, PaneZoomParams, ReadFormat, ReadSource, Request, SplitDirection,
 };
 
 pub(super) fn run_pane_command(args: &[String]) -> std::io::Result<i32> {

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1,9 +1,40 @@
 use crate::api::schema::{
-    Method, OutputMatch, PaneCurrentParams, PaneDirection, PaneEdgesParams,
+1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
+    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
+    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
+    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
+    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
+    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
+    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
+    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
+    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
+    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
+    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
+    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
+2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
     PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
-    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams, PaneReadParams,
-    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams, PaneReportAgentSessionParams,
-    PaneReportMetadataParams, PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
+    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
+    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
+    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
+    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
+3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
+    PaneMoveParams,
+4:     build_info::initialize();
+    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("error: {err}");
+            eprintln!("run 'herdr --help' for usage");
+            std::process::exit(2);
+        }
+    };
+5: /// Return the native process creation-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    process_creation_time(process.0).map(|value| value.to_string())
+}
+
+fn select_pane_foreground_job_from_snapshot(
     PaneSendKeysParams, PaneSendTextParams, PaneSplitParams, PaneSwapParams, PaneTarget,
     PaneWaitForOutputParams, PaneZoomMode, PaneZoomParams, ReadFormat, ReadSource, Request,
     SplitDirection,
@@ -31,8 +62,8 @@ pub(super) fn run_pane_command(args: &[String]) -> std::io::Result<i32> {
         "input" => pane_input(&args[1..]),
         "split" => pane_split(&args[1..]),
         "swap" => pane_swap(&args[1..]),
-        "move" => pane_move(&args[1..]),
         "close" => pane_close(&args[1..]),
+        "close-if" => pane_close_if(&args[1..]),
         "send-text" => pane_send_text(&args[1..]),
         "send-keys" => pane_send_keys(&args[1..]),
         "wait-output" => pane_wait_output(&args[1..]),
@@ -1022,6 +1053,25 @@ fn pane_close(args: &[String]) -> std::io::Result<i32> {
     super::runtime::pane_close(super::normalize_pane_id(raw_pane_id))
 }
 
+fn pane_close_if(args: &[String]) -> std::io::Result<i32> {
+    if args.len() != 5 || args[1] != "--request-id" || args[3] != "--observation-json" {
+        eprintln!("usage: herdr pane close-if <pane_id> --request-id ID --observation-json JSON");
+        return Ok(2);
+    }
+    let observation = match serde_json::from_str::<PaneProcessObservation>(&args[4]) {
+        Ok(observation) => observation,
+        Err(err) => {
+            eprintln!("invalid observation JSON: {err}");
+            return Ok(2);
+        }
+    };
+    super::runtime::pane_close_if(PaneCloseIfParams {
+        pane_id: super::normalize_pane_id(&args[0]),
+        request_id: args[2].clone(),
+        observation,
+    })
+}
+
 fn pane_send_text(args: &[String]) -> std::io::Result<i32> {
     if args.len() < 2 {
         eprintln!("usage: herdr pane send-text <pane_id> <text>");
@@ -1651,6 +1701,7 @@ fn print_pane_help() {
     eprintln!("  herdr pane move <pane_id> --new-tab [--workspace ID] [--label TEXT] [--focus|--no-focus]");
     eprintln!("  herdr pane move <pane_id> --new-workspace [--label TEXT] [--tab-label TEXT] [--focus|--no-focus]");
     eprintln!("  herdr pane close <pane_id>");
+    eprintln!("  herdr pane close-if <pane_id> --request-id ID --observation-json JSON");
     eprintln!("  herdr pane send-text <pane_id> <text>");
     eprintln!("  herdr pane send-keys <pane_id> <key> [key ...]");
     eprintln!("  herdr pane wait-output <pane_id> (--match TEXT | --regex PATTERN) [--source visible|recent|recent-unwrapped] [--lines N] [--timeout MS] [--raw]");

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -1,5 +1,40 @@
 use crate::api::schema::{
-    EmptyParams, Method, PaneFocusDirectionParams, PaneInputSetParams, PaneMoveParams,
+1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
+    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
+    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
+    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
+    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
+    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
+    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
+    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
+    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
+    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
+    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
+    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
+2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
+    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
+    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
+    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
+    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
+    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
+3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
+    PaneMoveParams,
+4:     build_info::initialize();
+    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("error: {err}");
+            eprintln!("run 'herdr --help' for usage");
+            std::process::exit(2);
+        }
+    };
+5: /// Return the native process creation-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    process_creation_time(process.0).map(|value| value.to_string())
+}
+
+fn select_pane_foreground_job_from_snapshot(
     PaneRenameParams, PaneResizeParams, PaneSplitParams, PaneSwapParams, PaneTarget,
     PaneZoomParams, Request, TabCreateParams, TabListParams, TabRenameParams, TabTarget,
     WorkspaceCreateParams, WorkspaceRenameParams, WorkspaceTarget, WorktreeCreateParams,
@@ -123,4 +158,8 @@ pub(super) fn pane_move(params: PaneMoveParams) -> std::io::Result<i32> {
 
 pub(super) fn pane_close(pane_id: String) -> std::io::Result<i32> {
     print_method_response("cli:pane:close", Method::PaneClose(PaneTarget { pane_id }))
+}
+
+pub(super) fn pane_close_if(params: PaneCloseIfParams) -> std::io::Result<i32> {
+    print_method_response("cli:pane:close_if", Method::PaneCloseIf(params))
 }

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -1,43 +1,8 @@
 use crate::api::schema::{
-1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
-    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
-    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
-    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
-    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
-    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
-    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
-    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
-    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
-    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
-    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
-    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
-2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
-    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
-    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
-    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
-    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
-    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
-3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
-    PaneMoveParams,
-4:     build_info::initialize();
-    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
-        Ok(args) => args,
-        Err(err) => {
-            eprintln!("error: {err}");
-            eprintln!("run 'herdr --help' for usage");
-            std::process::exit(2);
-        }
-    };
-5: /// Return the native process creation-time generation for PID-reuse resistance.
-pub fn process_generation(pid: u32) -> Option<String> {
-    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
-    process_creation_time(process.0).map(|value| value.to_string())
-}
-
-fn select_pane_foreground_job_from_snapshot(
-    PaneRenameParams, PaneResizeParams, PaneSplitParams, PaneSwapParams, PaneTarget,
-    PaneZoomParams, Request, TabCreateParams, TabListParams, TabRenameParams, TabTarget,
-    WorkspaceCreateParams, WorkspaceRenameParams, WorkspaceTarget, WorktreeCreateParams,
+    EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
+    PaneMoveParams, PaneRenameParams, PaneResizeParams, PaneSplitParams, PaneSwapParams,
+    PaneTarget, PaneZoomParams, Request, TabCreateParams, TabListParams, TabRenameParams,
+    TabTarget, WorkspaceCreateParams, WorkspaceRenameParams, WorkspaceTarget, WorktreeCreateParams,
     WorktreeListParams, WorktreeOpenParams, WorktreeRemoveParams,
 };
 

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -574,6 +574,13 @@ fn pane_command() -> Command {
         )
         .subcommand(id_command("close", "pane_id", "Close a pane"))
         .subcommand(
+            Command::new("close-if")
+                .about("Close a pane only when its process observation matches")
+                .arg(required("pane_id", "PANE_ID"))
+                .arg(option("request-id", "ID").required(true))
+                .arg(option("observation-json", "JSON").required(true)),
+        )
+        .subcommand(
             Command::new("send-text")
                 .about("Send literal text to a pane")
                 .arg(required("pane_id", "PANE_ID"))

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -364,6 +364,23 @@ fn restart_needed_bool(server: &ServerRuntimeStatus) -> Option<bool> {
     Some(false)
 }
 
+fn print_json(value: &impl Serialize) -> std::io::Result<()> {
+    println!("{}", serde_json::to_string(value)?);
+    Ok(())
+}
+
+fn current_exe_label() -> String {
+    std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|err| format!("unknown ({err})"))
+}
+
+fn print_status_help() {
+    eprintln!("herdr status commands:");
+    eprintln!("  herdr status [--json]         show local client and running server status");
+    eprintln!("  herdr status server [--json]  show running server status");
+    eprintln!("  herdr status client [--json]  show local client binary status");
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -442,22 +459,4 @@ mod tests {
         }
         assert_eq!(restart_needed_bool(&missing_identity), None);
     }
-}
-
-fn print_json(value: &impl Serialize) -> std::io::Result<()> {
-    println!("{}", serde_json::to_string(value)?);
-    Ok(())
-}
-
-fn current_exe_label() -> String {
-    std::env::current_exe()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|err| format!("unknown ({err})"))
-}
-
-fn print_status_help() {
-    eprintln!("herdr status commands:");
-    eprintln!("  herdr status [--json]         show local client and running server status");
-    eprintln!("  herdr status server [--json]  show running server status");
-    eprintln!("  herdr status client [--json]  show local client binary status");
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -75,6 +75,7 @@ enum ServerRuntimeStatus {
         version: Option<String>,
         protocol: Option<u32>,
         capabilities: Option<crate::api::schema::ServerCapabilities>,
+        build_identity: Option<crate::api::schema::BuildIdentity>,
     },
     NotRunning,
 }
@@ -151,13 +152,13 @@ fn print_server_status_body(server: &ServerRuntimeStatus, indent: &str) {
         }
     }
 }
-
 fn read_server_runtime_status() -> std::io::Result<ServerRuntimeStatus> {
     match ApiClient::local().status() {
         Ok(status) => Ok(ServerRuntimeStatus::Running {
             version: status.version,
             protocol: status.protocol,
             capabilities: status.capabilities,
+            build_identity: status.build_identity,
         }),
         Err(ApiClientError::Io(err)) if super::server_not_running_error(&err) => {
             Ok(ServerRuntimeStatus::NotRunning)
@@ -192,13 +193,10 @@ fn compatibility_label(protocol: Option<u32>) -> &'static str {
 }
 
 fn restart_needed_label(server: &ServerRuntimeStatus) -> &'static str {
-    match server {
-        ServerRuntimeStatus::Running { version, .. } => match version.as_deref() {
-            Some(version) if version == crate::build_info::version() => "no",
-            Some(_) => "yes",
-            None => "unknown",
-        },
-        ServerRuntimeStatus::NotRunning => "no",
+    match restart_needed_bool(server) {
+        Some(true) => "yes",
+        Some(false) => "no",
+        None => "unknown",
     }
 }
 
@@ -216,6 +214,9 @@ struct ClientStatusJson {
     protocol: u32,
     binary: String,
     session: Option<String>,
+    source_commit: Option<String>,
+    executable_sha256: Option<String>,
+    release_manifest_digest: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -229,12 +230,21 @@ struct ServerStatusJson {
     socket: String,
     session: Option<String>,
     restart_needed: Option<bool>,
+    source_commit: Option<String>,
+    executable_sha256: Option<String>,
+    release_manifest_digest: Option<String>,
 }
 
 #[derive(Serialize)]
 struct ServerCapabilitiesJson {
     live_handoff: bool,
     detached_server_daemon: bool,
+    conditional_mutations: ConditionalMutationsJson,
+}
+
+#[derive(Serialize)]
+struct ConditionalMutationsJson {
+    pane_close: u32,
 }
 
 #[derive(Serialize)]
@@ -249,6 +259,9 @@ fn client_status_json() -> ClientStatusJson {
         protocol: crate::protocol::PROTOCOL_VERSION,
         binary: current_exe_label(),
         session: crate::session::active_name(),
+        source_commit: crate::build_info::source_commit().map(str::to_string),
+        executable_sha256: crate::build_info::executable_sha256(),
+        release_manifest_digest: crate::build_info::release_manifest_digest(),
     }
 }
 
@@ -258,6 +271,7 @@ fn server_status_json(server: &ServerRuntimeStatus) -> ServerStatusJson {
             version,
             protocol,
             capabilities,
+            build_identity,
         } => ServerStatusJson {
             status: "running",
             running: true,
@@ -268,11 +282,23 @@ fn server_status_json(server: &ServerRuntimeStatus) -> ServerStatusJson {
                 .map(|capabilities| ServerCapabilitiesJson {
                     live_handoff: capabilities.live_handoff,
                     detached_server_daemon: capabilities.detached_server_daemon,
+                    conditional_mutations: ConditionalMutationsJson {
+                        pane_close: capabilities.conditional_mutations.pane_close,
+                    },
                 }),
             compatible: protocol.map(|value| value == crate::protocol::PROTOCOL_VERSION),
             socket: api::socket_path().display().to_string(),
             session: crate::session::active_name(),
             restart_needed: restart_needed_bool(server),
+            source_commit: build_identity
+                .as_ref()
+                .and_then(|identity| identity.source_commit.clone()),
+            executable_sha256: build_identity
+                .as_ref()
+                .and_then(|identity| identity.executable_sha256.clone()),
+            release_manifest_digest: build_identity
+                .as_ref()
+                .and_then(|identity| identity.release_manifest_digest.clone()),
         },
         ServerRuntimeStatus::NotRunning => ServerStatusJson {
             status: "not_running",
@@ -284,6 +310,9 @@ fn server_status_json(server: &ServerRuntimeStatus) -> ServerStatusJson {
             socket: api::socket_path().display().to_string(),
             session: crate::session::active_name(),
             restart_needed: Some(false),
+            source_commit: None,
+            executable_sha256: None,
+            release_manifest_digest: None,
         },
     }
 }
@@ -295,13 +324,123 @@ fn update_status_json(server: &ServerRuntimeStatus) -> UpdateStatusJson {
 }
 
 fn restart_needed_bool(server: &ServerRuntimeStatus) -> Option<bool> {
-    match server {
-        ServerRuntimeStatus::Running { version, .. } => match version.as_deref() {
-            Some(version) if version == crate::build_info::version() => Some(false),
-            Some(_) => Some(true),
-            None => None,
-        },
-        ServerRuntimeStatus::NotRunning => Some(false),
+    let ServerRuntimeStatus::Running {
+        version,
+        protocol,
+        capabilities,
+        build_identity,
+    } = server
+    else {
+        return Some(false);
+    };
+    if version.as_deref()? != crate::build_info::version()
+        || (*protocol)? != crate::protocol::PROTOCOL_VERSION
+    {
+        return Some(true);
+    }
+    let expected_pane_close = u32::from(crate::platform::capabilities().pane_close_if);
+    if capabilities
+        .as_ref()
+        .map(|value| value.conditional_mutations.pane_close)?
+        != expected_pane_close
+    {
+        return Some(true);
+    }
+    let server_executable = build_identity.as_ref()?.executable_sha256.as_deref()?;
+    let client_executable = crate::build_info::executable_sha256()?;
+    if server_executable != client_executable {
+        return Some(true);
+    }
+    if let (Some(server_manifest), Some(client_manifest)) = (
+        build_identity
+            .as_ref()
+            .and_then(|value| value.release_manifest_digest.as_deref()),
+        crate::build_info::release_manifest_digest(),
+    ) {
+        if server_manifest != client_manifest {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_status_json_keeps_absent_build_identity_keys_visible() {
+        let status = server_status_json(&ServerRuntimeStatus::Running {
+            version: Some("0.1.0".into()),
+            protocol: Some(crate::protocol::PROTOCOL_VERSION),
+            capabilities: Some(crate::api::schema::ServerCapabilities {
+                live_handoff: true,
+                detached_server_daemon: false,
+                conditional_mutations: crate::api::schema::ConditionalMutations { pane_close: 1 },
+            }),
+            build_identity: Some(crate::api::schema::BuildIdentity::default()),
+        });
+        let json = serde_json::to_value(status).unwrap();
+        assert!(json.get("source_commit").is_some());
+        assert!(json.get("executable_sha256").is_some());
+        assert!(json.get("release_manifest_digest").is_some());
+        assert!(json["source_commit"].is_null());
+    }
+
+    #[test]
+    fn restart_needed_bool_requires_a_full_runtime_match() {
+        let executable_sha256 =
+            crate::build_info::executable_sha256().expect("test executable has an identity");
+        let matching_capabilities = crate::api::schema::ServerCapabilities {
+            conditional_mutations: crate::api::schema::ConditionalMutations {
+                pane_close: u32::from(crate::platform::capabilities().pane_close_if),
+            },
+            ..Default::default()
+        };
+        let matching_identity = crate::api::schema::BuildIdentity {
+            executable_sha256: Some(executable_sha256.clone()),
+            ..Default::default()
+        };
+        let matching = ServerRuntimeStatus::Running {
+            version: Some(crate::build_info::version()),
+            protocol: Some(crate::protocol::PROTOCOL_VERSION),
+            capabilities: Some(matching_capabilities),
+            build_identity: Some(matching_identity),
+        };
+        assert_eq!(restart_needed_bool(&matching), Some(false));
+
+        let mut protocol_mismatch = matching.clone();
+        if let ServerRuntimeStatus::Running { protocol, .. } = &mut protocol_mismatch {
+            *protocol = Some(crate::protocol::PROTOCOL_VERSION + 1);
+        }
+        assert_eq!(restart_needed_bool(&protocol_mismatch), Some(true));
+
+        let mut capability_mismatch = matching.clone();
+        if let ServerRuntimeStatus::Running { capabilities, .. } = &mut capability_mismatch {
+            capabilities
+                .as_mut()
+                .unwrap()
+                .conditional_mutations
+                .pane_close += 1;
+        }
+        assert_eq!(restart_needed_bool(&capability_mismatch), Some(true));
+
+        let mut identity_mismatch = matching.clone();
+        if let ServerRuntimeStatus::Running { build_identity, .. } = &mut identity_mismatch {
+            build_identity.as_mut().unwrap().executable_sha256 =
+                Some(if executable_sha256 == "0".repeat(64) {
+                    "1".repeat(64)
+                } else {
+                    "0".repeat(64)
+                });
+        }
+        assert_eq!(restart_needed_bool(&identity_mismatch), Some(true));
+
+        let mut missing_identity = matching;
+        if let ServerRuntimeStatus::Running { build_identity, .. } = &mut missing_identity {
+            *build_identity = Some(crate::api::schema::BuildIdentity::default());
+        }
+        assert_eq!(restart_needed_bool(&missing_identity), None);
     }
 }
 

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -71,7 +71,10 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
     let mut path = None;
     let mut label = None;
     let mut focus = false;
-
+    let mut permit_common_dir = None;
+    let mut permit_path = None;
+    let mut permit_branch = None;
+    let mut permit_head = None;
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
@@ -131,6 +134,38 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
                 focus = false;
                 index += 1;
             }
+            "--permit-common-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-common-dir");
+                    return Ok(2);
+                };
+                permit_common_dir = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-path" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-path");
+                    return Ok(2);
+                };
+                permit_path = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-branch" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-branch");
+                    return Ok(2);
+                };
+                permit_branch = Some(value.clone());
+                index += 2;
+            }
+            "--permit-head" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-head");
+                    return Ok(2);
+                };
+                permit_head = Some(value.clone());
+                index += 2;
+            }
             "--json" => index += 1,
             other => {
                 eprintln!("unknown option: {other}");
@@ -138,6 +173,14 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
             }
         }
     }
+    let permit = match parse_permit(permit_common_dir, permit_path, permit_branch, permit_head) {
+        Ok(permit) => permit,
+        Err(message) => {
+            eprintln!("{message}");
+            return Ok(2);
+        }
+    };
+
     if workspace_id.is_some() && cwd.is_some() {
         eprintln!(
             "usage: herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus] [--no-focus]"
@@ -153,9 +196,9 @@ fn worktree_create(args: &[String]) -> std::io::Result<i32> {
         path,
         label,
         focus,
+        permit,
     })
 }
-
 fn worktree_open(args: &[String]) -> std::io::Result<i32> {
     let mut workspace_id = None;
     let mut cwd = None;
@@ -248,7 +291,10 @@ fn worktree_open(args: &[String]) -> std::io::Result<i32> {
 fn worktree_remove(args: &[String]) -> std::io::Result<i32> {
     let mut workspace_id = None;
     let mut force = false;
-
+    let mut permit_common_dir = None;
+    let mut permit_path = None;
+    let mut permit_branch = None;
+    let mut permit_head = None;
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
@@ -264,6 +310,38 @@ fn worktree_remove(args: &[String]) -> std::io::Result<i32> {
                 force = true;
                 index += 1;
             }
+            "--permit-common-dir" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-common-dir");
+                    return Ok(2);
+                };
+                permit_common_dir = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-path" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-path");
+                    return Ok(2);
+                };
+                permit_path = Some(normalize_path_arg(value)?);
+                index += 2;
+            }
+            "--permit-branch" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-branch");
+                    return Ok(2);
+                };
+                permit_branch = Some(value.clone());
+                index += 2;
+            }
+            "--permit-head" => {
+                let Some(value) = args.get(index + 1) else {
+                    eprintln!("missing value for --permit-head");
+                    return Ok(2);
+                };
+                permit_head = Some(value.clone());
+                index += 2;
+            }
             "--json" => index += 1,
             other => {
                 eprintln!("unknown option: {other}");
@@ -277,9 +355,18 @@ fn worktree_remove(args: &[String]) -> std::io::Result<i32> {
         return Ok(2);
     };
 
+    let permit = match parse_permit(permit_common_dir, permit_path, permit_branch, permit_head) {
+        Ok(permit) => permit,
+        Err(message) => {
+            eprintln!("{message}");
+            return Ok(2);
+        }
+    };
+
     super::runtime::worktree_remove(WorktreeRemoveParams {
         workspace_id,
         force,
+        permit,
     })
 }
 
@@ -287,12 +374,14 @@ fn print_worktree_help() {
     eprintln!("herdr worktree commands:");
     eprintln!("  herdr worktree list [--workspace ID | --cwd PATH]");
     eprintln!(
-        "  herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus] [--no-focus]"
+        "  herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus] [--no-focus] [--permit-common-dir PATH --permit-path PATH --permit-branch NAME --permit-head OID]"
     );
     eprintln!(
         "  herdr worktree open [--workspace ID | --cwd PATH] (--path PATH | --branch NAME) [--label TEXT] [--focus] [--no-focus]"
     );
-    eprintln!("  herdr worktree remove --workspace ID [--force]");
+    eprintln!(
+        "  herdr worktree remove --workspace ID [--force] [--permit-common-dir PATH --permit-path PATH --permit-branch NAME --permit-head OID]"
+    );
 }
 
 fn normalize_path_arg(value: &str) -> std::io::Result<String> {
@@ -303,4 +392,61 @@ fn normalize_path_arg(value: &str) -> std::io::Result<String> {
         std::env::current_dir()?.join(path)
     };
     Ok(absolute.display().to_string())
+}
+
+fn parse_permit(
+    common_dir: Option<String>,
+    path: Option<String>,
+    branch: Option<String>,
+    head_oid: Option<String>,
+) -> Result<Option<crate::api::schema::WorktreeExactPermit>, &'static str> {
+    let supplied = [
+        common_dir.is_some(),
+        path.is_some(),
+        branch.is_some(),
+        head_oid.is_some(),
+    ];
+    if supplied.iter().any(|supplied| *supplied) && supplied.iter().any(|supplied| !*supplied) {
+        return Err("all four permit options are required together");
+    }
+    Ok(
+        common_dir.map(|repo_common_dir| crate::api::schema::WorktreeExactPermit {
+            repo_common_dir,
+            checkout_path: path.expect("permit path present when permit is present"),
+            branch: branch.expect("permit branch present when permit is present"),
+            head_oid: head_oid.expect("permit head present when permit is present"),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_permit;
+
+    #[test]
+    fn permit_options_must_be_all_or_none() {
+        let result = parse_permit(
+            Some("/repo/.git".into()),
+            Some("/checkout".into()),
+            None,
+            Some("deadbeef".into()),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn complete_permit_is_preserved() {
+        let permit = parse_permit(
+            Some("/repo/.git".into()),
+            Some("/checkout".into()),
+            Some("feature".into()),
+            Some("deadbeef".into()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(permit.repo_common_dir, "/repo/.git");
+        assert_eq!(permit.checkout_path, "/checkout");
+        assert_eq!(permit.branch, "feature");
+        assert_eq!(permit.head_oid, "deadbeef");
+    }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -20,6 +20,8 @@ pub struct ApiWorktreeAddRequest {
     pub source_repo_root: std::path::PathBuf,
     pub repo_key: String,
     pub repo_name: String,
+    pub branch: String,
+    pub permit: Option<crate::api::schema::WorktreeExactPermit>,
     pub label: Option<String>,
     pub focus: bool,
     pub respond_to: std::sync::mpsc::Sender<String>,
@@ -29,6 +31,7 @@ pub struct ApiWorktreeAddRequest {
 pub struct WorktreeAddResult {
     pub path: std::path::PathBuf,
     pub api_request: Option<ApiWorktreeAddRequest>,
+    pub receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
     pub result: Result<(), String>,
 }
 
@@ -37,6 +40,7 @@ pub struct ApiWorktreeRemoveRequest {
     pub id: String,
     pub operation_id: u64,
     pub checkout_key: std::path::PathBuf,
+    pub permit: Option<crate::api::schema::WorktreeExactPermit>,
     pub respond_to: std::sync::mpsc::Sender<String>,
 }
 
@@ -47,6 +51,7 @@ pub struct WorktreeRemoveResult {
     pub workspace: Option<Box<crate::api::schema::WorkspaceInfo>>,
     pub worktree: Option<Box<crate::api::schema::WorktreeInfo>>,
     pub forced: bool,
+    pub receipt: Option<crate::api::schema::WorktreeMutationReceipt>,
     pub api_request: Option<ApiWorktreeRemoveRequest>,
     pub result: Result<(), String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,27 +488,7 @@ where
 }
 
 fn main() -> io::Result<()> {
-1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
-    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
-    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
-    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
-    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
-    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
-    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
-    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
-    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
-    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
-    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
-    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
-2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
-    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
-    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
-    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
-    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
-    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
-3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
-    PaneMoveParams,
-4:     build_info::initialize();
+    build_info::initialize();
     let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
         Ok(args) => args,
         Err(err) => {
@@ -517,13 +497,6 @@ fn main() -> io::Result<()> {
             std::process::exit(2);
         }
     };
-5: /// Return the native process creation-time generation for PID-reuse resistance.
-pub fn process_generation(pid: u32) -> Option<String> {
-    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
-    process_creation_time(process.0).map(|value| value.to_string())
-}
-
-fn select_pane_foreground_job_from_snapshot(
     let args = match session::configure_from_args(&raw_args) {
         Ok(args) => args,
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,6 +488,27 @@ where
 }
 
 fn main() -> io::Result<()> {
+1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
+    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
+    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
+    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
+    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
+    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
+    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
+    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
+    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
+    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
+    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
+    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
+2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
+    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
+    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
+    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
+    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
+    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
+3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
+    PaneMoveParams,
+4:     build_info::initialize();
     let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
         Ok(args) => args,
         Err(err) => {
@@ -496,6 +517,13 @@ fn main() -> io::Result<()> {
             std::process::exit(2);
         }
     };
+5: /// Return the native process creation-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    process_creation_time(process.0).map(|value| value.to_string())
+}
+
+fn select_pane_foreground_job_from_snapshot(
     let args = match session::configure_from_args(&raw_args) {
         Ok(args) => args,
         Err(err) => {

--- a/src/platform/fallback.rs
+++ b/src/platform/fallback.rs
@@ -150,6 +150,11 @@ pub fn process_cwd(_pid: u32) -> Option<PathBuf> {
     None
 }
 
+/// Process generations are unavailable on unsupported platforms.
+pub fn process_generation(_pid: u32) -> Option<String> {
+    None
+}
+
 /// Unsupported platform stub.
 pub fn session_processes(_child_pid: u32) -> Vec<u32> {
     Vec::new()

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -380,6 +380,22 @@ pub fn process_cwd(pid: u32) -> Option<PathBuf> {
     std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
 }
 
+/// Return the kernel process start-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let close = stat.rfind(')')?;
+    let fields: Vec<&str> = stat.get(close + 2..)?.split_whitespace().collect();
+    // After (comm): state is index 0 and starttime (field 22) is index 19.
+    fields
+        .get(19)?
+        .parse::<u64>()
+        .ok()
+        .map(|value| value.to_string())
+}
+
 /// Read a Herdr agent identity hint from a process environment.
 pub fn process_agent_hint(pid: u32) -> Option<crate::detect::Agent> {
     if pid == 0 {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -905,6 +905,17 @@ pub fn process_cwd(pid: u32) -> Option<PathBuf> {
     }
     Some(PathBuf::from(OsStr::from_bytes(&vip_path[..nul])))
 }
+/// Return the kernel process start-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    let info = process_bsdinfo(pid)?;
+    Some(format!(
+        "{}:{}",
+        info.pbi_start_tvsec, info.pbi_start_tvusec
+    ))
+}
 
 pub fn session_processes(child_pid: u32) -> Vec<u32> {
     if child_pid == 0 {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -54,6 +54,7 @@ pub(crate) struct PlatformCapabilities {
     pub(crate) live_handoff: bool,
     pub(crate) direct_terminal_attach: bool,
     pub(crate) preserve_legacy_doubled_escape_input: bool,
+    pub(crate) pane_close_if: bool,
 }
 
 pub(crate) const fn capabilities() -> PlatformCapabilities {
@@ -61,6 +62,9 @@ pub(crate) const fn capabilities() -> PlatformCapabilities {
         live_handoff: cfg!(unix),
         direct_terminal_attach: cfg!(unix),
         preserve_legacy_doubled_escape_input: cfg!(target_os = "macos"),
+        // The Windows foreground-job reader currently returns only one selected
+        // process, so it cannot yet prove a complete process-set observation.
+        pane_close_if: cfg!(any(target_os = "linux", target_os = "macos")),
     }
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -696,36 +696,7 @@ pub fn process_cwd(pid: u32) -> Option<PathBuf> {
         .filter(|path| path.is_absolute())
 }
 
-1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
-    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
-    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
-    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
-    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
-    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
-    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
-    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
-    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
-    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
-    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
-    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
-2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
-    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
-    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
-    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
-    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
-    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
-3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
-    PaneMoveParams,
-4:     build_info::initialize();
-    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
-        Ok(args) => args,
-        Err(err) => {
-            eprintln!("error: {err}");
-            eprintln!("run 'herdr --help' for usage");
-            std::process::exit(2);
-        }
-    };
-5: /// Return the native process creation-time generation for PID-reuse resistance.
+/// Return the native process creation-time generation for PID-reuse resistance.
 pub fn process_generation(pid: u32) -> Option<String> {
     let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
     process_creation_time(process.0).map(|value| value.to_string())

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -696,6 +696,41 @@ pub fn process_cwd(pid: u32) -> Option<PathBuf> {
         .filter(|path| path.is_absolute())
 }
 
+1:     EventData, EventEnvelope, EventKind, PaneClearAgentAuthorityParams, PaneCloseIfOutcome,
+    PaneCurrentParams, PaneDirection, PaneEdgesParams, PaneEdgesResult, PaneFocusDirectionParams,
+    PaneFocusDirectionReason, PaneFocusDirectionResult, PaneInfo, PaneInputSetParams,
+    PaneLayoutPane, PaneLayoutParams, PaneLayoutRect, PaneLayoutSnapshot, PaneLayoutSplit,
+    PaneListParams, PaneMoveDestination, PaneMoveParams, PaneMoveReason, PaneMoveResult,
+    PaneNeighborParams, PaneNeighborResult, PaneProcessInfo, PaneProcessInfoParams,
+    PaneProcessInfoProcess, PaneProcessObservation, PaneReadParams, PaneReadResult,
+    PaneReleaseAgentParams, PaneRenameParams, PaneReportAgentParams,
+    PaneReportAgentSessionParams, PaneReportMetadataParams, PaneResizeParams, PaneResizeReason,
+    PaneResizeResult, PaneSendInputParams, PaneSendKeysParams, PaneSendTextParams,
+    PaneSplitParams, PaneSwapParams, PaneSwapReason, PaneSwapResult, PaneTarget, PaneZoomMode,
+    PaneZoomParams, PaneZoomReason, PaneZoomResult, ResponseResult,
+2:     Method, OutputMatch, PaneCloseIfParams, PaneCurrentParams, PaneDirection, PaneEdgesParams,
+    PaneFocusDirectionParams, PaneInputSetParams, PaneLayoutParams, PaneListParams,
+    PaneMoveDestination, PaneMoveParams, PaneNeighborParams, PaneProcessInfoParams,
+    PaneProcessObservation, PaneReadParams, PaneReleaseAgentParams, PaneRenameParams,
+    PaneReportAgentParams, PaneReportAgentSessionParams, PaneReportMetadataParams,
+    PaneResizeParams, PaneRightClickTarget, PaneSendInputParams,
+3:     EmptyParams, Method, PaneCloseIfParams, PaneFocusDirectionParams, PaneInputSetParams,
+    PaneMoveParams,
+4:     build_info::initialize();
+    let raw_args: Vec<String> = match args_as_utf8(std::env::args_os()) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("error: {err}");
+            eprintln!("run 'herdr --help' for usage");
+            std::process::exit(2);
+        }
+    };
+5: /// Return the native process creation-time generation for PID-reuse resistance.
+pub fn process_generation(pid: u32) -> Option<String> {
+    let process = ProcessHandle::open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+    process_creation_time(process.0).map(|value| value.to_string())
+}
+
 fn select_pane_foreground_job_from_snapshot(
     shell_pid: u32,
     snapshot: &ProcessSnapshot,

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 20;
+pub const PROTOCOL_VERSION: u32 = 21;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.

--- a/src/server/autodetect.rs
+++ b/src/server/autodetect.rs
@@ -513,6 +513,14 @@ test "$sid" = "$$"
         let _ = handle.join();
         assert_eq!(status.version.as_deref(), Some("0.5.5"));
         assert_eq!(status.protocol, Some(2));
+        assert_eq!(
+            status.capabilities,
+            Some(crate::api::schema::ServerCapabilities::default())
+        );
+        assert_eq!(
+            status.build_identity,
+            Some(crate::api::schema::BuildIdentity::default())
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -2316,7 +2316,7 @@ mod tests {
                 .unwrap();
             assert!(request.contains("\"method\":\"ping\""));
             let response = format!(
-                r#"{{"id":"runtime:status","result":{{"type":"pong","version":"{version}","protocol":{protocol},"capabilities":{{"live_handoff":true}}}}}}"#
+                r#"{{"id":"runtime:status","result":{{"type":"pong","version":"{version}","protocol":{protocol},"capabilities":{{"live_handoff":true,"conditional_mutations":{{"pane_close":0}}}},"build_identity":{{"source_commit":null,"executable_sha256":null,"release_manifest_digest":null}}}}}}"#
             );
             stream.write_all(response.as_bytes()).unwrap();
             stream.write_all(b"\n").unwrap();
@@ -2701,6 +2701,7 @@ mod tests {
             version: Some("0.5.5".to_string()),
             protocol: Some(2),
             capabilities: None,
+            build_identity: None,
         };
         let compatible_release = ReleaseInfo {
             version: Version::parse("0.5.6").unwrap(),
@@ -2757,7 +2758,11 @@ mod tests {
                 capabilities: Some(crate::api::schema::ServerCapabilities {
                     live_handoff: true,
                     detached_server_daemon: true,
+                    conditional_mutations: crate::api::schema::ConditionalMutations {
+                        pane_close: 0,
+                    },
                 }),
+                build_identity: None,
             },
         };
 
@@ -2943,6 +2948,7 @@ mod tests {
             version: Some("0.5.5".to_string()),
             protocol: Some(2),
             capabilities: None,
+            build_identity: None,
         };
         let release = ReleaseInfo {
             version: Version::parse("0.5.6").unwrap(),

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -151,6 +151,63 @@ pub(crate) fn canonical_or_original(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorktreeIdentity {
+    pub repo_common_dir: PathBuf,
+    pub checkout_path: PathBuf,
+    pub branch: Option<String>,
+    pub head_oid: String,
+}
+
+fn git_trimmed_output(path: &Path, args: &[&str]) -> Result<String, String> {
+    let output = crate::noninteractive_process::command("git")
+        .arg("-C")
+        .arg(path)
+        .args(args)
+        .output()
+        .map_err(|err| err.to_string())?;
+    if output.status.success() {
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !value.is_empty() {
+            return Ok(value);
+        }
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Err(if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("git command failed with status {}", output.status)
+    })
+}
+
+pub(crate) fn resolve_git_revision(repo_root: &Path, revision: &str) -> Result<String, String> {
+    git_trimmed_output(
+        repo_root,
+        &["rev-parse", "--verify", &format!("{revision}^{{commit}}")],
+    )
+}
+
+pub(crate) fn read_worktree_identity(path: &Path) -> Result<WorktreeIdentity, String> {
+    let common_dir = git_trimmed_output(path, &["rev-parse", "--git-common-dir"])?;
+    let common_dir = PathBuf::from(common_dir);
+    let common_dir = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        path.join(common_dir)
+    };
+    let branch = git_trimmed_output(path, &["symbolic-ref", "--quiet", "--short", "HEAD"]).ok();
+    let head_oid = git_trimmed_output(path, &["rev-parse", "--verify", "HEAD"])?;
+    Ok(WorktreeIdentity {
+        repo_common_dir: canonical_or_original(&common_dir),
+        checkout_path: canonical_or_original(path),
+        branch,
+        head_oid,
+    })
+}
+
 pub(crate) fn default_checkout_path(root: &Path, repo_name: &str, branch: &str) -> PathBuf {
     root.join(repo_name).join(branch_to_path_slug(branch))
 }
@@ -289,6 +346,31 @@ pub(crate) fn local_branch_exists(repo_root: &Path, branch: &str) -> Result<bool
     } else {
         Err(format!("git show-ref failed with status {}", output.status))
     }
+}
+
+pub(crate) fn delete_local_branch_if_matches(
+    repo_root: &Path,
+    branch: &str,
+    expected_head_oid: &str,
+) -> Result<(), String> {
+    let ref_name = format!("refs/heads/{branch}");
+    let actual_head_oid = resolve_git_revision(repo_root, &ref_name)?;
+    if !actual_head_oid.eq_ignore_ascii_case(expected_head_oid) {
+        return Err(format!(
+            "refusing to delete {ref_name}: expected {expected_head_oid}, observed {actual_head_oid}"
+        ));
+    }
+    run_worktree_command(&WorktreeCommand {
+        program: "git".to_string(),
+        args: vec![
+            "-C".to_string(),
+            repo_root.display().to_string(),
+            "update-ref".to_string(),
+            "-d".to_string(),
+            ref_name,
+            actual_head_oid,
+        ],
+    })
 }
 
 pub(crate) fn run_worktree_add_command(
@@ -860,6 +942,30 @@ prunable stale
         let remove = build_worktree_remove_command(&repo, &checkout, false);
         run_worktree_command(&remove).unwrap();
         assert!(!checkout.exists());
+
+        let _ = std::fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn local_branch_cleanup_requires_exact_head() {
+        let repo = create_committed_repo("worktree-branch-cleanup-repo");
+        let checkout = unique_temp_path("worktree-branch-cleanup-checkout");
+        let branch = "worktree/cleanup";
+        let add = build_worktree_add_new_branch_command(&repo, &checkout, branch, "HEAD");
+        run_worktree_command(&add).unwrap();
+        let head_oid = resolve_git_revision(&checkout, "HEAD").unwrap();
+        let remove = build_worktree_remove_command(&repo, &checkout, false);
+        run_worktree_command(&remove).unwrap();
+
+        assert!(delete_local_branch_if_matches(
+            &repo,
+            branch,
+            "0000000000000000000000000000000000000000"
+        )
+        .is_err());
+        assert!(local_branch_exists(&repo, branch).unwrap());
+        delete_local_branch_if_matches(&repo, branch, &head_oid).unwrap();
+        assert!(!local_branch_exists(&repo, branch).unwrap());
 
         let _ = std::fs::remove_dir_all(repo);
     }


### PR DESCRIPTION
## Summary
- add protocol-20 exact worktree mutation permits and protocol-21 `pane.close_if`
- expose canonical PID-reuse-safe process generations and fingerprinted pane observations across macOS, Linux, Windows, and fallback platforms
- return typed `closed`, `precondition_failed`, `not_found`, and `unsupported` outcomes with exact request/observation receipts
- publish running-server capabilities and build identity for fail-closed adapter selection
- wire the existing `pane move` CLI path so strict lint remains clean on current master

## Verification
- `cargo fmt --all`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- focused `pane_close_if`, `close_if`, generated-schema, server-status, restart-identity, listener-liveness, and pane-move parser tests
- full `cargo test --workspace --all-targets --all-features -- --test-threads=1`: 3106 passed; one randomized workspace-ID length assertion failed once and passed on isolated rerun
- disposable live canary against the commit-identified release: exact close -> `closed`; rotated process generation -> `precondition_failed`; concurrent identical requests -> exactly one `closed` and one `not_found`

The generated protocol schema is included.