### PR TITLE
fix: preserve workspace labels for root repositories

### DIFF
--- a/src/app/git_refresh.rs
+++ b/src/app/git_refresh.rs
@@ -253,6 +253,48 @@ mod tests {
     }
 
     #[test]
+    fn shared_root_repo_refresh_keeps_workspace_specific_fallback_labels() {
+        let cache_key = PathBuf::from("/");
+        let cached = GitStatusCacheEntry {
+            fingerprint: None,
+            retry_after: Some(Instant::now() + std::time::Duration::from_secs(30)),
+            snapshot: crate::workspace::WorkspaceGitStatusSnapshot {
+                auto_label: "/".into(),
+                branch: Some("main".into()),
+                ahead_behind: None,
+                space: Some(crate::workspace::GitSpaceMetadata {
+                    key: "/.git".into(),
+                    checkout_key: "/".into(),
+                    repo_name: "repo".into(),
+                    repo_root: cache_key.clone(),
+                    is_linked_worktree: false,
+                }),
+            },
+        };
+        let items = ["alpha", "beta"]
+            .into_iter()
+            .map(|name| WorkspaceGitRefreshItem {
+                workspace_id: name.into(),
+                resolved_identity_cwd: cache_key.join(name),
+                cache_key_hint: Some(cache_key.clone()),
+            })
+            .collect();
+
+        let output = refresh_workspace_git_statuses_with_cache_and_demand(
+            items,
+            &HashMap::from([(cache_key, cached)]),
+            GitStatusRefreshDemand::ALL,
+        );
+
+        assert_eq!(output.cache_updates.len(), 1);
+        assert_eq!(output.results.len(), 2);
+        assert_eq!(output.results[0].auto_label, "alpha");
+        assert_eq!(output.results[1].auto_label, "beta");
+        assert_eq!(output.results[0].branch.as_deref(), Some("main"));
+        assert_eq!(output.results[1].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
     fn git_refresh_item_collection_does_not_discover_uncached_cwd() {
         let mut app = test_app(&crate::config::Config::default());
         let cwd = std::env::temp_dir().join(format!("herdr-uncached-cwd-{}", std::process::id()));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -83,12 +83,19 @@ impl WorkspaceGitStatusSnapshot {
         status_cache_key: PathBuf,
         demand: GitStatusRefreshDemand,
     ) -> WorkspaceGitStatus {
+        let auto_label = self
+            .space
+            .as_ref()
+            .map(|space| {
+                self::git::automatic_workspace_label(&resolved_identity_cwd, &space.repo_root)
+            })
+            .unwrap_or_else(|| fallback_label_from_cwd(&resolved_identity_cwd));
         WorkspaceGitStatus {
             workspace_id,
             resolved_identity_cwd,
             status_cache_key,
             demand,
-            auto_label: self.auto_label,
+            auto_label,
             branch: self.branch,
             ahead_behind: self.ahead_behind,
             space: self.space,


### PR DESCRIPTION
## What changed

- derive automatic workspace labels per workspace after shared Git refreshes
- preserve repository-level Git status deduplication
- keep filesystem-root repositories active for branch/status while labeling child workspaces from their root-pane cwd

## Testing

- regression test failed before the fix and passes after
- `just check`

Refs #2594
