### PR TITLE
feat: install plugins from any https git host

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `plugin install` and `plugin uninstall` now accept `https://host/owner/repo[/subdir...]` URLs, so plugins can be installed from any https git host with the GitHub path layout — Forgejo, Gitea, GitLab, or self-hosted — and pinned with `--ref` exactly like GitHub installs.
 - Herdr now keeps the outer terminal window title in sync with the session through `ui.window_title`, so window managers and terminal tab bars show the active workspace and the host the panes actually run on.
 - The desktop tab bar now has configurable right-aligned status entries for zoom state, hostname, date/time, literal text, and asynchronously refreshed command output.
 - Optional `keys.move_tab_previous` and `keys.move_tab_next` bindings now reorder the active tab in place, wrapping at either end.

--- a/docs/preview/website/src/content/docs/cli-reference.mdx
+++ b/docs/preview/website/src/content/docs/cli-reference.mdx
@@ -394,13 +394,14 @@ Install, list, and remove plugins:
 
 ```bash
 herdr plugin install <owner>/<repo>[/subdir...] [--ref REF] [--yes]
+herdr plugin install https://<host>/<owner>/<repo>[/subdir...] [--ref REF] [--yes]
 herdr plugin list [--plugin ID] [--json]
-herdr plugin uninstall <plugin_id|owner/repo[/subdir...]>
+herdr plugin uninstall <plugin_id|owner/repo[/subdir...]|url>
 herdr plugin enable <plugin_id>
 herdr plugin disable <plugin_id>
 ```
 
-`plugin install` accepts GitHub shorthand only, such as `ogulcancelik/herdr-plugin-examples/worktree-bootstrap`. It uses `git`, shows a trust preview in interactive terminals, runs supported manifest build commands, and stores GitHub installs in a Herdr-managed directory. Use `--yes` for noninteractive installs. Reinstalling a GitHub-managed plugin replaces that managed checkout. Installing over a locally linked plugin is refused. Plugin manifests must declare `min_herdr_version`; install and link fail when the plugin requires a newer Herdr binary. `plugin list` is human-readable by default; pass `--json` for the raw API response.
+`plugin install` accepts GitHub shorthand, such as `ogulcancelik/herdr-plugin-examples/worktree-bootstrap`, or an `https://host/owner/repo[/subdir...]` URL for any git server with that path layout, such as Forgejo, Gitea, or GitLab. It uses `git`, shows a trust preview in interactive terminals, runs supported manifest build commands, and stores remote installs in a Herdr-managed directory. Use `--yes` for noninteractive installs. Reinstalling a managed plugin replaces that managed checkout. Installing over a locally linked plugin is refused. Plugin manifests must declare `min_herdr_version`; install and link fail when the plugin requires a newer Herdr binary. `plugin list` is human-readable by default; pass `--json` for the raw API response.
 
 Plugin installation and enabled state are global to the current user. A plugin installed, linked, enabled, or disabled through one Herdr session is immediately available with the same state in every session.
 

--- a/docs/preview/website/src/content/docs/ja/cli-reference.mdx
+++ b/docs/preview/website/src/content/docs/ja/cli-reference.mdx
@@ -366,13 +366,14 @@ herdr integration status [--outdated-only]
 
 ```bash
 herdr plugin install <owner>/<repo>[/subdir...] [--ref REF] [--yes]
+herdr plugin install https://<host>/<owner>/<repo>[/subdir...] [--ref REF] [--yes]
 herdr plugin list [--plugin ID] [--json]
-herdr plugin uninstall <plugin_id|owner/repo[/subdir...]>
+herdr plugin uninstall <plugin_id|owner/repo[/subdir...]|url>
 herdr plugin enable <plugin_id>
 herdr plugin disable <plugin_id>
 ```
 
-`plugin install` は `ogulcancelik/herdr-plugin-examples/worktree-bootstrap` のような GitHub 省略記法のみを受け付けます。`git` を使い、対話的なターミナルでは信頼プレビューを表示し、サポートされるマニフェストのビルドコマンドを実行し、GitHub インストールを Herdr 管理のディレクトリに保存します。非対話的なインストールには `--yes` を使ってください。GitHub 管理プラグインの再インストールは、その管理チェックアウトを置き換えます。ローカルにリンクされたプラグインへの上書きインストールは拒否されます。プラグインのマニフェストは `min_herdr_version` を宣言しなければならず、プラグインがより新しい Herdr バイナリを要求する場合、install と link は失敗します。`plugin list` はデフォルトで人間可読です。生の API レスポンスが欲しいときは `--json` を渡してください。
+`plugin install` は `ogulcancelik/herdr-plugin-examples/worktree-bootstrap` のような GitHub 省略記法に加えて、Forgejo、Gitea、GitLab など同じパス構成の git サーバーを指す `https://host/owner/repo[/subdir...]` 形式の URL も受け付けます。`git` を使い、対話的なターミナルでは信頼プレビューを表示し、サポートされるマニフェストのビルドコマンドを実行し、リモートインストールを Herdr 管理のディレクトリに保存します。非対話的なインストールには `--yes` を使ってください。管理プラグインの再インストールは、その管理チェックアウトを置き換えます。ローカルにリンクされたプラグインへの上書きインストールは拒否されます。プラグインのマニフェストは `min_herdr_version` を宣言しなければならず、プラグインがより新しい Herdr バイナリを要求する場合、install と link は失敗します。`plugin list` はデフォルトで人間可読です。生の API レスポンスが欲しいときは `--json` を渡してください。
 
 ローカル開発:
 

--- a/docs/preview/website/src/content/docs/ja/plugins.mdx
+++ b/docs/preview/website/src/content/docs/ja/plugins.mdx
@@ -190,10 +190,12 @@ herdr plugin pane open --plugin example.layout --entrypoint board
 herdr plugin log list --plugin example.layout
 ```
 
-`plugin install` は `owner/repo/subdir` のような GitHub 省略記法のみを受け付けます。
+`plugin install` は `owner/repo/subdir` のような GitHub 省略記法に加えて、
+Forgejo、Gitea、GitLab など同じパス構成の git サーバー上のプラグインを指す
+`https://host/owner/repo[/subdir...]` 形式の URL も受け付けます。
 `git` でクローンし、対話的なターミナルではプレビューを表示し、サポートされる
 ビルドコマンドを実行し、チェックアウトを Herdr 管理のプラグインデータの下に保存して
-登録します。非対話的なインストールには `--yes` を使ってください。GitHub 管理の
+登録します。非対話的なインストールには `--yes` を使ってください。管理された
 プラグインを再インストールすると、その管理チェックアウトが置き換えられます。
 インストール済みおよびリンク済みのプラグインと、その有効・無効の状態は現在の
 ユーザー全体で共有され、すべての Herdr セッションから利用できます。Herdr サーバーが
@@ -206,11 +208,11 @@ Herdr 0.7.3 の名前付きセッションだけにインストールしたプ�
 `plugin config-dir <id>` はセットアップドキュメントやシェルスクリプト向けに
 設定ディレクトリを表示します。
 
-`plugin uninstall <id-or-source>` はプラグインの登録を解除します。GitHub 管理の
+`plugin uninstall <id-or-source>` はプラグインの登録を解除します。管理された
 インストールでは管理チェックアウトも削除し、プラグイン id と、install で使うのと
-同じ `owner/repo[/subdir...]` 省略記法の両方を受け付けます。`plugin unlink <id>` は
+同じ `owner/repo[/subdir...]` 省略記法または URL を受け付けます。`plugin unlink <id>` は
 登録解除のみを行いファイルには触れないため、ローカル開発に便利です。v1 に独立した
-`plugin update` はありません。管理プラグインを更新するには GitHub から
+`plugin update` はありません。管理プラグインを更新するにはインストール元から
 再インストールしてください。
 
 サンプル集のリポジトリは `ogulcancelik/herdr-plugin-examples` です。
@@ -220,7 +222,7 @@ Herdr 0.7.3 の名前付きセッションだけにインストールしたプ�
 
 ## ビルドコマンド
 
-ビルドコマンドは GitHub からの `plugin install` 中、確認の後、Herdr がプラグインを
+ビルドコマンドはリモートからの `plugin install` 中、確認の後、Herdr がプラグインを
 登録する前に実行されます。ビルドコマンドが失敗するとインストールは中止され、
 プラグインは登録されません。`plugin link` はビルドコマンドを実行しません。
 ローカルの作者は自分で作業ツリーをビルドします。ビルドコマンドはファイルを生成して

--- a/docs/preview/website/src/content/docs/plugins.mdx
+++ b/docs/preview/website/src/content/docs/plugins.mdx
@@ -189,11 +189,13 @@ herdr plugin pane open --plugin example.layout --entrypoint board
 herdr plugin log list --plugin example.layout
 ```
 
-`plugin install` accepts GitHub shorthand only, such as
-`owner/repo/subdir`. It clones with `git`, shows a preview in interactive
-terminals, runs supported build commands, then stores the checkout under
-Herdr-managed plugin data and registers it. Use `--yes` for noninteractive
-installs. Reinstalling a GitHub-managed plugin replaces that managed checkout.
+`plugin install` accepts GitHub shorthand, such as `owner/repo/subdir`, or an
+`https://host/owner/repo[/subdir...]` URL for a plugin hosted on any git
+server with that path layout, such as Forgejo, Gitea, or GitLab. It clones
+with `git`, shows a preview in interactive terminals, runs supported build
+commands, then stores the checkout under Herdr-managed plugin data and
+registers it. Use `--yes` for noninteractive installs. Reinstalling a managed
+plugin replaces that managed checkout.
 Installed and linked plugins, including their enabled state, are global to the
 current user and available in every Herdr session. Both `plugin install` and
 `plugin link` can register plugins while no Herdr server is running. Plugins
@@ -204,12 +206,12 @@ local plugin first. `plugin install` and `plugin link` create the plugin's
 config and state directories, and `plugin config-dir <id>` prints the config
 directory for setup docs and shell scripts.
 
-`plugin uninstall <id-or-source>` unregisters the plugin. For GitHub-managed
-installs it also removes the managed checkout, and it accepts either the plugin
-id or the same `owner/repo[/subdir...]` shorthand used by install.
+`plugin uninstall <id-or-source>` unregisters the plugin. For managed installs
+it also removes the managed checkout, and it accepts the plugin id or the same
+`owner/repo[/subdir...]` shorthand or URL used by install.
 `plugin unlink <id>` only unregisters a plugin and leaves files alone, which is
 useful for local development. There is no separate `plugin update` in v1;
-reinstall from GitHub to refresh a managed plugin.
+reinstall from the source to refresh a managed plugin.
 
 The example cookbook repo is `ogulcancelik/herdr-plugin-examples`. It contains
 separate example plugins in subdirectories, including `agent-telegram-notify`,
@@ -218,7 +220,7 @@ not maintained official plugins.
 
 ## Build commands
 
-Build commands run during GitHub `plugin install` after confirmation and before
+Build commands run during remote `plugin install` after confirmation and before
 Herdr registers the plugin. If a build command fails, install aborts and the
 plugin is not registered. `plugin link` does not run build commands; local
 authors build their working tree themselves. Build commands may generate files,

--- a/docs/preview/website/src/content/docs/zh-cn/cli-reference.mdx
+++ b/docs/preview/website/src/content/docs/zh-cn/cli-reference.mdx
@@ -366,13 +366,14 @@ herdr integration status [--outdated-only]
 
 ```bash
 herdr plugin install <owner>/<repo>[/subdir...] [--ref REF] [--yes]
+herdr plugin install https://<host>/<owner>/<repo>[/subdir...] [--ref REF] [--yes]
 herdr plugin list [--plugin ID] [--json]
-herdr plugin uninstall <plugin_id|owner/repo[/subdir...]>
+herdr plugin uninstall <plugin_id|owner/repo[/subdir...]|url>
 herdr plugin enable <plugin_id>
 herdr plugin disable <plugin_id>
 ```
 
-`plugin install` 只接受 GitHub 简写,比如 `ogulcancelik/herdr-plugin-examples/worktree-bootstrap`。它使用 `git`,在交互式终端显示信任预览,运行受支持的清单构建命令,并把 GitHub 安装保存在 Herdr 管理的目录中。非交互式安装用 `--yes`。重新安装 GitHub 管理的插件会替换该托管检出。不允许覆盖安装到本地链接的插件之上。插件清单必须声明 `min_herdr_version`;当插件要求更新的 Herdr 二进制时,install 和 link 会失败。`plugin list` 默认是人类可读的;要原始 API 响应就传 `--json`。
+`plugin install` 接受 GitHub 简写,比如 `ogulcancelik/herdr-plugin-examples/worktree-bootstrap`,也接受 `https://host/owner/repo[/subdir...]` 形式的 URL,用于任何采用相同路径结构的 git 服务器(如 Forgejo、Gitea、GitLab)。它使用 `git`,在交互式终端显示信任预览,运行受支持的清单构建命令,并把远程安装保存在 Herdr 管理的目录中。非交互式安装用 `--yes`。重新安装受管理的插件会替换该托管检出。不允许覆盖安装到本地链接的插件之上。插件清单必须声明 `min_herdr_version`;当插件要求更新的 Herdr 二进制时,install 和 link 会失败。`plugin list` 默认是人类可读的;要原始 API 响应就传 `--json`。
 
 本地开发:
 

--- a/docs/preview/website/src/content/docs/zh-cn/plugins.mdx
+++ b/docs/preview/website/src/content/docs/zh-cn/plugins.mdx
@@ -174,10 +174,12 @@ herdr plugin pane open --plugin example.layout --entrypoint board
 herdr plugin log list --plugin example.layout
 ```
 
-`plugin install` 只接受 GitHub 简写,比如 `owner/repo/subdir`。它用 `git`
+`plugin install` 接受 GitHub 简写,比如 `owner/repo/subdir`,也接受
+`https://host/owner/repo[/subdir...]` 形式的 URL,用于托管在任何采用相同
+路径结构的 git 服务器(如 Forgejo、Gitea、GitLab)上的插件。它用 `git`
 克隆,在交互式终端展示预览,运行受支持的构建命令,然后把检出保存到
-Herdr 管理的插件数据下并注册。非交互式安装用 `--yes`。重新安装 GitHub
-管理的插件会替换该托管检出。已安装和已链接的插件及其启用状态对当前用户
+Herdr 管理的插件数据下并注册。非交互式安装用 `--yes`。重新安装受管理的
+插件会替换该托管检出。已安装和已链接的插件及其启用状态对当前用户
 全局生效,可在所有 Herdr 会话中使用。即使 Herdr 服务器没有运行,也可以通过
 `plugin install` 和 `plugin link` 注册插件。仅安装在 Herdr 0.7.3 命名会话中的
 插件必须重新 install 或 link;现有的插件配置和状态会保留。
@@ -186,11 +188,11 @@ Herdr 管理的插件数据下并注册。非交互式安装用 `--yes`。重新
 插件的配置和状态目录,`plugin config-dir <id>` 打印配置目录,方便安装
 文档和 shell 脚本使用。
 
-`plugin uninstall <id-or-source>` 注销插件。对 GitHub 管理的安装,它还会
-删除托管检出,并且既接受插件 id,也接受与 install 相同的
-`owner/repo[/subdir...]` 简写。`plugin unlink <id>` 只注销插件、不动文件,
+`plugin uninstall <id-or-source>` 注销插件。对受管理的安装,它还会
+删除托管检出,并且接受插件 id,也接受与 install 相同的
+`owner/repo[/subdir...]` 简写或 URL。`plugin unlink <id>` 只注销插件、不动文件,
 对本地开发很有用。v1 没有单独的 `plugin update`;要刷新托管插件,请从
-GitHub 重新安装。
+安装来源重新安装。
 
 示例菜谱仓库是 `ogulcancelik/herdr-plugin-examples`。它在子目录中包含
 多个独立示例插件,包括 `agent-telegram-notify`、`github-link-preview` 和
@@ -198,7 +200,7 @@ GitHub 重新安装。
 
 ## 构建命令
 
-构建命令在 GitHub `plugin install` 过程中运行,时机在确认之后、Herdr
+构建命令在远程 `plugin install` 过程中运行,时机在确认之后、Herdr
 注册插件之前。如果构建命令失败,安装中止,插件不会被注册。`plugin link`
 不运行构建命令;本地作者自己构建工作树。构建命令可以生成文件,但在
 安装预览之后修改 `herdr-plugin.toml` 会导致安装中止。构建失败时会显示

--- a/src/api/schema/plugins.rs
+++ b/src/api/schema/plugins.rs
@@ -72,6 +72,8 @@ pub struct PluginSourceInfo {
     #[serde(default)]
     pub kind: PluginSourceKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<String>,
@@ -91,6 +93,7 @@ impl Default for PluginSourceInfo {
     fn default() -> Self {
         Self {
             kind: PluginSourceKind::Local,
+            host: None,
             owner: None,
             repo: None,
             subdir: None,

--- a/src/app/api/plugins/mod.rs
+++ b/src/app/api/plugins/mod.rs
@@ -1076,6 +1076,7 @@ command = ["echo", " a", "first "]
                 enabled: true,
                 source: Some(PluginSourceInfo {
                     kind: PluginSourceKind::Github,
+                    host: None,
                     owner: Some("ogulcancelik".into()),
                     repo: Some("herdr-plugin-examples".into()),
                     subdir: Some("worktree-bootstrap".into()),

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -153,7 +153,9 @@ fn plugin_unlink(args: &[String]) -> std::io::Result<i32> {
 
 fn plugin_install(args: &[String]) -> std::io::Result<i32> {
     let Some(source_arg) = args.first() else {
-        eprintln!("usage: herdr plugin install <owner>/<repo>[/subdir...] [--ref REF] [--yes]");
+        eprintln!(
+            "usage: herdr plugin install <owner>/<repo>[/subdir...] | https://<host>/<owner>/<repo>[/subdir...] [--ref REF] [--yes]"
+        );
         return Ok(2);
     };
     let source = match GithubPluginSource::parse(source_arg) {
@@ -712,6 +714,7 @@ fn normalize_plugin_path_arg(value: &str) -> std::io::Result<String> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct GithubPluginSource {
+    host: Option<String>,
     owner: String,
     repo: String,
     subdir: Option<String>,
@@ -719,22 +722,51 @@ struct GithubPluginSource {
 
 impl GithubPluginSource {
     fn parse(value: &str) -> Result<Self, String> {
-        if value.starts_with("http://")
-            || value.starts_with("https://")
-            || value.starts_with("git@")
-            || value.contains(':')
-        {
-            return Err("plugin install v1 accepts only owner/repo[/subdir] shorthand".into());
+        if let Some(rest) = value.strip_prefix("https://") {
+            return Self::parse_url(rest);
+        }
+        if value.starts_with("http://") {
+            return Err("plugin install accepts https:// URLs only".into());
+        }
+        if value.starts_with("git@") || value.contains(':') {
+            return Err(
+                "plugin install accepts owner/repo[/subdir] shorthand (GitHub) or an https://host/owner/repo[/subdir] URL"
+                    .into(),
+            );
         }
         let parts = value.split('/').collect::<Vec<_>>();
         if parts.len() < 2 {
             return Err("usage: herdr plugin install <owner>/<repo>[/subdir...]".into());
         }
-        let owner = parts[0];
-        let repo = parts[1];
+        Self::from_parts(None, parts[0], parts[1], &parts[2..])
+    }
+
+    fn parse_url(value: &str) -> Result<Self, String> {
+        let parts = value.split('/').collect::<Vec<_>>();
+        if parts.len() < 3 {
+            return Err(
+                "usage: herdr plugin install https://<host>/<owner>/<repo>[/subdir...]".into(),
+            );
+        }
+        let host = parts[0];
+        validate_host_segment(host)?;
+        let repo = parts[2].strip_suffix(".git").unwrap_or(parts[2]);
+        let host = if host.eq_ignore_ascii_case("github.com") {
+            None
+        } else {
+            Some(host)
+        };
+        Self::from_parts(host, parts[1], repo, &parts[3..])
+    }
+
+    fn from_parts(
+        host: Option<&str>,
+        owner: &str,
+        repo: &str,
+        subdir_parts: &[&str],
+    ) -> Result<Self, String> {
         validate_github_segment("owner", owner)?;
         validate_github_segment("repo", repo)?;
-        let subdir_parts = &parts[2..];
         for part in subdir_parts {
             validate_subdir_segment(part)?;
         }
@@ -744,21 +776,31 @@ impl GithubPluginSource {
             Some(subdir_parts.join("/"))
         };
         Ok(Self {
+            host: host.map(str::to_string),
             owner: owner.to_string(),
             repo: repo.to_string(),
             subdir,
         })
     }
 
+    fn host(&self) -> &str {
+        self.host.as_deref().unwrap_or("github.com")
+    }
+
     fn remote_url(&self) -> String {
-        format!("https://github.com/{}/{}.git", self.owner, self.repo)
+        format!("https://{}/{}/{}.git", self.host(), self.owner, self.repo)
     }
 
     fn display(&self) -> String {
-        match &self.subdir {
-            Some(subdir) => format!("{}/{}/{}", self.owner, self.repo, subdir),
+        let mut display = match &self.host {
+            Some(host) => format!("{}/{}/{}", host, self.owner, self.repo),
             None => format!("{}/{}", self.owner, self.repo),
+        };
+        if let Some(subdir) = &self.subdir {
+            display.push('/');
+            display.push_str(subdir);
         }
+        display
     }
 
     fn manifest_root(&self, checkout: &Path) -> PathBuf {
@@ -777,6 +819,7 @@ impl GithubPluginSource {
     ) -> PluginSourceInfo {
         PluginSourceInfo {
             kind: PluginSourceKind::Github,
+            host: self.host.clone(),
             owner: Some(self.owner.clone()),
             repo: Some(self.repo.clone()),
             subdir: self.subdir.clone(),
@@ -797,7 +840,7 @@ fn ensure_replacement_allowed(
     };
     if existing.source.kind != PluginSourceKind::Github {
         return Err(std::io::Error::other(format!(
-            "plugin {} is already linked from a local path; uninstall/unlink it before installing from GitHub",
+            "plugin {} is already linked from a local path; uninstall/unlink it before installing from a git host",
             plugin.plugin_id
         )));
     }
@@ -818,6 +861,26 @@ fn validate_github_segment(label: &str, value: &str) -> Result<(), String> {
         return Err(format!(
             "GitHub {label} contains invalid characters: {value}"
         ));
+    }
+    Ok(())
+}
+
+fn validate_host_segment(value: &str) -> Result<(), String> {
+    let (name, port) = match value.split_once(':') {
+        Some((name, port)) => (name, Some(port)),
+        None => (value, None),
+    };
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '.'))
+    {
+        return Err(format!("invalid git host: {value}"));
+    }
+    if let Some(port) = port {
+        if port.is_empty() || !port.chars().all(|ch| ch.is_ascii_digit()) {
+            return Err(format!("invalid git host port: {value}"));
+        }
     }
     Ok(())
 }
@@ -1091,6 +1154,7 @@ fn plugin_by_github_source(
 
 fn plugin_matches_github_source(plugin: &InstalledPluginInfo, source: &GithubPluginSource) -> bool {
     plugin.source.kind == PluginSourceKind::Github
+        && plugin.source.host.as_deref() == source.host.as_deref()
         && plugin.source.owner.as_deref() == Some(source.owner.as_str())
         && plugin.source.repo.as_deref() == Some(source.repo.as_str())
         && plugin.source.subdir.as_deref() == source.subdir.as_deref()
@@ -1704,6 +1768,7 @@ mod tests {
             link_handlers: vec![],
             source: PluginSourceInfo {
                 kind: PluginSourceKind::Github,
+                host: None,
                 owner: Some(owner.to_string()),
                 repo: Some(repo.to_string()),
                 subdir: subdir.map(str::to_string),
@@ -1741,8 +1806,12 @@ mod tests {
     #[test]
     fn github_plugin_source_rejects_non_shorthand_sources() {
         for source in [
-            "https://github.com/ogulcancelik/herdr-plugin-examples",
             "git@github.com:ogulcancelik/herdr-plugin-examples.git",
+            "http://git.example.com/ogulcancelik/herdr-plugin-examples",
+            "https://git.example.com/ogulcancelik",
+            "https://bad_host/ogulcancelik/herdr-plugin-examples",
+            "https://git.example.com:notaport/ogulcancelik/herdr-plugin-examples",
+            "https://git.example.com/ogulcancelik/herdr-plugin-examples/../bad",
             "ogulcancelik",
             "ogulcancelik/herdr-plugin-examples/../bad",
             "ogulcancelik/herdr-plugin-examples//bad",
@@ -1752,6 +1821,74 @@ mod tests {
                 "{source} should be rejected"
             );
         }
+    }
+
+    #[test]
+    fn plugin_source_parses_https_url_with_host() {
+        let source =
+            GithubPluginSource::parse("https://git.example.com/ogulcancelik/herdr-plugin-examples")
+                .unwrap();
+        assert_eq!(source.host.as_deref(), Some("git.example.com"));
+        assert_eq!(source.owner, "ogulcancelik");
+        assert_eq!(source.repo, "herdr-plugin-examples");
+        assert_eq!(source.subdir, None);
+        assert_eq!(
+            source.remote_url(),
+            "https://git.example.com/ogulcancelik/herdr-plugin-examples.git"
+        );
+    }
+
+    #[test]
+    fn plugin_source_parses_https_url_with_port_git_suffix_and_subdir() {
+        let source = GithubPluginSource::parse(
+            "https://git.example.com:3000/ogulcancelik/herdr-plugin-examples.git/worktree-bootstrap",
+        )
+        .unwrap();
+        assert_eq!(source.host.as_deref(), Some("git.example.com:3000"));
+        assert_eq!(source.repo, "herdr-plugin-examples");
+        assert_eq!(source.subdir.as_deref(), Some("worktree-bootstrap"));
+        assert_eq!(
+            source.remote_url(),
+            "https://git.example.com:3000/ogulcancelik/herdr-plugin-examples.git"
+        );
+    }
+
+    #[test]
+    fn plugin_source_normalizes_github_url_to_shorthand() {
+        let url = GithubPluginSource::parse(
+            "https://github.com/ogulcancelik/herdr-plugin-examples/worktree-bootstrap",
+        )
+        .unwrap();
+        let shorthand =
+            GithubPluginSource::parse("ogulcancelik/herdr-plugin-examples/worktree-bootstrap")
+                .unwrap();
+        assert_eq!(url, shorthand);
+        assert_eq!(url.host, None);
+    }
+
+    #[test]
+    fn source_lookup_requires_matching_host() {
+        let github_target =
+            GithubPluginSource::parse("ogulcancelik/herdr-plugin-examples").unwrap();
+        let forge_target =
+            GithubPluginSource::parse("https://git.example.com/ogulcancelik/herdr-plugin-examples")
+                .unwrap();
+
+        let mut forge_install = github_plugin(
+            "examples.forge",
+            "ogulcancelik",
+            "herdr-plugin-examples",
+            None,
+        );
+        forge_install.source.host = Some("git.example.com".to_string());
+
+        assert!(plugin_by_github_source([forge_install.clone()], &github_target).is_none());
+        assert_eq!(
+            plugin_by_github_source([forge_install], &forge_target)
+                .unwrap()
+                .plugin_id,
+            "examples.forge"
+        );
     }
 
     #[test]

--- a/src/cli/spec.rs
+++ b/src/cli/spec.rs
@@ -771,8 +771,11 @@ fn plugin_command() -> Command {
         .about("Install and run workflow plugins")
         .subcommand(
             Command::new("install")
-                .about("Install a plugin from GitHub")
-                .arg(required("source", "OWNER/REPO[/SUBDIR]"))
+                .about("Install a plugin from GitHub or any https git host")
+                .arg(required(
+                    "source",
+                    "OWNER/REPO[/SUBDIR] | https://HOST/OWNER/REPO[/SUBDIR]",
+                ))
                 .arg(option("ref", "REF"))
                 .arg(
                     Arg::new("yes")

--- a/src/persist/plugin_registry.rs
+++ b/src/persist/plugin_registry.rs
@@ -226,6 +226,7 @@ mod tests {
         entry.enabled = false;
         entry.source = crate::api::schema::PluginSourceInfo {
             kind: crate::api::schema::PluginSourceKind::Github,
+            host: None,
             owner: Some("ogulcancelik".into()),
             repo: Some("herdr-plugin-examples".into()),
             subdir: Some("worktree-bootstrap".into()),


### PR DESCRIPTION
## Summary

- `plugin install` and `plugin uninstall` now also accept `https://HOST[:PORT]/OWNER/REPO[.git][/SUBDIR...]`, so plugins can live on any https git host with the GitHub path layout — Forgejo, Gitea, GitLab, or self-hosted
- the `owner/repo[/subdir]` shorthand is unchanged and still means github.com, and a `https://github.com/...` URL normalizes to it, so both spellings produce identical registry records
- installs reuse the existing shallow `git fetch` path unchanged — no new fetch machinery, and private hosts authenticate through git credential helpers exactly like private GitHub repos today
- `PluginSourceInfo` gains an optional `host` recorded per install; absent means github.com, so registries written before this field existed keep their meaning and GitHub records stay byte-identical. Source matching compares it, so the shorthand only matches GitHub installs and a URL only matches installs from that host
- `http://` and ssh remotes stay rejected with specific errors
- documented in the CLI reference and plugins guide in all three languages, changelog staged under `docs/next/`

## Usage

```bash
herdr plugin install https://git.example.com/acme/herdr-plugins/worktree-bootstrap --ref <rev> --yes
herdr plugin uninstall https://git.example.com/acme/herdr-plugins/worktree-bootstrap
```

## Testing

- new unit tests: URL parsing (host, port, `.git` suffix, subdirs), rejections (`http://`, invalid host, invalid port, `..` traversal), github.com URL normalization to the shorthand, and host-exact source matching in both directions
- `cargo fmt --check` and `cargo clippy --all-targets --locked -- -D warnings` pass; plugin-scoped `cargo test` passes (one pre-existing `app::api::layouts` test fails identically on clean `master` in this environment)
- `scripts/docs_translation_parity` passes on the docs changes
- live end-to-end against a Forgejo instance: install by URL with `--ref <exact commit>` (Forgejo serves the same shallow exact-SHA fetch the installer relies on), the registry record carries `host` and the resolved commit, shorthand uninstall correctly does not match the forge install, and URL uninstall removes it