### PR TITLE
feat: detect agents hosted in editor-embedded terminals

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Panes can now route normal right-click gestures to mouse-reporting applications through the pane menu, `herdr pane input`, `pane.input.set`, or the `pane split --right-click pane` launch option.
 - `theme.custom.sidebar_bg` can now give the desktop sidebar its own background without changing built-in theme defaults.
 - Settings and `ui.status_indicators = "symbols"` can now use distinct static shapes for blocked, working, done, idle, and unknown agent states. (#2260)
+- Agents launched inside editor-embedded terminals, such as opencode or codex started from an nvim plugin, are now detected and tracked in their pane.
 - The plugin marketplace now discovers valid manifests at repository roots and subdirectories, groups multiple plugins under each repository, and publishes their versions and exact default-branch commits.
 
 ### Changed

--- a/src/app/agents.rs
+++ b/src/app/agents.rs
@@ -437,6 +437,13 @@ fn live_runtime_agent(runtime: &crate::terminal::TerminalRuntime) -> Option<crat
                 .iter()
                 .find_map(|process| crate::platform::process_agent_hint(process.pid))
         })
+        .or_else(|| {
+            crate::detect::identify_agent_hosted_by_editor(
+                &job,
+                crate::platform::descendant_processes,
+            )
+            .map(|(agent, _)| agent)
+        })
 }
 
 pub(super) enum AgentStartError {

--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -225,9 +225,15 @@ pub fn identify_agent_in_job(job: &crate::platform::ForegroundJob) -> Option<(Ag
         }
     }
 
+    identify_agent_among_processes(&job.processes)
+}
+
+fn identify_agent_among_processes(
+    processes: &[crate::platform::ForegroundProcess],
+) -> Option<(Agent, String)> {
     let mut best: Option<(u8, Agent, String)> = None;
 
-    for process in &job.processes {
+    for process in processes {
         let candidate = normalized_process_name(process);
         let Some(agent) = identify_agent(&candidate) else {
             continue;
@@ -241,6 +247,32 @@ pub fn identify_agent_in_job(job: &crate::platform::ForegroundJob) -> Option<(Ag
     }
 
     best.map(|(_, agent, name)| (agent, name))
+}
+
+/// Editors that embed terminals where agents run on their own pty and process
+/// group (e.g. nvim plugins spawning `opencode` or `codex` in a `:terminal`
+/// buffer). Those agents are never members of the pane's foreground job, so
+/// identification has to walk the editor's descendants instead.
+fn is_terminal_hosting_editor(process: &crate::platform::ForegroundProcess) -> bool {
+    let effective = process.argv0.as_deref().unwrap_or(&process.name);
+    matches!(
+        normalized_agent_lookup_name(path_basename(effective)).as_str(),
+        "nvim" | "vim" | "vi"
+    )
+}
+
+/// Identify an agent hosted inside a terminal-embedding editor that is part of
+/// the pane's foreground job. `descendant_processes` resolves the descendant
+/// processes of an editor PID; production callers pass
+/// [`crate::platform::descendant_processes`].
+pub fn identify_agent_hosted_by_editor(
+    job: &crate::platform::ForegroundJob,
+    descendant_processes: impl Fn(u32) -> Vec<crate::platform::ForegroundProcess>,
+) -> Option<(Agent, String)> {
+    job.processes
+        .iter()
+        .filter(|process| is_terminal_hosting_editor(process))
+        .find_map(|editor| identify_agent_among_processes(&descendant_processes(editor.pid)))
 }
 
 /// Detect the state of an agent from the live terminal tail snapshot.
@@ -1249,6 +1281,65 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ---- Editor-hosted agent identification ----
+
+    fn editor_job(editor_name: &str) -> crate::platform::ForegroundJob {
+        crate::platform::ForegroundJob {
+            process_group_id: 42,
+            processes: vec![foreground_process(42, editor_name, &[editor_name])],
+        }
+    }
+
+    #[test]
+    fn editor_hosted_agent_is_identified_from_nvim_descendants() {
+        let descendants = vec![
+            foreground_process(120, "copilot-language-server", &["copilot-language-server"]),
+            foreground_process(121, "opencode", &["opencode"]),
+        ];
+
+        assert_eq!(
+            identify_agent_hosted_by_editor(&editor_job("nvim"), |pid| {
+                assert_eq!(pid, 42);
+                descendants.clone()
+            }),
+            Some((Agent::OpenCode, "opencode".to_string()))
+        );
+    }
+
+    #[test]
+    fn editor_hosted_agent_is_identified_from_wrapped_descendant() {
+        let descendants = vec![foreground_process(
+            120,
+            "node",
+            &["node", "/home/can/.local/bin/codex"],
+        )];
+
+        assert_eq!(
+            identify_agent_hosted_by_editor(&editor_job("vim"), |_| descendants.clone()),
+            Some((Agent::Codex, "codex".to_string()))
+        );
+    }
+
+    #[test]
+    fn editor_hosted_lookup_returns_none_without_agent_descendants() {
+        let descendants = vec![foreground_process(120, "rust-analyzer", &["rust-analyzer"])];
+
+        assert_eq!(
+            identify_agent_hosted_by_editor(&editor_job("nvim"), |_| descendants.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn editor_hosted_lookup_skips_non_editor_processes() {
+        assert_eq!(
+            identify_agent_hosted_by_editor(&editor_job("some_vm"), |_| {
+                panic!("descendants must not be scanned for non-editor processes")
+            }),
+            None
+        );
     }
 
     // ---- Screen detection routing ----

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -575,6 +575,7 @@ fn probe_foreground_process_from_jobs(
     leader_job: Option<crate::platform::ForegroundJob>,
     foreground_job: impl FnOnce() -> Option<crate::platform::ForegroundJob>,
     read_hint: impl Fn(u32) -> Option<Agent> + Copy,
+    editor_descendants: impl Fn(u32) -> Vec<crate::platform::ForegroundProcess> + Copy,
 ) -> ProcessProbeResult {
     if let Some(job) = leader_job.as_ref() {
         if let Some(hinted) = hinted_process_probe_result(job, pid, read_hint) {
@@ -607,7 +608,8 @@ fn probe_foreground_process_from_jobs(
             );
         }
 
-        let identified = crate::detect::identify_agent_in_job(job);
+        let identified = crate::detect::identify_agent_in_job(job)
+            .or_else(|| crate::detect::identify_agent_hosted_by_editor(job, editor_descendants));
         return ProcessProbeResult {
             process_group_id: Some(job.process_group_id),
             foreground_is_pane_shell: job.processes.iter().any(|process| process.pid == pid),
@@ -631,6 +633,7 @@ fn probe_foreground_process(pid: u32, foreground_pgid: Option<u32>) -> ProcessPr
         foreground_pgid.and_then(crate::detect::foreground_group_leader_job),
         || crate::detect::foreground_job(pid),
         crate::platform::process_agent_hint,
+        crate::platform::descendant_processes,
     )
 }
 
@@ -3692,6 +3695,7 @@ mod tests {
             Some(job),
             || None,
             |pid| (pid == 99).then_some(Agent::Claude),
+            |_| Vec::new(),
         );
 
         assert_eq!(result.agent, Some(Agent::Claude));
@@ -3711,6 +3715,7 @@ mod tests {
             None,
             || Some(job),
             |pid| (pid == 99).then_some(Agent::Claude),
+            |_| Vec::new(),
         );
 
         assert_eq!(result.agent, Some(Agent::Claude));
@@ -3733,6 +3738,7 @@ mod tests {
             None,
             || Some(job),
             |pid| (pid == 100).then_some(Agent::Claude),
+            |_| Vec::new(),
         );
 
         assert_eq!(result.agent, Some(Agent::Codex));
@@ -3755,10 +3761,54 @@ mod tests {
             None,
             || Some(job),
             |pid| (pid == 100).then_some(Agent::Claude),
+            |_| Vec::new(),
         );
 
         assert_eq!(result.agent, Some(Agent::Claude));
         assert_eq!(result.process_name.as_deref(), Some("claude"));
+    }
+
+    #[test]
+    fn editor_hosted_agent_is_probed_from_editor_descendants() {
+        let job = crate::platform::ForegroundJob {
+            process_group_id: 99,
+            processes: vec![foreground_process(99, "nvim")],
+        };
+
+        let result = probe_foreground_process_from_jobs(
+            42,
+            Some(99),
+            None,
+            || Some(job),
+            |_| None,
+            |pid| {
+                assert_eq!(pid, 99);
+                vec![foreground_process(120, "opencode")]
+            },
+        );
+
+        assert_eq!(result.agent, Some(Agent::OpenCode));
+        assert_eq!(result.process_name.as_deref(), Some("opencode"));
+        assert!(!result.foreground_is_pane_shell);
+    }
+
+    #[test]
+    fn non_editor_foreground_process_skips_descendant_probe() {
+        let job = crate::platform::ForegroundJob {
+            process_group_id: 99,
+            processes: vec![foreground_process(99, "some_vm")],
+        };
+
+        let result = probe_foreground_process_from_jobs(
+            42,
+            Some(99),
+            None,
+            || Some(job),
+            |_| None,
+            |_| panic!("descendants must not be scanned for non-editor processes"),
+        );
+
+        assert_eq!(result.agent, None);
     }
 
     fn process_probe_input() -> ProcessProbeInput {

--- a/src/platform/fallback.rs
+++ b/src/platform/fallback.rs
@@ -168,6 +168,11 @@ pub fn foreground_process_group_id(_child_pid: u32) -> Option<u32> {
 }
 
 /// Unsupported platform stub.
+pub fn descendant_processes(_root_pid: u32) -> Vec<super::ForegroundProcess> {
+    Vec::new()
+}
+
+/// Unsupported platform stub.
 pub fn process_cwd(_pid: u32) -> Option<PathBuf> {
     None
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -249,6 +249,35 @@ fn foreground_process_group_members_with(
     (!members.is_empty()).then_some(members)
 }
 
+const DESCENDANT_PROCESS_SCAN_LIMIT: usize = 64;
+
+/// Collect descendant processes of a root PID, bounded.
+///
+/// Used to find agents that run on their own pty inside terminal-embedding
+/// editors, where the agent is not part of the pane's foreground job.
+pub fn descendant_processes(root_pid: u32) -> Vec<ForegroundProcess> {
+    if root_pid == 0 {
+        return Vec::new();
+    }
+
+    process_tree_pids([root_pid], process_task_ids, process_task_children)
+        .into_iter()
+        .filter(|pid| *pid != root_pid)
+        .take(DESCENDANT_PROCESS_SCAN_LIMIT)
+        .filter_map(|pid| {
+            let (_, comm) = process_pgrp_and_comm(pid)?;
+            let argv = process_argv(pid);
+            Some(ForegroundProcess {
+                pid,
+                name: comm,
+                argv0: None,
+                cmdline: argv.as_ref().map(|parts| parts.join(" ")),
+                argv,
+            })
+        })
+        .collect()
+}
+
 fn process_tree_pids(
     roots: impl IntoIterator<Item = u32>,
     mut task_ids: impl FnMut(u32) -> Vec<u32>,
@@ -754,6 +783,33 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn descendant_processes_finds_spawned_child() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("sleep should spawn");
+        let child_pid = child.id();
+
+        let mut found = false;
+        for _ in 0..20 {
+            found = descendant_processes(std::process::id())
+                .iter()
+                .any(|process| process.pid == child_pid && process.name == "sleep");
+            if found {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(found, "spawned sleep child should appear in descendants");
     }
 
     #[test]

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -20,6 +20,8 @@ pub(crate) use super::unix_common::{
 };
 
 const PROC_PGRP_ONLY: u32 = 2;
+const PROC_PPID_ONLY: u32 = 6;
+const DESCENDANT_PROCESS_SCAN_LIMIT: usize = 64;
 const SERVER_NOFILE_LIMIT_TARGET: libc::rlim_t = 8192;
 
 pub(crate) fn should_draw_host_cursor_by_default() -> bool {
@@ -324,6 +326,14 @@ pub fn foreground_group_leader_job(process_group_id: u32) -> Option<ForegroundJo
 }
 
 fn process_group_pids(process_group_id: u32) -> Vec<u32> {
+    proc_list_pids(PROC_PGRP_ONLY, process_group_id)
+}
+
+fn child_pids(parent_pid: u32) -> Vec<u32> {
+    proc_list_pids(PROC_PPID_ONLY, parent_pid)
+}
+
+fn proc_list_pids(list_kind: u32, list_key: u32) -> Vec<u32> {
     let mut capacity = 16usize;
 
     for _ in 0..8 {
@@ -331,8 +341,8 @@ fn process_group_pids(process_group_id: u32) -> Vec<u32> {
         let buffer_bytes = pids.len() * std::mem::size_of::<libc::pid_t>();
         let returned_bytes = unsafe {
             libc::proc_listpids(
-                PROC_PGRP_ONLY,
-                process_group_id,
+                list_kind,
+                list_key,
                 pids.as_mut_ptr() as *mut libc::c_void,
                 buffer_bytes as libc::c_int,
             )
@@ -350,6 +360,47 @@ fn process_group_pids(process_group_id: u32) -> Vec<u32> {
     }
 
     Vec::new()
+}
+
+/// Collect descendant processes of a root PID, breadth-first and bounded.
+///
+/// Used to find agents that run on their own pty inside terminal-embedding
+/// editors, where the agent is not part of the pane's foreground job.
+pub fn descendant_processes(root_pid: u32) -> Vec<ForegroundProcess> {
+    if root_pid == 0 {
+        return Vec::new();
+    }
+
+    let mut pending = std::collections::VecDeque::from([root_pid]);
+    let mut visited = std::collections::HashSet::from([root_pid]);
+    let mut processes = Vec::new();
+
+    while let Some(pid) = pending.pop_front() {
+        for child in child_pids(pid) {
+            if child == 0 || !visited.insert(child) {
+                continue;
+            }
+            if processes.len() >= DESCENDANT_PROCESS_SCAN_LIMIT {
+                return processes;
+            }
+            pending.push_back(child);
+
+            let Some(name) = process_bsdinfo(child).and_then(|info| comm_from_bsdinfo(&info))
+            else {
+                continue;
+            };
+            let argv = process_argv(child);
+            processes.push(ForegroundProcess {
+                pid: child,
+                name,
+                argv0: process_argv0_name(child),
+                cmdline: argv.as_ref().map(|parts| parts.join(" ")),
+                argv,
+            });
+        }
+    }
+
+    processes
 }
 
 /// Read `e_tpgid` (foreground process group of the controlling terminal)
@@ -1013,6 +1064,33 @@ mod tests {
             target_nofile_soft_limit(16_384, libc::RLIM_INFINITY, 8192),
             None
         );
+    }
+
+    #[test]
+    fn descendant_processes_finds_spawned_child() {
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("sleep should spawn");
+        let child_pid = child.id();
+
+        let mut found = false;
+        for _ in 0..20 {
+            found = descendant_processes(std::process::id())
+                .iter()
+                .any(|process| process.pid == child_pid && process.name == "sleep");
+            if found {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(found, "spawned sleep child should appear in descendants");
     }
 
     fn build_procargs2(exec_path: &str, argv: &[&str], env: &[&str]) -> Vec<u8> {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -978,6 +978,21 @@ fn process_is_ancestor(
     false
 }
 
+const DESCENDANT_PROCESS_SCAN_LIMIT: usize = 64;
+
+/// Collect descendant processes of a root PID, bounded.
+///
+/// Used to find agents hosted inside terminal-embedding editors, where the
+/// agent is not part of the pane's foreground job.
+pub fn descendant_processes(root_pid: u32) -> Vec<super::ForegroundProcess> {
+    let entries = snapshot_processes();
+    descendant_entries(root_pid, &entries)
+        .into_iter()
+        .take(DESCENDANT_PROCESS_SCAN_LIMIT)
+        .map(foreground_process_from_entry)
+        .collect()
+}
+
 fn descendant_entries(root_pid: u32, entries: &[WindowsProcessEntry]) -> Vec<&WindowsProcessEntry> {
     let mut children: HashMap<u32, Vec<&WindowsProcessEntry>> = HashMap::new();
     for entry in entries {


### PR DESCRIPTION
## Summary

Agents launched from nvim/vim `:terminal` buffers (e.g. opencode or codex started by an nvim plugin) run on their own pty and process group, so they never join the pane's foreground job and were invisible to herdr's process-based agent identification on Unix. Windows already finds them via descendant traversal; this brings Unix to parity.

## Changes

- `platform::descendant_processes(root_pid)`: bounded (64) BFS descendant walk — macOS `proc_listpids(PROC_PPID_ONLY)`, Linux `/proc/*/task/*/children`, Windows snapshot reuse, fallback stub
- `detect::identify_agent_hosted_by_editor`: when the foreground job contains a terminal-hosting editor (`nvim`/`vim`/`vi`) and no agent was identified, identify agents among the editor's descendants using the existing scoring (including runtime-wrapped agents)
- Wired as a last-resort fallback in the pane detection probe and `live_runtime_agent`; descendants are scanned only when an editor is foreground and nothing else matched, so normal panes pay no extra cost

## Testing

- Unit tests: editor-hosted identification (direct, runtime-wrapped, no-agent descendants, non-editor skip) and probe fallback wiring
- Live tests: `descendant_processes` finds a spawned child on macOS and Linux
- Manual (macOS, debug session): `nvim -c ':terminal codex'` → pane reports `agent: codex`, detected through nvim → `nvim --embed` → agent; clears after the agent exits while nvim keeps running, and when nvim exits
- `cargo nextest` green; `cargo clippy -D warnings` clean on host and `x86_64-pc-windows-msvc`; `docs/next` changelog updated
