### PR TITLE
feat(pi): treat senpi as pi successor

### DIFF
--- a/src/detect/mod.rs
+++ b/src/detect/mod.rs
@@ -181,8 +181,10 @@ pub(crate) fn parse_canonical_agent_label(label: &str) -> Option<Agent> {
 }
 
 fn lookup_agent(name: &str) -> Option<Agent> {
+    if name == "pi" || name.starts_with("senpi") {
+        return Some(Agent::Pi);
+    }
     match name {
-        "pi" => Some(Agent::Pi),
         "claude" | "claude-code" => Some(Agent::Claude),
         "codex" => Some(Agent::Codex),
         "gemini" => Some(Agent::Gemini),
@@ -548,6 +550,11 @@ fn agent_name_from_known_package_path(path: &str) -> Option<String> {
                 "cli",
             ]
         {
+            return Some(agent_label(Agent::Pi).to_string());
+        }
+    }
+    for window in components.windows(4) {
+        if window == ["node_modules", "@code-yeongyu", "senpi", "dist"] {
             return Some(agent_label(Agent::Pi).to_string());
         }
     }

--- a/src/integration/targets.rs
+++ b/src/integration/targets.rs
@@ -76,7 +76,27 @@ pub(crate) fn install_pi() -> io::Result<PathBuf> {
 
     let path = dir.join(PI_EXTENSION_INSTALL_NAME);
     fs::write(&path, PI_EXTENSION_ASSET)?;
+    // senpi is the successor to pi — it shares the same integration lifecycle.
+    // If a ~/.senpi tree exists, keep it in sync so `herdr integration install pi`
+    // covers both without requiring a separate target.
+    sync_pi_extension_to_senpi_dirs();
     Ok(path)
+}
+
+fn sync_pi_extension_to_senpi_dirs() {
+    let Ok(home) = crate::integration::env::home_dir() else {
+        return;
+    };
+    for candidate in [
+        home.join(".senpi/agent/extensions"),
+        home.join(".senpi2/agent/extensions"),
+        home.join(".senpi3/agent/extensions"),
+    ] {
+        if candidate.is_dir() {
+            let dest = candidate.join(PI_EXTENSION_INSTALL_NAME);
+            let _ = fs::write(&dest, PI_EXTENSION_ASSET);
+        }
+    }
 }
 
 pub(crate) fn install_omp() -> io::Result<OmpInstallPaths> {
@@ -527,7 +547,28 @@ pub(crate) fn install_hermes() -> io::Result<HermesInstallPaths> {
     })
 }
 
+fn remove_pi_extension_from_senpi_dirs() {
+    let Ok(home) = crate::integration::env::home_dir() else {
+        return;
+    };
+    for candidate in [
+        home.join(".senpi/agent/extensions"),
+        home.join(".senpi2/agent/extensions"),
+        home.join(".senpi3/agent/extensions"),
+    ] {
+        let path = candidate.join(PI_EXTENSION_INSTALL_NAME);
+        if path.is_file() {
+            if let Ok(content) = fs::read_to_string(&path) {
+                if content.contains("HERDR_INTEGRATION_ID=pi") {
+                    let _ = fs::remove_file(&path);
+                }
+            }
+        }
+    }
+}
+
 pub(crate) fn uninstall_pi() -> io::Result<PiUninstallResult> {
+    remove_pi_extension_from_senpi_dirs();
     let extension_path = pi_extension_dir()?.join(PI_EXTENSION_INSTALL_NAME);
     let removed_extension = remove_file_if_exists(&extension_path)?;
 


### PR DESCRIPTION
senpi (code-yeongyu/senpi) is an opinionated fork of pi-mono that rebrands via \`piConfig.name=configDir=.senpi\` and resolves its agent dir through \`SENPI_CODING_AGENT_DIR\` (with \`PI_\` as legacy fallback). It is wire-compatible with the \`pi\` lifecycle but today herdr does not recognise it.

This makes \`senpi\` a first-class successor to \`pi\` without adding a new agent:

- **Process detection**: \`lookup_agent("senpi" | "senpi2" | "senpi3" | "senpi*")\` → \`Agent::Pi\`, so any \`senpi\` binary, wrapper, or isolated instance (\`SENPI_CODING_AGENT_DIR=~/.senpi2/agent\`) is detected as \`pi\`.
- **Package path**: \`node_modules/@code-yeongyu/senpi/dist/*\` resolves to \`Pi\`, mirroring the existing \`@earendil-works/pi-coding-agent\` window.
- **Integration**: \`herdr integration install pi\` also syncs the pi extension to \`~/.senpi{,2,3}/agent/extensions\` when those trees exist; \`uninstall pi\` cleans them up. No new \`IntegrationTarget\` — \`senpi\` is \`pi\` (same screen manifest, same \`herdr:pi\` lifecycle authority / session identity).

Fixes the gap where \`senpi\` panes showed as \`unknown\` and never reported \`working/idle/blocked\` unless a custom extension was hand-patched.

Test: \`senpi\` / \`senpi2\` /\`senpi3\` wrappers on macOS + Linux (herdr 0.8.0) now appear as \`pi\` in \`herdr agent list\` / \`herdr pane list\` and the \`pi\` integration covers them.