### PR TITLE
fix: make just build cross-platform

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,6 +60,12 @@ install-hooks:
     @echo "installed git hooks from .githooks"
 
 # Build release binary
+[unix]
+build:
+    cargo build --release --locked
+
+[script("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File")]
+[windows]
 build:
     cargo build --release --locked
 


### PR DESCRIPTION
## What changed

`just build` currently uses the Unix shell on Windows. It prints the Cargo command, then fails when `sh` is not installed.

This keeps the existing Unix recipe as-is and adds a Windows variant using the same PowerShell recipe pattern already used by `lint` and `check`.

No extra script needed.

## Testing

- `just build` on Windows
- incremental `just build`
- `just --show build`
- `just lint`
