### PR TITLE
fix(popup): enable native text selection in popup panes

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2280,13 +2280,8 @@ impl AppState {
             return;
         }
 
-        let ws_idx = match self.active {
-            Some(ws_idx) if self.workspaces.get(ws_idx).is_some() => ws_idx,
-            _ => return,
-        };
-
         let text = self
-            .runtime_for_pane_in_workspace(terminal_runtimes, ws_idx, sel.pane_id)
+            .runtime_for_pane(terminal_runtimes, sel.pane_id)
             .and_then(|rt| rt.extract_selection(&sel));
         if let Some(text) = text {
             if !text.is_empty() {

--- a/src/app/api/plugins/context.rs
+++ b/src/app/api/plugins/context.rs
@@ -387,9 +387,16 @@ impl App {
         }
         let terminal_id = self
             .state
-            .workspaces
-            .iter()
-            .find_map(|workspace| workspace.terminal_id(pane_id))?;
+            .popup_pane
+            .as_ref()
+            .filter(|popup| popup.pane_id == pane_id)
+            .map(|popup| &popup.terminal_id)
+            .or_else(|| {
+                self.state
+                    .workspaces
+                    .iter()
+                    .find_map(|workspace| workspace.terminal_id(pane_id))
+            })?;
         self.terminal_runtimes
             .get(terminal_id)
             .and_then(|runtime| runtime.extract_selection(selection))

--- a/src/app/input/clipboard.rs
+++ b/src/app/input/clipboard.rs
@@ -289,4 +289,92 @@ mod tests {
             b"\x03"
         );
     }
+
+    fn app_with_popup_screen_bytes_and_input(
+        bytes: &[u8],
+    ) -> (
+        App,
+        crate::layout::PaneId,
+        Rect,
+        tokio::sync::mpsc::Receiver<Bytes>,
+    ) {
+        let mut app = app_for_mouse_test();
+        app.state.workspaces = vec![Workspace::test_new("test")];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.view.terminal_area = Rect::new(0, 0, 100, 30);
+
+        let pane_id = crate::layout::PaneId::alloc();
+        let terminal_id = crate::terminal::TerminalId::alloc();
+
+        app.state.popup_pane = Some(crate::app::state::PopupPaneState {
+            pane_id,
+            terminal_id: terminal_id.clone(),
+            width: None,
+            height: None,
+        });
+
+        let (_, inner) =
+            crate::ui::popup_pane_rects(&app.state, app.state.view.terminal_area).unwrap();
+
+        let (runtime, input_rx) =
+            crate::terminal::TerminalRuntime::test_with_channel_and_scrollback_bytes(
+                inner.width,
+                inner.height,
+                0,
+                bytes,
+                4,
+            );
+
+        app.terminal_runtimes.insert(terminal_id.clone(), runtime);
+        app.state.terminals.insert(
+            terminal_id.clone(),
+            crate::terminal::TerminalState::new(
+                terminal_id.clone(),
+                std::path::PathBuf::from("/popup"),
+            ),
+        );
+
+        (app, pane_id, inner, input_rx)
+    }
+
+    #[tokio::test]
+    async fn popup_pane_drag_selection_highlights_and_copies_to_clipboard() {
+        let (mut app, pane_id, inner, _rx) =
+            app_with_popup_screen_bytes_and_input(b"popup content");
+        app.state.copy_on_select = false;
+
+        let start_col = inner.x;
+        let end_col = inner.x + 5;
+        let row = inner.y;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), start_col, row));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), end_col, row));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), end_col, row));
+
+        assert_visible_selection(&app);
+        assert_eq!(app.state.selection.as_ref().unwrap().pane_id, pane_id);
+
+        app.state.copy_selection(&app.terminal_runtimes);
+        assert!(app.dispatch_pending_clipboard_write());
+        assert_eq!(clipboard_write_content(&mut app), b"popup");
+    }
+
+    #[tokio::test]
+    async fn popup_pane_copy_on_select_copies_on_mouse_up() {
+        let (mut app, _pane_id, inner, _rx) =
+            app_with_popup_screen_bytes_and_input(b"popup content");
+        app.state.copy_on_select = true;
+
+        let start_col = inner.x;
+        let end_col = inner.x + 5;
+        let row = inner.y;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), start_col, row));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), end_col, row));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), end_col, row));
+
+        assert_eq!(clipboard_write_content(&mut app), b"popup");
+    }
 }

--- a/src/app/input/copy_mode.rs
+++ b/src/app/input/copy_mode.rs
@@ -38,7 +38,7 @@ impl AppState {
         else {
             return;
         };
-        let Some(info) = self.pane_info_by_id(pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(pane_id) else {
             return;
         };
         if info.inner_rect.width == 0 || info.inner_rect.height == 0 {
@@ -339,7 +339,7 @@ impl AppState {
             return;
         };
         let pane_id = copy_mode.pane_id;
-        let Some(info) = self.pane_info_by_id(pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(pane_id) else {
             return;
         };
         let Some(metrics) = self.pane_scroll_metrics(terminal_runtimes, pane_id) else {
@@ -405,7 +405,7 @@ impl AppState {
         let Some(copy_mode) = self.copy_mode.as_ref() else {
             return;
         };
-        let Some(info) = self.pane_info_by_id(copy_mode.pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(copy_mode.pane_id) else {
             return;
         };
         if copy_mode.cursor_row >= info.inner_rect.height
@@ -458,7 +458,7 @@ impl AppState {
         let pane_id = copy_mode.pane_id;
         let mut cursor_row = copy_mode.cursor_row;
         let mut cursor_col = copy_mode.cursor_col;
-        let Some(info) = self.pane_info_by_id(pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(pane_id) else {
             self.exit_copy_mode(terminal_runtimes, false);
             return;
         };
@@ -508,7 +508,7 @@ impl AppState {
         };
         let pane_id = copy_mode.pane_id;
         let mut cursor_row = copy_mode.cursor_row;
-        let Some(info) = self.pane_info_by_id(pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(pane_id) else {
             self.exit_copy_mode(terminal_runtimes, false);
             return;
         };
@@ -844,7 +844,7 @@ impl AppState {
         let Some(selection) = copy_mode.selection else {
             return;
         };
-        let Some(info) = self.pane_info_by_id(copy_mode.pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(copy_mode.pane_id) else {
             return;
         };
         match selection {

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -354,6 +354,7 @@ impl App {
 
         if self.state.popup_pane.is_some() {
             self.handle_popup_mouse(mouse);
+            self.dispatch_pending_clipboard_write();
             return;
         }
         if self.handle_overlay_mouse(mouse) {
@@ -489,48 +490,121 @@ impl App {
         {
             return;
         }
-        let Some(rt) = self.popup_runtime() else {
-            self.close_popup_pane();
+        let Some(popup) = self.state.popup_pane.as_ref() else {
             return;
         };
-        let position = crate::input::mouse::Position::Cell {
-            column: mouse.column.saturating_sub(inner.x),
-            row: mouse.row.saturating_sub(inner.y),
-        };
-        let bytes = match mouse.kind {
-            MouseEventKind::ScrollUp
-            | MouseEventKind::ScrollDown
-            | MouseEventKind::ScrollLeft
-            | MouseEventKind::ScrollRight => match rt.wheel_routing() {
-                Some(crate::pane::WheelRouting::MouseReport) => {
-                    rt.encode_mouse_wheel(mouse.kind, position, mouse.modifiers)
-                }
-                Some(crate::pane::WheelRouting::AlternateScroll) => {
-                    rt.encode_alternate_scroll(mouse.kind)
-                }
-                Some(crate::pane::WheelRouting::HostScroll) | None => {
-                    let lines_per_notch = self.state.mouse_scroll_lines;
-                    match mouse.kind {
-                        MouseEventKind::ScrollUp => rt.scroll_up(lines_per_notch),
-                        MouseEventKind::ScrollDown => rt.scroll_down(lines_per_notch),
-                        _ => {}
+        let popup_pane_id = popup.pane_id;
+
+        let column = mouse.column.saturating_sub(inner.x);
+        let row = mouse.row.saturating_sub(inner.y);
+        let position = crate::input::mouse::Position::Cell { column, row };
+
+        let (bytes, scroll_metrics) = {
+            let Some(rt) = self.popup_runtime() else {
+                self.close_popup_pane();
+                return;
+            };
+            let bytes = match mouse.kind {
+                MouseEventKind::ScrollUp
+                | MouseEventKind::ScrollDown
+                | MouseEventKind::ScrollLeft
+                | MouseEventKind::ScrollRight => match rt.wheel_routing() {
+                    Some(crate::pane::WheelRouting::MouseReport) => {
+                        rt.encode_mouse_wheel(mouse.kind, position, mouse.modifiers)
                     }
-                    return;
+                    Some(crate::pane::WheelRouting::AlternateScroll) => {
+                        rt.encode_alternate_scroll(mouse.kind)
+                    }
+                    Some(crate::pane::WheelRouting::HostScroll) | None => {
+                        let lines_per_notch = self.state.mouse_scroll_lines;
+                        match mouse.kind {
+                            MouseEventKind::ScrollUp => rt.scroll_up(lines_per_notch),
+                            MouseEventKind::ScrollDown => rt.scroll_down(lines_per_notch),
+                            _ => {}
+                        }
+                        return;
+                    }
+                },
+                MouseEventKind::Down(_) | MouseEventKind::Up(_) | MouseEventKind::Drag(_) => {
+                    rt.encode_mouse_button(mouse.kind, position, mouse.modifiers)
                 }
-            },
-            MouseEventKind::Down(_) | MouseEventKind::Up(_) | MouseEventKind::Drag(_) => {
-                rt.encode_mouse_button(mouse.kind, position, mouse.modifiers)
+                MouseEventKind::Moved => {
+                    rt.encode_mouse_motion(mouse.kind, position, mouse.modifiers)
+                }
+            };
+            (bytes, rt.scroll_metrics())
+        };
+                    }
+                    Some(crate::pane::WheelRouting::AlternateScroll) => {
+                        rt.encode_alternate_scroll(mouse.kind)
+                    }
+                    Some(crate::pane::WheelRouting::HostScroll) | None => {
+                        let lines_per_notch = self.state.mouse_scroll_lines;
+                        match mouse.kind {
+                            MouseEventKind::ScrollUp => rt.scroll_up(lines_per_notch),
+                            MouseEventKind::ScrollDown => rt.scroll_down(lines_per_notch),
+                            _ => {}
+                        }
+                        return;
+                    }
+                },
+                MouseEventKind::Down(_) | MouseEventKind::Up(_) | MouseEventKind::Drag(_) => {
+                    rt.encode_mouse_button(mouse.kind, column, row, mouse.modifiers)
+                }
+
+        };
+
+        if let Some(bytes) = bytes {
+            self.state.selection = None;
+            if let Some(rt) = self.popup_runtime() {
+                if !matches!(mouse.kind, MouseEventKind::Moved) {
+                    rt.scroll_reset();
+                }
+                if let Err(err) = rt.try_send_bytes(Bytes::from(bytes)) {
+                    warn!(err = %err, kind = ?mouse.kind, "failed to forward popup mouse event");
+                }
             }
-            MouseEventKind::Moved => rt.encode_mouse_motion(mouse.kind, position, mouse.modifiers),
-        };
-        let Some(bytes) = bytes else {
             return;
-        };
-        if !matches!(mouse.kind, MouseEventKind::Moved) {
-            rt.scroll_reset();
         }
-        if let Err(err) = rt.try_send_bytes(Bytes::from(bytes)) {
-            warn!(err = %err, kind = ?mouse.kind, "failed to forward popup mouse event");
+
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.state.selection = Some(crate::selection::Selection::anchor(
+                    popup_pane_id,
+                    row,
+                    column,
+                    scroll_metrics,
+                ));
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if self
+                    .state
+                    .selection
+                    .as_ref()
+                    .is_some_and(|sel| sel.pane_id == popup_pane_id)
+                {
+                    self.state
+                        .update_selection_drag(&self.terminal_runtimes, mouse.column, mouse.row);
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if let Some(selection) = self.state.selection.as_ref() {
+                    if selection.pane_id == popup_pane_id {
+                        let was_click = selection.was_just_click();
+                        let was_finalized = selection.is_finalized();
+                        if was_click {
+                            self.state.selection = None;
+                        } else if was_finalized {
+                            // Selection already finalized
+                        } else if self.state.copy_on_select {
+                            self.state.copy_selection(&self.terminal_runtimes);
+                        } else if let Some(sel) = self.state.selection.as_mut() {
+                            sel.finish();
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -1451,8 +1451,24 @@ impl AppState {
         .then_some(MouseAction::FocusPane { ws_idx, pane_id })
     }
 
-    pub(crate) fn pane_info_by_id(&self, pane_id: crate::layout::PaneId) -> Option<&PaneInfo> {
-        self.view.pane_infos.iter().find(|info| info.id == pane_id)
+    pub(crate) fn pane_info_by_id(&self, pane_id: crate::layout::PaneId) -> Option<PaneInfo> {
+        if let Some(info) = self.view.pane_infos.iter().find(|info| info.id == pane_id) {
+            return Some(info.clone());
+        }
+        if let Some(popup) = &self.popup_pane {
+            if popup.pane_id == pane_id {
+                let (_, inner) = crate::ui::popup_pane_rects(self, self.view.terminal_area)?;
+                return Some(PaneInfo {
+                    id: pane_id,
+                    rect: inner,
+                    inner_rect: inner,
+                    scrollbar_rect: None,
+                    borders: ratatui::widgets::Borders::NONE,
+                    is_focused: true,
+                });
+            }
+        }
+        None
     }
 
     pub(super) fn pane_frame_at(&self, col: u16, row: u16) -> Option<&PaneInfo> {

--- a/src/app/input/selection.rs
+++ b/src/app/input/selection.rs
@@ -13,7 +13,7 @@ impl AppState {
         screen_col: u16,
         screen_row: u16,
     ) {
-        let Some(info) = self.pane_info_by_id(pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(pane_id) else {
             return;
         };
         let metrics = self.pane_scroll_metrics(terminal_runtimes, pane_id);
@@ -35,7 +35,7 @@ impl AppState {
         let Some(pane_id) = self.selection.as_ref().map(|selection| selection.pane_id) else {
             return;
         };
-        let Some(info) = self.pane_info_by_id(pane_id).cloned() else {
+        let Some(info) = self.pane_info_by_id(pane_id) else {
             return;
         };
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1604,6 +1604,11 @@ impl AppState {
         ws_idx: usize,
         pane_id: crate::layout::PaneId,
     ) -> Option<&'a crate::terminal::TerminalRuntime> {
+        if let Some(popup) = &self.popup_pane {
+            if popup.pane_id == pane_id {
+                return terminal_runtimes.get(&popup.terminal_id);
+            }
+        }
         #[cfg(test)]
         if let Some(runtime) = self.workspaces.get(ws_idx)?.test_runtimes.get(&pane_id) {
             return Some(runtime);
@@ -1622,12 +1627,16 @@ impl AppState {
         terminal_runtimes.get(terminal_id)
     }
 
-    #[cfg(test)]
     pub(crate) fn runtime_for_pane<'a>(
         &'a self,
         terminal_runtimes: &'a crate::terminal::TerminalRuntimeRegistry,
         pane_id: crate::layout::PaneId,
     ) -> Option<&'a crate::terminal::TerminalRuntime> {
+        if let Some(popup) = &self.popup_pane {
+            if popup.pane_id == pane_id {
+                return terminal_runtimes.get(&popup.terminal_id);
+            }
+        }
         self.workspaces.iter().find_map(|ws| {
             #[cfg(test)]
             if let Some(runtime) = ws.test_runtimes.get(&pane_id) {

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -471,6 +471,15 @@ pub(super) fn render_popup_pane(
     frame.render_widget(Clear, outer);
     frame.render_widget(block, outer);
     rt.render(frame, inner, !pane_is_scrolled_back(rt));
+    render_selection_highlight(
+        &app.selection,
+        frame,
+        popup.pane_id,
+        inner,
+        rt.scroll_metrics(),
+        &app.palette,
+        app.host_terminal_theme,
+    );
 }
 
 #[derive(Clone, Copy, Default)]


### PR DESCRIPTION
# Description

Popup panes could not use native text selection, so copying text from popups was broken or required copy-mode workarounds.

This routes popup input through the same selection/clipboard path as normal panes and adds popup-aware clipboard handling so mouse drag and standard copy behavior work in popup content.

# Changes

* Add popup clipboard helpers in `src/app/input/clipboard.rs`.
* Update input routing in `src/app/input/mod.rs` and mouse handling for popup panes.
* Adjust copy-mode, selection, actions, plugin context, state, and pane UI to support popup text selection.

# Tests

* Manually verified text can be selected and copied from popup panes with mouse drag.
* Existing copy-mode behavior for non-popup panes remains unchanged.

# Deployment Plan

N/A

# Related Issues

N/A