### PR TITLE
Add opt-in command layer for keyboard navigation

### DIFF
--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -107,6 +107,7 @@ impl App {
                 Mode::OpenExistingWorktree => self.handle_worktree_open_key(key_event),
                 Mode::ConfirmRemoveWorktree => self.handle_worktree_remove_key(key_event),
                 Mode::Resize => self.handle_resize_key_via_api(key),
+                Mode::FocusNav => self.handle_focus_nav_key(key),
                 Mode::ConfirmClose => self.handle_confirm_close_key_via_api(key_event),
                 Mode::ContextMenu => {
                     self.handle_context_menu_key_via_api(key_event);

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -449,6 +449,10 @@ pub(super) fn open_new_tab_dialog(state: &mut AppState) {
 }
 
 pub(super) fn leave_modal(state: &mut AppState) {
+    if state.command_layer {
+        state.mode = Mode::FocusNav;
+        return;
+    }
     if state.active.is_some() {
         state.mode = Mode::Terminal;
     } else {
@@ -747,6 +751,10 @@ pub(super) fn confirm_close_accept(state: &mut AppState) {
 }
 
 pub(super) fn confirm_close_cancel(state: &mut AppState) {
+    if state.command_layer {
+        state.mode = Mode::FocusNav;
+        return;
+    }
     state.mode = Mode::Navigate;
 }
 

--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -103,6 +103,67 @@ impl App {
         leave_command_mode(&mut self.state);
     }
 
+    /// Persistent command layer (vim-like normal mode). The whole prefix keymap is
+    /// live on bare keys and the mode stays open across actions. Escape or
+    /// re-pressing the trigger exits back to the terminal. Actions that open a text
+    /// dialog (rename, new tab/workspace name, ...) suspend the layer and return to
+    /// it on commit/cancel, since `command_layer` stays set and the shared
+    /// leave/modal helpers route back to `Mode::FocusNav`.
+    pub(crate) fn handle_focus_nav_key(&mut self, raw_key: TerminalKey) {
+        let key = raw_key.as_key_event();
+        self.state.update_dismissed = true;
+
+        if matches!(key.code, KeyCode::Modifier(_)) {
+            return;
+        }
+
+        if key.code == KeyCode::Esc
+            || self.state.keybinds.focus_nav.matches_prefix_key(&raw_key)
+            || self.state.keybinds.focus_nav.matches_direct_key(&raw_key)
+        {
+            self.state.command_layer = false;
+            leave_command_mode(&mut self.state);
+            return;
+        }
+
+        if let Some(action) =
+            non_indexed_action_for_key(&self.state, &raw_key, BindingDispatch::Prefix)
+        {
+            self.execute_prefix_key_action(action);
+        } else if let Some(binding) =
+            command_for_key(&self.state, &raw_key, BindingDispatch::Prefix)
+        {
+            self.cancel_copy_mode_if_active();
+            self.launch_custom_command(binding, ActionContext::Prefix);
+        } else if let Some(action) =
+            indexed_navigation_action(&self.state, &raw_key, BindingDispatch::Prefix)
+        {
+            self.execute_prefix_key_action(action);
+        }
+
+        // Actions run through the `*_via_api` layer, which resets `mode` to
+        // Terminal to drop you into the resulting pane. Re-assert the command
+        // layer so it stays open — unless the action opened a sub-UI (dialog,
+        // picker, copy/resize), which suspends the layer and returns to it on
+        // close via the `command_layer` guard in the leave/modal helpers.
+        if self.state.command_layer && !mode_suspends_command_layer(self.state.mode) {
+            self.state.mode = Mode::FocusNav;
+        }
+    }
+
+    /// Event-loop invariant: while the command layer is active, any operation that
+    /// dropped `mode` back to the terminal or navigator — including deferred
+    /// tab/pane creations that focus their result on a later frame — snaps back to
+    /// `Mode::FocusNav`. Suspending sub-UIs (dialogs, pickers, copy/resize) keep
+    /// control and are restored via the `command_layer` guard when they close.
+    pub(crate) fn enforce_command_layer(&mut self) {
+        if self.state.command_layer
+            && matches!(self.state.mode, Mode::Terminal | Mode::Navigate)
+        {
+            self.state.mode = Mode::FocusNav;
+        }
+    }
+
     fn execute_prefix_key_action(&mut self, action: NavigateAction) {
         if action == NavigateAction::EditScrollback {
             let previous_mode = self.state.mode;
@@ -395,6 +456,10 @@ impl App {
                 leave_navigate_mode(&mut self.state);
             }
             NavigateAction::EnterResizeMode => self.state.mode = Mode::Resize,
+            NavigateAction::EnterFocusNav => {
+                self.state.command_layer = true;
+                self.state.mode = Mode::FocusNav;
+            }
             NavigateAction::ResizePaneLeft => {
                 self.resize_pane_direction_via_api(NavDirection::Left);
                 leave_navigate_mode(&mut self.state);
@@ -750,7 +815,7 @@ impl App {
         Some((ws_idx, focused.id, target))
     }
 
-    fn relative_visible_workspace(&self, delta: isize) -> Option<usize> {
+    pub(super) fn relative_visible_workspace(&self, delta: isize) -> Option<usize> {
         let order = self.state.visible_workspace_order();
         if order.is_empty() {
             return None;
@@ -769,7 +834,7 @@ impl App {
         Some((ws_idx, source, insert))
     }
 
-    fn relative_tab(&self, delta: isize) -> Option<usize> {
+    pub(super) fn relative_tab(&self, delta: isize) -> Option<usize> {
         let ws = self
             .state
             .active
@@ -1416,6 +1481,7 @@ pub(crate) enum NavigateAction {
     CopyMode,
     Zoom,
     EnterResizeMode,
+    EnterFocusNav,
     ResizePaneLeft,
     ResizePaneDown,
     ResizePaneUp,
@@ -1566,6 +1632,7 @@ fn non_indexed_action_for_key(
         (&kb.close_pane, NavigateAction::ClosePane),
         (&kb.zoom, NavigateAction::Zoom),
         (&kb.resize_mode, NavigateAction::EnterResizeMode),
+        (&kb.focus_nav, NavigateAction::EnterFocusNav),
         (&kb.resize_pane_left, NavigateAction::ResizePaneLeft),
         (&kb.resize_pane_down, NavigateAction::ResizePaneDown),
         (&kb.resize_pane_up, NavigateAction::ResizePaneUp),
@@ -1809,6 +1876,10 @@ pub(super) fn execute_navigate_action_in_context(
             leave_navigate_mode(state);
         }
         NavigateAction::EnterResizeMode => state.mode = Mode::Resize,
+        NavigateAction::EnterFocusNav => {
+            state.command_layer = true;
+            state.mode = Mode::FocusNav;
+        }
         NavigateAction::ResizePaneLeft => {
             state.resize_pane(NavDirection::Left);
             leave_navigate_mode(state);
@@ -1927,7 +1998,38 @@ fn move_active_tab_relative(state: &mut AppState, delta: isize) {
     }
 }
 
+/// Modes that keep control when reached from the command layer (a text dialog,
+/// picker, or another persistent mode). While one of these is active the command
+/// layer stays suspended and is restored when it closes; any other mode is treated
+/// as an implicit drop back to the terminal and is snapped back to `Mode::FocusNav`.
+fn mode_suspends_command_layer(mode: Mode) -> bool {
+    matches!(
+        mode,
+        Mode::RenameWorkspace
+            | Mode::RenameTab
+            | Mode::RenamePane
+            | Mode::NewLinkedWorktree
+            | Mode::OpenExistingWorktree
+            | Mode::ConfirmRemoveWorktree
+            | Mode::ConfirmClose
+            | Mode::Settings
+            | Mode::KeybindHelp
+            | Mode::Navigator
+            | Mode::ContextMenu
+            | Mode::GlobalMenu
+            | Mode::Copy
+            | Mode::Resize
+            | Mode::Onboarding
+            | Mode::ReleaseNotes
+            | Mode::ProductAnnouncement
+    )
+}
+
 fn leave_navigate_mode(state: &mut AppState) {
+    if state.command_layer {
+        state.mode = Mode::FocusNav;
+        return;
+    }
     if state.active.is_some() {
         state.mode = Mode::Terminal;
     }
@@ -1954,6 +2056,10 @@ fn finish_custom_command_context(
 }
 
 fn leave_command_mode(state: &mut AppState) {
+    if state.command_layer {
+        state.mode = Mode::FocusNav;
+        return;
+    }
     if state.copy_mode_pane_is_focused() {
         state.mode = Mode::Copy;
     } else if state.active.is_some() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -539,6 +539,7 @@ impl App {
             previous_pane_focus: None,
             selected,
             mode,
+            command_layer: false,
             should_quit: false,
             detach_exits: no_session,
             detach_requested: false,
@@ -1902,6 +1903,9 @@ impl App {
             }
             Mode::Resize => {
                 self.handle_resize_key_via_api(key);
+            }
+            Mode::FocusNav => {
+                self.handle_focus_nav_key(key);
             }
             Mode::ConfirmClose => {
                 self.handle_confirm_close_key_via_api(key_event);

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -792,6 +792,7 @@ pub enum Mode {
     OpenExistingWorktree,
     ConfirmRemoveWorktree,
     Resize,
+    FocusNav,
     ConfirmClose,
     ContextMenu,
     Settings,
@@ -823,6 +824,7 @@ impl Mode {
                 | Mode::Navigator
                 | Mode::Copy
                 | Mode::Resize
+                | Mode::FocusNav
                 | Mode::ConfirmClose
                 | Mode::ConfirmRemoveWorktree
                 | Mode::ContextMenu
@@ -1335,6 +1337,10 @@ pub struct AppState {
     pub(crate) previous_pane_focus: Option<PaneFocusTarget>,
     pub selected: usize,
     pub mode: Mode,
+    /// True while the persistent focus-navigation command layer is active. Kept
+    /// set across text dialogs (rename, etc.) so cancelling/committing returns to
+    /// `Mode::FocusNav` instead of the terminal.
+    pub command_layer: bool,
     pub should_quit: bool,
     /// In monolithic --no-session mode, detach exits the app because there is no server to detach from.
     pub detach_exits: bool,
@@ -1704,6 +1710,7 @@ impl AppState {
             previous_pane_focus: None,
             selected: 0,
             mode: Mode::Navigate,
+            command_layer: false,
             should_quit: false,
             detach_exits: false,
             detach_requested: false,

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -352,6 +352,7 @@ pub struct Keybinds {
     pub close_pane: ActionKeybinds,
     pub zoom: ActionKeybinds,
     pub resize_mode: ActionKeybinds,
+    pub focus_nav: ActionKeybinds,
     pub resize_pane_left: ActionKeybinds,
     pub resize_pane_down: ActionKeybinds,
     pub resize_pane_up: ActionKeybinds,
@@ -520,6 +521,7 @@ impl Config {
             close_pane: empty_action!(),
             zoom: empty_action!(),
             resize_mode: empty_action!(),
+            focus_nav: empty_action!(),
             resize_pane_left: empty_action!(),
             resize_pane_down: empty_action!(),
             resize_pane_up: empty_action!(),
@@ -667,6 +669,7 @@ impl Config {
             apply_action!(keybinds.close_pane, close_pane, source);
             apply_action!(keybinds.zoom, zoom, source);
             apply_action!(keybinds.resize_mode, resize_mode, source);
+            apply_action!(keybinds.focus_nav, focus_nav, source);
             apply_action!(keybinds.resize_pane_left, resize_pane_left, source);
             apply_action!(keybinds.resize_pane_down, resize_pane_down, source);
             apply_action!(keybinds.resize_pane_up, resize_pane_up, source);

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -442,6 +442,10 @@ pub struct KeysConfig {
     pub zoom: BindingConfig,
     /// Enter resize mode. Default: "prefix+r"
     pub resize_mode: BindingConfig,
+    /// Enter focus-navigation mode: a persistent mode where h/j/k/l move pane
+    /// focus, Tab/Shift+Tab switch tabs, and ] / [ switch workspaces, staying
+    /// open until Escape. Unset by default.
+    pub focus_nav: BindingConfig,
     /// Resize the focused pane toward the left. Unset by default.
     pub resize_pane_left: BindingConfig,
     /// Resize the focused pane downward. Unset by default.
@@ -573,6 +577,8 @@ pub(crate) struct KeysConfigOverlay {
     #[serde(skip_serializing_if = "Option::is_none")]
     resize_mode: Option<BindingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    focus_nav: Option<BindingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     resize_pane_left: Option<BindingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     resize_pane_down: Option<BindingConfig>,
@@ -659,6 +665,7 @@ impl<'de> Deserialize<'de> for KeysConfig {
         apply_field!(close_pane);
         apply_field!(zoom);
         apply_field!(resize_mode);
+        apply_field!(focus_nav);
         apply_field!(resize_pane_left);
         apply_field!(resize_pane_down);
         apply_field!(resize_pane_up);
@@ -763,6 +770,7 @@ impl KeysConfig {
         copy_effective_action_field!(close_pane, keybinds.close_pane);
         copy_effective_action_field!(zoom, keybinds.zoom);
         copy_effective_action_field!(resize_mode, keybinds.resize_mode);
+        copy_effective_action_field!(focus_nav, keybinds.focus_nav);
         copy_effective_action_field!(resize_pane_left, keybinds.resize_pane_left);
         copy_effective_action_field!(resize_pane_down, keybinds.resize_pane_down);
         copy_effective_action_field!(resize_pane_up, keybinds.resize_pane_up);
@@ -1064,6 +1072,7 @@ impl Default for KeysConfig {
             close_pane: BindingConfig::one("prefix+x"),
             zoom: BindingConfig::one("prefix+z"),
             resize_mode: BindingConfig::one("prefix+r"),
+            focus_nav: BindingConfig::empty(),
             resize_pane_left: BindingConfig::empty(),
             resize_pane_down: BindingConfig::empty(),
             resize_pane_up: BindingConfig::empty(),

--- a/src/server/headless.rs
+++ b/src/server/headless.rs
@@ -670,6 +670,10 @@ impl HeadlessServer {
                 needs_graphics_render = false;
             }
 
+            // Keep the command layer sticky across deferred operations (tab/pane
+            // creation focuses its result and would otherwise drop to Terminal).
+            self.app.enforce_command_layer();
+
             self.poll_pending_alt_screen_reads(now);
             if self.process_deferred_alt_screen_reads() {
                 needs_render = true;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -28,8 +28,9 @@ use self::dialogs::{
 };
 use self::keybind_help::render_keybind_help_overlay;
 use self::menus::{
-    render_context_menu, render_copy_mode_overlay, render_global_launcher_menu,
-    render_navigate_overlay, render_prefix_overlay, render_resize_overlay,
+    render_context_menu, render_copy_mode_overlay, render_focus_nav_overlay,
+    render_global_launcher_menu, render_navigate_overlay, render_prefix_overlay,
+    render_resize_overlay,
 };
 use self::mobile::{
     compute_mobile_header_hit_areas, is_mobile_width, mobile_switcher_max_scroll_for_height,
@@ -439,6 +440,7 @@ pub fn render_with_runtime_registry(
         Mode::Prefix => render_prefix_overlay(app, frame, mode_bar_area),
         Mode::Copy => render_copy_mode_overlay(app, frame, mode_bar_area),
         Mode::Resize => render_resize_overlay(app, frame, mode_bar_area),
+        Mode::FocusNav => render_focus_nav_overlay(app, frame, mode_bar_area),
         Mode::ConfirmClose => {
             render_confirm_close_overlay(app, terminal_runtimes, frame, terminal_area)
         }

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -283,6 +283,31 @@ pub(super) fn render_resize_overlay(app: &AppState, frame: &mut Frame, area: Rec
     render_bottom_bar(frame, overlay_area, line, app.palette.panel_bg);
 }
 
+pub(super) fn render_focus_nav_overlay(app: &AppState, frame: &mut Frame, area: Rect) {
+    let key = Style::default()
+        .fg(app.palette.accent)
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(app.palette.overlay0);
+
+    let mode_style = Style::default()
+        .fg(panel_contrast_fg(&app.palette))
+        .bg(app.palette.green)
+        .add_modifier(Modifier::BOLD);
+
+    let line = Line::from(vec![
+        Span::styled(" CMD ", mode_style),
+        Span::raw("  "),
+        Span::styled("herdr keys active (no prefix)", dim),
+        Span::raw("  "),
+        Span::styled("esc", key),
+        Span::styled(" exit", dim),
+    ]);
+
+    let overlay_y = area.y + area.height.saturating_sub(1);
+    let overlay_area = Rect::new(area.x, overlay_y, area.width, 1);
+    render_bottom_bar(frame, overlay_area, line, app.palette.panel_bg);
+}
+
 pub(super) fn render_context_menu(app: &AppState, frame: &mut Frame) {
     let Some(menu) = &app.context_menu else {
         return;


### PR DESCRIPTION
Adds an optional command layer: a keybind (`focus_nav`, unbound by default) that
enters a persistent mode where the prefix keymap is available on bare keys, like a
vim normal mode. It stays open across actions instead of exiting after one, and
Escape returns to the terminal.

Opt-in: with `focus_nav` unset, nothing changes — no existing binding, mode, or
behaviour is touched.

Behaviour:
- Bare keys run the existing `prefix+*` bindings (focus panes, new tab, split,
  switch tab/workspace, pickers, ...).
- Text dialogs (rename, new-name prompts, confirm-close) suspend the layer and
  return to it on commit or cancel.

Implementation:
- New `Mode::FocusNav` and `handle_focus_nav_key`, which reuses the prefix dispatch.
- A `command_layer` flag, set on entry and kept across dialogs; the shared return
  helpers route back to `FocusNav` while it is set. The event loop re-asserts the
  mode after deferred/API operations that would otherwise focus their result pane.

Config:

    [keys]
    focus_nav = "prefix+space"

Verified with `nix build .#herdr` and `herdr config check`.
