### PR TITLE
fix: project direct attach bracketed paste mode

### DIFF
--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -3487,7 +3487,7 @@ impl HeadlessServer {
             return false;
         };
         let prepare_started = crate::render_prof::timer();
-        let Some(prepared) = client.render_state.prepare_frame(frame) else {
+        let Some(prepared) = client.render_state.prepare_frame(frame, None) else {
             client.clear_deferred_render();
             crate::render_prof::event("retained_send.skip_identical");
             crate::render_prof::duration_since("retained_send.prepare_frame", prepare_started);
@@ -3704,7 +3704,7 @@ impl HeadlessServer {
             };
             let has_graphics = !frame.graphics.is_empty();
             let prepare_started = crate::render_prof::timer();
-            let Some(mut prepared) = client.render_state.prepare_frame(frame) else {
+            let Some(mut prepared) = client.render_state.prepare_frame(frame, None) else {
                 client.clear_deferred_render();
                 crate::render_prof::event("full_render.skip_identical");
                 crate::render_prof::duration_since("full_render.prepare_frame", prepare_started);
@@ -3736,7 +3736,7 @@ impl HeadlessServer {
                     };
                     text_only_frame.graphics.clear();
                     let Some(text_only_prepared) =
-                        client.render_state.prepare_frame(text_only_frame)
+                        client.render_state.prepare_frame(text_only_frame, None)
                     else {
                         client.clear_deferred_render();
                         crate::render_prof::event("full_render.skip_identical_text_only");
@@ -8227,7 +8227,7 @@ next_tab = ""
         frame.cells[hyperlink_idx].hyperlink = Some(0);
         let prepared = client
             .render_state
-            .prepare_frame(frame)
+            .prepare_frame(frame, None)
             .expect("hyperlink frame differs");
         client.render_state.commit_sent_frame(prepared);
 

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -3579,7 +3579,7 @@ impl HeadlessServer {
         for (client_id, (cols, rows), cell_size, is_foreground, mode) in render_targets {
             let area = Rect::new(0, 0, cols, rows);
             let is_app_client = matches!(mode, ClientConnectionMode::App);
-            let mut frame = match mode {
+            let (mut frame, projected_bracketed_paste) = match mode {
                 ClientConnectionMode::App => {
                     let render_started = crate::render_prof::timer();
                     let render_cell_size =
@@ -3616,7 +3616,7 @@ impl HeadlessServer {
                         &hyperlinks,
                     );
                     crate::render_prof::duration_since("full_render.frame_build", frame_started);
-                    frame
+                    (frame, None)
                 }
                 ClientConnectionMode::TerminalAttach { terminal_id }
                 | ClientConnectionMode::TerminalObserve { terminal_id } => {
@@ -3632,6 +3632,12 @@ impl HeadlessServer {
                         broken_clients.push(client_id);
                         continue;
                     };
+                    let projected_bracketed_paste = Some(
+                        runtime
+                            .input_state()
+                            .map(|state| state.bracketed_paste)
+                            .unwrap_or(false),
+                    );
                     let render_started = crate::render_prof::timer();
                     let (buffer, cursor) =
                         crate::server::render_stream::render_terminal_virtual(runtime, area);
@@ -3652,7 +3658,7 @@ impl HeadlessServer {
                         &hyperlinks,
                     );
                     crate::render_prof::duration_since("full_render.frame_build", frame_started);
-                    frame
+                    (frame, projected_bracketed_paste)
                 }
             };
 
@@ -3704,7 +3710,10 @@ impl HeadlessServer {
             };
             let has_graphics = !frame.graphics.is_empty();
             let prepare_started = crate::render_prof::timer();
-            let Some(mut prepared) = client.render_state.prepare_frame(frame, None) else {
+            let Some(mut prepared) = client
+                .render_state
+                .prepare_frame(frame, projected_bracketed_paste)
+            else {
                 client.clear_deferred_render();
                 crate::render_prof::event("full_render.skip_identical");
                 crate::render_prof::duration_since("full_render.prepare_frame", prepare_started);
@@ -5109,14 +5118,27 @@ next_tab = ""
     }
 
     fn connect_pending_terminal_client(server: &mut HeadlessServer, client_id: u64) {
-        let _control_rx = connect_pending_terminal_client_with_control_rx(server, client_id);
+        let (_control_rx, _render_rx) =
+            connect_pending_terminal_client_with_receivers(server, client_id);
     }
 
     fn connect_pending_terminal_client_with_control_rx(
         server: &mut HeadlessServer,
         client_id: u64,
     ) -> std::sync::mpsc::Receiver<Vec<u8>> {
-        let (writer, control_rx, _render_rx) = test_client_writer();
+        let (control_rx, _render_rx) =
+            connect_pending_terminal_client_with_receivers(server, client_id);
+        control_rx
+    }
+
+    fn connect_pending_terminal_client_with_receivers(
+        server: &mut HeadlessServer,
+        client_id: u64,
+    ) -> (
+        std::sync::mpsc::Receiver<Vec<u8>>,
+        std::sync::mpsc::Receiver<Vec<u8>>,
+    ) {
+        let (writer, control_rx, render_rx) = test_client_writer();
         assert!(server.handle_server_event(ServerEvent::ClientConnected {
             client_id,
             cols: 100,
@@ -5128,7 +5150,7 @@ next_tab = ""
             direct_attach_requested: true,
             writer,
         }));
-        control_rx
+        (control_rx, render_rx)
     }
 
     #[test]
@@ -5189,6 +5211,82 @@ next_tab = ""
                 Some(ClientConnectionMode::TerminalObserve { terminal_id: observed })
                     if observed == &terminal_id.to_string()
             ));
+        });
+    }
+
+    #[test]
+    fn direct_terminal_frames_project_child_bracketed_paste_mode() {
+        with_terminal_session_test_server(|server, terminal_id, terminal_id_string, _| {
+            let (_control_rx, render_rx) =
+                connect_pending_terminal_client_with_receivers(server, 7);
+            assert!(
+                server.handle_server_event(ServerEvent::ClientControlTerminal {
+                    client_id: 7,
+                    target: terminal_id_string,
+                    takeover: false,
+                })
+            );
+
+            server.render_and_stream();
+            let disabled = match read_server_message(
+                render_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .expect("initial direct frame"),
+            ) {
+                ServerMessage::Terminal(frame) => frame,
+                other => panic!("expected terminal frame, got {other:?}"),
+            };
+            assert!(disabled.full);
+            assert!(disabled
+                .bytes
+                .windows(b"\x1b[?2004l".len())
+                .any(|window| window == b"\x1b[?2004l"));
+
+            server
+                .app
+                .terminal_runtimes
+                .get(&terminal_id)
+                .expect("runtime")
+                .test_process_pty_bytes(b"\x1b[?2004h");
+            server.render_and_stream();
+            let enabled = match read_server_message(
+                render_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .expect("mode-only direct frame"),
+            ) {
+                ServerMessage::Terminal(frame) => frame,
+                other => panic!("expected terminal frame, got {other:?}"),
+            };
+            assert!(!enabled.full);
+            assert_eq!(enabled.seq, disabled.seq + 1);
+            assert!(enabled
+                .bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|window| window == b"\x1b[?2004h"));
+
+            server.render_and_stream();
+            assert!(render_rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+            server
+                .clients
+                .get_mut(&7)
+                .expect("direct client")
+                .render_state
+                .reset_baseline();
+            server.render_and_stream();
+            let reset = match read_server_message(
+                render_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .expect("reset direct frame"),
+            ) {
+                ServerMessage::Terminal(frame) => frame,
+                other => panic!("expected terminal frame, got {other:?}"),
+            };
+            assert!(reset.full);
+            assert!(reset
+                .bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|window| window == b"\x1b[?2004h"));
         });
     }
 
@@ -7724,6 +7822,72 @@ next_tab = ""
             ServerMessage::ReloadSoundConfig
         ));
         assert!(client_rx.recv_timeout(Duration::from_millis(50)).is_err());
+    }
+
+    #[test]
+    fn deferred_direct_terminal_render_retries_uncommitted_mode_projection() {
+        with_terminal_session_test_server(|server, terminal_id, terminal_id_string, _| {
+            server
+                .app
+                .terminal_runtimes
+                .get(&terminal_id)
+                .expect("runtime")
+                .test_process_pty_bytes(b"\x1b[?2004h");
+
+            let (writer, _control_rx, render_rx) = test_client_writer();
+            let queued = HeadlessServer::frame_server_message(&ServerMessage::ReloadSoundConfig)
+                .expect("serialize dummy message");
+            writer
+                .render
+                .try_send(queued)
+                .expect("pre-fill render queue");
+            assert!(server.handle_server_event(ServerEvent::ClientConnected {
+                client_id: 7,
+                cols: 100,
+                rows: 30,
+                cell_width_px: 0,
+                cell_height_px: 0,
+                render_encoding: RenderEncoding::TerminalAnsi,
+                keybindings: None,
+                direct_attach_requested: true,
+                writer,
+            }));
+            assert!(
+                server.handle_server_event(ServerEvent::ClientControlTerminal {
+                    client_id: 7,
+                    target: terminal_id_string,
+                    takeover: false,
+                })
+            );
+
+            server.render_and_stream();
+            assert_eq!(server.clients[&7].render_state.terminal_seq(), Some(0));
+            assert_eq!(server.clients[&7].deferred_render(), DeferredRender::Full);
+            assert!(matches!(
+                read_server_message(
+                    render_rx
+                        .recv_timeout(Duration::from_millis(100))
+                        .expect("queued message")
+                ),
+                ServerMessage::ReloadSoundConfig
+            ));
+
+            assert!(server.handle_server_event(ServerEvent::ClientWriterDrained { client_id: 7 }));
+            server.render_and_stream();
+            let retried = match read_server_message(
+                render_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .expect("retried direct frame"),
+            ) {
+                ServerMessage::Terminal(frame) => frame,
+                other => panic!("expected terminal frame, got {other:?}"),
+            };
+            assert_eq!(retried.seq, 1);
+            assert!(retried
+                .bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|window| window == b"\x1b[?2004h"));
+        });
     }
 
     #[test]

--- a/src/server/render_stream.rs
+++ b/src/server/render_stream.rs
@@ -14,7 +14,11 @@ pub(crate) enum ClientRenderState {
     /// Semantic clients compare full frame data and skip identical frames.
     Semantic { last_frame: Option<FrameData> },
     /// Terminal-ANSI clients keep a terminal diff encoder and sequence number.
-    TerminalAnsi { blit_encoder: BlitEncoder, seq: u64 },
+    TerminalAnsi {
+        blit_encoder: BlitEncoder,
+        seq: u64,
+        projected_bracketed_paste: Option<bool>,
+    },
 }
 
 impl ClientRenderState {
@@ -24,6 +28,7 @@ impl ClientRenderState {
             RenderEncoding::TerminalAnsi => Self::TerminalAnsi {
                 blit_encoder: BlitEncoder::new(),
                 seq: 0,
+                projected_bracketed_paste: None,
             },
         }
     }
@@ -31,7 +36,14 @@ impl ClientRenderState {
     pub(crate) fn reset_baseline(&mut self) {
         match self {
             Self::Semantic { last_frame } => *last_frame = None,
-            Self::TerminalAnsi { blit_encoder, .. } => *blit_encoder = BlitEncoder::new(),
+            Self::TerminalAnsi {
+                blit_encoder,
+                projected_bracketed_paste,
+                ..
+            } => {
+                *blit_encoder = BlitEncoder::new();
+                *projected_bracketed_paste = None;
+            }
         }
     }
 
@@ -41,7 +53,11 @@ impl ClientRenderState {
         }
     }
 
-    pub(crate) fn prepare_frame(&mut self, frame: FrameData) -> Option<PreparedRender> {
+    pub(crate) fn prepare_frame(
+        &mut self,
+        frame: FrameData,
+        projected_bracketed_paste: Option<bool>,
+    ) -> Option<PreparedRender> {
         match self {
             Self::Semantic { last_frame } => {
                 if last_frame.as_ref() == Some(&frame) {
@@ -53,13 +69,28 @@ impl ClientRenderState {
                     message: ServerMessage::Frame(frame),
                 })
             }
-            Self::TerminalAnsi { blit_encoder, seq } => {
-                if blit_encoder.is_current(&frame) {
+            Self::TerminalAnsi {
+                blit_encoder,
+                seq,
+                projected_bracketed_paste: committed_bracketed_paste,
+            } => {
+                let projection_changed = *committed_bracketed_paste != projected_bracketed_paste;
+                if blit_encoder.is_current(&frame) && !projection_changed {
                     crate::render_prof::event("prepare_frame.ansi.skip_current");
                     return None;
                 }
                 let mut encoded = blit_encoder.encode(&frame, false);
                 crate::render_prof::event("prepare_frame.ansi.changed");
+                if encoded.full || projection_changed {
+                    if let Some(enabled) = projected_bracketed_paste {
+                        let sequence = if enabled {
+                            BRACKETED_PASTE_ENABLE
+                        } else {
+                            BRACKETED_PASTE_DISABLE
+                        };
+                        encoded.bytes.splice(0..0, sequence.iter().copied());
+                    }
+                }
                 crate::render_prof::counter("prepare_frame.ansi.bytes", encoded.bytes.len() as u64);
                 if encoded.full {
                     crate::render_prof::event("prepare_frame.ansi.full");
@@ -81,6 +112,7 @@ impl ClientRenderState {
                     }),
                     frame,
                     encoded: Some(encoded),
+                    projected_bracketed_paste,
                 })
             }
         }
@@ -102,14 +134,20 @@ impl ClientRenderState {
                 },
             ) => *last_frame = Some(frame),
             (
-                Self::TerminalAnsi { blit_encoder, seq },
+                Self::TerminalAnsi {
+                    blit_encoder,
+                    seq,
+                    projected_bracketed_paste: committed_bracketed_paste,
+                },
                 PreparedRender::TerminalAnsi {
                     frame,
                     encoded: Some(encoded),
+                    projected_bracketed_paste,
                     ..
                 },
             ) => {
                 blit_encoder.commit(frame, encoded);
+                *committed_bracketed_paste = projected_bracketed_paste;
                 *seq += 1;
             }
             _ => {}
@@ -125,6 +163,8 @@ impl ClientRenderState {
     }
 }
 
+const BRACKETED_PASTE_ENABLE: &[u8] = b"\x1b[?2004h";
+const BRACKETED_PASTE_DISABLE: &[u8] = b"\x1b[?2004l";
 const SYNC_OUTPUT_END: &[u8] = b"\x1b[?2026l";
 
 fn insert_graphics_before_sync_end(encoded: &mut Vec<u8>, graphics: &[u8]) {
@@ -158,6 +198,7 @@ pub(crate) enum PreparedRender {
         message: ServerMessage,
         frame: FrameData,
         encoded: Option<EncodedBlit>,
+        projected_bracketed_paste: Option<bool>,
     },
 }
 
@@ -448,4 +489,115 @@ fn focused_terminal_suppresses_host_cursor(
     app_state
         .runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, info.id)
         .is_some_and(crate::terminal::TerminalRuntime::synchronized_output_active)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::CellData;
+
+    fn test_frame(symbol: &str) -> FrameData {
+        FrameData {
+            cells: vec![CellData {
+                symbol: symbol.to_owned(),
+                fg: 0,
+                bg: 0,
+                modifier: 0,
+                skip: false,
+                hyperlink: None,
+            }],
+            width: 1,
+            height: 1,
+            cursor: None,
+            hyperlinks: Vec::new(),
+            graphics: Vec::new(),
+        }
+    }
+
+    fn terminal_frame(prepared: &PreparedRender) -> &TerminalFrame {
+        match prepared.message() {
+            ServerMessage::Terminal(frame) => frame,
+            other => panic!("expected terminal frame, got {other:?}"),
+        }
+    }
+
+    fn contains(bytes: &[u8], sequence: &[u8]) -> bool {
+        bytes
+            .windows(sequence.len())
+            .any(|window| window == sequence)
+    }
+
+    #[test]
+    fn terminal_ansi_projects_bracketed_paste_on_full_mode_only_and_reset_frames() {
+        let mut state = ClientRenderState::new(RenderEncoding::TerminalAnsi);
+        let frame = test_frame("x");
+
+        let disabled = state
+            .prepare_frame(frame.clone(), Some(false))
+            .expect("initial full frame");
+        assert!(terminal_frame(&disabled).full);
+        assert!(contains(
+            &terminal_frame(&disabled).bytes,
+            BRACKETED_PASTE_DISABLE
+        ));
+        state.commit_sent_frame(disabled);
+
+        assert!(state.prepare_frame(frame.clone(), Some(false)).is_none());
+
+        let enabled = state
+            .prepare_frame(frame.clone(), Some(true))
+            .expect("mode-only transition");
+        assert!(!terminal_frame(&enabled).full);
+        assert_eq!(terminal_frame(&enabled).seq, 2);
+        assert!(contains(
+            &terminal_frame(&enabled).bytes,
+            BRACKETED_PASTE_ENABLE
+        ));
+        state.commit_sent_frame(enabled);
+
+        assert!(state.prepare_frame(frame.clone(), Some(true)).is_none());
+
+        state.reset_baseline();
+        let reset = state
+            .prepare_frame(frame, Some(true))
+            .expect("reset full frame");
+        assert!(terminal_frame(&reset).full);
+        assert!(contains(
+            &terminal_frame(&reset).bytes,
+            BRACKETED_PASTE_ENABLE
+        ));
+    }
+
+    #[test]
+    fn terminal_ansi_does_not_commit_an_unsent_mode_projection() {
+        let mut state = ClientRenderState::new(RenderEncoding::TerminalAnsi);
+        let frame = test_frame("x");
+
+        let pending = state
+            .prepare_frame(frame.clone(), Some(true))
+            .expect("pending frame");
+        assert_eq!(terminal_frame(&pending).seq, 1);
+        drop(pending);
+
+        let retry = state
+            .prepare_frame(frame, Some(true))
+            .expect("uncommitted mode must be retried");
+        assert_eq!(terminal_frame(&retry).seq, 1);
+        assert!(contains(
+            &terminal_frame(&retry).bytes,
+            BRACKETED_PASTE_ENABLE
+        ));
+    }
+
+    #[test]
+    fn terminal_ansi_full_app_frame_has_no_bracketed_paste_projection() {
+        let mut state = ClientRenderState::new(RenderEncoding::TerminalAnsi);
+
+        let prepared = state
+            .prepare_frame(test_frame("x"), None)
+            .expect("initial full-app frame");
+        let bytes = &terminal_frame(&prepared).bytes;
+        assert!(!contains(bytes, BRACKETED_PASTE_ENABLE));
+        assert!(!contains(bytes, BRACKETED_PASTE_DISABLE));
+    }
 }


### PR DESCRIPTION
## Summary

- track an optional bracketed-paste projection in each terminal-ANSI client render baseline
- emit the child terminal mode for direct attach and observe frames, including mode-only transitions
- commit projected mode only after successful queue admission so deferred renders retry current state
- leave full-app and retained rendering unprojected and avoid wire-protocol changes

## Why

Direct-attach clients could receive terminal contents without the child terminal bracketed-paste mode. A client could then flatten a prompt submission: the text and line feed appeared, but the shell did not execute it as intended. Projecting the authoritative child mode through the existing ANSI stream lets clients encode one prompt submission correctly without an arbitrary delay.

## Verification

- `nix develop -c just test-one terminal_ansi_` — 11 passed
- `nix develop -c just test-one direct_terminal` — 2 passed
- `nix develop -c just test-one deferred_direct_terminal_render_retries_uncommitted_mode_projection` — 1 passed
- `cargo fmt --check` — passed
- `cargo clippy --all-targets --locked -- -D warnings` — passed
- `git diff --check origin/master...HEAD` — passed
- current upstream `master` and this branch merge without textual conflicts

The full `nix develop -c just check` run was bounded while the unchanged `ghostty::tests::deep_scrollback_resize_preserves_unicode_and_hyperlinks` stress test remained CPU-bound in this environment. The focused changed-path tests above are green.