### PR TITLE
feat(tui): middle-click a tab to close it

### DIFF
--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -417,6 +417,11 @@ impl App {
                         self.focus_workspace_idx_via_api(ws_idx)
                     }
                     MouseAction::FocusTab { tab_idx } => self.focus_tab_idx_via_api(tab_idx),
+                    MouseAction::CloseTab { ws_idx, tab_idx } => {
+                        self.focus_workspace_idx_via_api(ws_idx);
+                        self.focus_tab_idx_via_api(tab_idx);
+                        self.close_active_tab_via_api_requires_confirmation();
+                    }
                     MouseAction::FocusPane { ws_idx, pane_id } => {
                         self.focus_pane_internal_via_api(ws_idx, pane_id)
                     }

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -34,6 +34,10 @@ pub(super) enum MouseAction {
     FocusTab {
         tab_idx: usize,
     },
+    CloseTab {
+        ws_idx: usize,
+        tab_idx: usize,
+    },
     FocusPane {
         ws_idx: usize,
         pane_id: crate::layout::PaneId,
@@ -1066,6 +1070,17 @@ impl AppState {
                         list: MenuListState::new(0),
                     });
                     self.mode = Mode::ContextMenu;
+                }
+            }
+
+            MouseEventKind::Down(MouseButton::Middle)
+                if !self.mode_bar_covers_tab_row(mouse.column, mouse.row)
+                    && self.tab_at(mouse.column, mouse.row).is_some() =>
+            {
+                if let (Some(ws_idx), Some(tab_idx)) =
+                    (self.active, self.tab_at(mouse.column, mouse.row))
+                {
+                    return Some(MouseAction::CloseTab { ws_idx, tab_idx });
                 }
             }
 


### PR DESCRIPTION
### What

Middle-clicking a tab in the tab bar closes that tab — the convention in browsers, VS Code, iTerm2, and Windows Terminal. Today closing a non-focused tab takes either a keybinding that acts on the *focused* tab (switch first, then close) or right-click → Close. With many tabs open this turns one gesture into three.

### How

+20 lines, no behavior removed. The implementation reuses the exact machinery the right-click context menu's **Close** entry already uses:

- `src/app/input/mouse.rs` — new `MouseAction::CloseTab { ws_idx, tab_idx }` variant.
- `src/app/input/mouse.rs` — new `Down(MouseButton::Middle)` match arm, placed beside and guarded identically to the existing right-click-on-tab arm (`!mode_bar_covers_tab_row(..)` + `tab_at(col, row).is_some()`). Middle-clicks on empty tab-bar space, the mode bar, or inside panes match no arm and behave exactly as before.
- `src/app/input/mod.rs` — dispatch mirrors the context menu's Close path: focus the clicked workspace/tab via the API helpers, then `close_active_tab_via_api_requires_confirmation()`. This preserves existing semantics for free: closing a workspace's last tab routes through workspace-close including the implicit worktree-group confirmation dialog; everything else emits the standard `tui.tab.close` runtime action.

### Testing

- `cargo fmt --check` and `cargo clippy --release` clean.
- `cargo test --release`: identical results to the unpatched baseline (2958 passed; the 2 failures in my environment reproduce identically without this change — pre-existing/environmental).
- Automated interaction test: the patched binary driven in a pty (pyte-rendered screen, SGR mouse injection), asserting via `herdr tab list`:
  - middle-click on a **non-focused** tab closes *that* tab, not the active one;
  - remaining tabs and focus stay sane;
  - middle-click inside the pane area changes nothing.
- Manually verified with a physical mouse in Ghostty.

### Notes

- No config option added; if you'd prefer this behind a setting (e.g. `middle_click_tab = "close" | "none"`) happy to add one.
- Related but intentionally out of scope: in the normal `mouse_capture` path, pane apps currently receive middle-button `Up`/`Drag` but never `Down` (`handle_mouse` forwards Left on Down/Drag/Up, Middle only on Up/Drag). That breaks middle-click paste inside panes; I'll file it separately. This PR only touches the tab-bar region.
