### PR TITLE
fix: detect qwen localized active states

### DIFF
--- a/docs/next/CHANGELOG.md
+++ b/docs/next/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Experimental pane graphics now support bounded named layers, acknowledged full-RGBA primary-layer direct file frames on audited local terminals, owned BGRA fallback, exact pixel mouse input, and placement-only resize replay.
 
 ### Fixed
+- Qwen Code panes now use locale-independent terminal-title states and localized confirmation fallbacks, preventing active or blocked turns from appearing idle. (#2756)
 - Active Space and Agent rows now use dedicated theme colors that remain visible when the host terminal background matches the selected Herdr theme. (#2792)
 - `agent prompt` now rejects agents already waiting at approval or question dialogs with `agent_blocked`, without sending text or Enter. (#2788)
 - `prefix+e` now preserves logical lines when opening soft-wrapped scrollback in an editor. (#2733)

--- a/src/detect/manifests/qwen.toml
+++ b/src/detect/manifests/qwen.toml
@@ -1,14 +1,31 @@
 id = "qwen"
-version = "2026.08.12.1"
+version = "2026.08.14.1"
 min_engine_version = 2
-updated_at = "2026-08-12T00:00:00Z"
+updated_at = "2026-08-14T00:00:00Z"
 aliases = ["qwen-code", "qwen code"]
 
 # Qwen Code keeps its composer visible while responding, so the prompt box is
-# not idle evidence by itself. Active turns show an "esc to cancel" status
-# line; confirmation flows replace that line with a stable waiting phrase.
-# OSC 9;4 is supplemental because Qwen emits it only while a tool is executing
-# and only in terminals that advertise progress support.
+# not idle evidence by itself. Its status-prefixed terminal titles are the
+# primary locale-independent signals when ui.showStatusInTitle is enabled.
+# Exact screen fallbacks cover built-in locales and narrow terminals. OSC 9;4
+# is supplemental because Qwen emits it only while a tool is executing and
+# only in terminals that advertise progress support.
+
+[[rules]]
+id = "osc_title_blocked"
+state = "blocked"
+priority = 1200
+region = "osc_title"
+visible_blocker = true
+regex = ['^\x{2733}\x{FE0E}? ']
+
+[[rules]]
+id = "osc_title_working"
+state = "working"
+priority = 1100
+region = "osc_title"
+visible_working = true
+regex = ['^\x{25D0}\x{FE0E}? ']
 
 [[rules]]
 id = "waiting_for_confirmation"
@@ -16,7 +33,18 @@ state = "blocked"
 priority = 1000
 region = "bottom_non_empty_lines(20)"
 visible_blocker = true
-contains = ["waiting for user confirmation"]
+line_regex = ['^\s*⠏\s+.*\.\.\.\s*$']
+any = [
+  { contains = ["Waiting for user confirmation..."] },
+  { contains = ["等待用户确认..."] },
+  { contains = ["等待用戶確認..."] },
+  { contains = ["Warten auf Benutzerbestätigung..."] },
+  { contains = ["En attente de la confirmation de l'utilisateur..."] },
+  { contains = ["ユーザーの確認を待っています..."] },
+  { contains = ["Aguardando confirmação do usuário..."] },
+  { contains = ["Ожидание подтверждения от пользователя..."] },
+  { contains = ["Esperant la confirmació de l'usuari..."] },
+]
 
 [[rules]]
 id = "tool_confirmation"
@@ -39,8 +67,10 @@ state = "blocked"
 priority = 980
 region = "bottom_non_empty_lines(20)"
 visible_blocker = true
-contains = ["enter: select", "esc: cancel"]
-line_regex = ['^\s*[❯›]\s*1\.\s+']
+line_regex = [
+  '^\s*[❯›]\s*(?:\[(?: |✓)\]\s*)?\d+\.\s+',
+  '^\s*↑/↓\s*:.*(?:Enter|Return)\s*:',
+]
 
 [[rules]]
 id = "folder_trust_dialog"
@@ -64,7 +94,7 @@ state = "working"
 priority = 890
 region = "bottom_non_empty_lines(8)"
 visible_working = true
-line_regex = ['(?i)^\s*\(esc to cancel\)\s*$']
+line_regex = ['^\s*\(\d+(?:m(?:\s+\d+s)?|s)\s·\sesc to cancel\)\s*$']
 
 [[rules]]
 id = "osc_tool_progress_working"

--- a/website/agent-detection/qwen.toml
+++ b/website/agent-detection/qwen.toml
@@ -1,14 +1,31 @@
 id = "qwen"
-version = "2026.08.12.1"
+version = "2026.08.14.1"
 min_engine_version = 2
-updated_at = "2026-08-12T00:00:00Z"
+updated_at = "2026-08-14T00:00:00Z"
 aliases = ["qwen-code", "qwen code"]
 
 # Qwen Code keeps its composer visible while responding, so the prompt box is
-# not idle evidence by itself. Active turns show an "esc to cancel" status
-# line; confirmation flows replace that line with a stable waiting phrase.
-# OSC 9;4 is supplemental because Qwen emits it only while a tool is executing
-# and only in terminals that advertise progress support.
+# not idle evidence by itself. Its status-prefixed terminal titles are the
+# primary locale-independent signals when ui.showStatusInTitle is enabled.
+# Exact screen fallbacks cover built-in locales and narrow terminals. OSC 9;4
+# is supplemental because Qwen emits it only while a tool is executing and
+# only in terminals that advertise progress support.
+
+[[rules]]
+id = "osc_title_blocked"
+state = "blocked"
+priority = 1200
+region = "osc_title"
+visible_blocker = true
+regex = ['^\x{2733}\x{FE0E}? ']
+
+[[rules]]
+id = "osc_title_working"
+state = "working"
+priority = 1100
+region = "osc_title"
+visible_working = true
+regex = ['^\x{25D0}\x{FE0E}? ']
 
 [[rules]]
 id = "waiting_for_confirmation"
@@ -16,7 +33,18 @@ state = "blocked"
 priority = 1000
 region = "bottom_non_empty_lines(20)"
 visible_blocker = true
-contains = ["waiting for user confirmation"]
+line_regex = ['^\s*⠏\s+.*\.\.\.\s*$']
+any = [
+  { contains = ["Waiting for user confirmation..."] },
+  { contains = ["等待用户确认..."] },
+  { contains = ["等待用戶確認..."] },
+  { contains = ["Warten auf Benutzerbestätigung..."] },
+  { contains = ["En attente de la confirmation de l'utilisateur..."] },
+  { contains = ["ユーザーの確認を待っています..."] },
+  { contains = ["Aguardando confirmação do usuário..."] },
+  { contains = ["Ожидание подтверждения от пользователя..."] },
+  { contains = ["Esperant la confirmació de l'usuari..."] },
+]
 
 [[rules]]
 id = "tool_confirmation"
@@ -39,8 +67,10 @@ state = "blocked"
 priority = 980
 region = "bottom_non_empty_lines(20)"
 visible_blocker = true
-contains = ["enter: select", "esc: cancel"]
-line_regex = ['^\s*[❯›]\s*1\.\s+']
+line_regex = [
+  '^\s*[❯›]\s*(?:\[(?: |✓)\]\s*)?\d+\.\s+',
+  '^\s*↑/↓\s*:.*(?:Enter|Return)\s*:',
+]
 
 [[rules]]
 id = "folder_trust_dialog"
@@ -64,7 +94,7 @@ state = "working"
 priority = 890
 region = "bottom_non_empty_lines(8)"
 visible_working = true
-line_regex = ['(?i)^\s*\(esc to cancel\)\s*$']
+line_regex = ['^\s*\(\d+(?:m(?:\s+\d+s)?|s)\s·\sesc to cancel\)\s*$']
 
 [[rules]]
 id = "osc_tool_progress_working"


### PR DESCRIPTION
## Summary

- prioritize Qwen Code’s locale-independent `◐︎` working and `✳︎` blocked terminal-title signals
- add source-derived fallbacks for narrow working indicators, localized confirmation text, and `ask_user_question` dialogs
- synchronize the downloadable detection manifest and next-release changelog

## Testing

- `just check`
- live Qwen Code 0.21.11 verification in a disposable source-build Herdr session: working, English approval, Chinese approval, and Chinese question dialog

Refs #2756