### PR TITLE
fix(cli): include popup in plugin pane open --placement help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `herdr plugin pane open --help` and shell completions now list `popup` as an accepted `--placement` value, matching the CLI's actual parser and the documented `plugin.pane.open` override values.
+
 ## [0.8.0] - 2026-08-03
 
 ### Added

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -855,7 +855,7 @@ fn plugin_command() -> Command {
                         .arg(option("entrypoint", "ID"))
                         .arg(
                             option("placement", "PLACEMENT")
-                                .value_parser(["overlay", "split", "tab", "zoomed"]),
+                                .value_parser(["overlay", "popup", "split", "tab", "zoomed"]),
                         )
                         .arg(option("workspace", "ID"))
                         .arg(option("target-pane", "PANE"))
@@ -1219,6 +1219,7 @@ mod tests {
             .get_arguments()
             .any(|arg| arg.get_long() == Some("entrypoint")));
         assert!(option_values(open, "placement").contains(&"zoomed".to_string()));
+        assert!(option_values(open, "placement").contains(&"popup".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## What

`herdr plugin pane open --placement` accepts `popup` at runtime (the real parser in `src/cli/plugin.rs::parse_pane_placement` has handled it since `popup` shipped in 0.7.4), and the plugin docs already document `popup` as a valid override value for `plugin.pane.open`. But the clap `value_parser` used for `--help` output and shell completions in `src/cli/spec.rs` only listed `overlay, split, tab, zoomed` — so `--help` silently disagreed with both the actual CLI behavior and the published docs.

Found this while building a herdr plugin: a `pane open --placement popup` call worked exactly as documented, but `--help` implied it would be rejected.

## Fix

- Add `popup` to the `value_parser` array for `plugin pane open --placement` (`src/cli/spec.rs`).
- Extend the existing `spec_includes_nested_plugin_pane_open_options` test to assert `popup` is present, so this can't silently drift again — the previous test only checked for `zoomed`.
- CHANGELOG entry under `### Fixed`.

## Why the drift happened

The runtime parser and the clap help spec are two independent definitions of the same enum. Someone added `popup` support to the parser and to `print_plugin_pane_help()`'s manual `eprintln!` (which already lists `popup` correctly), but missed the separate `value_parser` array in `spec.rs` used for `--help`/completions.

## Test plan

- [ ] `cargo test --lib cli::spec::tests::spec_includes_nested_plugin_pane_open_options` (I could not run this locally — this environment's cargo registry requires an authenticated credential provider I don't have configured. Change is a single-token array edit mirroring the existing `zoomed` entry; happy to iterate if CI flags anything.)
- [x] Manually confirmed `parse_pane_placement` in `src/cli/plugin.rs` already accepts `popup`
- [x] Manually confirmed `herdr.dev/docs/plugins/#panes` documents `popup` as a valid `plugin.pane.open` override
