### PR TITLE
wip: native status grok integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,7 +306,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix 0.31.2",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -393,6 +403,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -481,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +564,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -608,7 +655,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
- "windows-sys",
+ "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -616,6 +664,88 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "id-arena"
@@ -628,6 +758,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -673,7 +824,7 @@ dependencies = [
  "libc",
  "recvmsg",
  "widestring",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -750,6 +901,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -846,7 +1003,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -902,7 +1059,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -992,6 +1149,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1130,6 +1293,15 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1343,6 +1515,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,7 +1547,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1534,6 +1755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1874,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1769,6 +2019,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tokio"
@@ -1941,10 +2201,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2095,6 +2394,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,12 +2519,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2313,6 +2703,95 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 unicode-width = "0.2"
 schemars = { version = "1.2.1", features = ["derive"] }
+# Bounded in-process HTTPS for the status-bar WAN IP collector (rustls, no curl).
+ureq = { version = "2.12", default-features = false, features = ["tls"] }
 
 [patch.crates-io]
 portable-pty = { path = "vendor/portable-pty" }

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -326,6 +326,9 @@ impl App {
                     MouseAction::NewWorkspace => {
                         self.begin_tui_workspace_create("tui.mouse.workspace.create")
                     }
+                    MouseAction::OpenNavigator => {
+                        self.state.open_navigator_from(&self.terminal_runtimes)
+                    }
                     MouseAction::Settings(action) => match action {
                         SettingsAction::SaveTheme(name) => self.save_theme(&name),
                         SettingsAction::SaveSound(enabled) => self.save_sound(enabled),

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -27,6 +27,7 @@ use super::{
 
 pub(super) enum MouseAction {
     NewWorkspace,
+    OpenNavigator,
     Settings(SettingsAction),
     FocusWorkspace {
         ws_idx: usize,
@@ -110,6 +111,13 @@ impl AppState {
             && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
         {
             return Some(MouseAction::FocusToastTarget);
+        }
+
+        if matches!(self.mode, Mode::Terminal | Mode::Prefix | Mode::Resize)
+            && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && rect_contains(self.view.status_identity_hit_area, mouse.column, mouse.row)
+        {
+            return Some(MouseAction::OpenNavigator);
         }
 
         if self.mode == Mode::Terminal

--- a/src/app/input/sidebar.rs
+++ b/src/app/input/sidebar.rs
@@ -1516,10 +1516,12 @@ mod tests {
         app.state.sidebar_spaces.row_gap = 1;
         crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
 
-        assert_eq!(app.state.workspace_drop_index_at_row(0), Some(0));
+        // Status bar occupies row 0; sidebar list starts at y=1.
+        assert_eq!(app.state.workspace_drop_index_at_row(0), None);
         assert_eq!(app.state.workspace_drop_index_at_row(1), Some(0));
         assert_eq!(app.state.workspace_drop_index_at_row(2), Some(0));
-        assert_eq!(app.state.workspace_drop_index_at_row(3), Some(1));
+        assert_eq!(app.state.workspace_drop_index_at_row(3), Some(0));
+        assert_eq!(app.state.workspace_drop_index_at_row(4), Some(1));
 
         let _ = fs::remove_dir_all(first_repo);
         let _ = fs::remove_dir_all(second_repo);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -38,6 +38,8 @@ pub(crate) const HEADLESS_ANIMATION_TICK_STEP: u32 = 8;
 pub(crate) const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(30);
 const RESIZE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const GIT_REMOTE_STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(1500);
+/// Clock/metrics status-row invalidation while panes are quiet.
+pub(crate) const STATUS_METRICS_REFRESH_INTERVAL: Duration = Duration::from_millis(1000);
 const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
 const PENDING_AGENT_RESUME_THEME_WAIT: Duration = Duration::from_millis(750);
 const SESSION_SAVE_DEBOUNCE: Duration = Duration::from_secs(5);
@@ -122,6 +124,7 @@ pub struct App {
     pub(crate) pending_url_click_sources: HashSet<InputSourceId>,
     pub(crate) next_resize_poll: Instant,
     pub(crate) next_animation_tick: Option<Instant>,
+    pub(crate) next_status_metrics_refresh: Option<Instant>,
     pub(crate) next_auto_update_check: Option<Instant>,
     pub(crate) next_agent_manifest_update_check: Option<Instant>,
     pub(crate) update_version_check_enabled: bool,
@@ -583,6 +586,8 @@ impl App {
             mobile_switcher_scroll: 0,
             view: state::ViewState {
                 layout: state::ViewLayout::Desktop,
+                status_bar_rect: Rect::default(),
+                status_identity_hit_area: Rect::default(),
                 sidebar_rect: Rect::default(),
                 workspace_card_areas: Vec::new(),
                 tab_bar_rect: Rect::default(),
@@ -748,6 +753,13 @@ impl App {
             pending_url_click_sources: HashSet::new(),
             next_resize_poll: Instant::now() + RESIZE_POLL_INTERVAL,
             next_animation_tick: None,
+            next_status_metrics_refresh: if cfg!(test) {
+                // Keep deadline-isolation tests deterministic; production still
+                // arms the status-row clock so idle sessions repaint time/metrics.
+                None
+            } else {
+                Some(Instant::now())
+            },
             next_auto_update_check: version_check_enabled
                 .then_some(Instant::now() + AUTO_UPDATE_CHECK_INTERVAL),
             next_agent_manifest_update_check: manifest_check_enabled

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -324,6 +324,17 @@ impl App {
             changed = true;
         }
 
+        // Status-row clock/metrics: low-cost invalidation so time updates even
+        // when all panes are idle. Collection stays off the Ratatui draw path.
+        if self
+            .next_status_metrics_refresh
+            .is_some_and(|deadline| now >= deadline)
+        {
+            let _ = crate::platform::status_metrics::refresh_status_metrics_if_due();
+            self.next_status_metrics_refresh = Some(now + super::STATUS_METRICS_REFRESH_INTERVAL);
+            changed = true;
+        }
+
         if self
             .selection_autoscroll_deadline
             .is_some_and(|deadline| now >= deadline)
@@ -642,6 +653,7 @@ impl App {
             self.state.next_managed_agent_deadline(),
             self.copy_feedback_deadline,
             self.next_animation_tick,
+            self.next_status_metrics_refresh,
             include_git_refresh
                 .then(|| self.git_refresh_deadline())
                 .flatten(),
@@ -781,6 +793,8 @@ mod tests {
             tokio::sync::mpsc::unbounded_channel().1,
             crate::api::EventHub::default(),
         );
+        // Isolate scheduled-task tests from the independent status-row clock.
+        app.next_status_metrics_refresh = None;
         let ws = Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
         app.state.workspaces.push(ws);
@@ -879,6 +893,8 @@ mod tests {
         app.state.workspaces.push(Workspace::test_new("test"));
         let now = Instant::now();
         app.last_git_remote_status_refresh = now - super::super::GIT_REMOTE_STATUS_REFRESH_INTERVAL;
+        // Isolate the git-refresh timer from the independent status-row clock.
+        app.next_status_metrics_refresh = None;
 
         assert_eq!(
             app.next_headless_loop_deadline_with_git_refresh(now, false, false),
@@ -1015,6 +1031,7 @@ mod tests {
             tokio::sync::mpsc::unbounded_channel().1,
             crate::api::EventHub::default(),
         );
+        app.next_status_metrics_refresh = None;
         let mut ws = Workspace::test_new("test");
         let pane_id = ws.tabs[0].root_pane;
         let runtime =
@@ -1150,6 +1167,8 @@ mod tests {
             dedupe_key: "herdr:codex\0codex\0Id\0codex-session".into(),
         });
         app.pending_agent_resume_deadline = Some(Instant::now() - Duration::from_millis(1));
+        // Isolate agent-resume behavior from the independent status-row clock.
+        app.next_status_metrics_refresh = None;
 
         assert!(!app.handle_scheduled_tasks(Instant::now(), true));
         assert!(app.terminal_runtimes.get(&terminal_id).is_none());

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -774,6 +774,10 @@ pub enum ViewLayout {
 
 pub struct ViewState {
     pub layout: ViewLayout,
+    /// Full-width top status row (tmux-parity). Empty on mobile / tiny heights.
+    pub status_bar_rect: Rect,
+    /// Click target for the identity segment (`home:1.1`).
+    pub status_identity_hit_area: Rect,
     pub sidebar_rect: Rect,
     pub workspace_card_areas: Vec<WorkspaceCardArea>,
     pub tab_bar_rect: Rect,
@@ -1828,6 +1832,8 @@ impl AppState {
             mobile_switcher_scroll: 0,
             view: ViewState {
                 layout: ViewLayout::Desktop,
+                status_bar_rect: Rect::default(),
+                status_identity_hit_area: Rect::default(),
                 sidebar_rect: Rect::default(),
                 workspace_card_areas: Vec::new(),
                 tab_bar_rect: Rect::default(),

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -159,6 +159,9 @@ mod fallback;
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 pub use fallback::*;
 
+/// Cached native metrics for the full-width top status bar (tmux-parity).
+pub(crate) mod status_metrics;
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub(crate) fn available_pane_shell_from_job(child_pid: u32, job: ForegroundJob) -> Option<String> {
     if job.process_group_id != child_pid

--- a/src/platform/status_metrics.rs
+++ b/src/platform/status_metrics.rs
@@ -1,0 +1,1548 @@
+//! Native system metrics for the Herdr status bar.
+//!
+//! Collectors stay in-process: libc/sysctl/mach/IOKit and /proc|/sys only.
+//! No shell-outs to tmux, powerline, `ps`, `vm_stat`, `pmset`, etc.
+//!
+//! Public IP is the one exception that needs the network: it is fetched with
+//! bounded in-process HTTPS (`ureq` + rustls, no external `curl`/process) on a
+//! background thread and cached to disk (powerline-compatible 5 minute TTL).
+//!
+//! Connect timeout ~1s, total/read timeout ~2s, body capped, IPv4-validated.
+//! A single-flight flag prevents concurrent WAN refreshes. Failed refreshes
+//! keep an unexpired last-good cache entry.
+//!
+//! The render path only reads the soft cache. Collection is scheduled onto a
+//! dedicated background worker so the event loop / Ratatui never blocks on
+//! syscalls or I/O.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime};
+
+#[cfg_attr(test, allow(dead_code))]
+const CACHE_TTL: Duration = Duration::from_millis(1500);
+
+/// Match tmux-powerline `network_ips` WAN cache TTL.
+#[cfg_attr(test, allow(dead_code))]
+const PUBLIC_IP_TTL_SECS: u64 = 300;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct StatusMetrics {
+    pub cpu_percent: Option<u8>,
+    pub mem_used_gb: Option<f32>,
+    pub mem_total_gb: Option<f32>,
+    pub battery_percent: Option<u8>,
+    pub battery_charging: Option<bool>,
+    pub local_ip: Option<String>,
+    pub tailscale_ip: Option<String>,
+    pub public_ip: Option<String>,
+    pub net_down_kib: Option<u64>,
+    pub net_up_kib: Option<u64>,
+    /// Primary uplink kind for the bandwidth glyph (wifi vs ethernet).
+    pub net_kind: NetKind,
+    /// True when a VPN/tunnel (utun/wg/tailscale/tun) is up.
+    pub vpn_active: bool,
+    /// True when this process is running over SSH/mosh.
+    pub remote_session: bool,
+    pub hostname: String,
+    pub username: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum NetKind {
+    #[default]
+    Unknown,
+    Wifi,
+    Ethernet,
+}
+
+#[cfg_attr(test, allow(dead_code))]
+struct Cache {
+    at: Instant,
+    value: StatusMetrics,
+}
+
+#[cfg_attr(test, allow(dead_code))]
+static CACHE: Mutex<Option<Cache>> = Mutex::new(None);
+
+/// Previous CPU tick sample for rate calculation (idle, total).
+#[cfg_attr(
+    not(any(test, target_os = "macos", target_os = "linux")),
+    allow(dead_code)
+)]
+static CPU_PREV: Mutex<Option<(u64, u64)>> = Mutex::new(None);
+
+/// Previous interface byte counters (rx, tx) + sample time for bandwidth.
+#[cfg_attr(
+    not(any(test, target_os = "macos", target_os = "linux")),
+    allow(dead_code)
+)]
+static NET_PREV: Mutex<Option<(u64, u64, Instant)>> = Mutex::new(None);
+
+/// Only one public-IP refresh in flight at a time.
+static PUBLIC_IP_FETCHING: AtomicBool = AtomicBool::new(false);
+/// Only one full metrics collection in flight at a time.
+#[cfg_attr(test, allow(dead_code))]
+static METRICS_COLLECTING: AtomicBool = AtomicBool::new(false);
+
+fn metrics_cache_lock() -> std::sync::MutexGuard<'static, Option<Cache>> {
+    match CACHE.lock() {
+        Ok(guard) => guard,
+        // Soft cache: recover from poison so a panicked collector cannot
+        // permanently disable the status bar metrics.
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(any(test, target_os = "macos", target_os = "linux"))]
+fn cpu_prev_lock() -> std::sync::MutexGuard<'static, Option<(u64, u64)>> {
+    match CPU_PREV.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(any(test, target_os = "macos", target_os = "linux"))]
+fn net_prev_lock() -> std::sync::MutexGuard<'static, Option<(u64, u64, Instant)>> {
+    match NET_PREV.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// Cheap snapshot for the render path. Never collects, never blocks on I/O.
+pub(crate) fn status_metrics() -> StatusMetrics {
+    // UI characterization tests hash the full frame. Live host metrics would
+    // make those digests non-deterministic, so tests always get a fixture.
+    #[cfg(test)]
+    {
+        return status_metrics_fixture();
+    }
+
+    #[cfg(not(test))]
+    {
+        let guard = metrics_cache_lock();
+        if let Some(cache) = guard.as_ref() {
+            return cache.value.clone();
+        }
+        StatusMetrics {
+            hostname: hostname(),
+            username: username(),
+            remote_session: is_remote_session(),
+            ..StatusMetrics::default()
+        }
+    }
+}
+
+/// Refresh cached metrics when the TTL has elapsed. Safe to call from the
+/// event-loop scheduler; kicks platform collection onto a background worker so
+/// the Ratatui draw / event-loop path never blocks on syscalls or I/O.
+///
+/// Returns `true` when a collection was scheduled (or the cache was already
+/// warm enough that the idle timer alone should still repaint the clock).
+pub(crate) fn refresh_status_metrics_if_due() -> bool {
+    #[cfg(test)]
+    {
+        return false;
+    }
+
+    #[cfg(not(test))]
+    {
+        {
+            let guard = metrics_cache_lock();
+            if let Some(cache) = guard.as_ref() {
+                if cache.at.elapsed() < CACHE_TTL {
+                    // Still due for an idle-clock repaint; collection not needed.
+                    return false;
+                }
+            }
+        }
+        spawn_metrics_collection();
+        // Always request a redraw on the idle tick so the clock/date segments
+        // advance even when collection is still in flight or was skipped.
+        true
+    }
+}
+
+/// Force a metrics refresh (used by unit tests and first-paint warmup).
+#[allow(dead_code)]
+pub(crate) fn refresh_status_metrics() {
+    #[cfg(test)]
+    {
+        return;
+    }
+    #[cfg(not(test))]
+    {
+        spawn_metrics_collection();
+    }
+}
+
+/// Schedule one background collection if none is already running.
+#[cfg(not(test))]
+fn spawn_metrics_collection() {
+    if METRICS_COLLECTING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    let spawned = std::thread::Builder::new()
+        .name("herdr-status-metrics".into())
+        .spawn(|| {
+            let value = collect_status_metrics();
+            {
+                let mut guard = metrics_cache_lock();
+                *guard = Some(Cache {
+                    at: Instant::now(),
+                    value,
+                });
+            }
+            METRICS_COLLECTING.store(false, Ordering::SeqCst);
+        })
+        .is_ok();
+    if !spawned {
+        METRICS_COLLECTING.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn status_metrics_fixture() -> StatusMetrics {
+    StatusMetrics {
+        cpu_percent: Some(12),
+        mem_used_gb: Some(8.0),
+        mem_total_gb: Some(16.0),
+        battery_percent: Some(88),
+        battery_charging: Some(false),
+        local_ip: Some("10.0.0.2".into()),
+        tailscale_ip: Some("100.64.0.1".into()),
+        public_ip: Some("203.0.113.10".into()),
+        net_down_kib: Some(120),
+        net_up_kib: Some(34),
+        net_kind: NetKind::Wifi,
+        vpn_active: true,
+        remote_session: false,
+        hostname: "testhost".into(),
+        username: "testuser".into(),
+    }
+}
+
+fn collect_status_metrics() -> StatusMetrics {
+    let mut metrics = StatusMetrics {
+        hostname: hostname(),
+        username: username(),
+        remote_session: is_remote_session(),
+        ..StatusMetrics::default()
+    };
+
+    #[cfg(target_os = "macos")]
+    collect_macos(&mut metrics);
+    #[cfg(target_os = "linux")]
+    collect_linux(&mut metrics);
+
+    // Public IP is OS-agnostic: disk cache + optional background refresh.
+    metrics.public_ip = public_ip_cached();
+
+    metrics
+}
+
+fn hostname() -> String {
+    #[cfg(unix)]
+    {
+        let mut buf = [0u8; 256];
+        // SAFETY: buf is a valid writable buffer of known length.
+        let rc = unsafe { libc::gethostname(buf.as_mut_ptr().cast(), buf.len()) };
+        if rc == 0 {
+            let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+            let name = String::from_utf8_lossy(&buf[..end]).into_owned();
+            return short_host(&name);
+        }
+    }
+    std::env::var("COMPUTERNAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|s| short_host(&s))
+        .unwrap_or_else(|| "localhost".into())
+}
+
+fn username() -> String {
+    if let Ok(user) = std::env::var("USER").or_else(|_| std::env::var("USERNAME")) {
+        if !user.is_empty() {
+            return user;
+        }
+    }
+    #[cfg(unix)]
+    {
+        // SAFETY: getuid is always safe; getpwuid returns static/heap-owned data.
+        let uid = unsafe { libc::getuid() };
+        let pwd = unsafe { libc::getpwuid(uid) };
+        if !pwd.is_null() {
+            // SAFETY: pwd is non-null; pw_name is a NUL-terminated C string.
+            let name = unsafe { std::ffi::CStr::from_ptr((*pwd).pw_name) };
+            return name.to_string_lossy().into_owned();
+        }
+        return uid.to_string();
+    }
+    #[cfg(not(unix))]
+    {
+        "user".into()
+    }
+}
+
+fn short_host(name: &str) -> String {
+    name.split('.').next().unwrap_or(name).to_string()
+}
+
+fn is_remote_session() -> bool {
+    for key in ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY", "MOSH"] {
+        if std::env::var_os(key).is_some_and(|v| !v.is_empty()) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn collect_macos(metrics: &mut StatusMetrics) {
+    if let Some(total) = sysctl_u64(c"hw.memsize") {
+        metrics.mem_total_gb = Some(total as f32 / 1_073_741_824.0);
+    }
+    metrics.mem_used_gb = macos_mem_used_gb();
+    metrics.cpu_percent = sample_cpu_percent(macos_cpu_ticks);
+    let (pct, charging) = macos_battery();
+    metrics.battery_percent = pct;
+    metrics.battery_charging = charging;
+    let (local, tailscale) = interface_ipv4s();
+    metrics.local_ip = local;
+    metrics.tailscale_ip = tailscale;
+    metrics.vpn_active = macos_vpn_active() || metrics.tailscale_ip.is_some();
+    metrics.net_kind = macos_net_kind();
+    if let Some((down, up)) = sample_bandwidth(macos_primary_iface_bytes) {
+        metrics.net_down_kib = Some(down);
+        metrics.net_up_kib = Some(up);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn collect_linux(metrics: &mut StatusMetrics) {
+    if let Some((used, total)) = linux_mem_gb() {
+        metrics.mem_used_gb = Some(used);
+        metrics.mem_total_gb = Some(total);
+    }
+    metrics.cpu_percent = sample_cpu_percent(linux_cpu_ticks);
+    let (pct, charging) = linux_battery();
+    metrics.battery_percent = pct;
+    metrics.battery_charging = charging;
+    let (local, tailscale) = interface_ipv4s();
+    metrics.local_ip = local;
+    metrics.tailscale_ip = tailscale;
+    let iface = linux_default_iface();
+    metrics.net_kind = linux_net_kind(iface.as_deref());
+    metrics.vpn_active = linux_vpn_active() || metrics.tailscale_ip.is_some();
+    if let Some((down, up)) = sample_bandwidth(|| linux_primary_iface_bytes(iface.as_deref())) {
+        metrics.net_down_kib = Some(down);
+        metrics.net_up_kib = Some(up);
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn sample_cpu_percent(ticks: impl FnOnce() -> Option<(u64, u64)>) -> Option<u8> {
+    let (idle, total) = ticks()?;
+    let mut prev = cpu_prev_lock();
+    let result = if let Some((prev_idle, prev_total)) = *prev {
+        let d_idle = idle.saturating_sub(prev_idle);
+        let d_total = total.saturating_sub(prev_total);
+        if d_total > 0 {
+            let busy = d_total.saturating_sub(d_idle) as f64;
+            Some(((busy / d_total as f64) * 100.0).round().clamp(0.0, 100.0) as u8)
+        } else {
+            Some(0)
+        }
+    } else {
+        // First sample establishes the baseline; show 0 so the segment paints.
+        Some(0)
+    };
+    *prev = Some((idle, total));
+    result
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn sample_bandwidth(bytes: impl FnOnce() -> Option<(u64, u64)>) -> Option<(u64, u64)> {
+    let (rx, tx) = bytes()?;
+    let now = Instant::now();
+    let mut prev = net_prev_lock();
+    let result = if let Some((prev_rx, prev_tx, prev_at)) = *prev {
+        let secs = now.duration_since(prev_at).as_secs_f64().max(0.001);
+        // Counter reset / interface change: treat as a fresh baseline.
+        if rx < prev_rx || tx < prev_tx {
+            *prev = Some((rx, tx, now));
+            return Some((0, 0));
+        }
+        let down = ((rx.saturating_sub(prev_rx) as f64) / secs / 1024.0).round() as u64;
+        let up = ((tx.saturating_sub(prev_tx) as f64) / secs / 1024.0).round() as u64;
+        Some((down, up))
+    } else {
+        // First sample establishes the baseline; show 0K/s so the segment paints.
+        Some((0, 0))
+    };
+    *prev = Some((rx, tx, now));
+    result
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_u64(name: &std::ffi::CStr) -> Option<u64> {
+    let mut value: u64 = 0;
+    let mut len = std::mem::size_of::<u64>();
+    // SAFETY: name is a valid C string; value/len point to valid stack storage.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            (&raw mut value).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && len == std::mem::size_of::<u64>() {
+        Some(value)
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_mem_used_gb() -> Option<f32> {
+    const HOST_VM_INFO64: libc::c_int = 4;
+    const HOST_VM_INFO64_COUNT: libc::mach_msg_type_number_t =
+        (std::mem::size_of::<VmStatistics64>() / std::mem::size_of::<libc::integer_t>())
+            as libc::mach_msg_type_number_t;
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct VmStatistics64 {
+        free_count: u32,
+        active_count: u32,
+        inactive_count: u32,
+        wire_count: u32,
+        zero_fill_count: u64,
+        reactivations: u64,
+        pageins: u64,
+        pageouts: u64,
+        faults: u64,
+        cow_faults: u64,
+        lookups: u64,
+        hits: u64,
+        purges: u64,
+        purgeable_count: u32,
+        speculative_count: u32,
+        decompressions: u64,
+        compressions: u64,
+        swapins: u64,
+        swapouts: u64,
+        compressor_page_count: u32,
+        throttled_count: u32,
+        external_page_count: u32,
+        internal_page_count: u32,
+        total_uncompressed_pages_in_compressor: u64,
+    }
+
+    // SAFETY: host_self returns a send right we don't own; stats buffer is stack-owned.
+    let host = unsafe { mach_host_self() };
+    let mut stats = VmStatistics64::default();
+    let mut count = HOST_VM_INFO64_COUNT;
+    let rc = unsafe {
+        host_statistics64(
+            host,
+            HOST_VM_INFO64,
+            (&raw mut stats).cast::<libc::integer_t>(),
+            &mut count,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+    let page_size = sysctl_u64(c"hw.pagesize").unwrap_or(4096);
+    let total = sysctl_u64(c"hw.memsize")?;
+    // App memory ≈ internal + wired + compressor (matches Activity Monitor "Memory Used").
+    let used_pages = u64::from(stats.internal_page_count)
+        .saturating_add(u64::from(stats.wire_count))
+        .saturating_add(u64::from(stats.compressor_page_count));
+    let used = used_pages.saturating_mul(page_size).min(total);
+    Some(used as f32 / 1_073_741_824.0)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_cpu_ticks() -> Option<(u64, u64)> {
+    const HOST_CPU_LOAD_INFO: libc::c_int = 3;
+    const CPU_STATE_USER: usize = 0;
+    const CPU_STATE_SYSTEM: usize = 1;
+    const CPU_STATE_IDLE: usize = 2;
+    const CPU_STATE_NICE: usize = 3;
+    const HOST_CPU_LOAD_INFO_COUNT: libc::mach_msg_type_number_t = 4;
+
+    #[repr(C)]
+    struct HostCpuLoadInfo {
+        cpu_ticks: [u32; 4],
+    }
+
+    let host = unsafe { mach_host_self() };
+    let mut info = HostCpuLoadInfo { cpu_ticks: [0; 4] };
+    let mut count = HOST_CPU_LOAD_INFO_COUNT;
+    let rc = unsafe {
+        host_statistics(
+            host,
+            HOST_CPU_LOAD_INFO,
+            (&raw mut info).cast::<libc::integer_t>(),
+            &mut count,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+    let user = u64::from(info.cpu_ticks[CPU_STATE_USER]);
+    let system = u64::from(info.cpu_ticks[CPU_STATE_SYSTEM]);
+    let idle = u64::from(info.cpu_ticks[CPU_STATE_IDLE]);
+    let nice = u64::from(info.cpu_ticks[CPU_STATE_NICE]);
+    let total = user + system + idle + nice;
+    Some((idle, total))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_battery() -> (Option<u8>, Option<bool>) {
+    // SAFETY: IOKit power-source snapshot is retained; we release both blob and list.
+    unsafe {
+        let blob = IOPSCopyPowerSourcesInfo();
+        if blob.is_null() {
+            return (None, None);
+        }
+        let list = IOPSCopyPowerSourcesList(blob);
+        if list.is_null() {
+            CFRelease(blob);
+            return (None, None);
+        }
+        let count = CFArrayGetCount(list);
+        let mut best: Option<(u8, bool)> = None;
+        for i in 0..count {
+            let ps = CFArrayGetValueAtIndex(list, i);
+            if ps.is_null() {
+                continue;
+            }
+            let desc = IOPSGetPowerSourceDescription(blob, ps);
+            if desc.is_null() {
+                continue;
+            }
+            // Prefer internal batteries; fall back to any source with capacity.
+            let is_internal = cf_dict_string_eq(desc, IOPS_TYPE_KEY, IOPS_INTERNAL_BATTERY_TYPE);
+            let capacity = cf_dict_i32(desc, IOPS_CURRENT_CAPACITY_KEY).unwrap_or(-1);
+            if !(0..=100).contains(&capacity) {
+                continue;
+            }
+            let state = cf_dict_string(desc, IOPS_POWER_SOURCE_STATE_KEY).unwrap_or_default();
+            let charging = state == IOPS_AC_POWER_VALUE
+                || cf_dict_bool(desc, IOPS_IS_CHARGING_KEY).unwrap_or(false);
+            let candidate = (capacity as u8, charging);
+            if is_internal {
+                best = Some(candidate);
+                break;
+            }
+            if best.is_none() {
+                best = Some(candidate);
+            }
+        }
+        CFRelease(list);
+        CFRelease(blob);
+        match best {
+            Some((pct, charging)) => (Some(pct), Some(charging)),
+            None => (None, None),
+        }
+    }
+}
+
+/// Primary interface byte counters via `NET_RT_IFLIST2` / `if_data64`.
+///
+/// Prefer the default-route interface (`en0` fallback). Using 64-bit counters
+/// avoids the wraparound that 32-bit `getifaddrs` `if_data` hits on busy links.
+#[cfg(target_os = "macos")]
+fn macos_primary_iface_bytes() -> Option<(u64, u64)> {
+    let preferred = macos_default_iface().unwrap_or_else(|| "en0".into());
+    let snapshots = macos_iface_byte_snapshots()?;
+    if let Some((_, rx, tx)) = snapshots.iter().find(|(n, _, _)| n == &preferred) {
+        return Some((*rx, *tx));
+    }
+    // Fall back to the busiest non-loopback interface.
+    snapshots
+        .into_iter()
+        .filter(|(n, _, _)| !n.starts_with("lo"))
+        .max_by_key(|(_, rx, tx)| rx.saturating_add(*tx))
+        .map(|(_, rx, tx)| (rx, tx))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_iface_byte_snapshots() -> Option<Vec<(String, u64, u64)>> {
+    // CTL_NET / AF_ROUTE / NET_RT_IFLIST2
+    const CTL_NET: libc::c_int = 4;
+    const AF_ROUTE: libc::c_int = 17;
+    const NET_RT_IFLIST2: libc::c_int = 6;
+    const RTM_IFINFO2: u8 = 0x12;
+
+    // Darwin `IF_DATA_TIMEVAL` is `struct timeval32` (two u32s) on modern SDKs.
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct IfDataTimeval32 {
+        tv_sec: u32,
+        tv_usec: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct IfData64 {
+        ifi_type: u8,
+        ifi_typelen: u8,
+        ifi_physical: u8,
+        ifi_addrlen: u8,
+        ifi_hdrlen: u8,
+        ifi_recvquota: u8,
+        ifi_xmitquota: u8,
+        ifi_unused1: u8,
+        ifi_mtu: u32,
+        ifi_metric: u32,
+        ifi_baudrate: u64,
+        ifi_ipackets: u64,
+        ifi_ierrors: u64,
+        ifi_opackets: u64,
+        ifi_oerrors: u64,
+        ifi_collisions: u64,
+        ifi_ibytes: u64,
+        ifi_obytes: u64,
+        ifi_imcasts: u64,
+        ifi_omcasts: u64,
+        ifi_iqdrops: u64,
+        ifi_noproto: u64,
+        ifi_recvtiming: u32,
+        ifi_xmittiming: u32,
+        ifi_lastchange: IfDataTimeval32,
+    }
+
+    #[repr(C)]
+    struct IfMsghdr2 {
+        ifm_msglen: u16,
+        ifm_version: u8,
+        ifm_type: u8,
+        ifm_addrs: i32,
+        ifm_flags: i32,
+        ifm_index: u16,
+        _ifm_pad: u16,
+        ifm_snd_len: i32,
+        ifm_snd_maxlen: i32,
+        ifm_snd_drops: i32,
+        ifm_timer: i32,
+        ifm_data: IfData64,
+    }
+
+    let mut mib: [libc::c_int; 6] = [CTL_NET, AF_ROUTE, 0, 0, NET_RT_IFLIST2, 0];
+    let mut len: libc::size_t = 0;
+    // SAFETY: mib points at a valid 6-int array; size probe with null data pointer.
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            6,
+            std::ptr::null_mut(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 || len == 0 {
+        return None;
+    }
+    let mut buf = vec![0u8; len];
+    let rc = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            6,
+            buf.as_mut_ptr().cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+    buf.truncate(len);
+
+    // Layout sanity — Darwin if_msghdr2 is 160 bytes with timeval32 lastchange.
+    debug_assert_eq!(std::mem::size_of::<IfData64>(), 128);
+    debug_assert_eq!(std::mem::size_of::<IfMsghdr2>(), 160);
+
+    let mut out = Vec::new();
+    let mut offset = 0usize;
+    while offset + 4 <= buf.len() {
+        let msglen = u16::from_le_bytes([buf[offset], buf[offset + 1]]) as usize;
+        let ifm_type = buf[offset + 3];
+        if msglen == 0 || offset + msglen > buf.len() {
+            break;
+        }
+        if ifm_type == RTM_IFINFO2 && msglen >= std::mem::size_of::<IfMsghdr2>() {
+            // Copy out — route-table messages are not guaranteed 8-byte aligned.
+            let mut hdr = std::mem::MaybeUninit::<IfMsghdr2>::uninit();
+            // SAFETY: msglen bounds-checked; we copy exactly one header.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    buf.as_ptr().add(offset),
+                    hdr.as_mut_ptr().cast::<u8>(),
+                    std::mem::size_of::<IfMsghdr2>(),
+                );
+            }
+            let hdr = unsafe { hdr.assume_init() };
+            let sdl_off = offset + std::mem::size_of::<IfMsghdr2>();
+            if sdl_off + 8 <= offset + msglen {
+                let sdl_nlen = buf[sdl_off + 5] as usize;
+                let name_off = sdl_off + 8;
+                if sdl_nlen > 0 && name_off + sdl_nlen <= offset + msglen {
+                    let name =
+                        String::from_utf8_lossy(&buf[name_off..name_off + sdl_nlen]).into_owned();
+                    out.push((name, hdr.ifm_data.ifi_ibytes, hdr.ifm_data.ifi_obytes));
+                }
+            }
+        }
+        offset += msglen;
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+/// Best-effort default interface name via `route get default`-equivalent:
+/// parse the routing table for RTF_GATEWAY|RTF_UP default route. Falls back
+/// to the first `en*` interface with traffic.
+#[cfg(target_os = "macos")]
+fn macos_default_iface() -> Option<String> {
+    // Lightweight heuristic: prefer en0 (Wi-Fi on Apple Silicon / Intel Macs),
+    // then any en* with non-zero counters, then first non-lo.
+    let snaps = macos_iface_byte_snapshots()?;
+    if snaps.iter().any(|(n, _, _)| n == "en0") {
+        return Some("en0".into());
+    }
+    if let Some((n, _, _)) = snaps
+        .iter()
+        .filter(|(n, rx, tx)| n.starts_with("en") && (*rx > 0 || *tx > 0))
+        .max_by_key(|(_, rx, tx)| rx.saturating_add(*tx))
+    {
+        return Some(n.clone());
+    }
+    snaps
+        .into_iter()
+        .find(|(n, _, _)| !n.starts_with("lo"))
+        .map(|(n, _, _)| n)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_net_kind() -> NetKind {
+    match macos_default_iface().as_deref() {
+        // Apple Wi-Fi is almost always en0; en1/en2 are Thunderbolt bridges.
+        Some("en0") => NetKind::Wifi,
+        Some(name) if name.starts_with("en") => NetKind::Ethernet,
+        Some(name) if name.starts_with("eth") || name.starts_with("usb") => NetKind::Ethernet,
+        Some(name) if name.starts_with("wl") => NetKind::Wifi,
+        _ => NetKind::Unknown,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_vpn_active() -> bool {
+    // Any utun/ipsec/ppp interface with traffic indicates a tunnel.
+    let Some(snaps) = macos_iface_byte_snapshots() else {
+        return false;
+    };
+    snaps.iter().any(|(n, rx, tx)| {
+        let tun = n.starts_with("utun")
+            || n.starts_with("ipsec")
+            || n.starts_with("ppp")
+            || n.contains("tailscale");
+        tun && (*rx > 0 || *tx > 0)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn linux_mem_gb() -> Option<(f32, f32)> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let mut total_kb = None;
+    let mut available_kb = None;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            total_kb = parse_kb(rest);
+        } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            available_kb = parse_kb(rest);
+        }
+    }
+    let total = total_kb?;
+    let available = available_kb.unwrap_or(0);
+    let used = total.saturating_sub(available);
+    Some((used as f32 / 1_048_576.0, total as f32 / 1_048_576.0))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_kb(rest: &str) -> Option<u64> {
+    rest.split_whitespace().next()?.parse().ok()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_cpu_ticks() -> Option<(u64, u64)> {
+    let text = std::fs::read_to_string("/proc/stat").ok()?;
+    let line = text.lines().next()?;
+    let mut parts = line.split_whitespace();
+    if parts.next()? != "cpu" {
+        return None;
+    }
+    let mut vals = [0u64; 8];
+    for slot in vals.iter_mut() {
+        *slot = parts.next()?.parse().ok()?;
+    }
+    // user nice system idle iowait irq softirq steal
+    let idle = vals[3].saturating_add(vals[4]);
+    let total: u64 = vals.iter().sum();
+    Some((idle, total))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_battery() -> (Option<u8>, Option<bool>) {
+    let bat_dir = std::fs::read_dir("/sys/class/power_supply")
+        .ok()
+        .and_then(|rd| {
+            rd.filter_map(|e| e.ok()).map(|e| e.path()).find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("BAT"))
+            })
+        });
+    let Some(bat) = bat_dir else {
+        return (None, None);
+    };
+    let capacity = std::fs::read_to_string(bat.join("capacity"))
+        .ok()
+        .and_then(|s| s.trim().parse::<u8>().ok());
+    let status = std::fs::read_to_string(bat.join("status"))
+        .ok()
+        .map(|s| s.trim().to_ascii_lowercase());
+    let charging = status.map(|s| s == "charging" || s == "full");
+    (capacity, charging)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_default_iface() -> Option<String> {
+    // /proc/net/route: destination 00000000 is the default route.
+    let text = std::fs::read_to_string("/proc/net/route").ok()?;
+    for line in text.lines().skip(1) {
+        let mut cols = line.split_whitespace();
+        let iface = cols.next()?;
+        let dest = cols.next()?;
+        if dest == "00000000" {
+            return Some(iface.to_string());
+        }
+    }
+    // Fall back to first non-lo interface with a stats file.
+    let rd = std::fs::read_dir("/sys/class/net").ok()?;
+    for entry in rd.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name != "lo" {
+            return Some(name);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn linux_net_kind(iface: Option<&str>) -> NetKind {
+    let Some(iface) = iface else {
+        return NetKind::Unknown;
+    };
+    if std::path::Path::new(&format!("/sys/class/net/{iface}/wireless")).exists() {
+        return NetKind::Wifi;
+    }
+    // type 1 = ARPHRD_ETHER
+    let type_path = format!("/sys/class/net/{iface}/type");
+    if let Ok(t) = std::fs::read_to_string(type_path) {
+        if t.trim() == "1" {
+            return NetKind::Ethernet;
+        }
+    }
+    if iface.starts_with("wl") || iface.starts_with("wlan") {
+        NetKind::Wifi
+    } else if iface.starts_with("eth") || iface.starts_with("en") {
+        NetKind::Ethernet
+    } else {
+        NetKind::Unknown
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_vpn_active() -> bool {
+    let Ok(rd) = std::fs::read_dir("/sys/class/net") else {
+        return false;
+    };
+    rd.flatten().any(|e| {
+        let name = e.file_name().to_string_lossy().into_owned();
+        name.starts_with("tun")
+            || name.starts_with("wg")
+            || name.starts_with("tailscale")
+            || name.starts_with("ppp")
+            || name.starts_with("ipsec")
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn linux_primary_iface_bytes(iface: Option<&str>) -> Option<(u64, u64)> {
+    let iface = match iface {
+        Some(name) if !name.is_empty() => name.to_string(),
+        _ => linux_default_iface()?,
+    };
+    let rx = std::fs::read_to_string(format!("/sys/class/net/{iface}/statistics/rx_bytes"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    let tx = std::fs::read_to_string(format!("/sys/class/net/{iface}/statistics/tx_bytes"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    Some((rx, tx))
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn interface_ipv4s() -> (Option<String>, Option<String>) {
+    // SAFETY: getifaddrs/freeifaddrs pair.
+    unsafe {
+        let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
+        if libc::getifaddrs(&mut ifap) != 0 || ifap.is_null() {
+            return (None, None);
+        }
+
+        // Collect candidates so we can prefer physical LAN over virtual bridges.
+        let mut lan_preferred: Option<String> = None;
+        let mut lan_fallback: Option<String> = None;
+        let mut tailscale: Option<String> = None;
+        let mut cur = ifap;
+        while !cur.is_null() {
+            let entry = &*cur;
+            if entry.ifa_addr.is_null() {
+                cur = entry.ifa_next;
+                continue;
+            }
+            if (*entry.ifa_addr).sa_family as i32 != libc::AF_INET {
+                cur = entry.ifa_next;
+                continue;
+            }
+            let sin = &*(entry.ifa_addr as *const libc::sockaddr_in);
+            let addr = u32::from_be(sin.sin_addr.s_addr);
+            if addr == 0 || (addr >> 24) == 127 {
+                cur = entry.ifa_next;
+                continue;
+            }
+            let ip = format!(
+                "{}.{}.{}.{}",
+                (addr >> 24) & 0xff,
+                (addr >> 16) & 0xff,
+                (addr >> 8) & 0xff,
+                addr & 0xff
+            );
+            let name = if entry.ifa_name.is_null() {
+                String::new()
+            } else {
+                std::ffi::CStr::from_ptr(entry.ifa_name)
+                    .to_string_lossy()
+                    .into_owned()
+            };
+
+            let is_tunnel = name.contains("tailscale")
+                || name.starts_with("utun")
+                || name.starts_with("tun")
+                || name.starts_with("wg")
+                || name.starts_with("ppp")
+                || name.starts_with("ipsec");
+            // Tailscale userspace networking advertises CGNAT 100.64/10 on a tunnel iface.
+            let is_tailscale = name.contains("tailscale") || (is_cgnat(addr) && is_tunnel);
+
+            if is_tailscale {
+                if tailscale.is_none() {
+                    tailscale = Some(ip);
+                }
+            } else if !is_tunnel {
+                let preferred = name.starts_with("en")
+                    || name.starts_with("eth")
+                    || name.starts_with("wl")
+                    || name.starts_with("wlan");
+                if preferred {
+                    if lan_preferred.is_none() {
+                        lan_preferred = Some(ip);
+                    }
+                } else if lan_fallback.is_none() {
+                    lan_fallback = Some(ip);
+                }
+            }
+            cur = entry.ifa_next;
+        }
+        libc::freeifaddrs(ifap);
+        (lan_preferred.or(lan_fallback), tailscale)
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn is_cgnat(addr: u32) -> bool {
+    // 100.64.0.0/10
+    (addr >> 22) == (0x6440_0000 >> 22)
+}
+
+// ---------------------------------------------------------------------------
+// Public IP — disk-cached, background-refreshed (never blocks render)
+// ---------------------------------------------------------------------------
+
+fn public_ip_cache_path() -> PathBuf {
+    // Prefer a stable user cache dir; fall back to /tmp like powerline does.
+    if let Some(home) = std::env::var_os("HOME") {
+        let dir = PathBuf::from(home).join(".cache/herdr");
+        let _ = std::fs::create_dir_all(&dir);
+        return dir.join("public-ip");
+    }
+    PathBuf::from("/tmp/herdr-public-ip")
+}
+
+fn public_ip_cached() -> Option<String> {
+    let path = public_ip_cache_path();
+    if let Some(ip) = read_public_ip_cache(&path) {
+        // Refresh in the background once the entry is past half-life so the
+        // next paint after TTL still has a warm value.
+        if public_ip_cache_age_secs(&path).is_some_and(|age| age > PUBLIC_IP_TTL_SECS / 2) {
+            spawn_public_ip_refresh(path);
+        }
+        return Some(ip);
+    }
+    // One-shot migration from the tmux-powerline WAN cache so the first Herdr
+    // paint after switching already shows the public IP.
+    let legacy = std::path::Path::new("/tmp/tmux-powerline-wan-ip");
+    if let Some(ip) = read_public_ip_cache(legacy) {
+        let _ = std::fs::write(&path, format!("{ip}\n"));
+        return Some(ip);
+    }
+    spawn_public_ip_refresh(path);
+    None
+}
+
+fn read_public_ip_cache(path: &std::path::Path) -> Option<String> {
+    let age = public_ip_cache_age_secs(path)?;
+    if age > PUBLIC_IP_TTL_SECS {
+        return None;
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    let ip = text.trim();
+    if is_plausible_ipv4(ip) {
+        Some(ip.to_string())
+    } else {
+        None
+    }
+}
+
+fn public_ip_cache_age_secs(path: &std::path::Path) -> Option<u64> {
+    let meta = std::fs::metadata(path).ok()?;
+    let modified = meta.modified().ok()?;
+    let age = SystemTime::now().duration_since(modified).ok()?;
+    Some(age.as_secs())
+}
+
+fn spawn_public_ip_refresh(path: PathBuf) {
+    if PUBLIC_IP_FETCHING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    std::thread::Builder::new()
+        .name("herdr-public-ip".into())
+        .spawn(move || {
+            let ip = fetch_public_ip();
+            if let Some(ip) = ip {
+                let _ = std::fs::write(&path, format!("{ip}\n"));
+            }
+            PUBLIC_IP_FETCHING.store(false, Ordering::SeqCst);
+        })
+        .ok();
+}
+
+/// Max response body bytes accepted from a WAN IP endpoint.
+const PUBLIC_IP_BODY_CAP: u64 = 64;
+
+/// HTTPS endpoints that return a bare IPv4 body (one address per line).
+const PUBLIC_IP_ENDPOINTS: &[&str] = &[
+    "https://ifconfig.me/ip",
+    "https://icanhazip.com/",
+    "https://ipv4.icanhazip.com/",
+];
+
+fn fetch_public_ip() -> Option<String> {
+    // Production path: bounded in-process HTTPS via ureq + rustls.
+    fetch_public_ip_with(https_get_public_ip_body)
+}
+
+/// Injectable seam for offline unit tests — tries each endpoint URL until a
+/// body parses as a plausible IPv4 address.
+fn fetch_public_ip_with(fetch_body: impl Fn(&str) -> Option<String>) -> Option<String> {
+    for url in PUBLIC_IP_ENDPOINTS {
+        if let Some(body) = fetch_body(url) {
+            if let Some(ip) = parse_public_ip_body(&body) {
+                return Some(ip);
+            }
+        }
+    }
+    None
+}
+
+/// Parse a WAN-IP response body: first non-empty line, trimmed, IPv4 only.
+fn parse_public_ip_body(body: &str) -> Option<String> {
+    let ip = body.lines().next().unwrap_or("").trim();
+    if is_plausible_ipv4(ip) {
+        Some(ip.to_string())
+    } else {
+        None
+    }
+}
+
+fn https_get_public_ip_body(url: &str) -> Option<String> {
+    use std::io::Read;
+    use std::time::Duration;
+
+    // Connect ~1s, total/read ~2s. Single-flight is enforced by the caller
+    // (`PUBLIC_IP_FETCHING`); this helper only bounds one request.
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(1))
+        .timeout_read(Duration::from_secs(2))
+        .timeout(Duration::from_secs(2))
+        .user_agent("herdr-status")
+        .build();
+
+    let response = agent.get(url).call().ok()?;
+    let mut reader = response.into_reader().take(PUBLIC_IP_BODY_CAP);
+    let mut body = String::new();
+    reader.read_to_string(&mut body).ok()?;
+    Some(body)
+}
+
+fn is_plausible_ipv4(s: &str) -> bool {
+    let mut parts = s.split('.');
+    let mut n = 0;
+    for part in parts.by_ref() {
+        n += 1;
+        if n > 4 {
+            return false;
+        }
+        let Ok(v) = part.parse::<u8>() else {
+            return false;
+        };
+        let _ = v;
+    }
+    n == 4 && parts.next().is_none()
+}
+
+// ---------------------------------------------------------------------------
+// macOS FFI
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn mach_host_self() -> libc::mach_port_t;
+    fn host_statistics(
+        host: libc::mach_port_t,
+        flavor: libc::c_int,
+        host_info_out: *mut libc::integer_t,
+        host_info_outCnt: *mut libc::mach_msg_type_number_t,
+    ) -> libc::c_int;
+    fn host_statistics64(
+        host: libc::mach_port_t,
+        flavor: libc::c_int,
+        host_info_out: *mut libc::integer_t,
+        host_info_outCnt: *mut libc::mach_msg_type_number_t,
+    ) -> libc::c_int;
+}
+
+#[cfg(target_os = "macos")]
+type CfTypeRef = *const std::ffi::c_void;
+#[cfg(target_os = "macos")]
+type CfArrayRef = *const std::ffi::c_void;
+#[cfg(target_os = "macos")]
+type CfDictionaryRef = *const std::ffi::c_void;
+#[cfg(target_os = "macos")]
+type CfStringRef = *const std::ffi::c_void;
+#[cfg(target_os = "macos")]
+type CfNumberRef = *const std::ffi::c_void;
+#[cfg(target_os = "macos")]
+type CfBooleanRef = *const std::ffi::c_void;
+#[cfg(target_os = "macos")]
+type CfIndex = isize;
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFRelease(cf: CfTypeRef);
+    fn CFArrayGetCount(theArray: CfArrayRef) -> CfIndex;
+    fn CFArrayGetValueAtIndex(theArray: CfArrayRef, idx: CfIndex) -> CfTypeRef;
+    fn CFDictionaryGetValue(theDict: CfDictionaryRef, key: CfTypeRef) -> CfTypeRef;
+    fn CFStringCreateWithCString(
+        alloc: CfTypeRef,
+        cStr: *const libc::c_char,
+        encoding: u32,
+    ) -> CfStringRef;
+    fn CFStringGetCString(
+        theString: CfStringRef,
+        buffer: *mut libc::c_char,
+        bufferSize: CfIndex,
+        encoding: u32,
+    ) -> u8;
+    fn CFNumberGetValue(number: CfNumberRef, theType: i32, valuePtr: *mut std::ffi::c_void) -> u8;
+    fn CFBooleanGetValue(boolean: CfBooleanRef) -> u8;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "IOKit", kind = "framework")]
+unsafe extern "C" {
+    fn IOPSCopyPowerSourcesInfo() -> CfTypeRef;
+    fn IOPSCopyPowerSourcesList(blob: CfTypeRef) -> CfArrayRef;
+    fn IOPSGetPowerSourceDescription(blob: CfTypeRef, ps: CfTypeRef) -> CfDictionaryRef;
+}
+
+#[cfg(target_os = "macos")]
+const CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+#[cfg(target_os = "macos")]
+const CF_NUMBER_INT_TYPE: i32 = 9;
+
+// IOKit power-source keys (from IOKit/ps/IOPSKeys.h).
+#[cfg(target_os = "macos")]
+const IOPS_TYPE_KEY: &str = "Type";
+#[cfg(target_os = "macos")]
+const IOPS_INTERNAL_BATTERY_TYPE: &str = "InternalBattery";
+#[cfg(target_os = "macos")]
+const IOPS_CURRENT_CAPACITY_KEY: &str = "Current Capacity";
+#[cfg(target_os = "macos")]
+const IOPS_POWER_SOURCE_STATE_KEY: &str = "Power Source State";
+#[cfg(target_os = "macos")]
+const IOPS_AC_POWER_VALUE: &str = "AC Power";
+#[cfg(target_os = "macos")]
+const IOPS_IS_CHARGING_KEY: &str = "Is Charging";
+
+#[cfg(target_os = "macos")]
+unsafe fn cf_dict_i32(dict: CfDictionaryRef, key: &str) -> Option<i32> {
+    let key_ref = CFStringCreateWithCString(
+        std::ptr::null(),
+        std::ffi::CString::new(key).ok()?.as_ptr(),
+        CF_STRING_ENCODING_UTF8,
+    );
+    if key_ref.is_null() {
+        return None;
+    }
+    let val = CFDictionaryGetValue(dict, key_ref);
+    CFRelease(key_ref);
+    if val.is_null() {
+        return None;
+    }
+    let mut out: i32 = 0;
+    if CFNumberGetValue(val, CF_NUMBER_INT_TYPE, (&raw mut out).cast()) == 0 {
+        return None;
+    }
+    Some(out)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cf_dict_bool(dict: CfDictionaryRef, key: &str) -> Option<bool> {
+    let key_ref = CFStringCreateWithCString(
+        std::ptr::null(),
+        std::ffi::CString::new(key).ok()?.as_ptr(),
+        CF_STRING_ENCODING_UTF8,
+    );
+    if key_ref.is_null() {
+        return None;
+    }
+    let val = CFDictionaryGetValue(dict, key_ref);
+    CFRelease(key_ref);
+    if val.is_null() {
+        return None;
+    }
+    Some(CFBooleanGetValue(val) != 0)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cf_dict_string(dict: CfDictionaryRef, key: &str) -> Option<String> {
+    let key_ref = CFStringCreateWithCString(
+        std::ptr::null(),
+        std::ffi::CString::new(key).ok()?.as_ptr(),
+        CF_STRING_ENCODING_UTF8,
+    );
+    if key_ref.is_null() {
+        return None;
+    }
+    let val = CFDictionaryGetValue(dict, key_ref);
+    CFRelease(key_ref);
+    if val.is_null() {
+        return None;
+    }
+    let mut buf = [0i8; 128];
+    if CFStringGetCString(
+        val,
+        buf.as_mut_ptr(),
+        buf.len() as CfIndex,
+        CF_STRING_ENCODING_UTF8,
+    ) == 0
+    {
+        return None;
+    }
+    let cstr = std::ffi::CStr::from_ptr(buf.as_ptr());
+    Some(cstr.to_string_lossy().into_owned())
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cf_dict_string_eq(dict: CfDictionaryRef, key: &str, expect: &str) -> bool {
+    cf_dict_string(dict, key).is_some_and(|s| s == expect)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_is_deterministic() {
+        let a = status_metrics();
+        let b = status_metrics_fixture();
+        assert_eq!(a.hostname, b.hostname);
+        assert_eq!(a.username, b.username);
+        assert_eq!(a.cpu_percent, b.cpu_percent);
+        assert_eq!(a.public_ip.as_deref(), Some("203.0.113.10"));
+        assert_eq!(a.net_kind, NetKind::Wifi);
+        assert!(a.vpn_active);
+    }
+
+    #[test]
+    fn short_host_strips_domain() {
+        assert_eq!(short_host("macbook16.local"), "macbook16");
+        assert_eq!(short_host("localhost"), "localhost");
+    }
+
+    #[test]
+    fn plausible_ipv4_accepts_dotted_quad() {
+        assert!(is_plausible_ipv4("144.2.117.58"));
+        assert!(!is_plausible_ipv4("not-an-ip"));
+        assert!(!is_plausible_ipv4("1.2.3"));
+        assert!(!is_plausible_ipv4("1.2.3.4.5"));
+        assert!(!is_plausible_ipv4("999.0.0.1"));
+    }
+
+    #[test]
+    fn cgnat_detects_tailscale_range() {
+        // 100.64.0.1
+        let addr = (100u32 << 24) | (64 << 16) | 1;
+        assert!(is_cgnat(addr));
+        // 192.168.1.1
+        let addr = (192u32 << 24) | (168 << 16) | (1 << 8) | 1;
+        assert!(!is_cgnat(addr));
+        // 100.63.0.1 — outside /10
+        let addr = (100u32 << 24) | (63 << 16) | 1;
+        assert!(!is_cgnat(addr));
+        // 100.127.255.255 — inside
+        let addr = (100u32 << 24) | (127 << 16) | (255 << 8) | 255;
+        assert!(is_cgnat(addr));
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn collect_returns_identity() {
+        let m = collect_status_metrics();
+        assert!(!m.hostname.is_empty());
+        assert!(!m.username.is_empty());
+        // Identity must always resolve; optional collectors may be None on first sample.
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn cpu_sample_warms_then_reports() {
+        let first = collect_status_metrics();
+        std::thread::sleep(Duration::from_millis(200));
+        let second = collect_status_metrics();
+        // First sample establishes baseline (may be None); second should land.
+        let _ = first.cpu_percent;
+        // Bandwidth also needs two samples.
+        let _ = (second.net_down_kib, second.net_up_kib, second.cpu_percent);
+        // Public IP may come from disk cache / powerline migration.
+        let _ = second.public_ip;
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_iface_snapshots_include_en0_or_any() {
+        let snaps = macos_iface_byte_snapshots().expect("NET_RT_IFLIST2 should work");
+        assert!(!snaps.is_empty());
+        // At least one non-loopback interface should appear.
+        assert!(snaps.iter().any(|(n, _, _)| !n.starts_with("lo")));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_battery_reads_or_skips_cleanly() {
+        let (pct, charging) = macos_battery();
+        if let Some(p) = pct {
+            assert!(p <= 100);
+            assert!(charging.is_some());
+        }
+    }
+
+    #[test]
+    fn recovers_poisoned_metrics_cache() {
+        // Poison the soft cache, then ensure status_metrics still returns the fixture
+        // under cfg(test) and that the lock helper recovers outside the test fixture path.
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = CACHE.lock().unwrap();
+            panic!("poison status metrics cache");
+        });
+        // After poison, lock must still be usable via into_inner recovery.
+        {
+            let guard = metrics_cache_lock();
+            let _ = guard.as_ref();
+        }
+        let metrics = status_metrics();
+        assert_eq!(metrics.hostname, "testhost");
+    }
+
+    #[test]
+    fn recovers_poisoned_cpu_and_net_prev_locks() {
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = CPU_PREV.lock().unwrap();
+            panic!("poison cpu prev");
+        });
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = NET_PREV.lock().unwrap();
+            panic!("poison net prev");
+        });
+        // Helpers must recover via into_inner so subsequent samples still work.
+        {
+            let guard = cpu_prev_lock();
+            let _ = *guard;
+        }
+        {
+            let guard = net_prev_lock();
+            let _ = *guard;
+        }
+    }
+
+    #[test]
+    fn public_ip_fetch_does_not_reference_curl_helper() {
+        // Source-level contract: production WAN fetch is pure in-process HTTPS.
+        // (Runtime network is not exercised here.)
+        let src = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/platform/status_metrics.rs"
+        ));
+        // Bound the production helpers between the PUBLIC_IP_ENDPOINTS table and
+        // is_plausible_ipv4, excluding the offline unit tests that deliberately
+        // mention forbidden strings.
+        let fetch_region = src
+            .split("const PUBLIC_IP_ENDPOINTS")
+            .nth(1)
+            .and_then(|s| s.split("fn is_plausible_ipv4").next())
+            .expect("public IP HTTPS region");
+        assert!(
+            !fetch_region.contains("curl_command")
+                && !fetch_region.contains("Command::new")
+                && !fetch_region.contains("std::process")
+                && !fetch_region.contains("TcpStream")
+                && !fetch_region.contains("http://"),
+            "WAN fetch must not shell out or use plain HTTP"
+        );
+        assert!(
+            fetch_region.contains("ureq")
+                && fetch_region.contains("https://")
+                && fetch_region.contains("https_get_public_ip_body")
+                && fetch_region.contains("timeout_connect")
+                && fetch_region.contains("PUBLIC_IP_BODY_CAP"),
+            "WAN fetch must use bounded in-process HTTPS"
+        );
+    }
+
+    #[test]
+    fn parse_public_ip_body_accepts_first_line_ipv4() {
+        assert_eq!(
+            parse_public_ip_body("203.0.113.10\n").as_deref(),
+            Some("203.0.113.10")
+        );
+        assert_eq!(
+            parse_public_ip_body("  198.51.100.7 \nextra\n").as_deref(),
+            Some("198.51.100.7")
+        );
+        assert_eq!(parse_public_ip_body("not-an-ip\n"), None);
+        assert_eq!(parse_public_ip_body(""), None);
+        assert_eq!(parse_public_ip_body("1.2.3\n"), None);
+    }
+
+    #[test]
+    fn fetch_public_ip_with_uses_first_valid_endpoint() {
+        let calls = std::sync::Mutex::new(Vec::new());
+        let ip = fetch_public_ip_with(|url| {
+            calls.lock().unwrap().push(url.to_string());
+            if url.contains("icanhazip.com") && !url.contains("ipv4") {
+                Some("203.0.113.44\n".into())
+            } else {
+                Some("not-an-ip".into())
+            }
+        });
+        assert_eq!(ip.as_deref(), Some("203.0.113.44"));
+        let seen = calls.lock().unwrap().clone();
+        assert_eq!(seen[0], "https://ifconfig.me/ip");
+        assert!(seen.iter().any(|u| u == "https://icanhazip.com/"));
+        // Stop after first valid response — ipv4 fallback not required.
+        assert!(!seen.iter().any(|u| u.contains("ipv4.icanhazip")));
+    }
+
+    #[test]
+    fn fetch_public_ip_with_skips_failed_and_invalid_bodies() {
+        let ip = fetch_public_ip_with(|url| {
+            if url.contains("ifconfig.me") {
+                None
+            } else if url.contains("ipv4.icanhazip") {
+                Some("198.51.100.9".into())
+            } else {
+                Some("garbage".into())
+            }
+        });
+        assert_eq!(ip.as_deref(), Some("198.51.100.9"));
+    }
+
+    #[test]
+    fn fetch_public_ip_with_returns_none_when_all_endpoints_fail() {
+        assert_eq!(fetch_public_ip_with(|_| None), None);
+        assert_eq!(fetch_public_ip_with(|_| Some("nope".into())), None);
+    }
+
+    #[test]
+    fn public_ip_endpoints_are_https_only() {
+        assert!(!PUBLIC_IP_ENDPOINTS.is_empty());
+        for url in PUBLIC_IP_ENDPOINTS {
+            assert!(url.starts_with("https://"), "endpoint must be HTTPS: {url}");
+            assert!(!url.starts_with("http://"), "plain HTTP forbidden: {url}");
+        }
+    }
+
+    #[test]
+    fn public_ip_body_cap_is_small() {
+        // Keep the WAN body bound tight so a misbehaving endpoint cannot
+        // allocate unbounded memory on the collector thread.
+        assert!(PUBLIC_IP_BODY_CAP <= 256);
+        assert!(PUBLIC_IP_BODY_CAP >= 16);
+    }
+
+    #[test]
+    fn public_ip_ttl_is_five_minutes() {
+        assert_eq!(PUBLIC_IP_TTL_SECS, 300);
+    }
+}

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -3968,6 +3968,16 @@ impl HeadlessServer {
 
         if self
             .app
+            .next_status_metrics_refresh
+            .is_some_and(|deadline| now >= deadline)
+        {
+            let _ = crate::platform::status_metrics::refresh_status_metrics_if_due();
+            self.app.next_status_metrics_refresh = Some(now + app::STATUS_METRICS_REFRESH_INTERVAL);
+            changed = true;
+        }
+
+        if self
+            .app
             .selection_autoscroll_deadline
             .is_some_and(|deadline| now >= deadline)
         {
@@ -4490,6 +4500,9 @@ mod tests {
         app.state.local_sound_playback = false;
         app.local_terminal_notifications = false;
         app.local_input_source_switch = false;
+        // Tests that assert "no scheduled work" should not be tripped by the
+        // independent status-row clock; production App::new still arms it.
+        app.next_status_metrics_refresh = None;
 
         let dir = std::env::temp_dir().join(format!(
             "hh-{}-{}",
@@ -5977,6 +5990,8 @@ next_tab = ""
             dedupe_key: "herdr:codex\0codex\0Id\0codex-session".into(),
         });
         server.app.pending_agent_resume_deadline = Some(Instant::now() - Duration::from_millis(1));
+        // Isolate agent-resume behavior from the independent status-row clock.
+        server.app.next_status_metrics_refresh = None;
 
         assert!(!server.handle_scheduled_tasks_headless(Instant::now(), true));
         assert!(server.app.terminal_runtimes.get(&terminal_id).is_none());
@@ -6031,6 +6046,8 @@ next_tab = ""
             dedupe_key: "herdr:codex\0codex\0Id\0codex-session".into(),
         });
         server.app.pending_agent_resume_deadline = Some(Instant::now() - Duration::from_millis(1));
+        // Isolate agent-resume behavior from the independent status-row clock.
+        server.app.next_status_metrics_refresh = None;
 
         assert!(!server.handle_scheduled_tasks_headless(Instant::now(), false));
         assert!(server.app.terminal_runtimes.get(&terminal_id).is_none());
@@ -7328,7 +7345,9 @@ next_tab = ""
         );
         assert!(!mobile_surface.contains("background"));
 
-        let foreground_terminal_area = Rect::new(26, 1, 94, 39);
+        // Full-width status bar occupies row 0; terminal chrome starts at y=1 (tab bar)
+        // and the terminal surface at y=2.
+        let foreground_terminal_area = Rect::new(26, 2, 94, 38);
         let expected_pane_size = (
             foreground_terminal_area.height,
             foreground_terminal_area.width.saturating_sub(1),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -54,8 +54,8 @@ pub(crate) use self::scrollbar::{
 use self::settings::render_settings_overlay;
 use self::sidebar::{render_sidebar, render_sidebar_collapsed};
 use self::status::{
-    copy_feedback_rect, render_config_diagnostic, render_copy_feedback, render_toast_notification,
-    toast_notification_rect,
+    copy_feedback_rect, render_config_diagnostic, render_copy_feedback, render_status_bar,
+    render_toast_notification, status_identity_hit_area, toast_notification_rect,
 };
 pub(crate) use self::tab_surface::{
     compute_tab_surface, render_tab_surface, resize_tab_surface, TabSurfaceLayout,
@@ -220,6 +220,17 @@ fn compute_view_internal(
         return;
     }
 
+    // Full-width top status row (tmux-parity): spans the whole client, with
+    // sidebar + tabs below. Reserve it before the horizontal split so the bar
+    // is never squeezed into the main column only.
+    let (status_bar_rect, body_area) = if area.height > 1 {
+        let [status_bar_rect, body_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(area);
+        (status_bar_rect, body_area)
+    } else {
+        (Rect::default(), area)
+    };
+
     let sidebar_w = if app.sidebar_collapsed {
         match app.sidebar_collapsed_mode {
             crate::config::SidebarCollapsedModeConfig::Compact => COLLAPSED_WIDTH,
@@ -231,7 +242,7 @@ fn compute_view_internal(
     };
 
     let [sidebar_area, main_area] =
-        Layout::horizontal([Constraint::Length(sidebar_w), Constraint::Min(1)]).areas(area);
+        Layout::horizontal([Constraint::Length(sidebar_w), Constraint::Min(1)]).areas(body_area);
 
     let (tab_bar_rect, terminal_area) = app
         .active
@@ -300,8 +311,11 @@ fn compute_view_internal(
         })
         .unwrap_or_default();
 
+    let status_identity_hit_area = status_identity_hit_area(app, status_bar_rect);
     app.view = crate::app::ViewState {
         layout: ViewLayout::Desktop,
+        status_bar_rect,
+        status_identity_hit_area,
         sidebar_rect: sidebar_area,
         workspace_card_areas,
         tab_bar_rect,
@@ -365,6 +379,8 @@ fn compute_mobile_view(
 
     app.view = crate::app::ViewState {
         layout: ViewLayout::Mobile,
+        status_bar_rect: Rect::default(),
+        status_identity_hit_area: Rect::default(),
         sidebar_rect: Rect::default(),
         workspace_card_areas: Vec::new(),
         tab_bar_rect: Rect::default(),
@@ -397,6 +413,10 @@ pub fn render_with_runtime_registry(
     let sidebar_area = app.view.sidebar_rect;
     let tab_bar_area = app.view.tab_bar_rect;
     let terminal_area = app.view.terminal_area;
+
+    if app.view.layout != ViewLayout::Mobile {
+        render_status_bar(app, frame, app.view.status_bar_rect);
+    }
 
     if app.view.layout == ViewLayout::Mobile {
         render_mobile_header(app, terminal_runtimes, frame, app.view.mobile_header_rect);
@@ -802,16 +822,19 @@ mod tests {
 
         compute_view(&mut app, Rect::new(0, 0, 80, 20));
         let single_tab_terminal_area = app.view.terminal_area;
+        // Full-width status bar occupies row 0; chrome starts at y=1.
+        assert_eq!(app.view.status_bar_rect, Rect::new(0, 0, 80, 1));
         assert_eq!(app.view.tab_bar_rect, Rect::default());
-        assert_eq!(single_tab_terminal_area, Rect::new(26, 0, 54, 20));
+        assert_eq!(single_tab_terminal_area, Rect::new(26, 1, 54, 19));
         assert!(app.view.tab_hit_areas.is_empty());
         assert_eq!(app.view.new_tab_hit_area, Rect::default());
 
         app.workspaces[0].test_add_tab(Some("logs"));
         compute_view(&mut app, Rect::new(0, 0, 80, 20));
 
-        assert_eq!(app.view.tab_bar_rect, Rect::new(26, 0, 54, 1));
-        assert_eq!(app.view.terminal_area, Rect::new(26, 1, 54, 19));
+        assert_eq!(app.view.status_bar_rect, Rect::new(0, 0, 80, 1));
+        assert_eq!(app.view.tab_bar_rect, Rect::new(26, 1, 54, 1));
+        assert_eq!(app.view.terminal_area, Rect::new(26, 2, 54, 18));
         assert_eq!(app.view.tab_hit_areas.len(), 2);
         assert!(app.view.tab_hit_areas.iter().all(|rect| rect.width > 0));
         assert!(app.view.new_tab_hit_area.width > 0);
@@ -855,8 +878,9 @@ mod tests {
         let one_tab_size = app.workspaces[0].tabs[0].runtimes[&one_tab_pane].current_size();
         let two_tab_size =
             app.workspaces[1].tabs[background_tab].runtimes[&two_tab_pane].current_size();
-        assert_eq!(one_tab_size, (20, 53));
-        assert_eq!(two_tab_size, (19, 53));
+        // Status bar reserves one full-width row; single-tab workspaces reclaim the tab bar.
+        assert_eq!(one_tab_size, (19, 53));
+        assert_eq!(two_tab_size, (18, 53));
     }
 
     #[tokio::test]
@@ -969,14 +993,74 @@ mod tests {
 
         compute_view(&mut app, Rect::new(0, 0, 80, 20));
 
-        assert_eq!(app.view.sidebar_rect, Rect::new(0, 0, 0, 20));
-        assert_eq!(app.view.tab_bar_rect, Rect::new(0, 0, 80, 1));
-        assert_eq!(app.view.terminal_area, Rect::new(0, 1, 80, 19));
+        // Status bar is full-width on row 0; sidebar/tabs/terminal sit below.
+        assert_eq!(app.view.status_bar_rect, Rect::new(0, 0, 80, 1));
+        assert_eq!(app.view.sidebar_rect, Rect::new(0, 1, 0, 19));
+        assert_eq!(app.view.tab_bar_rect, Rect::new(0, 1, 80, 1));
+        assert_eq!(app.view.terminal_area, Rect::new(0, 2, 80, 18));
         assert!(app.view.workspace_card_areas.is_empty());
 
         let backend = TestBackend::new(80, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|frame| render(&app, frame)).unwrap();
+    }
+
+    #[test]
+    fn desktop_status_bar_spans_full_width_above_sidebar() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.workspaces = vec![Workspace::test_new("one")];
+        app.active = Some(0);
+        app.selected = 0;
+        app.mode = Mode::Terminal;
+        app.sidebar_width = 26;
+
+        compute_view(&mut app, Rect::new(0, 0, 100, 24));
+
+        assert_eq!(app.view.status_bar_rect, Rect::new(0, 0, 100, 1));
+        assert_eq!(app.view.sidebar_rect.y, 1);
+        assert_eq!(app.view.sidebar_rect.height, 23);
+        assert!(app.view.sidebar_rect.x == 0);
+        assert_eq!(app.view.sidebar_rect.width, 26);
+        // Terminal/tab chrome never occupy the status-bar row.
+        assert!(app.view.terminal_area.y >= 1);
+        assert!(app.view.tab_bar_rect.y >= 1 || app.view.tab_bar_rect == Rect::default());
+    }
+
+    #[test]
+    fn status_identity_hit_area_populated_on_desktop() {
+        let mut app = crate::app::state::AppState::test_new();
+        let mut ws = Workspace::test_new("repo");
+        ws.set_custom_name("home".into());
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+        app.selected = 0;
+        app.mode = Mode::Terminal;
+        app.sidebar_width = 26;
+
+        compute_view(&mut app, Rect::new(0, 0, 100, 24));
+
+        assert_eq!(app.view.status_bar_rect, Rect::new(0, 0, 100, 1));
+        assert!(
+            app.view.status_identity_hit_area.width > 0,
+            "desktop must expose identity hit area"
+        );
+        assert_eq!(app.view.status_identity_hit_area.y, 0);
+    }
+
+    #[test]
+    fn mobile_layout_leaves_status_bar_empty() {
+        let mut app = crate::app::state::AppState::test_new();
+        app.workspaces = vec![Workspace::test_new("one")];
+        app.active = Some(0);
+        app.selected = 0;
+        app.mode = Mode::Terminal;
+        app.mobile_width_threshold = 90;
+
+        compute_view(&mut app, Rect::new(0, 0, 80, 20));
+
+        assert_eq!(app.view.layout, ViewLayout::Mobile);
+        assert_eq!(app.view.status_bar_rect, Rect::default());
+        assert_eq!(app.view.status_identity_hit_area, Rect::default());
     }
 
     #[test]

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -1,3 +1,7 @@
+use std::path::{Path, PathBuf};
+#[cfg(not(test))]
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -6,13 +10,604 @@ use ratatui::{
     Frame,
 };
 
-use super::text::display_width_u16;
+use super::text::{display_width, display_width_u16, truncate_end};
 use super::widgets::panel_contrast_fg;
 use crate::{
-    app::state::{CopyFeedback, Palette, ToastKind, ToastNotification},
+    app::state::{CopyFeedback, Mode, Palette, ToastKind, ToastNotification},
+    app::AppState,
     config::{ToastClipboardPosition, ToastHerdrPosition},
     detect::AgentState,
+    platform::status_metrics::{status_metrics, NetKind, StatusMetrics},
 };
+
+/// Full-width top status row — native parity with the user's tmux powerline.
+///
+/// Left:  [prefix]  workspace:tab.pane · host ·  user · cwd ·  branch
+/// Right: 󰛳 lan 󰌘 ts  wan ·  [] ↓/↑ ·  mem ·  cpu · battery ·  date · time
+///
+/// Layout: spans the full client width above the sidebar. On narrow widths,
+/// right-side segments drop in the locked priority order, then left context is
+/// shortened/dropped while the identity segment is preserved last.
+pub(crate) fn render_status_bar(app: &AppState, frame: &mut Frame, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let p = &app.palette;
+    let bg = Style::default().bg(p.panel_bg);
+    frame.render_widget(Paragraph::new("").style(bg), area);
+
+    let metrics = status_metrics();
+    let layout = build_status_layout(
+        app,
+        &metrics,
+        app.mode == Mode::Prefix,
+        p,
+        area.width as usize,
+    );
+
+    let mut spans: Vec<Span> = Vec::new();
+    for seg in &layout.left {
+        let style = if seg.preserve_bg {
+            seg.style
+        } else {
+            seg.style.bg(p.panel_bg)
+        };
+        spans.push(Span::styled(seg.text.clone(), style));
+    }
+    if layout.pad > 0 {
+        spans.push(Span::styled(" ".repeat(layout.pad), bg));
+    }
+    for seg in &layout.right {
+        let style = if seg.preserve_bg {
+            seg.style
+        } else {
+            seg.style.bg(p.panel_bg)
+        };
+        spans.push(Span::styled(seg.text.clone(), style));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)).style(bg), area);
+}
+
+/// Identity click target within the full-width status row.
+pub(crate) fn status_identity_hit_area(app: &AppState, area: Rect) -> Rect {
+    if area.width == 0 || area.height == 0 {
+        return Rect::default();
+    }
+    let metrics = status_metrics();
+    let layout = build_status_layout(
+        app,
+        &metrics,
+        app.mode == Mode::Prefix,
+        &app.palette,
+        area.width as usize,
+    );
+    if layout.identity_width == 0 {
+        return Rect::default();
+    }
+    let width =
+        (layout.identity_width as u16).min(area.width.saturating_sub(layout.identity_x as u16));
+    if width == 0 {
+        return Rect::default();
+    }
+    Rect {
+        x: area.x.saturating_add(layout.identity_x as u16),
+        y: area.y,
+        width,
+        height: area.height.min(1),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Segment {
+    text: String,
+    style: Style,
+    /// When true, `style` already carries its own background (prefix pill).
+    preserve_bg: bool,
+    kind: SegmentKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SegmentKind {
+    Prefix,
+    Identity,
+    Host,
+    User,
+    Cwd,
+    Branch,
+    LanIp,
+    TailscaleIp,
+    WanIp,
+    Bandwidth,
+    Memory,
+    Cpu,
+    Battery,
+    Date,
+    Time,
+}
+
+#[derive(Debug, Clone)]
+struct StatusLayout {
+    left: Vec<Segment>,
+    right: Vec<Segment>,
+    pad: usize,
+    identity_x: usize,
+    identity_width: usize,
+}
+
+fn build_status_layout(
+    app: &AppState,
+    metrics: &StatusMetrics,
+    prefix_active: bool,
+    p: &Palette,
+    width: usize,
+) -> StatusLayout {
+    let mut left = left_segments(app, metrics, prefix_active, p);
+    let mut right = right_segments(metrics, p);
+    fit_segments(&mut left, &mut right, width);
+
+    let identity_x = left
+        .iter()
+        .take_while(|s| s.kind != SegmentKind::Identity)
+        .map(|s| display_width(&s.text))
+        .sum();
+    let identity_width = left
+        .iter()
+        .find(|s| s.kind == SegmentKind::Identity)
+        .map(|s| display_width(&s.text))
+        .unwrap_or(0);
+
+    let used_left: usize = left.iter().map(|s| display_width(&s.text)).sum();
+    let used_right: usize = right.iter().map(|s| display_width(&s.text)).sum();
+    let pad = width.saturating_sub(used_left).saturating_sub(used_right);
+
+    StatusLayout {
+        left,
+        right,
+        pad,
+        identity_x,
+        identity_width,
+    }
+}
+
+/// Right-side drop order (first entry is removed first).
+const RIGHT_DROP_ORDER: &[SegmentKind] = &[
+    SegmentKind::WanIp,
+    SegmentKind::TailscaleIp,
+    SegmentKind::LanIp,
+    SegmentKind::Bandwidth,
+    SegmentKind::Battery,
+    SegmentKind::Date,
+    SegmentKind::Cpu,
+    SegmentKind::Memory,
+    SegmentKind::Time,
+];
+
+/// Left-side drop order after shortening (first entry is removed first).
+const LEFT_DROP_ORDER: &[SegmentKind] = &[
+    SegmentKind::User,
+    SegmentKind::Host,
+    SegmentKind::Branch,
+    SegmentKind::Cwd,
+];
+
+fn fit_segments(left: &mut Vec<Segment>, right: &mut Vec<Segment>, width: usize) {
+    let total = |left: &[Segment], right: &[Segment]| -> usize {
+        left.iter().map(|s| display_width(&s.text)).sum::<usize>()
+            + right.iter().map(|s| display_width(&s.text)).sum::<usize>()
+    };
+
+    // 1) Drop right-side detail in the locked priority order.
+    for kind in RIGHT_DROP_ORDER {
+        if total(left, right) <= width {
+            return;
+        }
+        right.retain(|s| s.kind != *kind);
+    }
+
+    // 2) Shorten cwd / branch to cell-safe forms.
+    let overflow = total(left, right).saturating_sub(width);
+    if overflow > 0 {
+        shorten_left_context(left, overflow);
+    }
+
+    // 3) Drop left non-identity context in the locked order.
+    for kind in LEFT_DROP_ORDER {
+        if total(left, right) <= width {
+            return;
+        }
+        left.retain(|s| s.kind != *kind);
+    }
+
+    // 4) As a last resort, hard-truncate the identity text (never drop it).
+    if total(left, right) > width {
+        let overflow = total(left, right).saturating_sub(width);
+        if let Some(seg) = left.iter_mut().find(|s| s.kind == SegmentKind::Identity) {
+            let keep = display_width(&seg.text).saturating_sub(overflow);
+            seg.text = truncate_end(&seg.text, keep.max(1));
+        }
+    }
+}
+
+fn shorten_left_context(left: &mut [Segment], mut need: usize) {
+    if need == 0 {
+        return;
+    }
+    for kind in [SegmentKind::Cwd, SegmentKind::Branch] {
+        if need == 0 {
+            break;
+        }
+        if let Some(seg) = left.iter_mut().find(|s| s.kind == kind) {
+            let before = display_width(&seg.text);
+            let target = before.saturating_sub(need).max(4);
+            let shortened = match kind {
+                SegmentKind::Cwd => {
+                    // text is " {path} "
+                    let inner = seg.text.trim();
+                    format!(" {} ", shorten_path_str(inner, target.saturating_sub(2)))
+                }
+                SegmentKind::Branch => {
+                    let inner = seg.text.trim().trim_start_matches('').trim();
+                    format!("  {} ", shorten_branch(inner, target.saturating_sub(4)))
+                }
+                _ => seg.text.clone(),
+            };
+            let after = display_width(&shortened);
+            if after < before {
+                need = need.saturating_sub(before - after);
+                seg.text = shortened;
+            }
+        }
+    }
+}
+
+fn left_segments(
+    app: &AppState,
+    metrics: &StatusMetrics,
+    prefix_active: bool,
+    p: &Palette,
+) -> Vec<Segment> {
+    let mut out = Vec::new();
+
+    if prefix_active {
+        // Match tmux `#{?client_prefix,... § ...}`.
+        out.push(Segment {
+            text: " § ".into(),
+            style: Style::default()
+                .fg(p.panel_bg)
+                .bg(p.yellow)
+                .add_modifier(Modifier::BOLD),
+            preserve_bg: true,
+            kind: SegmentKind::Prefix,
+        });
+    }
+
+    let identity = focused_identity(app);
+    out.push(Segment {
+        text: format!("  {} ", identity.label),
+        style: Style::default().fg(p.blue),
+        preserve_bg: false,
+        kind: SegmentKind::Identity,
+    });
+
+    // hostname / remote marker
+    if !metrics.hostname.is_empty() {
+        let host_text = if metrics.remote_session {
+            format!(" 󰣀 {} ", metrics.hostname)
+        } else {
+            format!(" {} ", metrics.hostname)
+        };
+        out.push(Segment {
+            text: host_text,
+            style: Style::default().fg(p.green),
+            preserve_bg: false,
+            kind: SegmentKind::Host,
+        });
+    }
+
+    if !metrics.username.is_empty() {
+        out.push(Segment {
+            text: format!("  {} ", metrics.username),
+            style: Style::default().fg(p.teal),
+            preserve_bg: false,
+            kind: SegmentKind::User,
+        });
+    }
+
+    if let Some(cwd) = identity.cwd {
+        let display = shorten_path(&cwd, 40);
+        out.push(Segment {
+            text: format!(" {display} "),
+            style: Style::default().fg(p.mauve),
+            preserve_bg: false,
+            kind: SegmentKind::Cwd,
+        });
+    }
+
+    if let Some(branch) = identity.branch {
+        let branch = shorten_branch(&branch, 24);
+        out.push(Segment {
+            text: format!("  {branch} "),
+            style: Style::default().fg(p.yellow),
+            preserve_bg: false,
+            kind: SegmentKind::Branch,
+        });
+    }
+
+    out
+}
+
+fn right_segments(metrics: &StatusMetrics, p: &Palette) -> Vec<Segment> {
+    let mut out = Vec::new();
+
+    // Separate IP segments so the locked drop order can remove WAN → TS → LAN.
+    if let Some(ip) = &metrics.local_ip {
+        out.push(Segment {
+            text: format!(" 󰛳 {ip} "),
+            style: Style::default().fg(p.teal),
+            preserve_bg: false,
+            kind: SegmentKind::LanIp,
+        });
+    }
+    if let Some(ip) = &metrics.tailscale_ip {
+        out.push(Segment {
+            text: format!(" 󰌘 {ip} "),
+            style: Style::default().fg(p.teal),
+            preserve_bg: false,
+            kind: SegmentKind::TailscaleIp,
+        });
+    }
+    if let Some(ip) = &metrics.public_ip {
+        out.push(Segment {
+            text: format!("  {ip} "),
+            style: Style::default().fg(p.teal),
+            preserve_bg: false,
+            kind: SegmentKind::WanIp,
+        });
+    }
+
+    // bandwidth: wifi/eth glyph + optional VPN lock + ↓/↑ KiB/s
+    if let (Some(down), Some(up)) = (metrics.net_down_kib, metrics.net_up_kib) {
+        let kind_icon = match metrics.net_kind {
+            NetKind::Ethernet => "󰈀",
+            NetKind::Wifi | NetKind::Unknown => "",
+        };
+        let vpn = if metrics.vpn_active { " " } else { "" };
+        out.push(Segment {
+            text: format!(" {kind_icon}{vpn} ↓{down}K/s ↑{up}K/s "),
+            style: Style::default().fg(p.green),
+            preserve_bg: false,
+            kind: SegmentKind::Bandwidth,
+        });
+    }
+
+    if let (Some(used), Some(total)) = (metrics.mem_used_gb, metrics.mem_total_gb) {
+        out.push(Segment {
+            text: format!("  {used:.1}/{total:.0} GB "),
+            style: Style::default().fg(p.yellow),
+            preserve_bg: false,
+            kind: SegmentKind::Memory,
+        });
+    }
+
+    if let Some(cpu) = metrics.cpu_percent {
+        out.push(Segment {
+            text: format!("  {cpu}% "),
+            style: Style::default().fg(p.red),
+            preserve_bg: false,
+            kind: SegmentKind::Cpu,
+        });
+    }
+
+    if let Some(pct) = metrics.battery_percent {
+        let icon = match metrics.battery_charging {
+            Some(true) => "󰂄",
+            _ => battery_icon(pct),
+        };
+        out.push(Segment {
+            text: format!(" {icon} {pct}% "),
+            style: Style::default().fg(p.blue),
+            preserve_bg: false,
+            kind: SegmentKind::Battery,
+        });
+    }
+
+    let (date, time) = local_date_time();
+    out.push(Segment {
+        text: format!("  {date} "),
+        style: Style::default().fg(p.overlay0),
+        preserve_bg: false,
+        kind: SegmentKind::Date,
+    });
+    out.push(Segment {
+        text: format!(" {time} "),
+        style: Style::default().fg(p.subtext0),
+        preserve_bg: false,
+        kind: SegmentKind::Time,
+    });
+
+    out
+}
+
+/// Nerd Font battery glyph by charge bucket.
+fn battery_icon(pct: u8) -> &'static str {
+    match pct {
+        0..=10 => "󰁺",
+        11..=20 => "󰁻",
+        21..=30 => "󰁼",
+        31..=40 => "󰁽",
+        41..=50 => "󰁾",
+        51..=60 => "󰁿",
+        61..=70 => "󰂀",
+        71..=80 => "󰂁",
+        81..=90 => "󰂂",
+        _ => "󰁹",
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FocusedIdentity {
+    /// Compact `workspace:tab.pane` label (e.g. `home:1.1`).
+    label: String,
+    cwd: Option<PathBuf>,
+    branch: Option<String>,
+}
+
+fn focused_identity(app: &AppState) -> FocusedIdentity {
+    let Some(ws_idx) = app.active else {
+        return FocusedIdentity {
+            label: "?:1.1".into(),
+            cwd: None,
+            branch: None,
+        };
+    };
+    let Some(ws) = app.workspaces.get(ws_idx) else {
+        return FocusedIdentity {
+            label: "?:1.1".into(),
+            cwd: None,
+            branch: None,
+        };
+    };
+
+    let ws_name = ws.display_name();
+    let tab_idx = ws.active_tab_index();
+    let tab_label = ws
+        .public_tab_number(tab_idx)
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| (tab_idx + 1).to_string());
+    let pane_id = ws.focused_pane_id();
+    // Prefer stable public pane numbers (tmux #P parity), not internal PaneId.
+    let pane_label = pane_id
+        .and_then(|id| ws.public_pane_number(id))
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "1".into());
+
+    // Prefer live focused-pane terminal cwd; fall back to workspace identity.
+    let cwd = pane_id
+        .and_then(|pane_id| {
+            ws.tabs
+                .get(tab_idx)
+                .and_then(|tab| tab.panes.get(&pane_id))
+                .and_then(|pane| app.terminals.get(&pane.attached_terminal_id))
+                .map(|terminal| terminal.cwd.clone())
+        })
+        .or_else(|| ws.resolved_identity_cwd())
+        .or_else(|| Some(ws.identity_cwd.clone()));
+    let branch = ws.cached_git_branch.clone();
+
+    FocusedIdentity {
+        label: format!("{ws_name}:{tab_label}.{pane_label}"),
+        cwd,
+        branch,
+    }
+}
+
+fn shorten_path(path: &Path, max_width: usize) -> String {
+    shorten_path_str(&path.to_string_lossy(), max_width)
+}
+
+fn shorten_path_str(raw: &str, max_width: usize) -> String {
+    let display = if let Ok(home) = std::env::var("HOME") {
+        if let Some(rest) = raw.strip_prefix(&home) {
+            // Powerline `pwd` collapses $HOME to `~` (keeping the slash as `~/…`).
+            format!("~{rest}")
+        } else {
+            raw.to_string()
+        }
+    } else {
+        raw.to_string()
+    };
+    if display_width(&display) <= max_width {
+        return display;
+    }
+    // Left-truncate like powerline: keep the trailing path, prefix with `…/`.
+    left_truncate_path(&display, max_width)
+}
+
+fn left_truncate_path(display: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    // Never shorter than the final path component if possible.
+    let file = display.rsplit('/').next().unwrap_or(display);
+    let file_w = display_width(file);
+    if file_w >= max_width {
+        return truncate_end(file, max_width);
+    }
+    let ellipsis = "…/";
+    let ellipsis_w = display_width(ellipsis);
+    if ellipsis_w + file_w >= max_width {
+        return truncate_end(file, max_width);
+    }
+    let budget = max_width.saturating_sub(ellipsis_w);
+    // Take a suffix of `display` that fits in budget, then force a clean `…/rest`.
+    let mut width = 0usize;
+    let mut start = display.len();
+    for (idx, ch) in display.char_indices().rev() {
+        let ch_w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_w > budget {
+            break;
+        }
+        width += ch_w;
+        start = idx;
+    }
+    let mut suffix = &display[start..];
+    // Drop a partial leading component so we always start on a path boundary when possible.
+    if let Some(slash) = suffix.find('/') {
+        suffix = &suffix[slash + 1..];
+    }
+    if suffix.is_empty() {
+        suffix = file;
+    }
+    format!("{ellipsis}{suffix}")
+}
+
+fn shorten_branch(branch: &str, max_width: usize) -> String {
+    if display_width(branch) <= max_width {
+        branch.to_string()
+    } else {
+        truncate_end(branch, max_width)
+    }
+}
+
+fn local_date_time() -> (String, String) {
+    // Characterization tests hash the full frame; freeze wall-clock there.
+    #[cfg(test)]
+    {
+        return ("2026-01-02".into(), "03:04".into());
+    }
+
+    // Format via libc localtime to avoid a chrono dependency.
+    #[cfg(not(test))]
+    {
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        #[cfg(unix)]
+        {
+            // SAFETY: localtime_r writes into our stack tm.
+            let mut tm = unsafe { std::mem::zeroed::<libc::tm>() };
+            let t = secs as libc::time_t;
+            let rc = unsafe { libc::localtime_r(&t, &mut tm) };
+            if !rc.is_null() {
+                let date = format!(
+                    "{:04}-{:02}-{:02}",
+                    tm.tm_year + 1900,
+                    tm.tm_mon + 1,
+                    tm.tm_mday
+                );
+                let time = format!("{:02}:{:02}", tm.tm_hour, tm.tm_min);
+                return (date, time);
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = secs;
+        }
+        ("----/--/--".into(), "--:--".into())
+    }
+}
 
 pub(crate) fn copy_feedback_rect(
     area: Rect,
@@ -321,5 +916,220 @@ mod tests {
             bottom_center.x,
             area.x + area.width.saturating_sub(bottom_center.width) / 2
         );
+    }
+
+    #[test]
+    fn shorten_path_uses_tilde_for_home() {
+        // Other tests mutate HOME; pin a private value for this assertion.
+        let home = "/tmp/herdr-status-home-fixture";
+        // SAFETY: tests run single-threaded in CI for env-sensitive cases; we restore below.
+        let previous = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        let path = PathBuf::from(format!("{home}/Code/personal/home"));
+        let display = shorten_path(&path, 80);
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var("HOME", value);
+            },
+            None => unsafe {
+                std::env::remove_var("HOME");
+            },
+        }
+        assert!(
+            display.starts_with("~/") || display.starts_with("~\\"),
+            "expected tilde-shortened path, got {display}"
+        );
+        assert!(display.contains("Code"));
+    }
+
+    #[test]
+    fn local_date_time_returns_plausible_shapes() {
+        let (date, time) = local_date_time();
+        assert_eq!(date.len(), 10, "YYYY-MM-DD");
+        assert_eq!(time.len(), 5, "HH:MM");
+        assert_eq!(&date[4..5], "-");
+        assert_eq!(&date[7..8], "-");
+        assert_eq!(&time[2..3], ":");
+    }
+
+    // -----------------------------------------------------------------------
+    // Native status-bar identity / fit / hit-testing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn focused_identity_uses_workspace_display_name_and_public_numbers() {
+        let mut app = crate::app::AppState::test_new();
+        let mut ws = crate::workspace::Workspace::test_new("repo");
+        ws.set_custom_name("home".into());
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+        app.selected = 0;
+
+        let identity = focused_identity(&app);
+        assert_eq!(identity.label, "home:1.1");
+    }
+
+    #[test]
+    fn focused_identity_uses_public_tab_and_pane_not_session() {
+        let mut app = crate::app::AppState::test_new();
+        let mut ws = crate::workspace::Workspace::test_new("repo");
+        ws.set_custom_name("agents".into());
+        // Add a second tab so public tab numbers stay stable (1, 2, ...).
+        ws.test_add_tab(Some("two"));
+        ws.active_tab = 1;
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+
+        let identity = focused_identity(&app);
+        // Public tab number is 2; the new tab's root pane receives the next public
+        // pane number (2), not an internal PaneId.
+        let tab_no = app.workspaces[0].public_tab_number(1).unwrap();
+        let pane_id = app.workspaces[0].focused_pane_id().unwrap();
+        let pane_no = app.workspaces[0].public_pane_number(pane_id).unwrap();
+        assert_eq!(tab_no, 2);
+        assert_eq!(identity.label, format!("agents:{tab_no}.{pane_no}"));
+        assert!(!identity.label.contains("session"));
+    }
+
+    #[test]
+    fn status_layout_identity_segment_matches_home_tab_pane_form() {
+        let mut app = crate::app::AppState::test_new();
+        let mut ws = crate::workspace::Workspace::test_new("repo");
+        ws.set_custom_name("home".into());
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+
+        let metrics = crate::platform::status_metrics::status_metrics_fixture();
+        let layout = build_status_layout(&app, &metrics, false, &app.palette, 200);
+        let identity = layout
+            .left
+            .iter()
+            .find(|s| s.kind == SegmentKind::Identity)
+            .expect("identity segment");
+        assert!(
+            identity.text.contains("home:1.1"),
+            "identity text was {:?}",
+            identity.text
+        );
+        // Must not use session:workspaceIndex.pane
+        assert!(!identity.text.contains("main:1.1") || identity.text.contains("home:1.1"));
+        assert!(!identity.text.contains("session"));
+    }
+
+    #[test]
+    fn right_side_drops_wan_before_time() {
+        let metrics = crate::platform::status_metrics::status_metrics_fixture();
+        let mut app = crate::app::AppState::test_new();
+        let mut ws = crate::workspace::Workspace::test_new("repo");
+        ws.set_custom_name("home".into());
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+
+        // Wide enough for left, but force progressive right drops.
+        let wide = build_status_layout(&app, &metrics, false, &app.palette, 400);
+        assert!(
+            wide.right.iter().any(|s| s.kind == SegmentKind::WanIp),
+            "expected WAN on wide layout"
+        );
+        assert!(wide.right.iter().any(|s| s.kind == SegmentKind::Time));
+
+        // Shrink until WAN is gone but time may still remain (WAN drops first).
+        let mut found = false;
+        for w in (40..400).rev() {
+            let layout = build_status_layout(&app, &metrics, false, &app.palette, w);
+            let has_wan = layout.right.iter().any(|s| s.kind == SegmentKind::WanIp);
+            let has_time = layout.right.iter().any(|s| s.kind == SegmentKind::Time);
+            if !has_wan && has_time {
+                found = true;
+                break;
+            }
+            if !has_wan && !has_time {
+                // Both gone — still OK if we never saw WAN-gone/time-kept; check drop order via ranks.
+                break;
+            }
+        }
+        // Verify drop order ranking regardless of width sampling.
+        let kinds_at = |w: usize| {
+            build_status_layout(&app, &metrics, false, &app.palette, w)
+                .right
+                .iter()
+                .map(|s| s.kind)
+                .collect::<Vec<_>>()
+        };
+        // Find two widths where the set of right kinds decreases by WAN first.
+        let full = kinds_at(500);
+        assert!(full.contains(&SegmentKind::WanIp));
+        assert!(full.contains(&SegmentKind::Time));
+        // After removing only the first drop (WAN), time remains.
+        let mut right = right_segments(&metrics, &app.palette);
+        let left = left_segments(&app, &metrics, false, &app.palette);
+        // Simulate single WAN drop:
+        right.retain(|s| s.kind != SegmentKind::WanIp);
+        assert!(right.iter().any(|s| s.kind == SegmentKind::Time));
+        let _ = (left, found);
+    }
+
+    #[test]
+    fn fit_preserves_identity_when_extremely_narrow() {
+        let metrics = crate::platform::status_metrics::status_metrics_fixture();
+        let mut app = crate::app::AppState::test_new();
+        let mut ws = crate::workspace::Workspace::test_new("repo");
+        ws.set_custom_name("home".into());
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+
+        let layout = build_status_layout(&app, &metrics, false, &app.palette, 12);
+        assert!(
+            layout.left.iter().any(|s| s.kind == SegmentKind::Identity),
+            "identity must survive narrow widths"
+        );
+        let used: usize = layout
+            .left
+            .iter()
+            .map(|s| display_width(&s.text))
+            .sum::<usize>()
+            + layout
+                .right
+                .iter()
+                .map(|s| display_width(&s.text))
+                .sum::<usize>();
+        assert!(used <= 12, "layout used {used} cells at width 12");
+    }
+
+    #[test]
+    fn shorten_path_collapses_home_prefix() {
+        // Use a synthetic HOME so parallel suites that mutate env cannot flake
+        // this assertion. Restore afterward.
+        let previous = std::env::var_os("HOME");
+        let home = "/tmp/herdr-status-home-fixture";
+        // SAFETY: test-only env mutation, restored before the test ends.
+        unsafe { std::env::set_var("HOME", home) };
+        let path = format!("{home}/Code/worktrees/demo");
+        let short = shorten_path_str(&path, 80);
+        match previous {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        assert!(short.starts_with("~/"), "got {short}");
+        assert!(short.ends_with("Code/worktrees/demo") || short.contains("demo"));
+    }
+
+    #[test]
+    fn status_identity_hit_area_covers_identity_segment() {
+        let mut app = crate::app::AppState::test_new();
+        let mut ws = crate::workspace::Workspace::test_new("repo");
+        ws.set_custom_name("home".into());
+        app.workspaces = vec![ws];
+        app.active = Some(0);
+
+        let area = Rect::new(0, 0, 200, 1);
+        let hit = status_identity_hit_area(&app, area);
+        assert!(hit.width > 0, "expected non-empty identity hit area");
+        assert_eq!(hit.y, 0);
+        assert_eq!(hit.height, 1);
+        // Hit should start after optional prefix; without prefix, near x=0.
+        assert!(hit.x < 5);
     }
 }

--- a/src/ui/tab_surface.rs
+++ b/src/ui/tab_surface.rs
@@ -194,7 +194,8 @@ mod tests {
         let full_area = Rect::new(0, 0, 106, 20);
         crate::ui::compute_view(&mut app, full_area);
         let area = app.view.terminal_area;
-        assert_eq!(area, Rect::new(26, 1, 80, 19));
+        // Status bar occupies row 0; tab bar at y=1; terminal below.
+        assert_eq!(area, Rect::new(26, 2, 80, 18));
         let surface = compute_tab_surface(
             &app,
             &TerminalRuntimeRegistry::new(),
@@ -295,16 +296,18 @@ mod tests {
         let frame = full_app_frame(&mut app, Rect::new(0, 0, 106, 20));
 
         assert_eq!((frame.width, frame.height), (106, 20));
-        assert_eq!(app.view.sidebar_rect, Rect::new(0, 0, 26, 20));
-        assert_eq!(app.view.tab_bar_rect, Rect::new(26, 0, 80, 1));
-        assert_eq!(app.view.terminal_area, Rect::new(26, 1, 80, 19));
+        // Status bar occupies row 0 full-width; chrome starts at y=1.
+        assert_eq!(app.view.status_bar_rect, Rect::new(0, 0, 106, 1));
+        assert_eq!(app.view.sidebar_rect, Rect::new(0, 1, 26, 19));
+        assert_eq!(app.view.tab_bar_rect, Rect::new(26, 1, 80, 1));
+        assert_eq!(app.view.terminal_area, Rect::new(26, 2, 80, 18));
         assert_eq!(app.view.pane_infos.len(), 2);
         assert!(!app.view.split_borders.is_empty());
         assert!(frame.cursor.is_some());
         assert_eq!(frame.hyperlinks, vec![uri.to_owned()]);
         assert_eq!(
             frame_digest(&frame),
-            "ce383feeaac30922502b7c4f8af53b5ca30e816ec4503ca6d015738b584da487"
+            "c77d61eef6d5303a1fefb64d77e00a8d37eddfaf5cab6eaa1bd931a45d1a1691"
         );
     }
 


### PR DESCRIPTION
## Summary
- WIP save of native full-width status bar metrics collector (`status_metrics`) and UI wiring.
- Furthest dirty worktree (`herdr-status-grok-integration`) committed so work is not lost.
- Overlapping metrics/ui worktrees intentionally left uncommitted / stashed as superseded by this branch.

## Test plan
- [ ] Build on macOS and confirm status bar renders CPU/mem/battery/IPs
- [ ] Confirm WAN IP refresh is cached and non-blocking
- [ ] Smoke-test mouse/sidebar interactions still work with status bar present