### PR TITLE
ui: add pane movement and split orientation context actions

### DIFF
--- a/docs/next/api/herdr-api.schema.json
+++ b/docs/next/api/herdr-api.schema.json
@@ -2264,6 +2264,21 @@
             }
           ]
         },
+        "LayoutSetSplitDirectionParams": {
+          "properties": {
+            "direction": {
+              "$ref": "#/schemas/request/$defs/SplitDirection"
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "direction"
+          ],
+          "type": "object"
+        },
         "LayoutSetSplitRatioParams": {
           "properties": {
             "pane_id": {
@@ -5235,6 +5250,22 @@
             },
             "params": {
               "$ref": "#/schemas/request/$defs/LayoutSetSplitRatioParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "layout.set_split_direction",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/LayoutSetSplitDirectionParams"
             }
           },
           "required": [

--- a/docs/next/website/src/content/docs/ja/socket-api.mdx
+++ b/docs/next/website/src/content/docs/ja/socket-api.mdx
@@ -101,7 +101,7 @@ herdr pane read w1:p2 --source recent --lines 50
 | タブ | `tab.create`、`tab.list`、`tab.get`、`tab.focus`、`tab.rename`、`tab.move`、`tab.close` |
 | ペイン | `pane.split`、`pane.swap`、`pane.move`、`pane.zoom`、`pane.layout`、`pane.process_info`、`pane.neighbor`、`pane.edges`、`pane.focus_direction`、`pane.resize`、`pane.list`、`pane.current`、`pane.get`、`pane.rename`、`pane.send_text`、`pane.send_keys`、`pane.send_input`、`pane.read`、`pane.graphics.info`、`pane.graphics.set`、`pane.graphics.clear`、`pane.graphics.stream`、`pane.report_agent`、`pane.report_agent_session`、`pane.report_metadata`、`pane.clear_agent_authority`、`pane.release_agent`、`pane.close`、`pane.wait_for_output` |
 | ポップアップ | `popup.close` |
-| レイアウト | `layout.export`、`layout.apply`、`layout.set_split_ratio` |
+| レイアウト | `layout.export`、`layout.apply`、`layout.set_split_ratio`、`layout.set_split_direction` |
 | エージェント | `agent.list`、`agent.get`、`agent.read`、`agent.explain`、`agent.send_keys`、`agent.prompt`、`agent.wait`、`agent.rename`、`agent.focus`、`agent.start` |
 | イベント | `events.subscribe`、`events.wait` |
 | インテグレーション | `integration.install`、`integration.uninstall` |
@@ -209,6 +209,12 @@ CLI の `herdr api snapshot` は、クライアントやエージェントが簡
 
 ```json
 {"id":"req_ratio","method":"layout.set_split_ratio","params":{"tab_id":"w1:t1","path":[],"ratio":0.6}}
+```
+
+`layout.set_split_direction` は、ペインを含む分割の向きを反転し、左右分割と上下分割を切り替えます。レスポンスは、更新済みの移植可能な `layout` を含む `type: "layout_split_ratio_set"` です。ペインに親の分割がない場合、または既に指定した向きの場合は `split_not_found` を返します。
+
+```json
+{"id":"req_dir","method":"layout.set_split_direction","params":{"pane_id":"w1:p1","direction":"down"}}
 ```
 
 プロセスを起動するメソッドは `env` オブジェクトを受け付けます。Herdr はそのキー/値ペアを新しく起動されるプロセスにのみ適用します。Herdr は管理下のペインプロセスに `HERDR_SOCKET_PATH`、`HERDR_ENV=1`、`HERDR_WORKSPACE_ID`、`HERDR_TAB_ID`、`HERDR_PANE_ID` も注入します。呼び出し側が与えた環境変数と衝突した場合、Herdr 管理の変数が権威を持ちます。

--- a/docs/next/website/src/content/docs/socket-api.mdx
+++ b/docs/next/website/src/content/docs/socket-api.mdx
@@ -105,7 +105,7 @@ Raw socket method names use dot notation:
 | Tab | `tab.create`, `tab.list`, `tab.get`, `tab.focus`, `tab.rename`, `tab.move`, `tab.close` |
 | Pane | `pane.split`, `pane.swap`, `pane.move`, `pane.zoom`, `pane.layout`, `pane.process_info`, `pane.neighbor`, `pane.edges`, `pane.focus_direction`, `pane.resize`, `pane.list`, `pane.current`, `pane.get`, `pane.rename`, `pane.send_text`, `pane.send_keys`, `pane.send_input`, `pane.read`, `pane.graphics.info`, `pane.graphics.set`, `pane.graphics.clear`, `pane.graphics.stream`, `pane.report_agent`, `pane.report_agent_session`, `pane.report_metadata`, `pane.clear_agent_authority`, `pane.release_agent`, `pane.close`, `pane.wait_for_output` |
 | Popup | `popup.close` |
-| Layout | `layout.export`, `layout.apply`, `layout.set_split_ratio` |
+| Layout | `layout.export`, `layout.apply`, `layout.set_split_ratio`, `layout.set_split_direction` |
 | Agent | `agent.list`, `agent.get`, `agent.read`, `agent.explain`, `agent.send_keys`, `agent.prompt`, `agent.wait`, `agent.rename`, `agent.focus`, `agent.start`, `agent.view.set`, `agent.view.clear` |
 | Events | `events.subscribe`, `events.wait` |
 | Integrations | `integration.install`, `integration.uninstall` |
@@ -293,6 +293,16 @@ is `type: "layout_split_ratio_set"` with the updated portable `layout`.
 
 ```json
 {"id":"req_ratio","method":"layout.set_split_ratio","params":{"tab_id":"w1:t1","path":[],"ratio":0.6}}
+```
+
+`layout.set_split_direction` flips the orientation of the split that contains a
+pane, turning a side-by-side split into a stacked one and back. The response is
+`type: "layout_split_ratio_set"` with the updated portable `layout`. It returns
+`split_not_found` when the pane has no enclosing split or already uses the
+requested orientation.
+
+```json
+{"id":"req_dir","method":"layout.set_split_direction","params":{"pane_id":"w1:p1","direction":"down"}}
 ```
 
 Process-launching methods accept an `env` object. Herdr applies those key/value

--- a/docs/next/website/src/content/docs/zh-cn/socket-api.mdx
+++ b/docs/next/website/src/content/docs/zh-cn/socket-api.mdx
@@ -101,7 +101,7 @@ herdr pane read w1:p2 --source recent --lines 50
 | 标签页 | `tab.create`、`tab.list`、`tab.get`、`tab.focus`、`tab.rename`、`tab.move`、`tab.close` |
 | 窗格 | `pane.split`、`pane.swap`、`pane.move`、`pane.zoom`、`pane.layout`、`pane.process_info`、`pane.neighbor`、`pane.edges`、`pane.focus_direction`、`pane.resize`、`pane.list`、`pane.current`、`pane.get`、`pane.rename`、`pane.send_text`、`pane.send_keys`、`pane.send_input`、`pane.read`、`pane.graphics.info`、`pane.graphics.set`、`pane.graphics.clear`、`pane.graphics.stream`、`pane.report_agent`、`pane.report_agent_session`、`pane.report_metadata`、`pane.clear_agent_authority`、`pane.release_agent`、`pane.close`、`pane.wait_for_output` |
 | 弹窗 | `popup.close` |
-| 布局 | `layout.export`、`layout.apply`、`layout.set_split_ratio` |
+| 布局 | `layout.export`、`layout.apply`、`layout.set_split_ratio`、`layout.set_split_direction` |
 | 智能体 | `agent.list`、`agent.get`、`agent.read`、`agent.explain`、`agent.send_keys`、`agent.prompt`、`agent.wait`、`agent.rename`、`agent.focus`、`agent.start` |
 | 事件 | `events.subscribe`、`events.wait` |
 | 集成 | `integration.install`、`integration.uninstall` |
@@ -209,6 +209,12 @@ CLI 的 `herdr api snapshot` 会把当前 `session.snapshot` 响应输出为 JSO
 
 ```json
 {"id":"req_ratio","method":"layout.set_split_ratio","params":{"tab_id":"w1:t1","path":[],"ratio":0.6}}
+```
+
+`layout.set_split_direction` 翻转包含某个窗格的分割方向,在左右分割与上下分割之间切换。响应是 `type: "layout_split_ratio_set"`,并包含更新后的可移植 `layout`。当窗格没有父级分割,或已经是所请求的方向时,返回 `split_not_found`。
+
+```json
+{"id":"req_dir","method":"layout.set_split_direction","params":{"pane_id":"w1:p1","direction":"down"}}
 ```
 
 启动进程的方法接受一个 `env` 对象。Herdr 只把这些键值对应用到新启动的进程。Herdr 还向受管窗格进程注入 `HERDR_SOCKET_PATH`、`HERDR_ENV=1`、`HERDR_WORKSPACE_ID`、`HERDR_TAB_ID` 和 `HERDR_PANE_ID`。与调用方提供的环境变量冲突时,Herdr 管理的变量保持权威。

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -41,6 +41,7 @@ pub(crate) fn request_changes_ui(request: &Request) -> bool {
             | Method::TabMove(_)
             | Method::TabClose(_)
             | Method::LayoutApply(_)
+            | Method::LayoutSetSplitDirection(_)
             | Method::LayoutSetSplitRatio(_)
             | Method::AgentRename(_)
             | Method::AgentViewSet(_)

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -145,6 +145,8 @@ pub enum Method {
     LayoutApply(LayoutApplyParams),
     #[serde(rename = "layout.set_split_ratio")]
     LayoutSetSplitRatio(LayoutSetSplitRatioParams),
+    #[serde(rename = "layout.set_split_direction")]
+    LayoutSetSplitDirection(LayoutSetSplitDirectionParams),
     #[serde(rename = "pane.neighbor")]
     PaneNeighbor(PaneNeighborParams),
     #[serde(rename = "pane.edges")]

--- a/src/api/schema/panes.rs
+++ b/src/api/schema/panes.rs
@@ -165,6 +165,12 @@ pub struct LayoutSetSplitRatioParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct LayoutSetSplitDirectionParams {
+    pub pane_id: String,
+    pub direction: SplitDirection,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct LayoutDescription {
     pub workspace_id: String,
     pub tab_id: String,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -432,6 +432,7 @@ fn api_method_name(method: &Method) -> &'static str {
         Method::LayoutExport(_) => "layout.export",
         Method::LayoutApply(_) => "layout.apply",
         Method::LayoutSetSplitRatio(_) => "layout.set_split_ratio",
+        Method::LayoutSetSplitDirection(_) => "layout.set_split_direction",
         Method::PaneNeighbor(_) => "pane.neighbor",
         Method::PaneEdges(_) => "pane.edges",
         Method::PaneFocusDirection(_) => "pane.focus_direction",

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -1093,6 +1093,9 @@ impl App {
             Method::LayoutSetSplitRatio(params) => {
                 return self.handle_layout_set_split_ratio(request.id, params);
             }
+            Method::LayoutSetSplitDirection(params) => {
+                return self.handle_layout_set_split_direction(request.id, params);
+            }
             Method::PaneNeighbor(params) => return self.handle_pane_neighbor(request.id, params),
             Method::PaneEdges(params) => return self.handle_pane_edges(request.id, params),
             Method::PaneFocusDirection(params) => {

--- a/src/app/api/layouts.rs
+++ b/src/app/api/layouts.rs
@@ -4,7 +4,8 @@ use ratatui::layout::Direction;
 
 use crate::api::schema::{
     EventData, EventEnvelope, EventKind, LayoutApplyParams, LayoutDescription, LayoutExportParams,
-    LayoutNode, LayoutPane, LayoutSetSplitRatioParams, ResponseResult, SplitDirection,
+    LayoutNode, LayoutPane, LayoutSetSplitDirectionParams, LayoutSetSplitRatioParams,
+    ResponseResult, SplitDirection,
 };
 use crate::app::{App, Mode};
 use crate::layout::{Node, PaneId};
@@ -243,6 +244,43 @@ impl App {
             return encode_error(id, "split_not_found", "split path not found");
         }
 
+        self.schedule_session_save();
+        let Some(layout) = self.layout_description(ws_idx, tab_idx) else {
+            return encode_error(id, "layout_not_found", "layout unavailable");
+        };
+        self.emit_layout_updated_event(ws_idx, tab_idx);
+        encode_success(id, ResponseResult::LayoutSplitRatioSet { layout })
+    }
+
+    pub(super) fn handle_layout_set_split_direction(
+        &mut self,
+        id: String,
+        params: LayoutSetSplitDirectionParams,
+    ) -> String {
+        let Some((ws_idx, tab_idx)) = self.parse_pane_id(&params.pane_id).and_then(|(ws, pane)| {
+            self.state.workspaces[ws]
+                .find_tab_index_for_pane(pane)
+                .map(|tab| (ws, tab))
+        }) else {
+            return encode_error(id, "pane_not_found", "pane target not found");
+        };
+        let Some((_, pane_id)) = self.parse_pane_id(&params.pane_id) else {
+            return encode_error(id, "pane_not_found", "pane target not found");
+        };
+        let direction = match params.direction {
+            SplitDirection::Right => ratatui::layout::Direction::Horizontal,
+            SplitDirection::Down => ratatui::layout::Direction::Vertical,
+        };
+        let changed = self.state.workspaces[ws_idx].tabs[tab_idx]
+            .layout
+            .set_split_direction_for_pane(pane_id, direction);
+        if !changed {
+            return encode_error(
+                id,
+                "split_not_found",
+                "split orientation unchanged or unavailable",
+            );
+        }
         self.schedule_session_save();
         let Some(layout) = self.layout_description(ws_idx, tab_idx) else {
             return encode_error(id, "layout_not_found", "layout unavailable");

--- a/src/app/input/modal.rs
+++ b/src/app/input/modal.rs
@@ -1273,6 +1273,88 @@ impl App {
                 ContextMenuKind::Pane {
                     ws_idx, pane_id, ..
                 },
+                Some("Swap to horizontal"),
+            ) => self.set_context_pane_split_direction(
+                ws_idx,
+                pane_id,
+                crate::api::schema::SplitDirection::Right,
+            ),
+            (
+                ContextMenuKind::Pane {
+                    ws_idx, pane_id, ..
+                },
+                Some("Swap to vertical"),
+            ) => self.set_context_pane_split_direction(
+                ws_idx,
+                pane_id,
+                crate::api::schema::SplitDirection::Down,
+            ),
+            (
+                ContextMenuKind::Pane {
+                    ws_idx,
+                    tab_idx,
+                    pane_id,
+                    ..
+                },
+                Some("Move to previous tab"),
+            ) => self.move_context_pane_to_tab(ws_idx, pane_id, tab_idx.checked_sub(1)),
+            (
+                ContextMenuKind::Pane {
+                    ws_idx,
+                    tab_idx,
+                    pane_id,
+                    ..
+                },
+                Some("Move to next tab"),
+            ) => self.move_context_pane_to_tab(
+                ws_idx,
+                pane_id,
+                self.state
+                    .workspaces
+                    .get(ws_idx)
+                    .and_then(|ws| (tab_idx + 1 < ws.tabs.len()).then_some(tab_idx + 1)),
+            ),
+            (
+                ContextMenuKind::Pane {
+                    ws_idx, pane_id, ..
+                },
+                Some("Move to previous workspace"),
+            ) => self.move_context_pane_to_workspace(ws_idx, pane_id, ws_idx.checked_sub(1)),
+            (
+                ContextMenuKind::Pane {
+                    ws_idx, pane_id, ..
+                },
+                Some("Move to next workspace"),
+            ) => self.move_context_pane_to_workspace(
+                ws_idx,
+                pane_id,
+                (ws_idx + 1 < self.state.workspaces.len()).then_some(ws_idx + 1),
+            ),
+            (
+                ContextMenuKind::Pane {
+                    ws_idx, pane_id, ..
+                },
+                Some("Move to new workspace"),
+            ) => {
+                if let Some(source_pane_id) = self.public_pane_id(ws_idx, pane_id) {
+                    self.runtime_pane_move(
+                        "tui.pane.move.new_workspace",
+                        crate::api::schema::PaneMoveParams {
+                            pane_id: source_pane_id,
+                            destination: crate::api::schema::PaneMoveDestination::NewWorkspace {
+                                label: None,
+                                tab_label: None,
+                            },
+                            focus: true,
+                        },
+                    );
+                }
+                self.state.mode = Mode::Terminal;
+            }
+            (
+                ContextMenuKind::Pane {
+                    ws_idx, pane_id, ..
+                },
                 Some("Clear pane name"),
             ) => {
                 if let Some(pane_id) = self.public_pane_id(ws_idx, pane_id) {
@@ -1381,6 +1463,103 @@ impl App {
             }
             _ => leave_modal(&mut self.state),
         }
+    }
+
+    fn move_context_pane_to_tab(
+        &mut self,
+        source_ws_idx: usize,
+        pane_id: crate::layout::PaneId,
+        target_tab_idx: Option<usize>,
+    ) {
+        let Some(target_tab_idx) = target_tab_idx else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        let Some(source_pane_id) = self.public_pane_id(source_ws_idx, pane_id) else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        let Some(tab_id) = self.public_tab_id(source_ws_idx, target_tab_idx) else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        let target_pane = self.state.workspaces[source_ws_idx].tabs[target_tab_idx]
+            .layout
+            .focused();
+        let Some(target_pane_id) = self.public_pane_id(source_ws_idx, target_pane) else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        self.runtime_pane_move(
+            "tui.pane.move.tab",
+            crate::api::schema::PaneMoveParams {
+                pane_id: source_pane_id,
+                destination: crate::api::schema::PaneMoveDestination::Tab {
+                    tab_id,
+                    target_pane_id: Some(target_pane_id),
+                    split: crate::api::schema::SplitDirection::Right,
+                    ratio: None,
+                },
+                focus: true,
+            },
+        );
+        self.state.mode = Mode::Terminal;
+    }
+
+    fn set_context_pane_split_direction(
+        &mut self,
+        ws_idx: usize,
+        pane_id: crate::layout::PaneId,
+        direction: crate::api::schema::SplitDirection,
+    ) {
+        if let Some(pane_id) = self.public_pane_id(ws_idx, pane_id) {
+            self.runtime_layout_set_split_direction(
+                "tui.layout.set_split_direction",
+                crate::api::schema::LayoutSetSplitDirectionParams { pane_id, direction },
+            );
+        }
+        self.state.mode = Mode::Terminal;
+    }
+
+    fn move_context_pane_to_workspace(
+        &mut self,
+        source_ws_idx: usize,
+        pane_id: crate::layout::PaneId,
+        target_ws_idx: Option<usize>,
+    ) {
+        let Some(target_ws_idx) = target_ws_idx else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        let Some(source_pane_id) = self.public_pane_id(source_ws_idx, pane_id) else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        let Some(tab_id) = self.public_tab_id(target_ws_idx, 0) else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        let target_pane = self.state.workspaces[target_ws_idx].tabs[0]
+            .layout
+            .focused();
+        let Some(target_pane_id) = self.public_pane_id(target_ws_idx, target_pane) else {
+            self.state.mode = Mode::Terminal;
+            return;
+        };
+        self.runtime_pane_move(
+            "tui.pane.move.workspace",
+            crate::api::schema::PaneMoveParams {
+                pane_id: source_pane_id,
+                destination: crate::api::schema::PaneMoveDestination::Tab {
+                    tab_id,
+                    target_pane_id: Some(target_pane_id),
+                    split: crate::api::schema::SplitDirection::Right,
+                    ratio: None,
+                },
+                focus: true,
+            },
+        );
+        self.state.mode = Mode::Terminal;
     }
 }
 

--- a/src/app/input/mouse.rs
+++ b/src/app/input/mouse.rs
@@ -3662,19 +3662,29 @@ mod tests {
         app.state.selected = 0;
         let pane_id = app.state.workspaces[0].tabs[0].root_pane;
         let runtime_count = app.terminal_runtimes.len();
-        app.state.context_menu = Some(ContextMenuState {
-            kind: ContextMenuKind::Pane {
-                ws_idx: 0,
-                tab_idx: 0,
-                pane_id,
-                source_pane_id: None,
-                has_manual_label: false,
-                right_click_passthrough: false,
-            },
+        let menu_kind = ContextMenuKind::Pane {
+            ws_idx: 0,
+            tab_idx: 0,
+            pane_id,
+            source_pane_id: None,
+            has_manual_label: false,
+            right_click_passthrough: false,
+        };
+        let mut menu = ContextMenuState {
+            kind: menu_kind,
             x: 2,
             y: 2,
-            list: MenuListState::new(1),
-        });
+            list: MenuListState::new(0),
+        };
+        // Resolve by label rather than a hardcoded index so adding menu entries
+        // cannot silently repoint this test at a different action.
+        let split_right_idx = menu
+            .items()
+            .iter()
+            .position(|item| *item == "Split right")
+            .expect("pane context menu should offer 'Split right'");
+        menu.list = MenuListState::new(split_right_idx);
+        app.state.context_menu = Some(menu);
         app.state.mode = Mode::ContextMenu;
 
         handle_context_menu_key(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4034,6 +4034,15 @@ mod tests {
                 crate::api::schema::AgentViewClearParams::default(),
             ),
         };
+        let split_direction = crate::api::schema::Request {
+            id: "req_10".into(),
+            method: crate::api::schema::Method::LayoutSetSplitDirection(
+                crate::api::schema::LayoutSetSplitDirectionParams {
+                    pane_id: "w1:p1".into(),
+                    direction: crate::api::schema::SplitDirection::Right,
+                },
+            ),
+        };
 
         assert!(!crate::api::request_changes_ui(&read_only));
         assert!(!crate::api::request_changes_ui(&worktree_list));
@@ -4044,6 +4053,7 @@ mod tests {
         assert!(crate::api::request_changes_ui(&pane_focus_direction));
         assert!(crate::api::request_changes_ui(&pane_resize));
         assert!(crate::api::request_changes_ui(&agent_view));
+        assert!(crate::api::request_changes_ui(&split_direction));
     }
 
     #[test]

--- a/src/app/runtime_mutations.rs
+++ b/src/app/runtime_mutations.rs
@@ -1,9 +1,10 @@
 use crate::api::schema::{
-    EmptyParams, LayoutSetSplitRatioParams, Method, PaneFocusDirectionParams, PaneInputSetParams,
-    PaneRenameParams, PaneResizeParams, PaneSplitParams, PaneSwapParams, PaneTarget,
-    PaneZoomParams, TabCreateParams, TabMoveParams, TabRenameParams, TabTarget,
-    WorkspaceCreateParams, WorkspaceMoveBlockParams, WorkspaceMoveParams, WorkspaceRenameParams,
-    WorkspaceTarget, WorktreeCreateParams, WorktreeOpenParams, WorktreeRemoveParams,
+    EmptyParams, LayoutSetSplitDirectionParams, LayoutSetSplitRatioParams, Method,
+    PaneFocusDirectionParams, PaneInputSetParams, PaneMoveParams, PaneRenameParams,
+    PaneResizeParams, PaneSplitParams, PaneSwapParams, PaneTarget, PaneZoomParams, TabCreateParams,
+    TabMoveParams, TabRenameParams, TabTarget, WorkspaceCreateParams, WorkspaceMoveBlockParams,
+    WorkspaceMoveParams, WorkspaceRenameParams, WorkspaceTarget, WorktreeCreateParams,
+    WorktreeOpenParams, WorktreeRemoveParams,
 };
 
 use super::App;
@@ -145,6 +146,10 @@ impl App {
         self.dispatch_runtime_mutation(id, Method::PaneSwap(params))
     }
 
+    pub(crate) fn runtime_pane_move(&mut self, id: &'static str, params: PaneMoveParams) -> String {
+        self.dispatch_runtime_mutation(id, Method::PaneMove(params))
+    }
+
     pub(crate) fn runtime_pane_split(
         &mut self,
         id: &'static str,
@@ -163,6 +168,14 @@ impl App {
         params: LayoutSetSplitRatioParams,
     ) -> String {
         self.dispatch_runtime_mutation(id, Method::LayoutSetSplitRatio(params))
+    }
+
+    pub(crate) fn runtime_layout_set_split_direction(
+        &mut self,
+        id: &'static str,
+        params: LayoutSetSplitDirectionParams,
+    ) -> String {
+        self.dispatch_runtime_mutation(id, Method::LayoutSetSplitDirection(params))
     }
 
     pub(crate) fn runtime_worktree_create_deferred(

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1264,6 +1264,14 @@ impl ContextMenuState {
                 if source_pane_id.is_some() {
                     items.push("Swap with focused pane");
                 }
+                items.extend(["Swap to horizontal", "Swap to vertical"]);
+                items.extend([
+                    "Move to previous tab",
+                    "Move to next tab",
+                    "Move to previous workspace",
+                    "Move to next workspace",
+                    "Move to new workspace",
+                ]);
                 items.extend(["Split right", "Split down", "Zoom"]);
                 items.push(if right_click_passthrough {
                     "Use Herdr right-click menu"

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -276,6 +276,11 @@ impl TileLayout {
         set_ratio_at(&mut self.root, path, ratio.clamp(0.1, 0.9))
     }
 
+    /// Set the nearest split containing `pane` to the requested orientation.
+    pub fn set_split_direction_for_pane(&mut self, pane: PaneId, direction: Direction) -> bool {
+        set_split_direction_for_pane(&mut self.root, pane, direction)
+    }
+
     /// Adjust the nearest split in the given direction for the focused pane.
     /// `delta` is positive to grow, negative to shrink.
     pub fn resize_focused(&mut self, nav: NavDirection, delta: f32, area: Rect) {
@@ -477,6 +482,37 @@ fn count_panes(node: &Node) -> usize {
     match node {
         Node::Pane(_) => 1,
         Node::Split { first, second, .. } => count_panes(first) + count_panes(second),
+    }
+}
+
+fn set_split_direction_for_pane(node: &mut Node, pane: PaneId, direction: Direction) -> bool {
+    match node {
+        Node::Pane(_) => false,
+        Node::Split {
+            direction: current,
+            first,
+            second,
+            ..
+        } => {
+            if contains_pane(first, pane) || contains_pane(second, pane) {
+                if *current == direction {
+                    return false;
+                }
+                *current = direction;
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+fn contains_pane(node: &Node, pane: PaneId) -> bool {
+    match node {
+        Node::Pane(id) => *id == pane,
+        Node::Split { first, second, .. } => {
+            contains_pane(first, pane) || contains_pane(second, pane)
+        }
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -494,12 +494,18 @@ fn set_split_direction_for_pane(node: &mut Node, pane: PaneId, direction: Direct
             second,
             ..
         } => {
-            if contains_pane(first, pane) || contains_pane(second, pane) {
+            let pane_is_direct_child = matches!(first.as_ref(), Node::Pane(id) if *id == pane)
+                || matches!(second.as_ref(), Node::Pane(id) if *id == pane);
+            if pane_is_direct_child {
                 if *current == direction {
                     return false;
                 }
                 *current = direction;
                 true
+            } else if contains_pane(first, pane) {
+                set_split_direction_for_pane(first, pane, direction)
+            } else if contains_pane(second, pane) {
+                set_split_direction_for_pane(second, pane, direction)
             } else {
                 false
             }
@@ -874,6 +880,30 @@ mod tests {
         assert_eq!(splits.len(), 1);
         assert_eq!(splits[0].0, Direction::Horizontal);
         assert!((splits[0].1 - 0.333).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn set_split_direction_for_pane_changes_nearest_enclosing_split() {
+        let mut layout = sample_layout();
+
+        assert!(layout.set_split_direction_for_pane(pane(3), Direction::Vertical));
+
+        let splits = split_snapshot(&layout);
+        assert_eq!(
+            splits[0].0,
+            Direction::Horizontal,
+            "root split must remain unchanged"
+        );
+        assert_eq!(
+            splits[1].0,
+            Direction::Vertical,
+            "outer nested split must remain unchanged"
+        );
+        assert_eq!(
+            splits[2].0,
+            Direction::Vertical,
+            "pane's immediate parent split must change"
+        );
     }
 
     #[test]

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -299,7 +299,38 @@ pub(super) fn render_context_menu(app: &AppState, frame: &mut Frame) {
     let items: Vec<ListItem> = menu
         .items()
         .iter()
-        .map(|item| ListItem::new(Line::from(*item)))
+        .map(|item| {
+            let enabled = match (&menu.kind, *item) {
+                (
+                    crate::app::state::ContextMenuKind::Pane { tab_idx, .. },
+                    "Move to previous tab",
+                ) => *tab_idx > 0,
+                (
+                    crate::app::state::ContextMenuKind::Pane {
+                        ws_idx, tab_idx, ..
+                    },
+                    "Move to next tab",
+                ) => app
+                    .workspaces
+                    .get(*ws_idx)
+                    .is_some_and(|ws| *tab_idx + 1 < ws.tabs.len()),
+                (
+                    crate::app::state::ContextMenuKind::Pane { ws_idx, .. },
+                    "Move to previous workspace",
+                ) => *ws_idx > 0,
+                (
+                    crate::app::state::ContextMenuKind::Pane { ws_idx, .. },
+                    "Move to next workspace",
+                ) => *ws_idx + 1 < app.workspaces.len(),
+                _ => true,
+            };
+            let style = if enabled {
+                Style::default().fg(p.text)
+            } else {
+                Style::default().fg(p.overlay0)
+            };
+            ListItem::new(Line::from(*item).style(style))
+        })
         .collect();
     let list = List::new(items)
         .style(Style::default().fg(p.text))

--- a/tests/api_ping.rs
+++ b/tests/api_ping.rs
@@ -2531,3 +2531,101 @@ fn metadata_status_subscription_filter_and_ttl_expiry_are_observable() {
 
     cleanup_spawned_herdr(child, base);
 }
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn pane_move_and_split_direction_round_trip_over_public_api() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let socket_path = runtime_dir.join("herdr.sock");
+    let child = spawn_herdr(&config_home, &runtime_dir, &socket_path);
+    wait_for_socket(&socket_path, Duration::from_secs(5));
+
+    let created = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"create","method":"workspace.create","params":{{"cwd":"{}","focus":true}}}}"#,
+            base.display()
+        ),
+    );
+    let workspace_id = created["result"]["workspace"]["workspace_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let source_tab_id = created["result"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let source_pane_id = created["result"]["root_pane"]["pane_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let source_terminal_id = created["result"]["root_pane"]["terminal_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let created_tab = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"tab","method":"tab.create","params":{{"workspace_id":"{}","focus":true}}}}"#,
+            workspace_id
+        ),
+    );
+    let target_tab_id = created_tab["result"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let target_pane_id = created_tab["result"]["root_pane"]["pane_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let moved = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"move","method":"pane.move","params":{{"pane_id":"{}","destination":{{"type":"tab","tab_id":"{}","target_pane_id":"{}","split":"right"}},"focus":true}}}}"#,
+            source_pane_id, target_tab_id, target_pane_id
+        ),
+    );
+    assert_eq!(moved["result"]["type"], "pane_move");
+    assert_eq!(
+        moved["result"]["move_result"]["pane"]["pane_id"],
+        source_pane_id
+    );
+    assert_eq!(
+        moved["result"]["move_result"]["pane"]["terminal_id"],
+        source_terminal_id
+    );
+    assert_eq!(
+        moved["result"]["move_result"]["pane"]["tab_id"],
+        target_tab_id
+    );
+    assert_eq!(
+        moved["result"]["move_result"]["previous_tab_id"],
+        source_tab_id
+    );
+
+    let split = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"split","method":"pane.split","params":{{"target_pane_id":"{}","direction":"right","focus":false}}}}"#,
+            source_pane_id
+        ),
+    );
+    assert_eq!(split["result"]["type"], "pane_info");
+
+    let direction = send_request(
+        &socket_path,
+        &format!(
+            r#"{{"id":"direction","method":"layout.set_split_direction","params":{{"pane_id":"{}","direction":"down"}}}}"#,
+            source_pane_id
+        ),
+    );
+    assert_eq!(direction["result"]["type"], "layout_split_ratio_set");
+    assert!(direction["result"]["layout"]["root"].is_object());
+
+    cleanup_spawned_herdr(child, base);
+}

--- a/tests/cross_area.rs
+++ b/tests/cross_area.rs
@@ -1137,3 +1137,246 @@ fn cross_area_server_kill_then_restart_and_reconnect() {
 
     cleanup_spawned_herdr(server2, base);
 }
+
+// ---------------------------------------------------------------------------
+// Pane context-menu movement and split-orientation TUI acceptance
+// ---------------------------------------------------------------------------
+
+/// SGR right-button press at a 0-based cell position.
+fn sgr_right_click(col: u16, row: u16) -> Vec<u8> {
+    format!("\x1b[<2;{};{}M", col + 1, row + 1).into_bytes()
+}
+
+fn layout_export(socket_path: &Path, tab_id: &str) -> Value {
+    send_json_request(
+        socket_path,
+        "layout_export",
+        "layout.export",
+        json!({ "tab_id": tab_id }),
+    )
+}
+
+fn pane_split(socket_path: &Path, target_pane_id: &str, direction: &str) -> Value {
+    send_json_request(
+        socket_path,
+        "pane_split",
+        "pane.split",
+        json!({ "target_pane_id": target_pane_id, "direction": direction }),
+    )
+}
+
+fn tab_list(socket_path: &Path, workspace_id: &str) -> Value {
+    send_json_request(
+        socket_path,
+        "tab_list",
+        "tab.list",
+        json!({ "workspace_id": workspace_id }),
+    )
+}
+
+/// Root split direction of a tab's exported layout, if the root is a split.
+fn root_split_direction(layout: &Value) -> Option<String> {
+    let root = layout.pointer("/result/layout/root")?;
+    if root.get("type")?.as_str()? != "split" {
+        return None;
+    }
+    Some(root.get("direction")?.as_str()?.to_string())
+}
+
+fn collect_pane_ids(node: &Value, out: &mut Vec<String>) {
+    match node.get("type").and_then(Value::as_str) {
+        Some("pane") => {
+            if let Some(id) = node.get("pane_id").and_then(Value::as_str) {
+                out.push(id.to_string());
+            }
+        }
+        Some("split") => {
+            if let Some(first) = node.get("first") {
+                collect_pane_ids(first, out);
+            }
+            if let Some(second) = node.get("second") {
+                collect_pane_ids(second, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn tab_pane_ids(socket_path: &Path, tab_id: &str) -> Vec<String> {
+    let layout = layout_export(socket_path, tab_id);
+    let mut ids = Vec::new();
+    if let Some(root) = layout.pointer("/result/layout/root") {
+        collect_pane_ids(root, &mut ids);
+    }
+    ids
+}
+
+/// Drives the real TUI over the client socket: right-clicks a pane, walks the
+/// context menu with the keyboard, and activates a labeled entry. Asserts the
+/// menu actually rendered the entry before selecting it.
+fn right_click_and_activate(
+    client: &mut UnixStream,
+    col: u16,
+    row: u16,
+    label: &str,
+    steps_down: usize,
+) {
+    drain_server_messages(client, Duration::from_millis(200));
+    send_client_input(client, &sgr_right_click(col, row));
+
+    let opened = wait_for_frame_matching(client, Duration::from_secs(5), |frame| {
+        frame_contains_text(frame, label)
+    })
+    .expect("frame decoding should succeed");
+    assert!(
+        opened,
+        "right-click at ({col},{row}) should render a pane context menu containing {label:?}"
+    );
+
+    for _ in 0..steps_down {
+        send_client_input(client, b"\x1b[B");
+        thread::sleep(Duration::from_millis(30));
+    }
+    send_client_input(client, b"\r");
+    thread::sleep(Duration::from_millis(400));
+    drain_server_messages(client, Duration::from_millis(300));
+}
+
+#[test]
+fn pane_context_menu_swaps_split_orientation_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "orientation");
+    let ws_id = workspace_id_by_label(&workspace_list(&api_socket), "orientation");
+
+    let tabs = tab_list(&api_socket, &ws_id);
+    let tab_id = tabs
+        .pointer("/result/tabs/0/tab_id")
+        .and_then(Value::as_str)
+        .expect("tab id")
+        .to_string();
+
+    let root_pane = tab_pane_ids(&api_socket, &tab_id)
+        .first()
+        .cloned()
+        .expect("root pane");
+
+    // Build a real split so the root node is a split with a known direction.
+    pane_split(&api_socket, &root_pane, "right");
+    let before = layout_export(&api_socket, &tab_id);
+    assert_eq!(
+        root_split_direction(&before).as_deref(),
+        Some("right"),
+        "split right should produce a horizontal root split; layout: {before}"
+    );
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    // "Swap to vertical" is the entry after "Rename pane" and "Swap to horizontal"
+    // for a pane with no manual label and no pending swap source.
+    right_click_and_activate(&mut client, 40, 6, "Swap to vertical", 2);
+
+    let after = layout_export(&api_socket, &tab_id);
+    assert_eq!(
+        root_split_direction(&after).as_deref(),
+        Some("down"),
+        "context-menu 'Swap to vertical' must flip the real layout to a vertical split; \
+         before={before}, after={after}"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+#[test]
+fn pane_context_menu_moves_pane_to_new_workspace_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "movement");
+    let ws_id = workspace_id_by_label(&workspace_list(&api_socket), "movement");
+
+    let tabs = tab_list(&api_socket, &ws_id);
+    let tab_id = tabs
+        .pointer("/result/tabs/0/tab_id")
+        .and_then(Value::as_str)
+        .expect("tab id")
+        .to_string();
+
+    let root_pane = tab_pane_ids(&api_socket, &tab_id)
+        .first()
+        .cloned()
+        .expect("root pane");
+
+    // Two panes so moving one away leaves the source tab alive.
+    pane_split(&api_socket, &root_pane, "right");
+    let panes_before = tab_pane_ids(&api_socket, &tab_id);
+    assert_eq!(panes_before.len(), 2, "expected a split source tab");
+
+    // Write a marker into the pane so we can prove the process survived the move.
+    let marker = "herdr_move_marker_9137";
+    pane_send_text(&api_socket, &root_pane, &format!("echo {marker}\n"));
+    assert!(
+        pane_read_recent_contains(&api_socket, &root_pane, marker, Duration::from_secs(10)),
+        "marker should appear in the source pane before moving"
+    );
+
+    let workspaces_before = workspace_count(&api_socket);
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    // Rename pane, Swap to horizontal, Swap to vertical, Move to previous tab,
+    // Move to next tab, Move to previous workspace, Move to next workspace,
+    // Move to new workspace -> index 7.
+    right_click_and_activate(&mut client, 40, 6, "Move to new workspace", 7);
+
+    let workspaces_after = workspace_count(&api_socket);
+    assert_eq!(
+        workspaces_after,
+        workspaces_before + 1,
+        "'Move to new workspace' must create exactly one new workspace"
+    );
+
+    let panes_after = tab_pane_ids(&api_socket, &tab_id);
+    assert_eq!(
+        panes_after.len(),
+        1,
+        "the moved pane must leave the source tab; before={panes_before:?}, after={panes_after:?}"
+    );
+
+    // The moved pane keeps its identity and its live process/scrollback.
+    let moved = panes_before
+        .iter()
+        .find(|id| !panes_after.contains(id))
+        .expect("exactly one pane should have left the source tab");
+    assert!(
+        pane_read_recent_contains(&api_socket, moved, marker, Duration::from_secs(10)),
+        "moved pane {moved} must keep its live terminal contents after the move"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}

--- a/tests/cross_area.rs
+++ b/tests/cross_area.rs
@@ -1985,3 +1985,108 @@ fn pane_context_menu_moves_pane_to_previous_workspace_in_live_tui() {
     drop(client);
     cleanup_spawned_herdr(server, base);
 }
+
+/// The NEXT-side edges must also refuse rather than clamp. The pane sits on the
+/// LAST tab of the LAST workspace, with an earlier tab and an earlier workspace
+/// present so a clamping bug would have a visible destination to move into.
+#[test]
+fn pane_context_menu_next_edge_entries_are_inert_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "ws-first");
+    workspace_create(&api_socket, "ws-last");
+    let first_ws = workspace_id_by_label(&workspace_list(&api_socket), "ws-first");
+    let last_ws = workspace_id_by_label(&workspace_list(&api_socket), "ws-last");
+
+    let first_ws_tab = tab_ids(&api_socket, &first_ws)
+        .first()
+        .cloned()
+        .expect("first workspace tab");
+
+    // Two tabs in the last workspace; the pane goes on the LAST one.
+    tab_create(&api_socket, &last_ws, true);
+    let tabs = tab_ids(&api_socket, &last_ws);
+    assert_eq!(tabs.len(), 2, "expected two tabs; got {tabs:?}");
+    let earlier_tab = tabs[0].clone();
+    let last_tab = tabs[1].clone();
+
+    // Split so a move would be legal if the guard wrongly allowed it.
+    let last_root = tab_pane_ids(&api_socket, &last_tab)
+        .first()
+        .cloned()
+        .expect("last tab root pane");
+    pane_split(&api_socket, &last_root, "right");
+
+    send_json_request(
+        &api_socket,
+        "workspace_focus",
+        "workspace.focus",
+        json!({ "workspace_id": last_ws }),
+    );
+    send_json_request(
+        &api_socket,
+        "tab_focus",
+        "tab.focus",
+        json!({ "tab_id": last_tab }),
+    );
+    send_json_request(
+        &api_socket,
+        "pane_focus",
+        "pane.focus",
+        json!({ "pane_id": last_root }),
+    );
+
+    let source_before = tab_pane_ids(&api_socket, &last_tab);
+    let earlier_tab_before = tab_pane_ids(&api_socket, &earlier_tab);
+    let first_ws_before = tab_pane_ids(&api_socket, &first_ws_tab);
+    let workspaces_before = workspace_count(&api_socket);
+    assert_eq!(source_before.len(), 2, "source tab should hold two panes");
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    // Index 4 = "Move to next tab", disabled because this is the last tab.
+    right_click_and_activate(&mut client, 40, 6, "Move to next tab", 4);
+    assert_eq!(
+        tab_pane_ids(&api_socket, &last_tab),
+        source_before,
+        "'Move to next tab' on the last tab must not move the pane"
+    );
+    assert_eq!(
+        tab_pane_ids(&api_socket, &earlier_tab),
+        earlier_tab_before,
+        "'Move to next tab' on the last tab must not clamp back into an earlier tab"
+    );
+
+    // Index 6 = "Move to next workspace", disabled on the last workspace.
+    right_click_and_activate(&mut client, 40, 6, "Move to next workspace", 6);
+    assert_eq!(
+        tab_pane_ids(&api_socket, &last_tab),
+        source_before,
+        "'Move to next workspace' on the last workspace must not move the pane"
+    );
+    assert_eq!(
+        tab_pane_ids(&api_socket, &first_ws_tab),
+        first_ws_before,
+        "'Move to next workspace' on the last workspace must not clamp into an earlier workspace"
+    );
+    assert_eq!(
+        workspace_count(&api_socket),
+        workspaces_before,
+        "disabled next-side entries must not create workspaces"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}

--- a/tests/cross_area.rs
+++ b/tests/cross_area.rs
@@ -1335,17 +1335,13 @@ fn pane_context_menu_moves_pane_to_new_workspace_in_live_tui() {
 
     // Write a marker into the pane so we can prove the process survived the move.
     let marker = "herdr_move_marker_9137";
-    pane_send_text(&api_socket, &root_pane, &format!("echo {marker}\n"));
-    assert!(
-        pane_read_recent_contains(&api_socket, &root_pane, marker, Duration::from_secs(10)),
-        "marker should appear in the source pane before moving"
-    );
 
     let workspaces_before = workspace_count(&api_socket);
 
     let mut client = UnixStream::connect(&client_socket).expect("client should connect");
     client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
     assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+    seed_pane_marker(&api_socket, &root_pane, marker);
 
     // Rename pane, Swap to horizontal, Swap to vertical, Move to previous tab,
     // Move to next tab, Move to previous workspace, Move to next workspace,
@@ -1374,6 +1370,435 @@ fn pane_context_menu_moves_pane_to_new_workspace_in_live_tui() {
     assert!(
         pane_read_recent_contains(&api_socket, moved, marker, Duration::from_secs(10)),
         "moved pane {moved} must keep its live terminal contents after the move"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+fn tab_create(socket_path: &Path, workspace_id: &str, focus: bool) -> Value {
+    send_json_request(
+        socket_path,
+        "tab_create",
+        "tab.create",
+        json!({ "workspace_id": workspace_id, "focus": focus }),
+    )
+}
+
+fn tab_ids(socket_path: &Path, workspace_id: &str) -> Vec<String> {
+    tab_list(socket_path, workspace_id)["result"]["tabs"]
+        .as_array()
+        .expect("tabs array")
+        .iter()
+        .filter_map(|tab| tab["tab_id"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// Right-clicks a pane and returns the rendered frame text of the context menu,
+/// without activating anything. Used to assert entry presence and edge state.
+fn right_click_menu_text(client: &mut UnixStream, col: u16, row: u16) -> String {
+    drain_server_messages(client, Duration::from_millis(200));
+    send_client_input(client, &sgr_right_click(col, row));
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut last = String::new();
+    while Instant::now() < deadline {
+        match read_server_message_payload(client, Duration::from_millis(120)) {
+            Ok((1, payload)) => {
+                if let Ok(frame) = decode_frame_payload(&payload) {
+                    let width = frame.width.max(1) as usize;
+                    let mut text = String::new();
+                    for chunk in frame.cells.chunks(width) {
+                        for cell in chunk {
+                            text.push_str(&cell.symbol);
+                        }
+                        text.push('\n');
+                    }
+                    if text.contains("Move to new workspace") {
+                        return text;
+                    }
+                    last = text;
+                }
+            }
+            Ok(_) => {}
+            Err(err) if is_timeout(&err) => {}
+            Err(_) => break,
+        }
+    }
+    last
+}
+
+fn close_menu(client: &mut UnixStream) {
+    send_client_input(client, b"\x1b");
+    thread::sleep(Duration::from_millis(200));
+    drain_server_messages(client, Duration::from_millis(200));
+}
+
+/// Writes a marker into a pane's live shell, retrying until it is readable.
+/// A freshly spawned pane may not have its shell ready on the first write,
+/// which otherwise makes marker-based identity checks flaky under load.
+fn seed_pane_marker(socket_path: &Path, pane_id: &str, marker: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut attempt = 0;
+    while Instant::now() < deadline {
+        attempt += 1;
+        pane_send_text(socket_path, pane_id, &format!("echo {marker}\n"));
+        if pane_read_recent_contains(socket_path, pane_id, marker, Duration::from_secs(3)) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+    panic!("marker {marker} never appeared in pane {pane_id} after {attempt} attempts");
+}
+
+/// Every new context-menu entry must render for a pane, and the tab/workspace
+/// movement entries must be present regardless of whether they are enabled.
+#[test]
+fn pane_context_menu_renders_all_new_entries_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "entries");
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    let text = right_click_menu_text(&mut client, 40, 6);
+    for entry in [
+        "Swap to horizontal",
+        "Swap to vertical",
+        "Move to previous tab",
+        "Move to next tab",
+        "Move to previous workspace",
+        "Move to next workspace",
+        "Move to new workspace",
+    ] {
+        assert!(
+            text.contains(entry),
+            "pane context menu must render {entry:?}; menu frame was:\n{text}"
+        );
+    }
+
+    close_menu(&mut client);
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+/// Activating a disabled edge entry must be a no-op rather than moving the
+/// pane. This is set up so a broken guard would have somewhere to move: the
+/// workspace has a second tab and a second workspace exists, but the pane sits
+/// on the FIRST tab of the FIRST workspace, where "previous" is out of range.
+/// A guard that clamps instead of refusing would relocate the pane and fail.
+#[test]
+fn pane_context_menu_edge_entries_are_inert_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "edges");
+    let ws_id = workspace_id_by_label(&workspace_list(&api_socket), "edges");
+    let first_tab = tab_ids(&api_socket, &ws_id)
+        .first()
+        .cloned()
+        .expect("first tab");
+
+    // Give a clamping bug a real destination: a second tab in this workspace.
+    tab_create(&api_socket, &ws_id, false);
+    let tabs = tab_ids(&api_socket, &ws_id);
+    assert_eq!(tabs.len(), 2, "expected a second tab; got {tabs:?}");
+    let second_tab = tabs[1].clone();
+
+    // Split so the pane could legally move without collapsing the tab.
+    let root_pane = tab_pane_ids(&api_socket, &first_tab)
+        .first()
+        .cloned()
+        .expect("root pane");
+    pane_split(&api_socket, &root_pane, "right");
+
+    // Refocus the first tab and its original pane so the right-click targets it.
+    send_json_request(
+        &api_socket,
+        "tab_focus",
+        "tab.focus",
+        json!({ "tab_id": first_tab }),
+    );
+    send_json_request(
+        &api_socket,
+        "pane_focus",
+        "pane.focus",
+        json!({ "pane_id": root_pane }),
+    );
+
+    let panes_before = tab_pane_ids(&api_socket, &first_tab);
+    let second_before = tab_pane_ids(&api_socket, &second_tab);
+    let workspaces_before = workspace_count(&api_socket);
+    assert_eq!(panes_before.len(), 2, "source tab should hold two panes");
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    // Index 3 = "Move to previous tab", disabled because this is the first tab.
+    right_click_and_activate(&mut client, 40, 6, "Move to previous tab", 3);
+    assert_eq!(
+        tab_pane_ids(&api_socket, &first_tab),
+        panes_before,
+        "'Move to previous tab' on the first tab must not move the pane"
+    );
+    assert_eq!(
+        tab_pane_ids(&api_socket, &second_tab),
+        second_before,
+        "'Move to previous tab' on the first tab must not leak the pane into another tab"
+    );
+
+    // Index 5 = "Move to previous workspace", disabled on the first workspace.
+    right_click_and_activate(&mut client, 40, 6, "Move to previous workspace", 5);
+    assert_eq!(
+        tab_pane_ids(&api_socket, &first_tab),
+        panes_before,
+        "'Move to previous workspace' on the first workspace must not move the pane"
+    );
+    assert_eq!(
+        workspace_count(&api_socket),
+        workspaces_before,
+        "disabled edge entries must not create workspaces"
+    );
+    assert_eq!(
+        tab_ids(&api_socket, &ws_id).len(),
+        2,
+        "disabled edge entries must not create tabs"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+/// "Move to next tab" must relocate the pane into the adjacent tab and keep the
+/// live shell process attached to it.
+#[test]
+fn pane_context_menu_moves_pane_to_next_tab_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "nexttab");
+    let ws_id = workspace_id_by_label(&workspace_list(&api_socket), "nexttab");
+    let first_tab = tab_ids(&api_socket, &ws_id)
+        .first()
+        .cloned()
+        .expect("first tab");
+
+    // A second tab to move into, then return focus to the first tab.
+    tab_create(&api_socket, &ws_id, false);
+    let tabs = tab_ids(&api_socket, &ws_id);
+    assert_eq!(tabs.len(), 2, "expected two tabs; got {tabs:?}");
+    let second_tab = tabs[1].clone();
+
+    // Split so the source tab survives losing a pane.
+    let root_pane = tab_pane_ids(&api_socket, &first_tab)
+        .first()
+        .cloned()
+        .expect("root pane");
+    pane_split(&api_socket, &root_pane, "right");
+
+    let panes_before = tab_pane_ids(&api_socket, &first_tab);
+    assert_eq!(panes_before.len(), 2);
+    let second_before = tab_pane_ids(&api_socket, &second_tab);
+
+    let marker = "herdr_next_tab_marker_5521";
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+    seed_pane_marker(&api_socket, &root_pane, marker);
+
+    // Index 4 = "Move to next tab".
+    right_click_and_activate(&mut client, 40, 6, "Move to next tab", 4);
+
+    let panes_after = tab_pane_ids(&api_socket, &first_tab);
+    let second_after = tab_pane_ids(&api_socket, &second_tab);
+    assert_eq!(
+        panes_after.len(),
+        1,
+        "pane must leave the source tab; before={panes_before:?} after={panes_after:?}"
+    );
+    assert_eq!(
+        second_after.len(),
+        second_before.len() + 1,
+        "destination tab must gain the pane; before={second_before:?} after={second_after:?}"
+    );
+
+    let moved = second_after
+        .iter()
+        .find(|id| !second_before.contains(id))
+        .expect("destination tab should have exactly one new pane");
+    assert!(
+        pane_read_recent_contains(&api_socket, moved, marker, Duration::from_secs(10)),
+        "pane moved to the next tab must keep its live terminal contents"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+/// "Move to next workspace" must relocate the pane across workspaces and keep
+/// its live process.
+#[test]
+fn pane_context_menu_moves_pane_to_next_workspace_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "ws-source");
+    workspace_create(&api_socket, "ws-dest");
+    let source_id = workspace_id_by_label(&workspace_list(&api_socket), "ws-source");
+    let dest_id = workspace_id_by_label(&workspace_list(&api_socket), "ws-dest");
+
+    let source_tab = tab_ids(&api_socket, &source_id)
+        .first()
+        .cloned()
+        .expect("source tab");
+    let dest_tab = tab_ids(&api_socket, &dest_id)
+        .first()
+        .cloned()
+        .expect("dest tab");
+
+    let root_pane = tab_pane_ids(&api_socket, &source_tab)
+        .first()
+        .cloned()
+        .expect("root pane");
+    pane_split(&api_socket, &root_pane, "down");
+
+    let panes_before = tab_pane_ids(&api_socket, &source_tab);
+    assert_eq!(panes_before.len(), 2);
+    let dest_before = tab_pane_ids(&api_socket, &dest_tab);
+
+    let marker = "herdr_next_ws_marker_7744";
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+    seed_pane_marker(&api_socket, &root_pane, marker);
+
+    // Focus the source workspace pane, then index 6 = "Move to next workspace".
+    right_click_and_activate(&mut client, 40, 6, "Move to next workspace", 6);
+
+    let panes_after = tab_pane_ids(&api_socket, &source_tab);
+    let dest_after = tab_pane_ids(&api_socket, &dest_tab);
+
+    assert_eq!(
+        panes_after.len() + dest_after.len(),
+        panes_before.len() + dest_before.len(),
+        "moving across workspaces must conserve pane count; \
+         source before={panes_before:?} after={panes_after:?}, \
+         dest before={dest_before:?} after={dest_after:?}"
+    );
+    assert_eq!(
+        panes_after.len(),
+        1,
+        "pane must leave the source workspace tab"
+    );
+    assert_eq!(
+        dest_after.len(),
+        dest_before.len() + 1,
+        "destination workspace must gain the pane"
+    );
+
+    let moved = dest_after
+        .iter()
+        .find(|id| !dest_before.contains(id))
+        .expect("destination workspace should have exactly one new pane");
+    assert!(
+        pane_read_recent_contains(&api_socket, moved, marker, Duration::from_secs(10)),
+        "pane moved across workspaces must keep its live terminal contents"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+/// "Swap to horizontal" must flip a vertical split back to horizontal, the
+/// mirror of the vertical case.
+#[test]
+fn pane_context_menu_swaps_to_horizontal_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "horizontal");
+    let ws_id = workspace_id_by_label(&workspace_list(&api_socket), "horizontal");
+    let tab_id = tab_ids(&api_socket, &ws_id)
+        .first()
+        .cloned()
+        .expect("tab id");
+    let root_pane = tab_pane_ids(&api_socket, &tab_id)
+        .first()
+        .cloned()
+        .expect("root pane");
+
+    pane_split(&api_socket, &root_pane, "down");
+    let before = layout_export(&api_socket, &tab_id);
+    assert_eq!(
+        root_split_direction(&before).as_deref(),
+        Some("down"),
+        "split down should produce a vertical root split; layout: {before}"
+    );
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    // Index 1 = "Swap to horizontal".
+    right_click_and_activate(&mut client, 40, 6, "Swap to horizontal", 1);
+
+    let after = layout_export(&api_socket, &tab_id);
+    assert_eq!(
+        root_split_direction(&after).as_deref(),
+        Some("right"),
+        "context-menu 'Swap to horizontal' must flip the layout to a horizontal split; \
+         before={before}, after={after}"
     );
 
     send_client_detach(&mut client);

--- a/tests/cross_area.rs
+++ b/tests/cross_area.rs
@@ -1805,3 +1805,183 @@ fn pane_context_menu_swaps_to_horizontal_in_live_tui() {
     drop(client);
     cleanup_spawned_herdr(server, base);
 }
+
+/// "Move to previous tab" must relocate the pane into the preceding tab when it
+/// is enabled. The pane is placed on the SECOND tab so "previous" is in range.
+#[test]
+fn pane_context_menu_moves_pane_to_previous_tab_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "prevtab");
+    let ws_id = workspace_id_by_label(&workspace_list(&api_socket), "prevtab");
+    let first_tab = tab_ids(&api_socket, &ws_id)
+        .first()
+        .cloned()
+        .expect("first tab");
+
+    // Focus a second tab; its pane is the one we move backwards.
+    tab_create(&api_socket, &ws_id, true);
+    let tabs = tab_ids(&api_socket, &ws_id);
+    assert_eq!(tabs.len(), 2, "expected two tabs; got {tabs:?}");
+    let second_tab = tabs[1].clone();
+
+    // Split the second tab so it survives losing a pane.
+    let second_root = tab_pane_ids(&api_socket, &second_tab)
+        .first()
+        .cloned()
+        .expect("second tab root pane");
+    pane_split(&api_socket, &second_root, "right");
+    send_json_request(
+        &api_socket,
+        "pane_focus",
+        "pane.focus",
+        json!({ "pane_id": second_root }),
+    );
+
+    let source_before = tab_pane_ids(&api_socket, &second_tab);
+    let dest_before = tab_pane_ids(&api_socket, &first_tab);
+    assert_eq!(source_before.len(), 2, "source tab should hold two panes");
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    let marker = "herdr_prev_tab_marker_3310";
+    seed_pane_marker(&api_socket, &second_root, marker);
+
+    // Index 3 = "Move to previous tab".
+    right_click_and_activate(&mut client, 40, 6, "Move to previous tab", 3);
+
+    let source_after = tab_pane_ids(&api_socket, &second_tab);
+    let dest_after = tab_pane_ids(&api_socket, &first_tab);
+    assert_eq!(
+        source_after.len(),
+        1,
+        "pane must leave the source tab; before={source_before:?} after={source_after:?}"
+    );
+    assert_eq!(
+        dest_after.len(),
+        dest_before.len() + 1,
+        "previous tab must gain the pane; before={dest_before:?} after={dest_after:?}"
+    );
+
+    let moved = dest_after
+        .iter()
+        .find(|id| !dest_before.contains(id))
+        .expect("previous tab should have exactly one new pane");
+    assert!(
+        pane_read_recent_contains(&api_socket, moved, marker, Duration::from_secs(10)),
+        "pane moved to the previous tab must keep its live terminal contents"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}
+
+/// "Move to previous workspace" must relocate the pane into the preceding
+/// workspace when enabled. The pane starts in the SECOND workspace.
+#[test]
+fn pane_context_menu_moves_pane_to_previous_workspace_in_live_tui() {
+    let _lock = test_lock();
+    let base = unique_test_dir();
+    let config_home = base.join("config");
+    let runtime_dir = base.join("runtime");
+    let api_socket = runtime_dir.join("herdr.sock");
+    let client_socket = runtime_dir.join("herdr-client.sock");
+
+    let server = spawn_server(&config_home, &runtime_dir, &api_socket);
+    wait_for_socket(&api_socket, Duration::from_secs(10));
+    wait_for_socket(&client_socket, Duration::from_secs(10));
+
+    workspace_create(&api_socket, "ws-earlier");
+    workspace_create(&api_socket, "ws-later");
+    let earlier_id = workspace_id_by_label(&workspace_list(&api_socket), "ws-earlier");
+    let later_id = workspace_id_by_label(&workspace_list(&api_socket), "ws-later");
+
+    let earlier_tab = tab_ids(&api_socket, &earlier_id)
+        .first()
+        .cloned()
+        .expect("earlier tab");
+    let later_tab = tab_ids(&api_socket, &later_id)
+        .first()
+        .cloned()
+        .expect("later tab");
+
+    let later_root = tab_pane_ids(&api_socket, &later_tab)
+        .first()
+        .cloned()
+        .expect("later root pane");
+    pane_split(&api_socket, &later_root, "down");
+
+    // Focus the later workspace and its original pane.
+    send_json_request(
+        &api_socket,
+        "workspace_focus",
+        "workspace.focus",
+        json!({ "workspace_id": later_id }),
+    );
+    send_json_request(
+        &api_socket,
+        "pane_focus",
+        "pane.focus",
+        json!({ "pane_id": later_root }),
+    );
+
+    let source_before = tab_pane_ids(&api_socket, &later_tab);
+    let dest_before = tab_pane_ids(&api_socket, &earlier_tab);
+    assert_eq!(source_before.len(), 2);
+
+    let mut client = UnixStream::connect(&client_socket).expect("client should connect");
+    client_handshake(&mut client, CURRENT_PROTOCOL, 120, 32);
+    assert!(wait_for_frame(&mut client, Duration::from_secs(5)));
+
+    let marker = "herdr_prev_ws_marker_8802";
+    seed_pane_marker(&api_socket, &later_root, marker);
+
+    // Index 5 = "Move to previous workspace".
+    right_click_and_activate(&mut client, 40, 6, "Move to previous workspace", 5);
+
+    let source_after = tab_pane_ids(&api_socket, &later_tab);
+    let dest_after = tab_pane_ids(&api_socket, &earlier_tab);
+
+    assert_eq!(
+        source_after.len() + dest_after.len(),
+        source_before.len() + dest_before.len(),
+        "moving to the previous workspace must conserve pane count; \
+         source before={source_before:?} after={source_after:?}, \
+         dest before={dest_before:?} after={dest_after:?}"
+    );
+    assert_eq!(
+        source_after.len(),
+        1,
+        "pane must leave the later workspace tab"
+    );
+    assert_eq!(
+        dest_after.len(),
+        dest_before.len() + 1,
+        "earlier workspace must gain the pane"
+    );
+
+    let moved = dest_after
+        .iter()
+        .find(|id| !dest_before.contains(id))
+        .expect("earlier workspace should have exactly one new pane");
+    assert!(
+        pane_read_recent_contains(&api_socket, moved, marker, Duration::from_secs(10)),
+        "pane moved to the previous workspace must keep its live terminal contents"
+    );
+
+    send_client_detach(&mut client);
+    drop(client);
+    cleanup_spawned_herdr(server, base);
+}


### PR DESCRIPTION
Adds pane context-menu actions for changing split orientation and moving panes between adjacent tabs, adjacent workspaces, or a new workspace.

Also adds the public `layout.set_split_direction` API, client redraw classification, nearest-enclosing-split targeting, documentation, and live-TUI/API regression coverage.

Validation: `TMPDIR=/var/tmp/herdr-tests just check` passes.