### PR TITLE
feat(keybindings): allow configured double-prefix actions

### DIFF
--- a/src/app/input/navigate.rs
+++ b/src/app/input/navigate.rs
@@ -65,16 +65,6 @@ impl App {
             return;
         }
 
-        if self.state.is_prefix_key(&raw_key) {
-            if self.state.copy_mode_pane_is_focused() {
-                self.state.cancel_copy_mode(&self.terminal_runtimes);
-            }
-            if !self.pass_through_key_to_focused_pane(raw_key) {
-                leave_command_mode(&mut self.state);
-            }
-            return;
-        }
-
         if key.code == KeyCode::Esc {
             leave_command_mode(&mut self.state);
             return;
@@ -97,6 +87,16 @@ impl App {
             indexed_navigation_action(&self.state, &raw_key, BindingDispatch::Prefix)
         {
             self.execute_prefix_key_action(action);
+            return;
+        }
+
+        if self.state.is_prefix_key(&raw_key) {
+            if self.state.copy_mode_pane_is_focused() {
+                self.state.cancel_copy_mode(&self.terminal_runtimes);
+            }
+            if !self.pass_through_key_to_focused_pane(raw_key) {
+                leave_command_mode(&mut self.state);
+            }
             return;
         }
 
@@ -3226,6 +3226,69 @@ navigate_pane_down = "ctrl+j"
 
         assert_eq!(app.state.selected, 1);
         assert_eq!(app.state.mode, Mode::Navigate);
+    }
+
+    #[tokio::test]
+    async fn configured_double_prefix_toggles_zoom() {
+        let config: Config = toml::from_str(
+            r#"
+[keys]
+prefix = "ctrl+s"
+zoom = "prefix+ctrl+s"
+"#,
+        )
+        .unwrap();
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(&config, true, None, api_rx, crate::api::EventHub::default());
+        let mut workspace = Workspace::test_new("test");
+        workspace.test_split(Direction::Horizontal);
+        app.state.workspaces = vec![workspace];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Terminal;
+
+        assert!(!app.state.workspaces[0].tabs[0].zoomed);
+        app.handle_key(TerminalKey::new(
+            app.state.prefix_code,
+            app.state.prefix_mods,
+        ))
+        .await;
+        assert_eq!(app.state.mode, Mode::Prefix);
+
+        app.handle_key(TerminalKey::new(
+            app.state.prefix_code,
+            app.state.prefix_mods,
+        ))
+        .await;
+
+        assert!(app.state.workspaces[0].tabs[0].zoomed);
+        assert_eq!(app.state.mode, Mode::Terminal);
+    }
+
+    #[tokio::test]
+    async fn escape_precedes_configured_prefix_action() {
+        let config: Config = toml::from_str(
+            r#"
+[keys]
+prefix = "ctrl+s"
+zoom = "prefix+esc"
+"#,
+        )
+        .unwrap();
+        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut app = App::new(&config, true, None, api_rx, crate::api::EventHub::default());
+        let mut workspace = Workspace::test_new("test");
+        workspace.test_split(Direction::Horizontal);
+        app.state.workspaces = vec![workspace];
+        app.state.active = Some(0);
+        app.state.selected = 0;
+        app.state.mode = Mode::Prefix;
+
+        app.handle_key(TerminalKey::new(KeyCode::Esc, KeyModifiers::empty()))
+            .await;
+
+        assert!(!app.state.workspaces[0].tabs[0].zoomed);
+        assert_eq!(app.state.mode, Mode::Terminal);
     }
 
     #[tokio::test]

--- a/src/config/keybinds.rs
+++ b/src/config/keybinds.rs
@@ -1021,8 +1021,11 @@ fn reject_binding(
     diagnostics: &mut Vec<String>,
     source: BindingSource,
 ) -> bool {
-    if binding.trigger.is_prefix() && registry.prefix_rhs_is_reserved(binding.trigger.combo()) {
-        if source == BindingSource::Default && registry.prefix_source == BindingSource::User {
+    if binding.trigger.is_prefix()
+        && registry.prefix_rhs_is_reserved(binding.trigger.combo())
+        && source == BindingSource::Default
+    {
+        if registry.prefix_source == BindingSource::User {
             return true;
         }
         let diag = format!(
@@ -1778,22 +1781,20 @@ close_tab = "X"
     }
 
     #[test]
-    fn prefix_rhs_equal_to_configured_prefix_is_rejected() {
+    fn user_binding_can_override_double_prefix_passthrough() {
         let config: Config = toml::from_str(
             r#"
 [keys]
 prefix = "ctrl+a"
-help = "prefix+ctrl+a"
+zoom = "prefix+ctrl+a"
 "#,
         )
         .unwrap();
-        let diagnostics = config.collect_diagnostics();
-        assert!(config.keybinds().help.bindings.is_empty());
-        assert!(diagnostics.iter().any(|diag| {
-            diag.contains("reserved keybinding")
-                && diag.contains("keys.help")
-                && diag.contains("keys.prefix")
-        }));
+        let keybinds = config.keybinds();
+        assert!(keybinds
+            .zoom
+            .matches_prefix_key(&TerminalKey::new(KeyCode::Char('a'), KeyModifiers::CONTROL,)));
+        assert!(config.collect_diagnostics().is_empty());
 
         let config: Config = toml::from_str(
             r#"
@@ -1935,7 +1936,7 @@ navigate_workspace_down = "ctrl+a"
     }
 
     #[test]
-    fn custom_command_prefix_rhs_equal_to_configured_prefix_is_rejected() {
+    fn user_command_can_override_double_prefix_passthrough() {
         let config: Config = toml::from_str(
             r#"
 [keys]
@@ -1943,15 +1944,16 @@ prefix = "ctrl+b"
 
 [[keys.command]]
 key = "prefix+ctrl+b"
-command = "echo no"
+command = "echo yes"
 "#,
         )
         .unwrap();
-        let diagnostics = config.collect_diagnostics();
-        assert!(config.keybinds().custom_commands.is_empty());
-        assert!(diagnostics.iter().any(|diag| {
-            diag.contains("reserved keybinding") && diag.contains("keys.command[0].key")
-        }));
+        let keybinds = config.keybinds();
+        assert_eq!(keybinds.custom_commands.len(), 1);
+        assert!(keybinds.custom_commands[0]
+            .bindings
+            .matches_prefix_key(&TerminalKey::new(KeyCode::Char('b'), KeyModifiers::CONTROL,)));
+        assert!(config.collect_diagnostics().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow an explicit user keybinding whose prefix-mode key equals `keys.prefix`
- dispatch configured prefix actions before falling back to literal double-prefix passthrough
- preserve Escape precedence and the existing passthrough behavior when no override is configured

This enables configurations such as:

```toml
[keys]
prefix = "ctrl+s"
zoom = "prefix+ctrl+s"
```

## Tests

- `cargo fmt --check`
- `cargo test --bin herdr double_prefix`
- `cargo test --bin herdr escape_precedes_configured_prefix_action`
- `cargo test --bin herdr config::keybinds::tests`
- `cargo test --bin herdr app::input::navigate::tests`
