### PR TITLE
feat(ui): wheel over sidebar switches agent or workspace

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1339,8 +1339,7 @@ impl AppState {
         }
     }
 
-    #[cfg(test)]
-    pub fn next_workspace(&mut self) {
+    pub(crate) fn next_workspace(&mut self) {
         if self.workspaces.is_empty() {
             return;
         }
@@ -1351,8 +1350,7 @@ impl AppState {
         self.switch_workspace(next);
     }
 
-    #[cfg(test)]
-    pub fn previous_workspace(&mut self) {
+    pub(crate) fn previous_workspace(&mut self) {
         if self.workspaces.is_empty() {
             return;
         }
@@ -1513,8 +1511,7 @@ impl AppState {
         self.cycle_agent_entry(false);
     }
 
-    #[cfg(test)]
-    pub fn focus_agent_entry(&mut self, idx: usize) -> bool {
+    pub(crate) fn focus_agent_entry(&mut self, idx: usize) -> bool {
         let entries = crate::ui::agent_panel_entries(self);
         let Some(target) = entries.get(idx) else {
             return false;
@@ -1535,8 +1532,7 @@ impl AppState {
         false
     }
 
-    #[cfg(test)]
-    fn cycle_agent_entry(&mut self, forward: bool) {
+    pub(crate) fn cycle_agent_entry(&mut self, forward: bool) {
         let entries = crate::ui::agent_panel_entries(self);
         if entries.is_empty() {
             return;

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -988,7 +988,13 @@ impl AppState {
                 let over_agent_panel = agent_area != Rect::default()
                     && mouse.row >= agent_area.y
                     && mouse.row < agent_area.y + agent_area.height;
-                if over_agent_panel {
+                if self.sidebar_wheel == crate::config::SidebarWheelConfig::Switch {
+                    if over_agent_panel {
+                        self.cycle_agent_entry(false);
+                    } else {
+                        self.previous_workspace();
+                    }
+                } else if over_agent_panel {
                     if crate::ui::should_show_scrollbar(crate::ui::agent_panel_scroll_metrics(
                         self, agent_area,
                     )) {
@@ -1007,7 +1013,13 @@ impl AppState {
                 let over_agent_panel = agent_area != Rect::default()
                     && mouse.row >= agent_area.y
                     && mouse.row < agent_area.y + agent_area.height;
-                if over_agent_panel {
+                if self.sidebar_wheel == crate::config::SidebarWheelConfig::Switch {
+                    if over_agent_panel {
+                        self.cycle_agent_entry(true);
+                    } else {
+                        self.next_workspace();
+                    }
+                } else if over_agent_panel {
                     if crate::ui::should_show_scrollbar(crate::ui::agent_panel_scroll_metrics(
                         self, agent_area,
                     )) {
@@ -4776,5 +4788,86 @@ mod tests {
         };
 
         assert_eq!(wheel_routing(input_state), WheelRouting::HostScroll);
+    }
+
+    #[test]
+    fn wheel_over_agent_panel_switches_agent() {
+        let mut app = app_for_mouse_test();
+        let mut ws = Workspace::test_new("one");
+        let root = ws.tabs[0].root_pane;
+        let second = ws.test_split(Direction::Horizontal);
+        ws.tabs[0].layout.focus_pane(root);
+        app.state.workspaces = vec![ws];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+        app.state.ensure_test_terminals();
+
+        // Agent panel entries only include panes whose terminal has an agent
+        // label; give both panes one so cycle_agent_entry has entries to cycle.
+        let tids: Vec<_> = app.state.workspaces[0].tabs[0]
+            .panes
+            .values()
+            .map(|pane| pane.attached_terminal_id.clone())
+            .collect();
+        for tid in tids {
+            app.state
+                .terminals
+                .get_mut(&tid)
+                .expect("test terminal present")
+                .set_agent_name("test-agent".into());
+        }
+
+        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
+        let agent_area = app.state.agent_panel_rect();
+        assert_ne!(agent_area, Rect::default());
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, agent_area.x + 1, agent_area.y + 2));
+        assert_eq!(app.state.workspaces[0].focused_pane_id(), Some(second));
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, agent_area.x + 1, agent_area.y + 2));
+        assert_eq!(app.state.workspaces[0].focused_pane_id(), Some(root));
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollUp, agent_area.x + 1, agent_area.y + 2));
+        assert_eq!(app.state.workspaces[0].focused_pane_id(), Some(second));
+    }
+
+    #[test]
+    fn wheel_over_workspace_list_switches_workspace() {
+        let mut app = app_for_mouse_test();
+        app.state.workspaces = vec![Workspace::test_new("one"), Workspace::test_new("two")];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+
+        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
+        let ws_area = app.state.workspace_list_rect();
+        assert_ne!(ws_area, Rect::default());
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, ws_area.x + 1, ws_area.y + 2));
+        assert_eq!(app.state.active, Some(1));
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, ws_area.x + 1, ws_area.y + 2));
+        assert_eq!(app.state.active, Some(0)); // cycles back around
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollUp, ws_area.x + 1, ws_area.y + 2));
+        assert_eq!(app.state.active, Some(1));
+    }
+
+    #[test]
+    fn wheel_scroll_mode_preserves_scrolling() {
+        let mut app = app_for_mouse_test();
+        app.state.sidebar_wheel = crate::config::SidebarWheelConfig::Scroll;
+        app.state.workspaces = vec![Workspace::test_new("one"), Workspace::test_new("two")];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+
+        crate::ui::compute_view(&mut app.state, Rect::new(0, 0, 106, 20));
+        let ws_area = app.state.workspace_list_rect();
+
+        // Scroll mode only moves the highlight; it never switches the active workspace.
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, ws_area.x + 1, ws_area.y + 2));
+        assert_eq!(app.state.active, Some(0));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -633,6 +633,7 @@ impl App {
             agent_view_override: None,
             sidebar_agents: config.ui.sidebar.agents.clone(),
             sidebar_spaces: config.ui.sidebar.spaces.clone(),
+            sidebar_wheel: config.ui.sidebar.wheel,
             next_agent_state_change_seq: 0,
             mouse_capture: config.ui.mouse_capture,
             copy_on_select: config.ui.copy_on_select,
@@ -1503,6 +1504,7 @@ impl App {
                 self.state.status_indicators = config.ui.status_indicators;
                 self.state.sidebar_agents = config.ui.sidebar.agents.clone();
                 self.state.sidebar_spaces = config.ui.sidebar.spaces.clone();
+                self.state.sidebar_wheel = config.ui.sidebar.wheel;
                 self.state.agent_panel_scroll = 0;
                 self.state.accent = crate::config::parse_color(&config.ui.accent);
                 if !self.state.local_sound_playback && self.state.sound != config.ui.sound {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1422,6 +1422,7 @@ pub struct AppState {
     pub agent_view_override: Option<crate::api::schema::AgentViewSetParams>,
     pub sidebar_agents: crate::config::AgentsSidebarConfig,
     pub sidebar_spaces: crate::config::SpacesSidebarConfig,
+    pub sidebar_wheel: crate::config::SidebarWheelConfig,
     pub next_agent_state_change_seq: u64,
     /// Capture mouse input for Herdr's own mouse UI. When false, Herdr only
     /// captures mouse while the focused pane app requests mouse reporting.
@@ -1792,6 +1793,7 @@ impl AppState {
             agent_view_override: None,
             sidebar_agents: crate::config::AgentsSidebarConfig::default(),
             sidebar_spaces: crate::config::SpacesSidebarConfig::default(),
+            sidebar_wheel: crate::config::SidebarWheelConfig::default(),
             next_agent_state_change_seq: 0,
             mouse_capture: true,
             copy_on_select: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub use self::{
     },
     sidebar::{
         AgentSidebarToken, AgentsSidebarConfig, SidebarConfig, SidebarTokenStyle,
-        SpaceSidebarToken, SpacesSidebarConfig,
+        SidebarWheelConfig, SpaceSidebarToken, SpacesSidebarConfig,
     },
     sound::SoundConfig,
     tab_bar::TabBarRightEntryConfig,

--- a/src/config/sidebar.rs
+++ b/src/config/sidebar.rs
@@ -424,11 +424,30 @@ impl Default for SpacesSidebarConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub enum SidebarWheelConfig {
+    #[default]
+    #[serde(rename = "switch")]
+    Switch,
+    #[serde(rename = "scroll")]
+    Scroll,
+}
+
+impl SidebarWheelConfig {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Switch => "switch",
+            Self::Scroll => "scroll",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct SidebarConfig {
     pub agents: AgentsSidebarConfig,
     pub spaces: SpacesSidebarConfig,
+    pub wheel: SidebarWheelConfig,
 }
 
 #[cfg(test)]
@@ -644,5 +663,19 @@ rows = [[{ token = "git_status", fg = "#ff00aa" }], [{ token = "$jj", bold = tru
                 "accepted key {key:?}"
             );
         }
+    }
+
+    #[test]
+    fn wheel_defaults_to_switch() {
+        let config = SidebarConfig::default();
+        assert_eq!(config.wheel, SidebarWheelConfig::Switch);
+    }
+
+    #[test]
+    fn wheel_parses_switch_and_scroll() {
+        let switch: SidebarConfig = toml::from_str("wheel = 'switch'").unwrap();
+        assert_eq!(switch.wheel, SidebarWheelConfig::Switch);
+        let scroll: SidebarConfig = toml::from_str("wheel = 'scroll'").unwrap();
+        assert_eq!(scroll.wheel, SidebarWheelConfig::Scroll);
     }
 }


### PR DESCRIPTION
feat(ui): wheel over sidebar switches agent or workspace

## Problem

Scroll wheel over the sidebar does not switch focus:

- Over the **agent panel** it does nothing when the list is short, and scrolls the list content when it overflows.
- Over the **workspace list** it only moves the highlight (`move_selected_workspace_by_visible_delta`) without switching the active workspace, so nothing visibly changes in the main area.

## Change

- Reuse the existing `cycle_agent_entry` / `next_workspace` / `previous_workspace` logic (previously `#[cfg(test)]` only) for wheel input.
- In `switch` mode (default), wheel over the sidebar cycles focus, consistent with wheel-over-tab-bar: agent panel → focus next/prev agent; workspace area → switch next/prev active workspace. Wraps around.
- In `scroll` mode, the previous behavior (scroll list content / move highlight) is preserved.

## Config

```toml
[ui.sidebar]
wheel = "switch"   # "switch" (default) | "scroll"
```

## Tests

- `wheel_over_agent_panel_switches_agent`
- `wheel_over_workspace_list_switches_workspace`
- `wheel_scroll_mode_preserves_scrolling`
