### PR TITLE
fix(windows): strip elevated terminal title decoration

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -40,6 +40,11 @@ pub(crate) fn apply_pane_runtime_marker(command: &mut portable_pty::CommandBuild
 }
 
 #[cfg(not(windows))]
+pub(crate) fn terminal_title_for_presentation(title: &str) -> &str {
+    title
+}
+
+#[cfg(not(windows))]
 fn apply_pane_runtime_marker_platform(_command: &mut portable_pty::CommandBuilder) {}
 
 pub(crate) fn configure_background_command(command: &mut std::process::Command) {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -82,6 +82,11 @@ use super::{ClipboardImage, ForegroundJob, Signal};
 const STILL_ACTIVE: u32 = 259;
 const FOREGROUND_PROCESS_SNAPSHOT_CACHE_TTL: Duration = Duration::from_millis(250);
 const PANE_RUNTIME_MARKER_ENV_VAR: &str = "HERDR_PANE_RUNTIME_ID";
+
+pub(crate) fn terminal_title_for_presentation(title: &str) -> &str {
+    title.strip_prefix("Administrator: ").unwrap_or(title)
+}
+
 const MAX_PROCESS_ENVIRONMENT_BYTES: usize = 256 * 1024;
 const PROCESS_ENVIRONMENT_READ_CHUNK_BYTES: usize = 16 * 1024;
 const PROCESS_RUNTIME_MARKER_CACHE_CAPACITY: usize = 1_024;

--- a/src/terminal/title.rs
+++ b/src/terminal/title.rs
@@ -1,7 +1,7 @@
 const CLAUDE_ACTIVITY_GLYPHS: &str = "·✢✳✶✻✽";
 
 pub(crate) fn stripped_terminal_title(title: &str) -> Option<String> {
-    let title = title.trim();
+    let title = crate::platform::terminal_title_for_presentation(title).trim();
     if title.is_empty() {
         return None;
     }
@@ -60,5 +60,19 @@ mod tests {
         );
         assert_eq!(stripped_terminal_title("  "), None);
         assert_eq!(stripped_terminal_title("⠋   "), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strips_one_windows_elevation_decoration_before_activity_glyph() {
+        assert_eq!(
+            stripped_terminal_title("Administrator:   ⠋ task").as_deref(),
+            Some("task")
+        );
+        assert_eq!(
+            stripped_terminal_title("Administrator: Administrator: task").as_deref(),
+            Some("Administrator: task")
+        );
+        assert_eq!(stripped_terminal_title("Administrator: "), None);
     }
 }


### PR DESCRIPTION
## What changed

Windows can add `Administrator: ` to terminal titles. Herdr exposed that decoration through `terminal_title_stripped`, so it could leak into the sidebar and API consumers.

This removes one leading prefix only when deriving the Windows presentation title.

- raw `terminal_title` stays exact
- manual pane labels such as `Administrator: xyz` stay exact
- agent detection keeps using the raw OSC title
- non-Windows behavior stays unchanged

This supersedes #2433. The 200 ms approach handled one short transition shape, but it still published the decoration during startup and when it stayed longer. This uses the existing stripped-title boundary instead and adds no timing or pending state.

An application that intentionally sets the same prefix keeps it in raw `terminal_title`. The derived presentation field removes it by design.

## Before and after

On current upstream, when Windows reports a title such as `Administrator: task`, Herdr exposes the prefix through both title fields.

| Field | Current upstream | This change |
| --- | --- | --- |
| `terminal_title` | `Administrator: task` | `Administrator: task` |
| `terminal_title_stripped` | `Administrator: task` | `task` |
| Manual label `Administrator: xyz` | unchanged | unchanged |

Non-Windows behavior remains unchanged.

## Validation

- `just check` on current `master` with two Cargo jobs
- formatting and Clippy
- 151 Windows tests
- 25 transport tests and native-input coverage
- isolated named-session smoke after the final rebase