### PR TITLE
fix zon2nix: recursively fix perms on unpacked zig artifact

### DIFF
--- a/vendor/libghostty-vt/build.zig.zon.nix
+++ b/vendor/libghostty-vt/build.zig.zon.nix
@@ -21,7 +21,7 @@
     ''
       hash="$(cd "$TMPDIR" && zig fetch --global-cache-dir "$TMPDIR" ${artifact})"
       mv "$TMPDIR/p/$hash" "$out"
-      chmod 755 "$out"
+      chmod -R u+rwX "$out"
     '';
 
   fetchZig = {


### PR DESCRIPTION
zig fetch places unpacked tarballs at $TMPDIR/p/<hash>; when contents have restricted permissions (as with wuffs' test/data JPEGs), Nix's post-build NAR hashing fails with PermissionDenied on darwin.

Change chmod 755 "$out" to chmod -R u+rwX "$out" so nested files are always readable to the daemon.