### PR TITLE
fix(agent): focus Copilot before prompting

### DIFF
--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -420,7 +420,7 @@ mod tests {
             crate::terminal::TerminalRuntime::test_with_channel_and_scrollback_bytes(
                 80, 24, 0, b"", 3,
             );
-        runtime.test_process_pty_bytes(b"\x1b[?1004h\x1b[?2004h");
+        runtime.test_process_pty_bytes(b"\x1b[?2004h");
         app.state.insert_test_runtime(pane_id, runtime);
 
         let response = app.handle_agent_prompt(

--- a/src/app/api/agents.rs
+++ b/src/app/api/agents.rs
@@ -98,6 +98,16 @@ impl App {
                 ),
             );
         }
+        if expected_agent == crate::detect::Agent::GithubCopilot {
+            // Copilot ignores synthetic Enter after focus loss until it receives focus gained.
+            let focus = match crate::ghostty::encode_focus(crate::ghostty::FocusEvent::Gained) {
+                Ok(focus) => focus,
+                Err(err) => return encode_error(id, "agent_prompt_failed", err.to_string()),
+            };
+            if let Err(err) = runtime.try_send_bytes(Bytes::from(focus)) {
+                return encode_error(id, "agent_prompt_failed", err.to_string());
+            }
+        }
         let (text, enter) =
             crate::app::api_helpers::encode_api_submission_parts(runtime, &params.text);
         if let Err(err) = runtime.try_send_bytes(Bytes::from(text)) {
@@ -394,6 +404,50 @@ mod tests {
         let error: crate::api::schema::ErrorResponse = serde_json::from_str(&rejected).unwrap();
         assert_eq!(error.error.code, "agent_not_found");
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn agent_prompt_focuses_copilot_before_submitting() {
+        let mut app = app_with_agent();
+        let pane_id = app.state.workspaces[0].tabs[0].root_pane;
+        let terminal_id = app.state.workspaces[0].tabs[0].panes[&pane_id]
+            .attached_terminal_id
+            .clone();
+        let terminal = app.state.terminals.get_mut(&terminal_id).unwrap();
+        terminal.set_agent_name("reviewer".into());
+        terminal.set_detected_state(Some(Agent::GithubCopilot), AgentState::Idle);
+        let (runtime, mut rx) =
+            crate::terminal::TerminalRuntime::test_with_channel_and_scrollback_bytes(
+                80, 24, 0, b"", 3,
+            );
+        runtime.test_process_pty_bytes(b"\x1b[?1004h\x1b[?2004h");
+        app.state.insert_test_runtime(pane_id, runtime);
+
+        let response = app.handle_agent_prompt(
+            "req".into(),
+            AgentPromptParams {
+                target: "reviewer".into(),
+                text: "A != B".into(),
+                wait: None,
+            },
+        );
+        let success: SuccessResponse = serde_json::from_str(&response).unwrap();
+        assert!(matches!(
+            success.result,
+            ResponseResult::AgentPrompted { .. }
+        ));
+        assert_eq!(rx.try_recv().unwrap(), Bytes::from_static(b"\x1b[I"));
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            Bytes::from_static(b"\x1b[200~A != B\x1b[201~")
+        );
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            Bytes::from_static(b"\r")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- send a focus-gained sequence before prompting a detected GitHub Copilot pane
- force the sequence even when Herdr's restored focus-reporting snapshot is stale
- cover focus, paste, and delayed Enter ordering with a regression test

This works around github/copilot-cli#4213 and restores background prompt submission reported in #1698.

## Testing

- [x] Local code review completed
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- targeted Copilot prompt regression test
- full Rust suite: 3,268 passed with one unrelated test excluded after reproducing its failure on clean `origin/master`
- UI architecture, integration asset, and plugin marketplace tests

Docs are not needed because this restores the existing `agent prompt` contract.

<!-- watchtower:copilot-session=bd877b61-c1d1-4f9f-9d94-9528b24b1427 -->

<!-- watchtower:copilot-session=call_VsXbtjrc1HMbGwxt2CX8JqoB -->
