### PR TITLE
test(windows): serialize media player environment access

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -450,6 +450,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_media_player_reports_invalid_media_without_waiting_for_timeout() {
+        let _lock = crate::integration::integration_env_lock();
         let path = temp_sound_path();
         std::fs::write(&path, b"not an mp3").unwrap();
         let output = run_windows_player(&path).unwrap();


### PR DESCRIPTION
## What

Serialize the Windows MediaPlayer test with the existing integration environment lock.

## Why

The Windows check runs all tests matching `windows_` together. Some integration tests temporarily replace the process-wide `PATH`, while the MediaPlayer test starts `powershell.exe` by name.

If those overlap, the sound test can see the temporary `PATH` and fail with `program not found`, even though MediaPlayer itself is fine. Which then leads to unnecessarily flaky windows tests.

This keeps the existing test and production behavior unchanged. It only makes the test share the same lock as the environment-mutating tests.

## Validation

- `just check`
- `cargo test --locked --target x86_64-pc-windows-msvc --bin herdr sound::tests::windows_media_player_reports_invalid_media_without_waiting_for_timeout -- --exact`
- `cargo test --locked --target x86_64-pc-windows-msvc --bin herdr windows_ -- --test-threads=2` (150 passed)
